### PR TITLE
Fix poor visibility of MessageStack against grid

### DIFF
--- a/resources/themes/cura/theme.json
+++ b/resources/themes/cura/theme.json
@@ -120,7 +120,7 @@
         "save_button_printtime_text": [12, 169, 227, 255],
         "save_button_background": [249, 249, 249, 255],
 
-        "message": [205, 202, 201, 255],
+        "message": [160, 163, 171, 255],
         "message_text": [35, 35, 35, 255],
 
         "tool_panel_background": [255, 255, 255, 255]


### PR DESCRIPTION
The background of the MessageStack is the same as the (hardcoded) dark color of the buildplate grid. When the view is rotated so the MessageStack overlays the buildplate grid, the visibility of the messagestack is poor. 

This PR changes the backgroundcolor of the MessageStack to a darker shade, so it stands out against the grid. It uses the same color as the buttons, which may or may not be ideal. I'm a bit conflicted about changing the message text color to white for better contrast. But perhaps a different shade should be picked for the MessageStack background?