### PR TITLE
Fixing error message, which appears when loading Cura.

### DIFF
--- a/cura/CuraSplashScreen.py
+++ b/cura/CuraSplashScreen.py
@@ -21,8 +21,12 @@ class CuraSplashScreen(QSplashScreen):
 
         painter.setFont(QFont("Roboto", 20))
         painter.drawText(0, 0, 203, 230, Qt.AlignRight | Qt.AlignBottom, version[0])
-        painter.setFont(QFont("Roboto", 12))
-        painter.drawText(0, 0, 203, 255, Qt.AlignRight | Qt.AlignBottom, version[1])
+
+        # "master" release does not have an second entry in variable version.
+        # In this case skip to load version[1]...
+        if len(version) > 1:
+            painter.setFont(QFont("Roboto", 12))
+            painter.drawText(0, 0, 203, 255, Qt.AlignRight | Qt.AlignBottom, version[1])
 
         painter.restore()
         super().drawContents(painter)


### PR DESCRIPTION
It happens because the variable version has just one entry.
In case of a unversioned aka master codebase the only content is "master", so there is no second entry at all.
Now a len(version) checks whether there is a second entry or not.

I also wanted to fix the same in master, but it is already fixed there - https://github.com/Ultimaker/Cura/commit/e7fc881440a4b92598fb4bf64648c96b47e17bb5