### PR TITLE
Alternative fix for NVidia graphic cards

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -57,8 +57,10 @@ numpy.seterr(all="ignore")
 
 if platform.system() == "Linux": # Needed for platform.linux_distribution, which is not available on Windows and OSX
     # For Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
-    if platform.linux_distribution()[0] in ("Ubuntu", ): # Just in case it also happens on Debian, so it can be added
-        from OpenGL import GL
+    if platform.linux_distribution()[0] in ("Ubuntu", ): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
+        import ctypes
+        from ctypes.util import find_library
+        ctypes.CDLL(find_library('GL'), ctypes.RTLD_GLOBAL)
 
 try:
     from cura.CuraVersion import CuraVersion


### PR DESCRIPTION
As I upgraded my computer to a developer version of Ubuntu, I noticed that the OpenGL module, which is needed for our workaround, is currently broken.
So I browsed the web and found the reason why it is needed at all and found a alternative.
The reason for the problem is that Qt5 is dynamicly loading libGL.so instead of libGL.so.1, as the OpenGL module loads libGL.so.1.
So if you install the closed-source nvidia drivers it only creates a link from libGL.so.1 to it's binaries and the result is that PyQt5/Qt5 tries to load Mesa binaries together with NVidia binaries.
By importing the OpenGL module you preload the libGL.so.1, but this can also be done directly by using ctypes.

* Replaced the OpenGL fix with the ctypes fix
* Added a TODO