### PR TITLE
Adding traceback.print_exc()

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -3,12 +3,15 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the AGPLv3 or higher.
 
+import traceback
+
 try:
     import cura.CuraApplication
 
     app = cura.CuraApplication.CuraApplication.getInstance()
     app.run()
 except Exception as e:
+    traceback.print_exc()
     import cura.CrashHandler
     cura.CrashHandler.show()
 


### PR DESCRIPTION
Very useful when CrashHandler couldn't be found or isn't working at all.
The result is that a traceback message will be printed when a exception appears (in python style).