### PR TITLE
Improve visibility of layer slider 

### DIFF
--- a/resources/themes/cura/theme.json
+++ b/resources/themes/cura/theme.json
@@ -96,8 +96,8 @@
         "progressbar_control": [12, 169, 227, 255],
 
         "slider_groove": [245, 245, 245, 255],
-        "slider_groove_border": [205, 202, 201, 255],
-        "slider_groove_fill": [205, 202, 201, 255],
+        "slider_groove_border": [160, 163, 171, 255],
+        "slider_groove_fill": [160, 163, 171, 255],
         "slider_handle": [12, 169, 227, 255],
         "slider_handle_hover": [34, 150, 190, 255],
 


### PR DESCRIPTION
The layer slider (in Layer viewmode) has poor visibility against the background if the slider overlaps the checkerboard in the 3d scene. This patch changes the color of the slider to the same color that is used for buttons, setting it apart from the checkerboard.

Fixes https://github.com/Ultimaker/Cura/issues/93
