### PR TITLE
Write and Read Profile in g-code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *kdev*
+*.kate-swp
 __pycache__
 docs/html
 *.lprof

--- a/plugins/CuraProfileReader/CuraProfileReader.py
+++ b/plugins/CuraProfileReader/CuraProfileReader.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2015 Ultimaker B.V.
+# Cura is released under the terms of the AGPLv3 or higher.
+
+from UM.Application import Application #To get the machine manager to create the new profile in.
+from UM.Settings.Profile import Profile
+from UM.Settings.ProfileReader import ProfileReader
+
+##  A plugin that reads profile data from Cura profile files.
+#
+#   It reads a profile from a .curaprofile file, and returns it as a profile
+#   instance.
+class CuraProfileReader(ProfileReader):
+    ##  Initialises the cura profile reader.
+    #
+    #   This does nothing since the only other function is basically stateless.
+    def __init__(self):
+        super().__init__()
+
+    ##  Reads a cura profile from a file and returns it.
+    #
+    #   \param file_name The file to read the cura profile from.
+    #   \return The cura profile that was in the file, if any. If the file could
+    #   not be read or didn't contain a valid profile, \code None \endcode is
+    #   returned.
+    def read(self, file_name):
+        profile = Profile(machine_manager = Application.getInstance().getMachineManager(), read_only = False) #Create an empty profile.
+        serialised = ""
+        try:
+            with open(file_name) as f: #Open file for reading.
+                serialised = f.read()
+        except IOError as e:
+            Logger.log("e", "Unable to open file %s for reading: %s", file_name, str(e))
+            return None
+        
+        try:
+            profile.unserialise(serialised)
+        except Exception as e: #Parsing error. This is not a (valid) Cura profile then.
+            return None
+        return profile

--- a/plugins/CuraProfileReader/__init__.py
+++ b/plugins/CuraProfileReader/__init__.py
@@ -15,10 +15,12 @@ def getMetaData():
             "description": catalog.i18nc("@info:whatsthis", "Provides support for importing Cura profiles."),
             "api": 2
         },
-        "profile_reader": {
-            "extension": "curaprofile",
-            "description": catalog.i18nc("@item:inlistbox", "Cura Profile")
-        }
+        "profile_reader": [
+            {
+                "extension": "curaprofile",
+                "description": catalog.i18nc("@item:inlistbox", "Cura Profile")
+            }
+         ]
     }
 
 def register(app):

--- a/plugins/CuraProfileReader/__init__.py
+++ b/plugins/CuraProfileReader/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2015 Ultimaker B.V.
+# Cura is released under the terms of the AGPLv3 or higher.
+
+from . import CuraProfileReader
+
+from UM.i18n import i18nCatalog
+catalog = i18nCatalog("cura")
+
+def getMetaData():
+    return {
+        "plugin": {
+            "name": catalog.i18nc("@label", "Cura Profile Reader"),
+            "author": "Ultimaker",
+            "version": "1.0",
+            "description": catalog.i18nc("@info:whatsthis", "Provides support for importing Cura profiles."),
+            "api": 2
+        },
+        "profile_reader": {
+            "extension": "curaprofile",
+            "description": catalog.i18nc("@item:inlistbox", "Cura Profile")
+        }
+    }
+
+def register(app):
+    return { "profile_reader": CuraProfileReader.CuraProfileReader() }

--- a/plugins/CuraProfileWriter/CuraProfileWriter.py
+++ b/plugins/CuraProfileWriter/CuraProfileWriter.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2015 Ultimaker B.V.
+# Copyright (c) 2013 David Braam
+# Uranium is released under the terms of the AGPLv3 or higher.
+
+from UM.Settings.Profile import Profile
+from UM.Settings.ProfileWriter import ProfileWriter
+
+##  Writes profiles to Cura's own profile format with config files.
+class CuraProfileWriter(ProfileWriter):
+    ##  Writes a profile to the specified stream.
+    #
+    #   \param stream \type{IOStream} The stream to write the profile to.
+    #   \param profile \type{Profile} The profile to write to that stream.
+    #   \return \code True \endcode if the writing was successful, or \code
+    #   False \endcode if it wasn't.
+    def write(self, stream, profile):
+        serialised = profile.serialise()
+        stream.write(serialised)
+        return True

--- a/plugins/CuraProfileWriter/CuraProfileWriter.py
+++ b/plugins/CuraProfileWriter/CuraProfileWriter.py
@@ -2,18 +2,25 @@
 # Copyright (c) 2013 David Braam
 # Uranium is released under the terms of the AGPLv3 or higher.
 
+from UM.Logger import Logger
+from UM.SaveFile import SaveFile
 from UM.Settings.Profile import Profile
 from UM.Settings.ProfileWriter import ProfileWriter
 
 ##  Writes profiles to Cura's own profile format with config files.
 class CuraProfileWriter(ProfileWriter):
-    ##  Writes a profile to the specified stream.
+    ##  Writes a profile to the specified file path.
     #
-    #   \param stream \type{IOStream} The stream to write the profile to.
-    #   \param profile \type{Profile} The profile to write to that stream.
+    #   \param path \type{string} The file to output to.
+    #   \param profile \type{Profile} The profile to write to that file.
     #   \return \code True \endcode if the writing was successful, or \code
     #   False \endcode if it wasn't.
-    def write(self, stream, profile):
+    def write(self, path, profile):
         serialised = profile.serialise()
-        stream.write(serialised)
+        try:
+            with SaveFile(path, "wt", -1, "utf-8") as f: #Open the specified file.
+                f.write(serialised)
+        except Exception as e:
+            Logger.log("e", "Failed to write profile to %s: %s", path, str(e))
+            return False
         return True

--- a/plugins/CuraProfileWriter/__init__.py
+++ b/plugins/CuraProfileWriter/__init__.py
@@ -1,21 +1,21 @@
 # Copyright (c) 2015 Ultimaker B.V.
-# Cura is released under the terms of the AGPLv3 or higher.
+# Uranium is released under the terms of the AGPLv3 or higher.
 
-from . import CuraProfileReader
+from . import CuraProfileWriter
 
 from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
+catalog = i18nCatalog("uranium")
 
 def getMetaData():
     return {
         "plugin": {
-            "name": catalog.i18nc("@label", "Cura Profile Reader"),
+            "name": catalog.i18nc("@label", "Cura Profile Writer"),
             "author": "Ultimaker",
             "version": "1.0",
-            "description": catalog.i18nc("@info:whatsthis", "Provides support for importing Cura profiles."),
+            "description": catalog.i18nc("@info:whatsthis", "Provides support for exporting Cura profiles."),
             "api": 2
         },
-        "profile_reader": [
+        "profile_writer": [
             {
                 "extension": "curaprofile",
                 "description": catalog.i18nc("@item:inlistbox", "Cura Profile")
@@ -24,4 +24,4 @@ def getMetaData():
     }
 
 def register(app):
-    return { "profile_reader": CuraProfileReader.CuraProfileReader() }
+    return { "profile_writer": CuraProfileWriter.CuraProfileWriter() }

--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the AGPLv3 or higher.
 
-from UM.Application import Application #To get the current profile that should be updated with the settings from the g-code.
+from UM.Application import Application #To get the machine manager to create the new profile in.
 from UM.Settings.Profile import Profile
 from UM.Settings.ProfileReader import ProfileReader
 import re #Regular expressions for parsing escape characters in the settings.

--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -24,9 +24,9 @@ class GCodeProfileReader(ProfileReader):
     #   Note that the keys of this dictionary are regex strings. The values are
     #   not.
     escape_characters = {
-        "\\\\": "\\", #The escape character.
-        "\\n": "\n",  #Newlines. They break off the comment.
-        "\\r": "\r"   #Carriage return. Windows users may need this for visualisation in their editors.
+        re.escape("\\\\"): "\\", #The escape character.
+        re.escape("\\n"): "\n",  #Newlines. They break off the comment.
+        re.escape("\\r"): "\r"   #Carriage return. Windows users may need this for visualisation in their editors.
     }
 
     ##  Initialises the g-code reader as a profile reader.
@@ -40,7 +40,7 @@ class GCodeProfileReader(ProfileReader):
     #   specified file was no g-code or contained no parsable profile, \code
     #   None \endcode is returned.
     def read(self, file_name):
-        prefix = ";SETTING_" + str(version) + " "
+        prefix = ";SETTING_" + str(GCodeProfileReader.version) + " "
         prefix_length = len(prefix)
 
         #Loading all settings from the file. They are all at the end, but Python has no reverse seek any more since Python3. TODO: Consider moving settings to the start?
@@ -55,10 +55,9 @@ class GCodeProfileReader(ProfileReader):
             return None
 
         #Unescape the serialised profile.
-        escape_characters = dict((re.escape(key), value) for key, value in escape_characters.items())
-        pattern = re.compile("|".join(escape_characters.keys()))
-        serialised = pattern.sub(lambda m: escape_characters[re.escape(m.group(0))], serialised) #Perform the replacement with a regular expression.
-        
+        pattern = re.compile("|".join(GCodeProfileReader.escape_characters.keys()))
+        serialised = pattern.sub(lambda m: GCodeProfileReader.escape_characters[re.escape(m.group(0))], serialised) #Perform the replacement with a regular expression.
+
         #Apply the changes to the current profile.
         profile = Profile(machine_manager = Application.getInstance().getMachineManager(), read_only = False)
         try:

--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -2,7 +2,7 @@
 # Cura is released under the terms of the AGPLv3 or higher.
 
 from UM.Application import Application #To get the current profile that should be updated with the settings from the g-code.
-from UM.Mesh.MeshReader import MeshReader
+from UM.Settings.ProfileReader import ProfileReader
 import re #Regular expressions for parsing escape characters in the settings.
 
 ##  A class that reads profile data from g-code files.
@@ -10,7 +10,7 @@ import re #Regular expressions for parsing escape characters in the settings.
 #   It reads the profile data from g-code files and stores the profile as a new
 #   profile, and then immediately activates that profile.
 #   This class currently does not process the rest of the g-code in any way.
-class GCodeReader(MeshReader):
+class GCodeProfileReader(ProfileReader):
     ##  Initialises the g-code reader as a mesh reader.
     def __init__(self):
         super().__init__()

--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -8,15 +8,19 @@ import re #Regular expressions for parsing escape characters in the settings.
 
 ##  A class that reads profile data from g-code files.
 #
-#   It reads the profile data from g-code files and stores the profile as a new
-#   profile, and then immediately activates that profile.
+#   It reads the profile data from g-code files and stores it in a new profile.
 #   This class currently does not process the rest of the g-code in any way.
 class GCodeProfileReader(ProfileReader):
-    ##  Initialises the g-code reader as a mesh reader.
+    ##  Initialises the g-code reader as a profile reader.
     def __init__(self):
         super().__init__()
 
     ##  Reads a g-code file, loading the profile from it.
+    #
+    #   \param file_name The name of the file to read the profile from.
+    #   \return The profile that was in the specified file, if any. If the
+    #   specified file was no g-code or contained no parsable profile, \code
+    #   None \endcode is returned.
     def read(self, file_name):
         version = 1 #IF YOU CHANGE THIS FUNCTION IN A WAY THAT BREAKS REVERSE COMPATIBILITY, INCREMENT THIS VERSION NUMBER!
         prefix = ";SETTING_" + str(version) + " "

--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -11,6 +11,13 @@ import re #Regular expressions for parsing escape characters in the settings.
 #   It reads the profile data from g-code files and stores it in a new profile.
 #   This class currently does not process the rest of the g-code in any way.
 class GCodeProfileReader(ProfileReader):
+    ##  The file format version of the serialised g-code.
+    #
+    #   It can only read settings with the same version as the version it was
+    #   written with. If the file format is changed in a way that breaks reverse
+    #   compatibility, increment this version number!
+    version = 1
+    
     ##  Initialises the g-code reader as a profile reader.
     def __init__(self):
         super().__init__()
@@ -22,7 +29,6 @@ class GCodeProfileReader(ProfileReader):
     #   specified file was no g-code or contained no parsable profile, \code
     #   None \endcode is returned.
     def read(self, file_name):
-        version = 1 #IF YOU CHANGE THIS FUNCTION IN A WAY THAT BREAKS REVERSE COMPATIBILITY, INCREMENT THIS VERSION NUMBER!
         prefix = ";SETTING_" + str(version) + " "
         
         #Loading all settings from the file. They are all at the end, but Python has no reverse seek any more since Python3. TODO: Consider moving settings to the start?

--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -30,14 +30,15 @@ class GCodeProfileReader(ProfileReader):
     #   None \endcode is returned.
     def read(self, file_name):
         prefix = ";SETTING_" + str(version) + " "
-        
+        prefix_length = len(prefix)
+
         #Loading all settings from the file. They are all at the end, but Python has no reverse seek any more since Python3. TODO: Consider moving settings to the start?
         serialised = "" #Will be filled with the serialised profile.
         try:
             with open(file_name) as f:
                 for line in f:
                     if line.startswith(prefix):
-                        serialised += line[len(prefix):-1] #Remove the prefix and the newline from the line, and add it to the rest.
+                        serialised += line[prefix_length : -1] #Remove the prefix and the newline from the line, and add it to the rest.
         except IOError as e:
             Logger.log("e", "Unable to open file %s for reading: %s", file_name, str(e))
             return None

--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -18,6 +18,17 @@ class GCodeProfileReader(ProfileReader):
     #   compatibility, increment this version number!
     version = 1
     
+    ##  Dictionary that defines how characters are escaped when embedded in
+    #   g-code.
+    #
+    #   Note that the keys of this dictionary are regex strings. The values are
+    #   not.
+    escape_characters = {
+        "\\\\": "\\", #The escape character.
+        "\\n": "\n",  #Newlines. They break off the comment.
+        "\\r": "\r"   #Carriage return. Windows users may need this for visualisation in their editors.
+    }
+
     ##  Initialises the g-code reader as a profile reader.
     def __init__(self):
         super().__init__()
@@ -44,12 +55,6 @@ class GCodeProfileReader(ProfileReader):
             return None
 
         #Unescape the serialised profile.
-        escape_characters = { #Which special characters (keys) are replaced by what escape character (values).
-                              #Note: The keys are regex strings. Values are not.
-            "\\\\": "\\", #The escape character.
-            "\\n": "\n",  #Newlines. They break off the comment.
-            "\\r": "\r"   #Carriage return. Windows users may need this for visualisation in their editors.
-        }
         escape_characters = dict((re.escape(key), value) for key, value in escape_characters.items())
         pattern = re.compile("|".join(escape_characters.keys()))
         serialised = pattern.sub(lambda m: escape_characters[re.escape(m.group(0))], serialised) #Perform the replacement with a regular expression.

--- a/plugins/GCodeProfileReader/__init__.py
+++ b/plugins/GCodeProfileReader/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the AGPLv3 or higher.
 
-from . import GCodeReader
+from . import GCodeProfileReader
 
 from UM.i18n import i18nCatalog
 catalog = i18nCatalog("cura")
@@ -17,9 +17,9 @@ def getMetaData():
         },
         "profile_reader": {
             "extension": "gcode",
-            "description": catalog.i18nc("@item:inlistbox", "Gcode File")
+            "description": catalog.i18nc("@item:inlistbox", "G-code File")
         }
     }
 
 def register(app):
-    return { "profile_reader": GCodeReader.GCodeReader() }
+    return { "profile_reader": GCodeProfileReader.GCodeProfileReader() }

--- a/plugins/GCodeProfileReader/__init__.py
+++ b/plugins/GCodeProfileReader/__init__.py
@@ -15,10 +15,12 @@ def getMetaData():
             "description": catalog.i18nc("@info:whatsthis", "Provides support for importing profiles from g-code files."),
             "api": 2
         },
-        "profile_reader": {
-            "extension": "gcode",
-            "description": catalog.i18nc("@item:inlistbox", "G-code File")
-        }
+        "profile_reader": [
+            {
+                "extension": "gcode",
+                "description": catalog.i18nc("@item:inlistbox", "G-code File")
+            }
+        ]
     }
 
 def register(app):

--- a/plugins/GCodeReader/GCodeReader.py
+++ b/plugins/GCodeReader/GCodeReader.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the AGPLv3 or higher.
 
+from UM.Application import Application #To get the current profile that should be updated with the settings from the g-code.
 from UM.Mesh.MeshReader import MeshReader
+import re #Regular expressions for parsing escape characters in the settings.
 
 ##  A class that reads profile data from g-code files.
 #

--- a/plugins/GCodeReader/GCodeReader.py
+++ b/plugins/GCodeReader/GCodeReader.py
@@ -3,6 +3,42 @@
 
 from UM.Mesh.MeshReader import MeshReader
 
+##  A class that reads profile data from g-code files.
+#
+#   It reads the profile data from g-code files and stores the profile as a new
+#   profile, and then immediately activates that profile.
+#   This class currently does not process the rest of the g-code in any way.
 class GCodeReader(MeshReader):
+    ##  Initialises the g-code reader as a mesh reader.
+    def __init__(self):
+        super().__init__()
+
+    ##  Reads a g-code file, loading the profile from it.
     def read(self, file_name):
-        pass
+        version = 1 #IF YOU CHANGE THIS FUNCTION IN A WAY THAT BREAKS REVERSE COMPATIBILITY, INCREMENT THIS VERSION NUMBER!
+        prefix = ";SETTING_" + str(version) + " "
+        
+        #Loading all settings from the file. They are all at the end, but Python has no reverse seek any more since Python3. TODO: Consider moving settings to the start?
+        serialised = "" #Will be filled with the serialised profile.
+        try:
+            with open(file_name) as f:
+                for line in f:
+                    if line.startswith(prefix):
+                        serialised += line[len(prefix):] #Remove the prefix from the line, and add it to the rest.
+        except IOError as e:
+            Logger.log("e", "Unable to open file %s for reading: %s", file_name, str(e))
+        
+        #Unescape the serialised profile.
+        escape_characters = { #Which special characters (keys) are replaced by what escape character (values).
+                              #Note: The keys are regex strings. Values are not.
+            "\\\\": "\\", #The escape character.
+            "\\n": "\n",  #Newlines. They break off the comment.
+            "\\r": "\r"   #Carriage return. Windows users may need this for visualisation in their editors.
+        }
+        escape_characters = dict((re.escape(key), value) for key, value in escape_characters.items())
+        pattern = re.compile("|".join(escape_characters.keys()))
+        serialised = pattern.sub(lambda m: escape_characters[re.escape(m.group(0))], serialised) #Perform the replacement with a regular expression.
+        
+        #Apply the changes to the current profile.
+        profile = Application.getInstance().getMachineManager().getActiveProfile()
+        profile.unserialise(serialised)

--- a/plugins/GCodeReader/GCodeReader.py
+++ b/plugins/GCodeReader/GCodeReader.py
@@ -26,10 +26,10 @@ class GCodeReader(MeshReader):
             with open(file_name) as f:
                 for line in f:
                     if line.startswith(prefix):
-                        serialised += line[len(prefix):] #Remove the prefix from the line, and add it to the rest.
+                        serialised += line[len(prefix):-1] #Remove the prefix and the newline from the line, and add it to the rest.
         except IOError as e:
             Logger.log("e", "Unable to open file %s for reading: %s", file_name, str(e))
-        
+
         #Unescape the serialised profile.
         escape_characters = { #Which special characters (keys) are replaced by what escape character (values).
                               #Note: The keys are regex strings. Values are not.

--- a/plugins/GCodeReader/__init__.py
+++ b/plugins/GCodeReader/__init__.py
@@ -9,10 +9,10 @@ catalog = i18nCatalog("cura")
 def getMetaData():
     return {
         "plugin": {
-            "name": catalog.i18nc("@label", "GCode Reader"),
+            "name": catalog.i18nc("@label", "GCode Profile Reader"),
             "author": "Ultimaker",
             "version": "1.0",
-            "description": catalog.i18nc("@info:whatsthis", "Provides support for reading GCode files."),
+            "description": catalog.i18nc("@info:whatsthis", "Provides support for importing profiles from g-code files."),
             "api": 2
         },
         "profile_reader": {

--- a/plugins/GCodeReader/__init__.py
+++ b/plugins/GCodeReader/__init__.py
@@ -15,13 +15,11 @@ def getMetaData():
             "description": catalog.i18nc("@info:whatsthis", "Provides support for reading GCode files."),
             "api": 2
         },
-        "mesh_reader": [
-            {
-                "extension": "gcode",
-                "description": catalog.i18nc("@item:inlistbox", "Gcode File")
-            }
-        ]
+        "profile_reader": {
+            "extension": "gcode",
+            "description": catalog.i18nc("@item:inlistbox", "Gcode File")
+        }
     }
 
 def register(app):
-    return { "mesh_reader": GCodeReader.GCodeReader() }
+    return { "profile_reader": GCodeReader.GCodeReader() }

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -9,6 +9,12 @@ import re #For escaping characters in the settings.
 
 
 class GCodeWriter(MeshWriter):
+    ##  Serialisation version ID of the settings that get serialised in g-code.
+    #
+    #   If the format of settings is modified in any way that breaks backwards
+    #   compatibility, this version number must be incremented.
+    settings_version_id = 1
+    
     def __init__(self):
         super().__init__()
 
@@ -36,8 +42,8 @@ class GCodeWriter(MeshWriter):
     #   \param profile The profile to serialise.
     #   \return A serialised string of the profile.
     def _serialiseProfile(self, profile):
-        version = 1 #IF YOU CHANGE THIS FUNCTION IN A WAY THAT BREAKS REVERSE COMPATIBILITY, INCREMENT THIS VERSION NUMBER!
-        prefix = ";SETTING_" + str(version) + " " #The prefix to put before each line.
+        #IF YOU CHANGE THIS FUNCTION IN A WAY THAT BREAKS REVERSE COMPATIBILITY, INCREMENT settings_version_id!
+        prefix = ";SETTING_" + str(self.settings_version_id) + " " #The prefix to put before each line.
         
         serialised = profile.serialise()
         

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -5,6 +5,7 @@ from UM.Mesh.MeshWriter import MeshWriter
 from UM.Logger import Logger
 from UM.Application import Application
 import io
+import re #For escaping characters in the settings.
 
 
 class GCodeWriter(MeshWriter):
@@ -21,6 +22,33 @@ class GCodeWriter(MeshWriter):
         if gcode_list:
             for gcode in gcode_list:
                 stream.write(gcode)
+            profile = self._serialiseProfile(Application.getInstance().getMachineManager().getActiveProfile()) #Serialise the profile and put them at the end of the file.
+            stream.write(profile)
             return True
 
         return False
+
+    ##  Serialises the profile to prepare it for saving in the g-code.
+    #
+    #   The profile are serialised, and special characters (including newline)
+    #   are escaped.
+    #
+    #   \param profile The profile to serialise.
+    #   \return A serialised string of the profile.
+    def _serialiseProfile(self, profile):
+        serialised = profile.serialise()
+        
+        #Escape characters that have a special meaning in g-code comments.
+        escape_characters = { #Which special characters (keys) are replaced by what escape character (values).
+                              #Note: The keys are regex strings. Values are not.
+            "\\": "\\\\", #The escape character.
+            "\n": "\\n",  #Newlines. They break off the comment.
+            "\r": "\\r",  #Carriage return. Windows users may need this for visualisation in their editors.
+        }
+        pattern = re.compile("|".join(escape_characters.keys()))
+        serialised = pattern.sub(lambda m: escape_characters[m.group(0)], serialised) #Perform the replacement with a regular expression.
+        
+        #TODO: Introduce line breaks so that each comment is no longer than 80 characters.
+        #TODO: Prepend a prefix that includes the keyword "SETTING" and a serialised version number.
+        
+        return ";" + serialised

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -9,12 +9,6 @@ import re #For escaping characters in the settings.
 
 
 class GCodeWriter(MeshWriter):
-    ##  Serialisation version ID of the settings that get serialised in g-code.
-    #
-    #   If the format of settings is modified in any way that breaks backwards
-    #   compatibility, this version number must be incremented.
-    settings_version_id = 1
-    
     def __init__(self):
         super().__init__()
 
@@ -42,8 +36,8 @@ class GCodeWriter(MeshWriter):
     #   \param profile The profile to serialise.
     #   \return A serialised string of the profile.
     def _serialiseProfile(self, profile):
-        #IF YOU CHANGE THIS FUNCTION IN A WAY THAT BREAKS REVERSE COMPATIBILITY, INCREMENT settings_version_id!
-        prefix = ";SETTING_" + str(self.settings_version_id) + " " #The prefix to put before each line.
+        version = 1 #IF YOU CHANGE THIS FUNCTION IN A WAY THAT BREAKS REVERSE COMPATIBILITY, INCREMENT THIS VERSION NUMBER!
+        prefix = ";SETTING_" + str(version) + " " #The prefix to put before each line.
         
         serialised = profile.serialise()
         

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -22,9 +22,9 @@ class GCodeWriter(MeshWriter):
     #   Note that the keys of this dictionary are regex strings. The values are
     #   not.
     escape_characters = {
-        "\\": "\\\\", #The escape character.
-        "\n": "\\n",  #Newlines. They break off the comment.
-        "\r": "\\r"   #Carriage return. Windows users may need this for visualisation in their editors.
+        re.escape("\\"): "\\\\", #The escape character.
+        re.escape("\n"): "\\n",  #Newlines. They break off the comment.
+        re.escape("\r"): "\\r"   #Carriage return. Windows users may need this for visualisation in their editors.
     }
 
     def __init__(self):
@@ -54,15 +54,14 @@ class GCodeWriter(MeshWriter):
     #   \param profile The profile to serialise.
     #   \return A serialised string of the profile.
     def _serialiseProfile(self, profile):
-        prefix = ";SETTING_" + str(version) + " " #The prefix to put before each line.
+        prefix = ";SETTING_" + str(GCodeWriter.version) + " " #The prefix to put before each line.
         prefix_length = len(prefix)
         
         serialised = profile.serialise()
         
         #Escape characters that have a special meaning in g-code comments.
-        escape_characters = dict((re.escape(key), value) for key, value in escape_characters.items())
-        pattern = re.compile("|".join(escape_characters.keys()))
-        serialised = pattern.sub(lambda m: escape_characters[re.escape(m.group(0))], serialised) #Perform the replacement with a regular expression.
+        pattern = re.compile("|".join(GCodeWriter.escape_characters.keys()))
+        serialised = pattern.sub(lambda m: GCodeWriter.escape_characters[re.escape(m.group(0))], serialised) #Perform the replacement with a regular expression.
         
         #Introduce line breaks so that each comment is no longer than 80 characters. Prepend each line with the prefix.
         result = ""

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -15,7 +15,7 @@ class GCodeWriter(MeshWriter):
     #   written with. If the file format is changed in a way that breaks reverse
     #   compatibility, increment this version number!
     version = 1
-    
+
     def __init__(self):
         super().__init__()
 
@@ -44,6 +44,7 @@ class GCodeWriter(MeshWriter):
     #   \return A serialised string of the profile.
     def _serialiseProfile(self, profile):
         prefix = ";SETTING_" + str(version) + " " #The prefix to put before each line.
+        prefix_length = len(prefix)
         
         serialised = profile.serialise()
         
@@ -60,8 +61,8 @@ class GCodeWriter(MeshWriter):
         
         #Introduce line breaks so that each comment is no longer than 80 characters. Prepend each line with the prefix.
         result = ""
-        for pos in range(0, len(serialised), 80 - len(prefix)): #Lines have 80 characters, so the payload of each line is 80 - prefix.
-            result += prefix + serialised[pos : pos + 80 - len(prefix)] + "\n"
+        for pos in range(0, len(serialised), 80 - prefix_length): #Lines have 80 characters, so the payload of each line is 80 - prefix.
+            result += prefix + serialised[pos : pos + 80 - prefix_length] + "\n"
         serialised = result
         
         return serialised

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -9,6 +9,13 @@ import re #For escaping characters in the settings.
 
 
 class GCodeWriter(MeshWriter):
+    ##  The file format version of the serialised g-code.
+    #
+    #   It can only read settings with the same version as the version it was
+    #   written with. If the file format is changed in a way that breaks reverse
+    #   compatibility, increment this version number!
+    version = 1
+    
     def __init__(self):
         super().__init__()
 
@@ -36,7 +43,6 @@ class GCodeWriter(MeshWriter):
     #   \param profile The profile to serialise.
     #   \return A serialised string of the profile.
     def _serialiseProfile(self, profile):
-        version = 1 #IF YOU CHANGE THIS FUNCTION IN A WAY THAT BREAKS REVERSE COMPATIBILITY, INCREMENT THIS VERSION NUMBER!
         prefix = ";SETTING_" + str(version) + " " #The prefix to put before each line.
         
         serialised = profile.serialise()

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -16,6 +16,17 @@ class GCodeWriter(MeshWriter):
     #   compatibility, increment this version number!
     version = 1
 
+    ##  Dictionary that defines how characters are escaped when embedded in
+    #   g-code.
+    #
+    #   Note that the keys of this dictionary are regex strings. The values are
+    #   not.
+    escape_characters = {
+        "\\": "\\\\", #The escape character.
+        "\n": "\\n",  #Newlines. They break off the comment.
+        "\r": "\\r"   #Carriage return. Windows users may need this for visualisation in their editors.
+    }
+
     def __init__(self):
         super().__init__()
 
@@ -49,12 +60,6 @@ class GCodeWriter(MeshWriter):
         serialised = profile.serialise()
         
         #Escape characters that have a special meaning in g-code comments.
-        escape_characters = { #Which special characters (keys) are replaced by what escape character (values).
-                              #Note: The keys are regex strings. Values are not.
-            "\\": "\\\\", #The escape character.
-            "\n": "\\n",  #Newlines. They break off the comment.
-            "\r": "\\r"   #Carriage return. Windows users may need this for visualisation in their editors.
-        }
         escape_characters = dict((re.escape(key), value) for key, value in escape_characters.items())
         pattern = re.compile("|".join(escape_characters.keys()))
         serialised = pattern.sub(lambda m: escape_characters[re.escape(m.group(0))], serialised) #Perform the replacement with a regular expression.


### PR DESCRIPTION
This feature will write the profile to g-code when saving the g-code, and allows importing settings from g-code with the Import Profile button in the profile manager.

It also creates two new types of plug-ins: Profile Reader and Profile Writer, to fulfil said function as a plug-in (which is handy for later).

A similar pull request is made for Uranium. They should be tested together.