### PR TITLE
Adding supported stl mime-type

### DIFF
--- a/cura.desktop
+++ b/cura.desktop
@@ -8,5 +8,6 @@ TryExec=/usr/bin/cura_app.py
 Icon=/usr/share/cura/resources/images/cura-icon.png
 Terminal=false
 Type=Application
+MimeType=application/sla
 Categories=Graphics;
 Keywords=3D;Printing;


### PR DESCRIPTION
Related to the discussion at #407 just made the only needed modification to cura.desktop, that specifies which mime-types are supported by Cura.
This PR just adds the application/sla (as known as *.stl files) entry.