### PR TITLE
Fixes "could not create shader program" #385

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1,6 +1,13 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the AGPLv3 or higher.
 
+import platform
+
+if platform.system() == "Linux": # Needed for platform.linux_distribution, which is not available on Windows and OSX
+    # For Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
+    if platform.linux_distribution()[0] in ("Ubuntu", ): # Just in case it also happens on Debian, so it can be added
+        from OpenGL import GL
+
 from UM.Qt.QtApplication import QtApplication
 from UM.Scene.SceneNode import SceneNode
 from UM.Scene.Camera import Camera


### PR DESCRIPTION
For any reason this problem seems to be Ubuntu-specific and is also present since pyqt4.
* Updated the #131 pull request and added platform.linux_distribution to check for "Ubuntu"
* Added notice about the bug report above the if-clause
* Added comment why <platform.system() == "Linux"> is needed+

PS: If there is something missing to this PR, just let me know. I'll add it as soon as possible.

Regards