### PR TITLE
New plugin type: Backend output writer

### DIFF
--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the AGPLv3 or higher.
 
-from UM.Backend.OutputWriter import OutputWriter
+from UM.Backend.BackendOutputWriter import BackendOutputWriter
 from UM.Logger import Logger
 from UM.Application import Application
 import io
 import re #For escaping characters in the settings.
 
 
-class GCodeWriter(OutputWriter):
+class GCodeWriter(BackendOutputWriter):
     ##  The file format version of the serialised g-code.
     #
     #   It can only read settings with the same version as the version it was

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -30,8 +30,8 @@ class GCodeWriter(OutputWriter):
     def __init__(self):
         super().__init__()
 
-    def write(self, stream, scene):
-        #scene = Application.getInstance().getController().getScene()
+    def write(self, stream):
+        scene = Application.getInstance().getController().getScene()
         gcode_list = getattr(scene, "gcode_list")
         if gcode_list:
             for gcode in gcode_list:

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the AGPLv3 or higher.
 
-from UM.Mesh.MeshWriter import MeshWriter
+from UM.Backend.OutputWriter import OutputWriter
 from UM.Logger import Logger
 from UM.Application import Application
 import io
 import re #For escaping characters in the settings.
 
 
-class GCodeWriter(MeshWriter):
+class GCodeWriter(OutputWriter):
     ##  The file format version of the serialised g-code.
     #
     #   It can only read settings with the same version as the version it was
@@ -30,12 +30,8 @@ class GCodeWriter(MeshWriter):
     def __init__(self):
         super().__init__()
 
-    def write(self, stream, node, mode = MeshWriter.OutputMode.TextMode):
-        if mode != MeshWriter.OutputMode.TextMode:
-            Logger.log("e", "GCode Writer does not support non-text mode")
-            return False
-
-        scene = Application.getInstance().getController().getScene()
+    def write(self, stream, scene):
+        #scene = Application.getInstance().getController().getScene()
         gcode_list = getattr(scene, "gcode_list")
         if gcode_list:
             for gcode in gcode_list:

--- a/plugins/GCodeWriter/__init__.py
+++ b/plugins/GCodeWriter/__init__.py
@@ -16,15 +16,14 @@ def getMetaData():
             "api": 2
         },
 
-        "mesh_writer": {
+        "output_writer": {
             "output": [{
                 "extension": "gcode",
                 "description": catalog.i18nc("@item:inlistbox", "GCode File"),
-                "mime_type": "text/x-gcode",
-                "mode": GCodeWriter.GCodeWriter.OutputMode.TextMode
+                "mime_type": "text/x-gcode"
             }]
         }
     }
 
 def register(app):
-    return { "mesh_writer": GCodeWriter.GCodeWriter() }
+    return { "output_writer": GCodeWriter.GCodeWriter() }

--- a/plugins/GCodeWriter/__init__.py
+++ b/plugins/GCodeWriter/__init__.py
@@ -16,7 +16,7 @@ def getMetaData():
             "api": 2
         },
 
-        "output_writer": {
+        "backend_output_writer": {
             "output": [{
                 "extension": "gcode",
                 "description": catalog.i18nc("@item:inlistbox", "GCode File"),
@@ -26,4 +26,4 @@ def getMetaData():
     }
 
 def register(app):
-    return { "output_writer": GCodeWriter.GCodeWriter() }
+    return { "backend_output_writer": GCodeWriter.GCodeWriter() }

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -101,7 +101,7 @@ UM.MainWindow
                         MenuItem
                         {
                             text: model.description;
-                            onTriggered: UM.OutputDeviceManager.requestWriteToDevice(model.id, Printer.jobName);
+                            onTriggered: UM.OutputDeviceManager.requestWriteMeshToDevice(model.id, Printer.jobName);
                         }
                         onObjectAdded: saveAllMenu.insertItem(index, object)
                         onObjectRemoved: saveAllMenu.removeItem(object)

--- a/resources/qml/SaveButton.qml
+++ b/resources/qml/SaveButton.qml
@@ -83,7 +83,7 @@ Rectangle {
             text: UM.OutputDeviceManager.activeDeviceShortDescription
             onClicked:
             {
-                UM.OutputDeviceManager.requestWriteToDevice(UM.OutputDeviceManager.activeDevice, Printer.jobName)
+                UM.OutputDeviceManager.requestWriteOutputToDevice(UM.OutputDeviceManager.activeDevice, Printer.jobName)
             }
 
             style: ButtonStyle {

--- a/resources/qml/SaveButton.qml
+++ b/resources/qml/SaveButton.qml
@@ -83,7 +83,7 @@ Rectangle {
             text: UM.OutputDeviceManager.activeDeviceShortDescription
             onClicked:
             {
-                UM.OutputDeviceManager.requestWriteOutputToDevice(UM.OutputDeviceManager.activeDevice, Printer.jobName)
+                UM.OutputDeviceManager.requestWriteBackendOutputToDevice(UM.OutputDeviceManager.activeDevice, Printer.jobName)
             }
 
             style: ButtonStyle {


### PR DESCRIPTION
To separate the writers for the output from the backend from the writers for saving meshes, a new plugin type is created: Backend output writers. This writes the output from the backend somewhere.

This addresses issue CURA-611, which is actually a bug but since this change is so invasive I decided to make a branch for it. This corresponds to the branch `feature_outputwriterplugins` in Uranium (sorry, I didn't pay attention to the plurality).