### PR TITLE
Add bottom margin to MessageStack

### DIFF
--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -170,6 +170,7 @@ UM.MainWindow {
                     rightMargin: UM.Theme.sizes.window_margin.width;
                     top: parent.verticalCenter;
                     bottom: parent.bottom;
+                    bottomMargin: UM.Theme.sizes.window_margin.height;
                 }
             }
 


### PR DESCRIPTION
Messages showing in the MessageStack currently hug the window bottom. Not only is this graphically inconsistent with the Toolbar buttons (which have a left and bottom margin), but it also makes the messages stand out less. 

<strike>A compounding issue is that progressbars in messages (while loading objects, or loading layers in Layer view mode) are rendered below the MessageStack (instead of inside it), and are thus currently cut off. Adding a margin fixes this.</strike> This was indirectly caused by my smaller vertical margins.