### PR TITLE
Enable heated bed for i3 printer.

### DIFF
--- a/resources/machines/prusa_i3.json
+++ b/resources/machines/prusa_i3.json
@@ -10,6 +10,7 @@
     "inherits": "fdmprinter.json",
 
     "machine_settings": {
+        "machine_heated_bed": { "default": true },
         "machine_width": { "default": 200 },
         "machine_height": { "default": 200 },
         "machine_depth": { "default": 200 },
@@ -28,9 +29,5 @@
         "machine_end_gcode": {
             "default": "M104 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300  ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 X-20 Y-20 F9000 ;move Z up a bit and retract filament even more\nG28 X0 Y0 ;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nG90 ;absolute positioning"
         }
-    },
-
-    "overrides": {
-        "material_bed_temperature": { "visible": true }
     }
 }


### PR DESCRIPTION
When selecting the i3 printer, the heated bed option is not displayed.  This fixes that.