### PR TITLE
Adjust initial view to be slightly from the side

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -169,7 +169,7 @@ class CuraApplication(QtApplication):
         self._physics = PlatformPhysics.PlatformPhysics(controller, self._volume)
 
         camera = Camera("3d", root)
-        camera.setPosition(Vector(0, 250, 900))
+        camera.setPosition(Vector(-80, 250, 700))
         camera.setPerspective(True)
         camera.lookAt(Vector(0, 0, 0))
         controller.getScene().setActiveCamera("3d")


### PR DESCRIPTION
The default view on the build volume shows the volume head-on to match how a user sees his/her printer. When an object is added to the center of the buildplate, this default view causes the y and z axes to align, making it harder to manipulate the object (translate, rotate, scale):
![view1](https://cloud.githubusercontent.com/assets/143551/11063538/abbde8f0-87b7-11e5-98c6-6e2e7b0f574e.png)

Attached patch makes a small change to the default view to be slightly from the side, so the two axes don't align (and also places the camera slightly closer to the build volume so everything is less tiny):
![view1_patched](https://cloud.githubusercontent.com/assets/143551/11063539/ae817fe8-87b7-11e5-81f1-5c8a714b803c.png)
