### PR TITLE
Create wanhao_duplicator_i3.json

### DIFF
--- a/resources/machines/wanhao_duplicator_i3.json
+++ b/resources/machines/wanhao_duplicator_i3.json
@@ -1,0 +1,35 @@
+{
+    "id": "wanhao_duplicator_i3",
+    "version": 1, 
+    "name": "Duplicator i3",
+    "manufacturer": "Wanhao",
+    "author": "Other",
+    "icon": "icon_ultimaker2.png",
+    "platform": "prusai3_platform.stl",
+
+    "inherits": "fdmprinter.json",
+
+    "machine_settings": {
+        "machine_heated_bed": { "default": true },
+        "machine_width": { "default": 200 },
+        "machine_height": { "default": 180 },
+        "machine_depth": { "default": 200 },
+        "machine_center_is_zero": { "default": false },
+        "machine_nozzle_size": { "default": 0.4 },
+        "machine_nozzle_heat_up_speed": { "default": 2.0 },
+        "machine_nozzle_cool_down_speed": { "default": 2.0 },
+        "machine_head_shape_min_x": { "default": 75 },
+        "machine_head_shape_min_y": { "default": 18 },
+        "machine_head_shape_max_x": { "default": 18 },
+        "machine_head_shape_max_y": { "default": 35 },
+        "machine_nozzle_gantry_distance": { "default": 55 },
+        "machine_gcode_flavor": { "default": "RepRap (Marlin/Sprinter)" },
+
+        "machine_start_gcode": {
+            "default": "G21 ;metric values\nG90 ;absolute positioning\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG28 X0 Y0 ;move X/Y to min endstops\nG28 Z0 ;move Z to min endstops\nG1 Z15.0 F9000 ;move the platform down 15mm\nG92 E0 ;zero the extruded length\nG1 F200 E3 ;extrude 3mm of feed stock\nG92 E0 ;zero the extruded length again\nG1 F9000\n;Put printing message on LCD screen\nM117 Printing..."
+        },
+        "machine_end_gcode": {
+            "default": "M104 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300  ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 X-20 Y-20 F9000 ;move Z up a bit and retract filament even more\nG28 X0 Y0 ;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nG90 ;absolute positioning"
+        }
+    }
+}


### PR DESCRIPTION
I just got started with this printer. They say in the printers manual to use the prusa i3 settings, but that one has a different buildvolume. So I propose this file as it's own profile.