### PR TITLE
Adding new supported image formats

### DIFF
--- a/cura.desktop
+++ b/cura.desktop
@@ -8,6 +8,6 @@ TryExec=/usr/bin/cura_app.py
 Icon=/usr/share/cura/resources/images/cura-icon.png
 Terminal=false
 Type=Application
-MimeType=application/sla
+MimeType=application/sla;image/bmp;image/gif;image/jpeg;image/png
 Categories=Graphics;
 Keywords=3D;Printing;


### PR DESCRIPTION
Don't know how long we support opening images, but this commit adds them to the *.desktop file for Linux based desktops.
So "open with"-actions will now show Cura for these media-types.