### PR TITLE
Always show "General" page when opening preferences using Settings menu

### DIFF
--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -567,7 +567,7 @@ UM.MainWindow
 
         addMachine.onTriggered: addMachineWizard.visible = true;
 
-        preferences.onTriggered: { preferences.visible = true; }
+        preferences.onTriggered: { preferences.visible = true; preferences.setPage(0); }
         configureMachines.onTriggered: { preferences.visible = true; preferences.setPage(3); }
         manageProfiles.onTriggered: { preferences.visible = true; preferences.setPage(4); }
 


### PR DESCRIPTION
Settings->Preferences does not open the General Preferences page consistently.

Steps to reproduce:
* (re)launch Cura
* Use the Settings->Preferences menu
=> General page opens
* Close preferences
* User the Profile->Manage profiles menu
* Close preferences
* Use the Settings->Preferences menu

Expected result:
General preferences page opens
Actual result:
Profile preferences page opens