### PR TITLE
Feature delay cameraanimation

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -22,7 +22,6 @@ from UM.Message import Message
 from UM.PluginRegistry import PluginRegistry
 from UM.JobQueue import JobQueue
 from UM.Math.Polygon import Polygon
-from UM.Event import MouseEvent
 
 from UM.Scene.BoxRenderer import BoxRenderer
 from UM.Scene.Selection import Selection

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -22,6 +22,7 @@ from UM.Message import Message
 from UM.PluginRegistry import PluginRegistry
 from UM.JobQueue import JobQueue
 from UM.Math.Polygon import Polygon
+from UM.Event import MouseEvent
 
 from UM.Scene.BoxRenderer import BoxRenderer
 from UM.Scene.Selection import Selection
@@ -231,15 +232,24 @@ class CuraApplication(QtApplication):
                 else:
                     self.getController().setActiveTool("TranslateTool")
             if Preferences.getInstance().getValue("view/center_on_select"):
-                self._camera_animation.setStart(self.getController().getTool("CameraTool").getOrigin())
-                self._camera_animation.setTarget(Selection.getSelectedObject(0).getWorldPosition())
-                self._camera_animation.start()
+                print("connect")
+                print(self.getController().getInputDevice("qt_mouse").event)
+                self.getController().getInputDevice("qt_mouse").event.connect(self.onMouseEventAfterSelectionChanged)
         else:
             if self.getController().getActiveTool():
                 self._previous_active_tool = self.getController().getActiveTool().getPluginId()
                 self.getController().setActiveTool(None)
             else:
                 self._previous_active_tool = None
+
+    def onMouseEventAfterSelectionChanged(self, event):
+        print("event")
+        if event.type == MouseEvent.MouseReleaseEvent:
+            print("disconnect")
+            self.getController().getInputDevice("qt_mouse").event.disconnect(self.onMouseEventAfterSelectionChanged)
+            self._camera_animation.setStart(self.getController().getTool("CameraTool").getOrigin())
+            self._camera_animation.setTarget(Selection.getSelectedObject(0).getWorldPosition())
+            self._camera_animation.start()
 
     requestAddPrinter = pyqtSignal()
     activityChanged = pyqtSignal()


### PR DESCRIPTION
This patch delays the cameraanimation which happens when the selection is changed until after the operation that changed the animation is completed. This way, when a non-selected object is dragged, the cameraanimation only happens after the drag operation completes.

Fixes CURA-514