### PR TITLE
Fix cura 623

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -292,6 +292,9 @@ class CuraApplication(QtApplication):
     # Remove all selected objects from the scene.
     @pyqtSlot()
     def deleteSelection(self):
+        if not self.getController().getToolsEnabled():
+            return
+
         op = GroupedOperation()
         nodes = Selection.getAllSelectedObjects()
         for node in nodes:
@@ -305,6 +308,9 @@ class CuraApplication(QtApplication):
     #   Note that this only removes an object if it is selected.
     @pyqtSlot("quint64")
     def deleteObject(self, object_id):
+        if not self.getController().getToolsEnabled():
+            return
+
         node = self.getController().getScene().findObject(object_id)
 
         if not node and object_id != 0: #Workaround for tool handles overlapping the selected object
@@ -364,6 +370,9 @@ class CuraApplication(QtApplication):
     ##  Delete all mesh data on the scene.
     @pyqtSlot()
     def deleteAll(self):
+        if not self.getController().getToolsEnabled():
+            return
+
         nodes = []
         for node in DepthFirstIterator(self.getController().getScene().getRoot()):
             if type(node) is not SceneNode:

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -127,6 +127,7 @@ Item
     {
         id: deleteSelectionAction;
         text: catalog.i18nc("@action:inmenu menubar:edit","Delete &Selection");
+        enabled: UM.Controller.toolsEnabled;
         iconName: "edit-delete";
         shortcut: StandardKey.Delete;
     }
@@ -135,6 +136,7 @@ Item
     {
         id: deleteObjectAction;
         text: catalog.i18nc("@action:inmenu","Delete Object");
+        enabled: UM.Controller.toolsEnabled;
         iconName: "edit-delete";
     }
 
@@ -179,6 +181,7 @@ Item
     {
         id: deleteAllAction;
         text: catalog.i18nc("@action:inmenu menubar:edit","&Clear Build Platform");
+        enabled: UM.Controller.toolsEnabled;
         iconName: "edit-delete";
         shortcut: "Ctrl+D";
     }

--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -97,6 +97,7 @@ Item {
             y: UM.Theme.sizes.default_margin.height;
 
             source: UM.ActiveTool.valid ? UM.ActiveTool.activeToolPanel : "";
+            enabled: UM.Controller.toolsEnabled;
         }
     }
 }

--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -33,7 +33,7 @@ Item {
 
                 checkable: true;
                 checked: model.active;
-                enabled: UM.Selection.hasSelection;
+                enabled: UM.Selection.hasSelection && UM.Controller.toolsEnabled;
 
                 style: UM.Theme.styles.tool_button;
 


### PR DESCRIPTION
This patch disables tools while a tooloperation is running. Some tool-operations, such as the Lay Flat operation, take a while to complete. It should not be possible to relaunch the lay flat operation while the same operation is already loading. Also manipulating an object with a different tool while an operation is running may affect the outcome of either tools.

Fixes CURA-623

Also see https://github.com/Ultimaker/Uranium/pull/96
