### PR TITLE
i18n: de: Set of (better) translations for german

### DIFF
--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 17:26+0100\n"
+"PO-Revision-Date: 2016-02-01 17:33+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -613,10 +613,9 @@ msgid "0.0 m"
 msgstr "0,0 Meter"
 
 #: /home/tamara/2.1/Cura/resources/qml/JobSpecs.qml:218
-#, fuzzy
 msgctxt "@label"
 msgid "%1 m"
-msgstr "%1 Meter"
+msgstr "%1 m"
 
 #: /home/tamara/2.1/Cura/resources/qml/SidebarHeader.qml:29
 #, fuzzy

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 18:47+0100\n"
+"PO-Revision-Date: 2016-02-01 18:48+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -590,7 +590,7 @@ msgstr "00 Stunden 00 Minuten"
 #: /home/tamara/2.1/Cura/resources/qml/JobSpecs.qml:218
 msgctxt "@label"
 msgid "0.0 m"
-msgstr "0,0 Meter"
+msgstr "0.0 Meter"
 
 #: /home/tamara/2.1/Cura/resources/qml/JobSpecs.qml:218
 msgctxt "@label"

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 17:47+0100\n"
+"PO-Revision-Date: 2016-02-01 17:49+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -623,10 +623,9 @@ msgid "Nozzle:"
 msgstr "Düse:"
 
 #: /home/tamara/2.1/Cura/resources/qml/Sidebar.qml:89
-#, fuzzy
 msgctxt "@label:listbox"
 msgid "Setup"
-msgstr "Einrichtung"
+msgstr "Konfiguration"
 
 #: /home/tamara/2.1/Cura/resources/qml/Sidebar.qml:215
 #, fuzzy

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 17:49+0100\n"
+"PO-Revision-Date: 2016-02-01 17:57+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -606,13 +606,11 @@ msgid "%1 m"
 msgstr "%1 m"
 
 #: /home/tamara/2.1/Cura/resources/qml/SidebarHeader.qml:29
-#, fuzzy
 msgctxt "@label:listbox"
 msgid "Print Job"
 msgstr "Druckerauftrag"
 
 #: /home/tamara/2.1/Cura/resources/qml/SidebarHeader.qml:50
-#, fuzzy
 msgctxt "@label:listbox"
 msgid "Printer:"
 msgstr "Drucker:"
@@ -628,32 +626,27 @@ msgid "Setup"
 msgstr "Konfiguration"
 
 #: /home/tamara/2.1/Cura/resources/qml/Sidebar.qml:215
-#, fuzzy
 msgctxt "@title:tab"
 msgid "Simple"
 msgstr "Einfach"
 
 #: /home/tamara/2.1/Cura/resources/qml/Sidebar.qml:216
-#, fuzzy
 msgctxt "@title:tab"
 msgid "Advanced"
 msgstr "Erweitert"
 
 #: /home/tamara/2.1/Cura/resources/qml/AddMachineWizard.qml:18
-#, fuzzy
 msgctxt "@title:window"
 msgid "Add Printer"
 msgstr "Drucker hinzufügen"
 
 #: /home/tamara/2.1/Cura/resources/qml/AddMachineWizard.qml:25
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:99
-#, fuzzy
 msgctxt "@title"
 msgid "Add Printer"
 msgstr "Drucker hinzufügen"
 
 #: /home/tamara/2.1/Cura/resources/qml/LoadProfileDialog.qml:15
-#, fuzzy
 msgctxt "@title:window"
 msgid "Load profile"
 msgstr "Profil laden"
@@ -669,7 +662,6 @@ msgid "Show details."
 msgstr "Details anzeigen."
 
 #: /home/tamara/2.1/Cura/resources/qml/LoadProfileDialog.qml:50
-#, fuzzy
 msgctxt "@action:button"
 msgid "Merge settings"
 msgstr "Einstellungen zusammenführen"
@@ -680,7 +672,6 @@ msgid "Reset profile"
 msgstr "Profil zurücksetzen"
 
 #: /home/tamara/2.1/Cura/resources/qml/ProfileSetup.qml:28
-#, fuzzy
 msgctxt "@label"
 msgid "Profile:"
 msgstr "Profil:"
@@ -914,7 +905,6 @@ msgid "General"
 msgstr "Allgemein"
 
 #: /home/tamara/2.1/Cura/resources/qml/GeneralPage.qml:51
-#, fuzzy
 msgctxt "@label"
 msgid "Language:"
 msgstr "Sprache:"
@@ -966,7 +956,6 @@ msgid "Should opened files be scaled to the build volume if they are too large?"
 msgstr "Sollen offene Dateien an das Erstellungsvolumen angepasst werden, wenn Sie zu groß sind?"
 
 #: /home/tamara/2.1/Cura/resources/qml/GeneralPage.qml:136
-#, fuzzy
 msgctxt "@option:check"
 msgid "Scale large files"
 msgstr "Zu große Dateien anpassen"
@@ -977,13 +966,11 @@ msgid "Should anonymous data about your print be sent to Ultimaker? Note, no mod
 msgstr "Sollen anonyme Daten über Ihren Druck an Ultimaker gesendet werden? Beachten Sie, dass keine Modelle, IP-Adressen oder andere personenbezogene Daten gesendet oder gespeichert werden."
 
 #: /home/tamara/2.1/Cura/resources/qml/GeneralPage.qml:150
-#, fuzzy
 msgctxt "@option:check"
 msgid "Send (anonymous) print information"
 msgstr "(Anonyme) Druckinformationen senden"
 
 #: /home/tamara/2.1/Cura/resources/qml/ViewPage.qml:16
-#, fuzzy
 msgctxt "@title:window"
 msgid "View"
 msgstr "Ansicht"
@@ -1011,7 +998,6 @@ msgstr "Zentrieren Sie die Kamera, wenn das Element ausgewählt wurde"
 
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:72
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:275
-#, fuzzy
 msgctxt "@title"
 msgid "Check Printer"
 msgstr "Drucker prüfen"
@@ -1141,7 +1127,6 @@ msgid "If you bought your Ultimaker after october 2012 you will have the Extrude
 msgstr "Wenn Sie Ihren Ultimaker nach Oktober 2012 erworben haben, besitzen Sie das Upgrade für den Extruder-Driver. Dieses Upgrade ist äußerst empfehlenswert, um die Zuverlässigkeit zu erhöhen. Falls Sie es noch nicht besitzen, können Sie es im Ultimaker-Webshop kaufen. Außerdem finden Sie es im Thingiverse als Thing: 26094"
 
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:108
-#, fuzzy
 msgctxt "@label"
 msgid "Please select the type of printer:"
 msgstr "Wählen Sie den Druckertyp:"
@@ -1152,14 +1137,12 @@ msgid "This printer name has already been used. Please choose a different printe
 msgstr "Der Druckername wird bereits verwendet. Bitte wählen Sie einen anderen Druckernamen."
 
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:245
-#, fuzzy
 msgctxt "@label:textbox"
 msgid "Printer Name:"
 msgstr "Druckername:"
 
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:272
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/UpgradeFirmware.qml:22
-#, fuzzy
 msgctxt "@title"
 msgid "Upgrade Firmware"
 msgstr "Firmware aktualisieren"

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 18:14+0100\n"
+"PO-Revision-Date: 2016-02-01 18:15+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -428,25 +428,21 @@ msgid "Cura 15.04 profiles"
 msgstr "Cura 15.04-Profile"
 
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/FirmwareUpdateWindow.qml:20
-#, fuzzy
 msgctxt "@title:window"
 msgid "Firmware Update"
-msgstr "Firmware-Update"
+msgstr "Firmware-Aktualisierung"
 
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/FirmwareUpdateWindow.qml:38
-#, fuzzy
 msgctxt "@label"
 msgid "Starting firmware update, this may take a while."
-msgstr "Das Firmware-Update wird gestartet. Dies kann eine Weile dauern."
+msgstr "Das Firmware-Aktualisierung wird gestartet. Dies kann eine Weile dauern."
 
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/FirmwareUpdateWindow.qml:43
-#, fuzzy
 msgctxt "@label"
 msgid "Firmware update completed."
-msgstr "Firmware-Update abgeschlossen."
+msgstr "Firmware-Aktualisierung abgeschlossen."
 
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/FirmwareUpdateWindow.qml:48
-#, fuzzy
 msgctxt "@label"
 msgid "Updating firmware."
 msgstr "Die Firmware wird aktualisiert."

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 17:57+0100\n"
+"PO-Revision-Date: 2016-02-01 18:14+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -454,7 +454,6 @@ msgstr "Die Firmware wird aktualisiert."
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/FirmwareUpdateWindow.qml:80
 #: /home/tamara/2.1/Cura/resources/qml/EngineLog.qml:38
 #: /home/tamara/2.1/Cura/resources/qml/AboutDialog.qml:74
-#, fuzzy
 msgctxt "@action:button"
 msgid "Close"
 msgstr "Schließen"
@@ -465,13 +464,11 @@ msgid "Print with USB"
 msgstr "Über USB drucken"
 
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/ControlWindow.qml:28
-#, fuzzy
 msgctxt "@label"
 msgid "Extruder Temperature %1"
 msgstr "Extruder-Temperatur %1"
 
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/ControlWindow.qml:33
-#, fuzzy
 msgctxt "@label"
 msgid "Bed Temperature %1"
 msgstr "Druckbett-Temperatur %1"
@@ -575,7 +572,6 @@ msgid "Object profile"
 msgstr "Objektprofil"
 
 #: /home/tamara/2.1/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:126
-#, fuzzy
 msgctxt "@action:button"
 msgid "Add Setting"
 msgstr "Einstellung hinzufügen"
@@ -677,7 +673,6 @@ msgid "Profile:"
 msgstr "Profil:"
 
 #: /home/tamara/2.1/Cura/resources/qml/EngineLog.qml:15
-#, fuzzy
 msgctxt "@title:window"
 msgid "Engine Log"
 msgstr "Engine-Protokoll"
@@ -1083,7 +1078,6 @@ msgid "Checking"
 msgstr "Wird überprüft"
 
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:267
-#, fuzzy
 msgctxt "@label"
 msgid "bed temperature check:"
 msgstr "Temperaturprüfung des Druckbetts:"
@@ -1219,7 +1213,6 @@ msgid "Preparing to slice..."
 msgstr "Slicing vorbereiten..."
 
 #: /home/tamara/2.1/Cura/resources/qml/SaveButton.qml:28
-#, fuzzy
 msgctxt "@label:PrintjobStatus"
 msgid "Slicing..."
 msgstr "Das Slicing läuft..."

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 17:40+0100\n"
+"PO-Revision-Date: 2016-02-01 17:47+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -39,7 +39,6 @@ msgid "Setting up scene..."
 msgstr "Die Szene wird eingerichtet..."
 
 #: /home/tamara/2.1/Cura/cura/CuraApplication.py:192
-#, fuzzy
 msgctxt "@info:progress"
 msgid "Loading interface..."
 msgstr "Die Benutzeroberfläche wird geladen..."
@@ -94,7 +93,6 @@ msgid "Provides support for reading 3MF files."
 msgstr "Ermöglicht das Lesen von 3MF-Dateien."
 
 #: /home/tamara/2.1/Cura/plugins/3MFReader/__init__.py:21
-#, fuzzy
 msgctxt "@item:inlistbox"
 msgid "3MF File"
 msgstr "3MF-Datei"
@@ -105,7 +103,7 @@ msgid "Save to Removable Drive"
 msgstr "Auf Wechseldatenträger speichern"
 
 #: /home/tamara/2.1/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:21
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgctxt "@item:inlistbox"
 msgid "Save to Removable Drive {0}"
 msgstr "Auf Wechseldatenträger speichern {0}"
@@ -117,13 +115,12 @@ msgid "Saving to Removable Drive <filename>{0}</filename>"
 msgstr "Wird auf Wechseldatenträger gespeichert <filename>{0}</filename>"
 
 #: /home/tamara/2.1/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:85
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgctxt "@info:status"
 msgid "Saved to Removable Drive {0} as {1}"
 msgstr "Auf Wechseldatenträger gespeichert {0} als {1}"
 
 #: /home/tamara/2.1/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:86
-#, fuzzy
 msgctxt "@action:button"
 msgid "Eject"
 msgstr "Auswerfen"
@@ -168,13 +165,11 @@ msgid "Provides removable drive hotplugging and writing support"
 msgstr "Ermöglicht Hotplugging des Wechseldatenträgers und Beschreiben"
 
 #: /home/tamara/2.1/Cura/plugins/ChangeLogPlugin/ChangeLog.py:34
-#, fuzzy
 msgctxt "@item:inmenu"
 msgid "Show Changelog"
 msgstr "Änderungsprotokoll anzeigen"
 
 #: /home/tamara/2.1/Cura/plugins/ChangeLogPlugin/__init__.py:12
-#, fuzzy
 msgctxt "@label"
 msgid "Changelog"
 msgstr "Änderungsprotokoll"
@@ -348,31 +343,26 @@ msgid "Provides support for importing profiles from g-code files."
 msgstr "Ermöglicht das Importieren von Profilen aus G-Code-Dateien."
 
 #: /home/tamara/2.1/Cura/plugins/GCodeProfileReader/__init__.py:21
-#, fuzzy
 msgctxt "@item:inlistbox"
 msgid "G-code File"
 msgstr "G-Code-Datei"
 
 #: /home/tamara/2.1/Cura/plugins/SolidView/__init__.py:12
-#, fuzzy
 msgctxt "@label"
 msgid "Solid View"
 msgstr "Solide Ansicht"
 
 #: /home/tamara/2.1/Cura/plugins/SolidView/__init__.py:15
-#, fuzzy
 msgctxt "@info:whatsthis"
 msgid "Provides a normal solid mesh view."
 msgstr "Bietet eine normale, solide Netzansicht."
 
 #: /home/tamara/2.1/Cura/plugins/SolidView/__init__.py:19
-#, fuzzy
 msgctxt "@item:inmenu"
 msgid "Solid"
 msgstr "Solide"
 
 #: /home/tamara/2.1/Cura/plugins/LayerView/__init__.py:13
-#, fuzzy
 msgctxt "@label"
 msgid "Layer View"
 msgstr "Schichtenansicht"
@@ -487,7 +477,6 @@ msgid "Bed Temperature %1"
 msgstr "Druckbett-Temperatur %1"
 
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/ControlWindow.qml:60
-#, fuzzy
 msgctxt "@action:button"
 msgid "Print"
 msgstr "Drucken"
@@ -496,7 +485,6 @@ msgstr "Drucken"
 #: /home/tamara/2.1/Cura/plugins/ImageReader/ConfigUI.qml:200
 #: /home/tamara/2.1/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:303
 #: /home/tamara/2.1/Cura/resources/qml/LoadProfileDialog.qml:58
-#, fuzzy
 msgctxt "@action:button"
 msgid "Cancel"
 msgstr "Abbrechen"

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-01-29 19:11+0100\n"
+"PO-Revision-Date: 2016-02-01 17:26+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Last-Translator: Thomas Karl Pietrowski <thopiekar@googlemail.com>\n"
 "Language-Team: \n"
-"X-Generator: Poedit 1.8.4\n"
+"X-Generator: Poedit 1.8.6\n"
 
 #: /home/tamara/2.1/Cura/cura/CrashHandler.py:26
 msgctxt "@title:window"
@@ -61,28 +61,27 @@ msgctxt "@info:whatsthis"
 msgid "Provides support for importing Cura profiles."
 msgstr "Ermöglicht das Importieren von Cura-Profilen."
 
-#: /home/tamara/2.1/Cura/plugins/CuraProfileReader/__init__.py:21 /home/tamara/2.1/Cura/plugins/CuraProfileWriter/__init__.py:21
+#: /home/tamara/2.1/Cura/plugins/CuraProfileReader/__init__.py:21
+#: /home/tamara/2.1/Cura/plugins/CuraProfileWriter/__init__.py:21
 #, fuzzy
 msgctxt "@item:inlistbox"
 msgid "Cura Profile"
 msgstr "Cura-Profil"
 
 #: /home/tamara/2.1/Cura/plugins/XRayView/__init__.py:12
-#, fuzzy
 msgctxt "@label"
 msgid "X-Ray View"
-msgstr "X-Ray-Ansicht"
+msgstr "Röntgen-Ansicht"
 
 #: /home/tamara/2.1/Cura/plugins/XRayView/__init__.py:15
-#, fuzzy
 msgctxt "@info:whatsthis"
 msgid "Provides the X-Ray view."
-msgstr "Stellt die X-Ray-Ansicht bereit."
+msgstr "Stellt die Röntgen-Ansicht bereit."
 
 #: /home/tamara/2.1/Cura/plugins/XRayView/__init__.py:19
 msgctxt "@item:inlistbox"
 msgid "X-Ray"
-msgstr "X-Ray"
+msgstr "Röntgen"
 
 #: /home/tamara/2.1/Cura/plugins/3MFReader/__init__.py:12
 msgctxt "@label"
@@ -190,7 +189,8 @@ msgctxt "@info:status"
 msgid "Unable to slice. Please check your setting values for errors."
 msgstr "Es kann nicht in horizontale Ebenen geschnitten werden (Slicing). Bitte prüfen Sie Ihre Einstellungswerte auf Fehler."
 
-#: /home/tamara/2.1/Cura/plugins/CuraEngineBackend/ProcessSlicedObjectListJob.py:30 /home/tamara/2.1/Cura/plugins/CuraEngineBackend/ProcessSlicedObjectListJob.py:120
+#: /home/tamara/2.1/Cura/plugins/CuraEngineBackend/ProcessSlicedObjectListJob.py:30
+#: /home/tamara/2.1/Cura/plugins/CuraEngineBackend/ProcessSlicedObjectListJob.py:120
 msgctxt "@info:status"
 msgid "Processing Layers"
 msgstr "Schichten werden verarbeitet"
@@ -461,7 +461,9 @@ msgctxt "@label"
 msgid "Updating firmware."
 msgstr "Die Firmware wird aktualisiert."
 
-#: /home/tamara/2.1/Cura/plugins/USBPrinting/FirmwareUpdateWindow.qml:80 /home/tamara/2.1/Cura/resources/qml/EngineLog.qml:38 /home/tamara/2.1/Cura/resources/qml/AboutDialog.qml:74
+#: /home/tamara/2.1/Cura/plugins/USBPrinting/FirmwareUpdateWindow.qml:80
+#: /home/tamara/2.1/Cura/resources/qml/EngineLog.qml:38
+#: /home/tamara/2.1/Cura/resources/qml/AboutDialog.qml:74
 #, fuzzy
 msgctxt "@action:button"
 msgid "Close"
@@ -490,7 +492,10 @@ msgctxt "@action:button"
 msgid "Print"
 msgstr "Drucken"
 
-#: /home/tamara/2.1/Cura/plugins/USBPrinting/ControlWindow.qml:67 /home/tamara/2.1/Cura/plugins/ImageReader/ConfigUI.qml:200 /home/tamara/2.1/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:303 /home/tamara/2.1/Cura/resources/qml/LoadProfileDialog.qml:58
+#: /home/tamara/2.1/Cura/plugins/USBPrinting/ControlWindow.qml:67
+#: /home/tamara/2.1/Cura/plugins/ImageReader/ConfigUI.qml:200
+#: /home/tamara/2.1/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:303
+#: /home/tamara/2.1/Cura/resources/qml/LoadProfileDialog.qml:58
 #, fuzzy
 msgctxt "@action:button"
 msgid "Cancel"
@@ -654,7 +659,8 @@ msgctxt "@title:window"
 msgid "Add Printer"
 msgstr "Drucker hinzufügen"
 
-#: /home/tamara/2.1/Cura/resources/qml/AddMachineWizard.qml:25 /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:99
+#: /home/tamara/2.1/Cura/resources/qml/AddMachineWizard.qml:25
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:99
 #, fuzzy
 msgctxt "@title"
 msgid "Add Printer"
@@ -915,7 +921,8 @@ msgctxt "@label"
 msgid "Enable printing support structures. This will build up supporting structures below the model to prevent the model from sagging or printing in mid air."
 msgstr "Drucken einer Stützstruktur aktivieren. Dient zum Konstruieren von Stützstrukturen unter dem Modell, damit dieses nicht absinkt oder frei schwebend gedruckt wird."
 
-#: /home/tamara/2.1/Cura/resources/qml/GeneralPage.qml:14 /home/tamara/2.1/Cura/resources/qml/Cura.qml:492
+#: /home/tamara/2.1/Cura/resources/qml/GeneralPage.qml:14
+#: /home/tamara/2.1/Cura/resources/qml/Cura.qml:492
 msgctxt "@title:tab"
 msgid "General"
 msgstr "Allgemein"
@@ -1016,7 +1023,8 @@ msgctxt "@action:button"
 msgid "Center camera when item is selected"
 msgstr "Zentrieren Sie die Kamera, wenn das Element ausgewählt wurde"
 
-#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:72 /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:275
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:72
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:275
 #, fuzzy
 msgctxt "@title"
 msgid "Check Printer"
@@ -1057,13 +1065,19 @@ msgctxt "@label"
 msgid "Min endstop X: "
 msgstr "Min. Endstopp X: "
 
-#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:164 /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:183 /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:202 /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:357
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:164
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:183
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:202
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:357
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:368
 msgctxt "@info:status"
 msgid "Works"
 msgstr "Funktionsfähig"
 
-#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:164 /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:183 /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:202 /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:221
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:164
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:183
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:202
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:221
 #: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:277
 msgctxt "@info:status"
 msgid "Not checked"
@@ -1084,12 +1098,14 @@ msgctxt "@label"
 msgid "Nozzle temperature check: "
 msgstr "Temperaturprüfung der Düse: "
 
-#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:236 /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:292
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:236
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:292
 msgctxt "@action:button"
 msgid "Start Heating"
 msgstr "Aufheizen starten"
 
-#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:241 /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:297
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:241
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UltimakerCheckup.qml:297
 msgctxt "@info:progress"
 msgid "Checking"
 msgstr "Wird überprüft"
@@ -1105,7 +1121,8 @@ msgctxt "@label"
 msgid "Everything is in order! You're done with your CheckUp."
 msgstr "Alles ist in Ordnung! Der Check-up ist abgeschlossen."
 
-#: /home/tamara/2.1/Cura/resources/qml/WizardPages/SelectUpgradedParts.qml:31 /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:269
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/SelectUpgradedParts.qml:31
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:269
 msgctxt "@title"
 msgid "Select Upgraded Parts"
 msgstr "Wählen Sie die aktualisierten Teile"
@@ -1154,7 +1171,8 @@ msgctxt "@label:textbox"
 msgid "Printer Name:"
 msgstr "Druckername:"
 
-#: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:272 /home/tamara/2.1/Cura/resources/qml/WizardPages/UpgradeFirmware.qml:22
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/AddMachine.qml:272
+#: /home/tamara/2.1/Cura/resources/qml/WizardPages/UpgradeFirmware.qml:22
 #, fuzzy
 msgctxt "@title"
 msgid "Upgrade Firmware"

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 18:15+0100\n"
+"PO-Revision-Date: 2016-02-01 18:47+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -595,7 +595,7 @@ msgstr "0,0 Meter"
 #: /home/tamara/2.1/Cura/resources/qml/JobSpecs.qml:218
 msgctxt "@label"
 msgid "%1 m"
-msgstr "%1 m"
+msgstr "%1 Meter"
 
 #: /home/tamara/2.1/Cura/resources/qml/SidebarHeader.qml:29
 msgctxt "@label:listbox"

--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-01 17:33+0100\n"
+"PO-Revision-Date: 2016-02-01 17:40+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -143,7 +143,7 @@ msgstr "Konnte nicht auf dem Wechseldatenträger gespeichert werden {0}: {1}"
 #: /home/tamara/2.1/Cura/plugins/RemovableDriveOutputDevice/WindowsRemovableDrivePlugin.py:58
 msgctxt "@item:intext"
 msgid "Removable Drive"
-msgstr "Wechsellaufwerk"
+msgstr "Wechseldatenträger"
 
 #: /home/tamara/2.1/Cura/plugins/RemovableDriveOutputDevice/RemovableDrivePlugin.py:46
 #, python-brace-format


### PR DESCRIPTION
I just reviewed the translations and some some parts, which I (as native speaker) would translate another way.
The commits in this PR should be good documented.
Would love to see feedback ( maybe from @TMHogenhout ) to understand why you exactly translated things your way.
For example "X-Ray" is untranslated, but I don't see a reason, why you don't use "Röntgen". I don't think it sounds so bad.