### PR TITLE
prevent "GCode of death" ;)

### DIFF
--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -5,6 +5,7 @@ from UM.Mesh.MeshWriter import MeshWriter
 from UM.Logger import Logger
 from UM.Application import Application
 import io
+import re
 
 
 class GCodeWriter(MeshWriter):
@@ -19,6 +20,23 @@ class GCodeWriter(MeshWriter):
         scene = Application.getInstance().getController().getScene()
         gcode_list = getattr(scene, "gcode_list")
         if gcode_list:
+            
+            # start extrusion safety check
+            check_lines = []
+            for layer in gcode_list:
+                check_lines.extend(layer.split("\n"))
+            cur_extrude = 0.0;
+            extrude_safety = 10.0;
+            for i, line in enumerate(check_lines):
+                match = re.search(r'E([0-9.]+)', line)
+                if match:
+                    extrude = float( match.group(1) )
+                    if extrude > cur_extrude + extrude_safety:
+                        Logger.log("e", "GCode is not safe! Extrusion gap from "+str(cur_extrude)+" to "+str(extrude))
+                        return False
+                    cur_extrude = extrude
+            # end extrusion safety check                        
+
             for gcode in gcode_list:
                 stream.write(gcode)
             return True


### PR DESCRIPTION
I know that playing with master isn't always safe, but the cura master built managed to somehow produce a GCode, which will start with a HUGE extrusion without movements. The result is that my Ultimaker2 freezes and you can hear the extruder motor scream in pain. And afterwards, everything is clogged up and the nozzle is sticking to the heatbed and I needed to disassemble the feeder to get out all of the filament scraps. So that kind of GCode is REALLY annoying.

Here's the start of the buggy gcode file:

```
;FLAVOR:UltiGCode
;TIME:55356
;MATERIAL:62176
;MATERIAL2:0
;FLAVOR:UltiGCode
;TIME:44321
;MATERIAL:68468
;MATERIAL2:0
;LAYER:4
G0 X94.979 Y100.853 Z1.000
;TYPE:WALL-INNER
G1 F3000.000 X94.569 Y101.055 E4719.78767
G1 X93.072 Y98.014 E4720.05883
```

To me, that looks like Cura somehow started the slicing multiple times and then interleaved the results. But in any case, that E4719.78767 value is obviously a problem. As a first step towards finding the base issue that is causing bad GCode to be generated, I added a safety check to GCodeWriter.py which will log an error and abort if there is an extrusion difference > 10.0 between any two lines in the GCode.

So after applying this patch, Cura will cancel the GCode writing with an error message if there has been any screwup during slicing that resulted in overly large extrusion value jumps.
