### PR TITLE
Fast Simple<->Advanced Switch

### DIFF
--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -47,7 +47,7 @@ Item {
 
             options: UM.ProfilesModel { addUseGlobal: true }
 
-            value: UM.ActiveTool.properties.Model.getItem(base.currentIndex).profile
+            value: UM.ActiveTool.properties.getValue("Model").getItem(base.currentIndex).profile
 
             onItemValueChanged: {
                 var item = UM.ActiveTool.properties.Model.getItem(base.currentIndex);
@@ -63,7 +63,7 @@ Item {
             Repeater {
                 id: settings;
 
-                model: UM.ActiveTool.properties.Model.getItem(base.currentIndex).settings
+                model: UM.ActiveTool.properties.getValue("Model").getItem(base.currentIndex).settings
 
                 UM.SettingItem {
                     width: UM.Theme.sizes.setting.width;
@@ -91,7 +91,7 @@ Item {
                         width: UM.Theme.sizes.setting.height;
                         height: UM.Theme.sizes.setting.height;
 
-                        onClicked: UM.ActiveTool.properties.Model.removeSettingOverride(UM.ActiveTool.properties.Model.getItem(base.currentIndex).id, model.key)
+                        onClicked: UM.ActiveTool.properties.getValue("Model").removeSettingOverride(UM.ActiveTool.properties.getValue("Model").getItem(base.currentIndex).id, model.key)
 
                         style: ButtonStyle
                         {

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -464,7 +464,7 @@ UM.MainWindow
                 height: childrenRect.height;
                 Label
                 {
-                    text: UM.ActiveTool.properties.Rotation != undefined ? "%1°".arg(UM.ActiveTool.properties.Rotation) : "";
+                    text: UM.ActiveTool.properties.getValue("Rotation") != undefined ? "%1°".arg(UM.ActiveTool.properties.Rotation) : "";
                 }
 
                 visible: UM.ActiveTool.valid && UM.ActiveTool.properties.Rotation != undefined;

--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -82,6 +82,10 @@ Rectangle
     onCurrentModeIndexChanged:
     {
         UM.Preferences.setValue("cura/active_mode", currentModeIndex);
+        if(modesListModel.count > base.currentModeIndex)
+        {
+            sidebarContents.push({ "item": modesListModel.get(base.currentModeIndex).item, "replace": true });
+        }
     }
 
     Label {
@@ -153,31 +157,40 @@ Rectangle
         }
     }
 
-    Loader
+    StackView
     {
-        id: sidebarContents;
+        id: sidebarContents
+
         anchors.bottom: footerSeparator.top
         anchors.top: profileItem.bottom
         anchors.topMargin: UM.Theme.sizes.default_margin.height
         anchors.left: base.left
         anchors.right: base.right
 
-        source: modesListModel.count > base.currentModeIndex ? modesListModel.get(base.currentModeIndex).file : "";
-
-        property Item sidebar: base;
-
-        onLoaded:
+        delegate: StackViewDelegate
         {
-            if(item)
+            function transitionFinished(properties)
             {
-                item.configureSettings = base.configureMachinesAction;
-                if(item.onShowTooltip != undefined)
+                properties.exitItem.opacity = 1
+            }
+
+            pushTransition: StackViewTransition
+            {
+                PropertyAnimation
                 {
-                    item.showTooltip.connect(base.showTooltip)
+                    target: enterItem
+                    property: "opacity"
+                    from: 0
+                    to: 1
+                    duration: 100
                 }
-                if(item.onHideTooltip != undefined)
+                PropertyAnimation
                 {
-                    item.hideTooltip.connect(base.hideTooltip)
+                    target: exitItem
+                    property: "opacity"
+                    from: 1
+                    to: 0
+                    duration: 100
                 }
             }
         }
@@ -210,10 +223,25 @@ Rectangle
         id: modesListModel;
     }
 
+    SidebarSimple
+    {
+        id: sidebarSimple;
+        visible: false;
+    }
+    SidebarAdvanced
+    {
+        id: sidebarAdvanced;
+        visible: false;
+
+        configureSettings: base.configureMachinesAction;
+        onShowTooltip: base.showTooltip(item, location, text)
+        onHideTooltip: base.hideTooltip()
+    }
+
     Component.onCompleted:
     {
-        modesListModel.append({ text: catalog.i18nc("@title:tab", "Simple"), file: "SidebarSimple.qml" })
-        modesListModel.append({ text: catalog.i18nc("@title:tab", "Advanced"), file: "SidebarAdvanced.qml" })
-        sidebarContents.setSource(modesListModel.get(base.currentModeIndex).file)
+        modesListModel.append({ text: catalog.i18nc("@title:tab", "Simple"), item: sidebarSimple })
+        modesListModel.append({ text: catalog.i18nc("@title:tab", "Advanced"), item: sidebarAdvanced })
+        sidebarContents.push({ "item": modesListModel.get(base.currentModeIndex).item, "immediate": true });
     }
 }

--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -11,7 +11,6 @@ import UM 1.1 as UM
 Item
 {
     id: base;
-    anchors.fill: parent;
 
     signal showTooltip(Item item, point location, string text);
     signal hideTooltip();


### PR DESCRIPTION
Rather than reloading the panel every time the mode changes, use a StackView and create static instances of SimpleMode and AdvancedMode.

Requires https://github.com/Ultimaker/Uranium/pull/102