### PR TITLE
Change the default UMO uprade options

### DIFF
--- a/resources/qml/WizardPages/SelectUpgradedParts.qml
+++ b/resources/qml/WizardPages/SelectUpgradedParts.qml
@@ -47,6 +47,7 @@ Item
                 CheckBox
                 {
                     text: catalog.i18nc("@action:checkbox","Extruder driver ugrades")
+                    checked: true
                 }
                 CheckBox
                 {
@@ -59,7 +60,6 @@ Item
                 CheckBox
                 {
                     text: catalog.i18nc("@action:checkbox","Dual extrusion (experimental)")
-                    checked: true
                 }
             }
 


### PR DESCRIPTION

From https://ultimaker.com/en/community/view/17296-cura-1510-open-beta?page=1&sort=#reply-117393:
first opening-select your printer --> Ultimaker Original: by default only the dual extrusion upgrade box is ticked. Should it be the opposite by default only the extruder driver upgrade?

This PR restores the default upgrade to what it was with legacy Cura.
