### PR TITLE
Fix crash when a profile cannot be loaded

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -35,13 +35,13 @@ class BuildVolume(SceneNode):
 
 
     def setWidth(self, width):
-        self._width = width
+        if width: self._width = width
 
     def setHeight(self, height):
-        self._height = height
+        if height: self._height = height
 
     def setDepth(self, depth):
-        self._depth = depth
+        if depth: self._depth = depth
 
     def getDisallowedAreas(self):
         return self._disallowed_areas


### PR DESCRIPTION
If a profile is not properly loaded, the width & height of the buildvolume may be set to None. This then causes an exception in buildvolume.rebuild().

Steps to reproduce the issue:
* remove %userprofile%/cura
* create a new profile, adding a machine, by running 15.06
* close 15.06 and open a master build of Cura
* witness crash in buildvolume.py:rebuild (trying to divide self._width by 2 when self._width == None)

Note: The actual mechanism of this crash is probably due to ongoing profile work by @awhiemstra. It could be worthwhile to fix the cause instead of fixing the symptom. 