### PR TITLE
Terminate engine when a ToolOperation starts

### DIFF
--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -107,15 +107,7 @@ class CuraEngineBackend(Backend):
             return
 
         if self._slicing:
-            self._slicing = False
-            self._restart = True
-            if self._process is not None:
-                Logger.log("d", "Killing engine process")
-                try:
-                    self._process.terminate()
-                except: # terminating a process that is already terminating causes an exception, silently ignore this.
-                    pass
-
+            self._terminate()
 
             if self._message:
                 self._message.hide()
@@ -148,16 +140,15 @@ class CuraEngineBackend(Backend):
         job.finished.connect(self._onStartSliceCompleted)
 
     def _terminate(self):
-        if self._slicing:
-            self._slicing = False
-            self._restart = True
-            if self._process is not None:
-                Logger.log("d", "Killing engine process")
-                try:
-                    self._process.terminate()
-                except: # terminating a process that is already terminating causes an exception, silently ignore this.
-                    pass
-        
+        self._slicing = False
+        self._restart = True
+        if self._process is not None:
+            Logger.log("d", "Killing engine process")
+            try:
+                self._process.terminate()
+            except: # terminating a process that is already terminating causes an exception, silently ignore this.
+                pass
+
     def _onStartSliceCompleted(self, job):
         if job.getError() or job.getResult() != True:
             if self._message:
@@ -277,12 +268,5 @@ class CuraEngineBackend(Backend):
 
 
     def _onInstanceChanged(self):
-        self._slicing = False
-        self._restart = True
-        if self._process is not None:
-            Logger.log("d", "Killing engine process")
-            try:
-                self._process.terminate()
-            except: # terminating a process that is already terminating causes an exception, silently ignore this.
-                pass
+        self._terminate()
         self.slicingCancelled.emit()

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -147,6 +147,17 @@ class CuraEngineBackend(Backend):
         job.start()
         job.finished.connect(self._onStartSliceCompleted)
 
+    def _terminate(self):
+        if self._slicing:
+            self._slicing = False
+            self._restart = True
+            if self._process is not None:
+                Logger.log("d", "Killing engine process")
+                try:
+                    self._process.terminate()
+                except: # terminating a process that is already terminating causes an exception, silently ignore this.
+                    pass
+        
     def _onStartSliceCompleted(self, job):
         if job.getError() or job.getResult() != True:
             if self._message:
@@ -245,6 +256,7 @@ class CuraEngineBackend(Backend):
             self._restart = False
 
     def _onToolOperationStarted(self, tool):
+        self._terminate() # Do not continue slicing once a tool has started
         self._enabled = False # Do not reslice when a tool is doing it's 'thing'
 
     def _onToolOperationStopped(self, tool):


### PR DESCRIPTION
Currently if the user starts using a Tool (eg the Move tool by moving an object, or the LayFlat tool) while a slice operation is ongoing, the slice operation continues during the operation. This unnecessarily loads the CPU, and makes the UI less responsive than it could be, because after the operation has finished we can be certain that a reslice is necessary.

This PR terminates the engine process when a ToolOperation starts, thus freeing up CPU cycles to perform the ToolOperation. It also makes "continuous slicing" slightly less obnoxious because it tries to get out of the way more.