### PR TITLE
Support UM2 with Olsson block

### DIFF
--- a/resources/machines/ultimaker.json
+++ b/resources/machines/ultimaker.json
@@ -1,0 +1,15 @@
+{
+    "id": "ultimaker_base",
+    "version": 1,
+    "visible": false,
+    "name": "Ultimaker",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "inherits": "fdmprinter.json",
+
+    "machine_preferences": {
+        "prefered_profile": "Normal Quality",
+        "prefered_variant": "0.4 mm",
+        "prefered_material": "PLA"
+    }
+}

--- a/resources/machines/ultimaker2.json
+++ b/resources/machines/ultimaker2.json
@@ -9,7 +9,7 @@
     "platform_texture": "Ultimaker2backplate.png",
     "file_formats": "text/x-gcode",
 
-    "inherits": "fdmprinter.json",
+    "inherits": "ultimaker.json",
 
     "pages": [
         "SelectUpgradedPartsUM2"

--- a/resources/machines/ultimaker2.json
+++ b/resources/machines/ultimaker2.json
@@ -1,6 +1,6 @@
 {
     "id": "ultimaker2",
-    "version": 1, 
+    "version": 1,
     "name": "Ultimaker 2",
     "manufacturer": "Ultimaker",
     "author": "Ultimaker",
@@ -11,14 +11,17 @@
 
     "inherits": "fdmprinter.json",
 
-    
+    "pages": [
+        "SelectUpgradedPartsUM2"
+    ],
+
     "machine_extruder_trains": [
         {
-            "machine_nozzle_heat_up_speed": { 
-                "default": 2.0 
+            "machine_nozzle_heat_up_speed": {
+                "default": 2.0
             },
-            "machine_nozzle_cool_down_speed": { 
-                "default": 2.0 
+            "machine_nozzle_cool_down_speed": {
+                "default": 2.0
             },
             "machine_nozzle_tip_outer_diameter": {
                 "default": 1
@@ -29,7 +32,7 @@
             "machine_nozzle_expansion_angle": {
                 "default": 45
             },
-            "machine_heat_zone_length": { 
+            "machine_heat_zone_length": {
                 "default": 16
             }
         }
@@ -77,7 +80,7 @@
             [[ 115.0, -112.5], [ 108.0, -112.5], [ 110.0, -104.5], [ 115.0, -104.5]]
         ]},
         "machine_platform_offset": { "default": [9.0, 0.0, 0.0] },
-        
+
         "machine_nozzle_tip_outer_diameter": { "default": 1.0 },
         "machine_nozzle_head_distance": { "default": 3.0 },
         "machine_nozzle_expansion_angle": { "default": 45 }

--- a/resources/machines/ultimaker2_extended.json
+++ b/resources/machines/ultimaker2_extended.json
@@ -10,6 +10,10 @@
     "file_formats": "text/x-gcode",
     "inherits": "ultimaker2.json",
 
+    "pages": [
+        "SelectUpgradedPartsUM2"
+    ],
+
     "machine_settings": {
         "machine_width": { "default": 230 },
         "machine_depth": { "default": 225 },

--- a/resources/machines/ultimaker2_extended_olsson.json
+++ b/resources/machines/ultimaker2_extended_olsson.json
@@ -1,0 +1,19 @@
+{
+    "id": "ultimaker2_extended_olsson_base",
+    "version": 1, 
+    "name": "Ultimaker 2 Extended with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+    "inherits": "ultimaker2.json",
+
+    "machine_settings": {
+        "machine_width": { "default": 230 },
+        "machine_depth": { "default": 225 },
+        "machine_height": { "default": 310 },
+        "machine_show_variants": { "default": true },
+        "gantry_height": { "default": 50 }
+    }
+}

--- a/resources/machines/ultimaker2_extended_olsson_025.json
+++ b/resources/machines/ultimaker2_extended_olsson_025.json
@@ -1,0 +1,16 @@
+{
+    "id": "ultimaker2_extended_olsson",
+    "version": 1, 
+    "name": "Ultimaker 2 Extended with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+    "inherits": "ultimaker2_extended_olsson.json",
+    "variant": "0.25 mm",
+    "profiles_machine": "ultimaker2_olsson",
+    "machine_settings": {
+        "machine_nozzle_size": { "default": 0.25 }
+    }
+}

--- a/resources/machines/ultimaker2_extended_olsson_040.json
+++ b/resources/machines/ultimaker2_extended_olsson_040.json
@@ -1,0 +1,16 @@
+{
+    "id": "ultimaker2_extended_olsson",
+    "version": 1, 
+    "name": "Ultimaker 2 Extended with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+    "inherits": "ultimaker2_extended_olsson.json",
+    "variant": "0.4 mm",
+    "profiles_machine": "ultimaker2_olsson",
+    "machine_settings": {
+        "machine_nozzle_size": { "default": 0.40 }
+    }
+}

--- a/resources/machines/ultimaker2_extended_olsson_060.json
+++ b/resources/machines/ultimaker2_extended_olsson_060.json
@@ -1,0 +1,16 @@
+{
+    "id": "ultimaker2_extended_olsson",
+    "version": 1, 
+    "name": "Ultimaker 2 Extended with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+    "inherits": "ultimaker2_extended_olsson.json",
+    "variant": "0.6 mm",
+    "profiles_machine": "ultimaker2_olsson",
+    "machine_settings": {
+        "machine_nozzle_size": { "default": 0.60 }
+    }
+}

--- a/resources/machines/ultimaker2_extended_olsson_080.json
+++ b/resources/machines/ultimaker2_extended_olsson_080.json
@@ -1,0 +1,16 @@
+{
+    "id": "ultimaker2_extended_olsson",
+    "version": 1, 
+    "name": "Ultimaker 2 Extended with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+    "inherits": "ultimaker2_extended_olsson.json",
+    "variant": "0.8 mm",
+    "profiles_machine": "ultimaker2_olsson",
+    "machine_settings": {
+        "machine_nozzle_size": { "default": 0.80 }
+    }
+}

--- a/resources/machines/ultimaker2_olsson.json
+++ b/resources/machines/ultimaker2_olsson.json
@@ -1,0 +1,39 @@
+{
+    "id": "ultimaker2_olsson_base",
+    "version": 1, 
+    "name": "Ultimaker 2 with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+
+    "inherits": "ultimaker2.json",
+
+    "overrides": {
+        "machine_show_variants": { "default": true },
+        "shell_thickness": { "default": 1.2 },
+        "top_bottom_thickness": { "inherit_function": "(parent_value / 3) * 2" },
+        "travel_compensate_overlapping_walls_enabled": { "default": true },
+        "skin_alternate_rotation": { "default": true },
+        "skin_outline_count": { "default": 2 },
+        "infill_sparse_density": { "default": 10 },
+        "infill_overlap": { "default": 14, "inherit_function": "14 if infill_sparse_density < 95 else 0" },
+        "infill_wipe_dist": { "default": 0.35, "inherit_function": "wall_line_width_0" },
+        "retraction_amount": { "default": 6 },
+        "retraction_min_travel": { "default": 4.5 },
+        "retraction_count_max": { "default": 6 },
+        "retraction_extrusion_window": { "default": 6.0 },
+        "speed_print": { "default": 50 },
+        "speed_wall": { "inherit_function": "parent_value / 50 * 30" },
+        "speed_wall_x": { "inherit_function": "speed_print / 50 * 40" },
+        "speed_topbottom": { "inherit_function": "parent_value / 50 * 20" },
+        "speed_layer_0": { "default": 20 },
+        "skirt_speed": { "default": 20 },
+        "travel_avoid_distance": { "default": 1.0 },
+        "coasting_enable": { "default": true },
+        "coasting_volume": { "default": 0.4 },
+        "support_angle": { "default": 50 },
+        "adhesion_type": { "default": "brim" }
+    }
+}

--- a/resources/machines/ultimaker2_olsson_025.json
+++ b/resources/machines/ultimaker2_olsson_025.json
@@ -1,0 +1,30 @@
+{
+    "id": "ultimaker2_olsson",
+    "version": 1, 
+    "name": "Ultimaker 2 with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+
+    "inherits": "ultimaker2_olsson.json",
+
+    "variant": "0.25 mm",
+
+    "overrides": {
+        "machine_nozzle_size": { "default": 0.25 },
+
+        "layer_height": { "default": 0.06 },
+        "layer_height_0": { "default": 0.15 },
+
+        "infill_sparse_density": { "default": 12 },
+        "speed_print": { "default": 30 },
+        "speed_wall": { "inherit_function": "parent_value / 30 * 20" },
+        "speed_wall_x": { "inherit_function": "speed_print / 30 * 25" },
+        "speed_topbottom": { "inherit_function": "parent_value / 30 * 20" },
+
+        "coasting_volume": { "default": 0.1 },
+        "coasting_min_volume": { "default": 0.17 }
+    }
+}

--- a/resources/machines/ultimaker2_olsson_040.json
+++ b/resources/machines/ultimaker2_olsson_040.json
@@ -1,0 +1,21 @@
+{
+    "id": "ultimaker2_olsson",
+    "version": 1,
+    "name": "Ultimaker 2 with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+
+    "inherits": "ultimaker2_olsson.json",
+
+    "variant": "0.4 mm",
+
+    "overrides": {
+        "machine_nozzle_size": { "default": 0.40 },
+
+        "wall_line_width_0": { "inherit_function": "parent_value * 0.875" },
+        "skin_line_width": { "inherit_function": "parent_value * 0.875" }
+    }
+}

--- a/resources/machines/ultimaker2_olsson_060.json
+++ b/resources/machines/ultimaker2_olsson_060.json
@@ -1,0 +1,31 @@
+{
+    "id": "ultimaker2_olsson",
+    "version": 1,
+    "name": "Ultimaker 2 with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+
+    "inherits": "ultimaker2_olsson.json",
+
+    "variant": "0.6 mm",
+
+    "overrides": {
+        "machine_nozzle_size": { "default": 0.60 },
+
+        "layer_height": { "default": 0.15 },
+        "layer_height_0": { "default": 0.4 },
+
+        "shell_thickness": { "default": 1.8 },
+
+        "infill_sparse_density": { "default": 15 },
+        "speed_print": { "default": 55 },
+        "speed_wall": { "inherit_function": "parent_value / 55 * 25" },
+        "speed_wall_x": { "inherit_function": "speed_print / 55 * 40" },
+        "speed_topbottom": { "inherit_function": "parent_value / 55 * 20" },
+
+        "coasting_volume": { "default": 1.36 }
+    }
+}

--- a/resources/machines/ultimaker2_olsson_080.json
+++ b/resources/machines/ultimaker2_olsson_080.json
@@ -1,0 +1,32 @@
+{
+    "id": "ultimaker2_olsson",
+    "version": 1,
+    "name": "Ultimaker 2 with Olsson Block",
+    "manufacturer": "Ultimaker",
+    "author": "Ultimaker",
+    "platform": "ultimaker2_platform.obj",
+    "platform_texture": "Ultimaker2backplate.png",
+    "visible": false,
+
+    "inherits": "ultimaker2_olsson.json",
+
+    "variant": "0.8 mm",
+
+    "overrides": {
+        "machine_nozzle_size": { "default": 0.80 },
+
+        "layer_height": { "default": 0.2 },
+        "layer_height_0": { "default": 0.5 },
+
+        "shell_thickness": { "default": 2.4 },
+        "top_bottom_thickness": { "inherit_function": "parent_value / 2" },
+
+        "infill_sparse_density": { "default": 16 },
+        "speed_print": { "default": 40 },
+        "speed_wall": { "inherit_function": "parent_value / 40 * 20" },
+        "speed_wall_x": { "inherit_function": "speed_print / 40 * 30" },
+        "speed_topbottom": { "inherit_function": "parent_value / 40 * 20" },
+
+        "coasting_volume": { "default": 3.22 }
+    }
+}

--- a/resources/machines/ultimaker_original.json
+++ b/resources/machines/ultimaker_original.json
@@ -7,7 +7,7 @@
     "icon": "icon_ultimaker.png",
     "platform": "ultimaker_platform.stl",
     "file_formats": "text/x-gcode",
-    "inherits": "fdmprinter.json",
+    "inherits": "ultimaker.json",
 
     "pages": [
         "SelectUpgradedParts",

--- a/resources/profiles/ultimaker2_olsson/0.25_high.curaprofile
+++ b/resources/profiles/ultimaker2_olsson/0.25_high.curaprofile
@@ -1,0 +1,43 @@
+[general]
+version = 1
+name = High Quality
+machine_type = ultimaker2_olsson
+machine_variant = 0.25 mm
+
+[settings]
+retraction_combing = All
+top_thickness = 0.72
+speed_layer_0 = 20
+speed_print = 20
+speed_wall_0 = 20
+raft_interface_line_spacing = 3.0
+shell_thickness = 0.88
+infill_overlap = 15
+retraction_hop = 0.0
+skin_no_small_gaps_heuristic = False
+retraction_speed = 40.0
+raft_surface_line_width = 0.4
+raft_base_line_width = 1.0
+raft_margin = 5.0
+adhesion_type = brim
+skirt_minimal_length = 150.0
+layer_height = 0.06
+brim_line_count = 36
+infill_before_walls = False
+raft_surface_thickness = 0.27
+raft_airgap = 0.0
+skirt_gap = 3.0
+raft_interface_line_width = 0.4
+speed_topbottom = 20
+support_pattern = lines
+layer_height_0 = 0.15
+infill_sparse_density = 22
+top_bottom_thickness = 0.72
+speed_infill = 30
+magic_mesh_surface_mode = False
+bottom_thickness = 0.72
+speed_wall_x = 25
+machine_nozzle_size = 0.22
+raft_surface_line_spacing = 3.0
+support_enable = False
+

--- a/resources/profiles/ultimaker2_olsson/0.4_fast.curaprofile
+++ b/resources/profiles/ultimaker2_olsson/0.4_fast.curaprofile
@@ -1,0 +1,42 @@
+[general]
+version = 1
+name = Fast Prints
+machine_type = ultimaker2_olsson
+machine_variant = 0.4 mm
+
+[settings]
+retraction_combing = All
+top_thickness = 0.75
+speed_print = 40
+speed_wall_0 = 40
+raft_surface_line_spacing = 3.0
+shell_thickness = 0.7
+infill_sparse_density = 18
+retraction_hop = 0.0
+skin_no_small_gaps_heuristic = False
+retraction_speed = 40.0
+raft_surface_line_width = 0.4
+raft_base_line_width = 1.0
+raft_margin = 5.0
+adhesion_type = brim
+skirt_minimal_length = 150.0
+layer_height = 0.15
+brim_line_count = 22
+infill_before_walls = False
+raft_surface_thickness = 0.27
+raft_airgap = 0.0
+infill_overlap = 15
+raft_interface_line_width = 0.4
+speed_topbottom = 30
+support_pattern = lines
+layer_height_0 = 0.26
+raft_interface_line_spacing = 3.0
+speed_travel = 150
+skirt_gap = 3.0
+magic_mesh_surface_mode = False
+bottom_thickness = 0.75
+speed_wall_x = 50
+machine_nozzle_size = 0.35
+top_bottom_thickness = 0.75
+support_enable = False
+

--- a/resources/profiles/ultimaker2_olsson/0.4_high.curaprofile
+++ b/resources/profiles/ultimaker2_olsson/0.4_high.curaprofile
@@ -1,0 +1,43 @@
+[general]
+version = 1
+name = High Quality
+machine_type = ultimaker2_olsson
+machine_variant = 0.4 mm
+
+[settings]
+retraction_combing = All
+top_thickness = 0.72
+speed_layer_0 = 20
+speed_print = 30
+speed_wall_0 = 30
+raft_interface_line_spacing = 3.0
+shell_thickness = 1.05
+infill_overlap = 15
+retraction_hop = 0.0
+skin_no_small_gaps_heuristic = False
+retraction_speed = 40.0
+raft_surface_line_width = 0.4
+raft_base_line_width = 1.0
+raft_margin = 5.0
+adhesion_type = brim
+skirt_minimal_length = 150.0
+layer_height = 0.06
+brim_line_count = 22
+infill_before_walls = False
+raft_surface_thickness = 0.27
+raft_airgap = 0.0
+skirt_gap = 3.0
+raft_interface_line_width = 0.4
+speed_topbottom = 20
+support_pattern = lines
+layer_height_0 = 0.26
+infill_sparse_density = 22
+top_bottom_thickness = 0.72
+speed_infill = 50
+magic_mesh_surface_mode = False
+bottom_thickness = 0.72
+speed_wall_x = 40
+machine_nozzle_size = 0.35
+raft_surface_line_spacing = 3.0
+support_enable = False
+

--- a/resources/profiles/ultimaker2_olsson/0.4_normal.curaprofile
+++ b/resources/profiles/ultimaker2_olsson/0.4_normal.curaprofile
@@ -1,0 +1,38 @@
+[general]
+version = 1
+name = Normal Quality
+machine_type = ultimaker2_olsson
+machine_variant = 0.4 mm
+
+[settings]
+retraction_combing = All
+shell_thickness = 1.05
+speed_print = 30
+speed_wall_0 = 30
+raft_interface_line_spacing = 3.0
+speed_layer_0 = 20
+layer_height_0 = 0.26
+retraction_hop = 0.0
+skirt_gap = 3.0
+retraction_speed = 40.0
+raft_surface_line_width = 0.4
+raft_base_line_width = 1.0
+raft_margin = 5.0
+adhesion_type = brim
+skirt_minimal_length = 150.0
+brim_line_count = 22
+infill_before_walls = False
+raft_surface_thickness = 0.27
+raft_airgap = 0.0
+infill_overlap = 15
+raft_interface_line_width = 0.4
+speed_topbottom = 20
+support_pattern = lines
+speed_infill = 50
+skin_no_small_gaps_heuristic = False
+magic_mesh_surface_mode = False
+speed_wall_x = 40
+machine_nozzle_size = 0.35
+raft_surface_line_spacing = 3.0
+support_enable = False
+

--- a/resources/profiles/ultimaker2_olsson/0.6_normal.curaprofile
+++ b/resources/profiles/ultimaker2_olsson/0.6_normal.curaprofile
@@ -1,0 +1,42 @@
+[general]
+version = 1
+name = Normal Quality
+machine_type = ultimaker2_olsson
+machine_variant = 0.6 mm
+
+[settings]
+retraction_combing = All
+top_thickness = 1.2
+speed_layer_0 = 20
+speed_print = 25
+speed_wall_0 = 25
+raft_interface_line_spacing = 3.0
+shell_thickness = 1.59
+infill_overlap = 15
+retraction_hop = 0.0
+skin_no_small_gaps_heuristic = False
+retraction_speed = 40.0
+raft_surface_line_width = 0.4
+raft_base_line_width = 1.0
+raft_margin = 5.0
+adhesion_type = brim
+skirt_minimal_length = 150.0
+layer_height = 0.15
+brim_line_count = 15
+infill_before_walls = False
+raft_surface_thickness = 0.27
+raft_airgap = 0.0
+skirt_gap = 3.0
+raft_interface_line_width = 0.4
+speed_topbottom = 20
+support_pattern = lines
+layer_height_0 = 0.39
+top_bottom_thickness = 1.2
+speed_infill = 55
+magic_mesh_surface_mode = False
+bottom_thickness = 1.2
+speed_wall_x = 40
+machine_nozzle_size = 0.53
+raft_surface_line_spacing = 3.0
+support_enable = False
+

--- a/resources/profiles/ultimaker2_olsson/0.8_fast.curaprofile
+++ b/resources/profiles/ultimaker2_olsson/0.8_fast.curaprofile
@@ -1,0 +1,42 @@
+[general]
+version = 1
+name = Fast Prints
+machine_type = ultimaker2_olsson
+machine_variant = 0.8 mm
+
+[settings]
+retraction_combing = All
+top_thickness = 1.2
+speed_layer_0 = 20
+speed_print = 20
+speed_wall_0 = 25
+raft_interface_line_spacing = 3.0
+shell_thickness = 2.1
+infill_overlap = 15
+retraction_hop = 0.0
+skin_no_small_gaps_heuristic = False
+retraction_speed = 40.0
+raft_surface_line_width = 0.4
+raft_base_line_width = 1.0
+raft_margin = 5.0
+adhesion_type = brim
+skirt_minimal_length = 150.0
+layer_height = 0.2
+brim_line_count = 11
+infill_before_walls = False
+raft_surface_thickness = 0.27
+raft_airgap = 0.0
+skirt_gap = 3.0
+raft_interface_line_width = 0.4
+speed_topbottom = 20
+support_pattern = lines
+layer_height_0 = 0.5
+top_bottom_thickness = 1.2
+speed_infill = 40
+magic_mesh_surface_mode = False
+bottom_thickness = 1.2
+speed_wall_x = 30
+machine_nozzle_size = 0.7
+raft_surface_line_spacing = 3.0
+support_enable = False
+

--- a/resources/qml/WizardPages/AddMachine.qml
+++ b/resources/qml/WizardPages/AddMachine.qml
@@ -212,6 +212,9 @@ Item
                     case "SelectUpgradedParts":
                         base.wizard.appendPage(Qt.resolvedUrl("SelectUpgradedParts.qml"), catalog.i18nc("@title", "Select Upgraded Parts"));
                         break;
+                    case "SelectUpgradedPartsUM2":
+                        base.wizard.appendPage(Qt.resolvedUrl("SelectUpgradedPartsUM2.qml"), catalog.i18nc("@title", "Select Upgraded Parts"));
+                        break;
                     case "UpgradeFirmware":
                         base.wizard.appendPage(Qt.resolvedUrl("UpgradeFirmware.qml"), catalog.i18nc("@title", "Upgrade Firmware"));
                         break;

--- a/resources/qml/WizardPages/SelectUpgradedPartsUM2.qml
+++ b/resources/qml/WizardPages/SelectUpgradedPartsUM2.qml
@@ -31,7 +31,14 @@ Item
     Component.onDestruction:
     {
         if (hotendCheckBox.checked == true){
-            UM.MachineManager.setMachineDefinitionType("ultimaker2_olsson")
+            switch(UM.MachineManager.getMachineDefinitionType()) {
+                case "ultimaker2":
+                    UM.MachineManager.setMachineDefinitionType("ultimaker2_olsson")
+                    break;
+                case "ultimaker2_extended":
+                    UM.MachineManager.setMachineDefinitionType("ultimaker2_extended_olsson")
+                    break;
+            }
         }
     }
     Label

--- a/resources/qml/WizardPages/SelectUpgradedPartsUM2.qml
+++ b/resources/qml/WizardPages/SelectUpgradedPartsUM2.qml
@@ -1,0 +1,73 @@
+// Copyright (c) 2015 Ultimaker B.V.
+// Cura is released under the terms of the AGPLv3 or higher.
+
+import QtQuick 2.2
+import QtQuick.Controls 1.1
+import QtQuick.Window 2.1
+
+import UM 1.1 as UM
+
+Item
+{
+    id: wizardPage
+    property string title
+
+    SystemPalette{id: palette}
+    UM.I18nCatalog { id: catalog; name:"cura"}
+
+    property variant wizard: null;
+
+    Connections
+    {
+        target: wizardPage.wizard
+        onNextClicked: //You can add functions here that get triggered when the final button is clicked in the wizard-element
+        {
+            if(wizardPage.wizard.lastPage ==  true){
+                wizardPage.wizard.visible = false
+            }
+        }
+    }
+
+    Component.onDestruction:
+    {
+        if (hotendCheckBox.checked == true){
+            UM.MachineManager.setMachineDefinitionType("ultimaker2_olsson")
+        }
+    }
+    Label
+    {
+        id: pageTitle
+        width: parent.width
+        text: catalog.i18nc("@title", "Select Upgraded Parts")
+        wrapMode: Text.WordWrap
+        font.pointSize: 18
+    }
+    Label
+    {
+        id: pageDescription
+        anchors.top: pageTitle.bottom
+        anchors.topMargin: UM.Theme.sizes.default_margin.height
+        width: parent.width
+        wrapMode: Text.WordWrap
+        text: catalog.i18nc("@label","To assist you in having better default settings for your Ultimaker. Cura would like to know which upgrades you have in your machine:")
+    }
+
+    Item
+    {
+        id: pageCheckboxes
+        height: childrenRect.height
+        anchors.left: parent.left
+        anchors.leftMargin: UM.Theme.sizes.default_margin.width
+        anchors.top: pageDescription.bottom
+        anchors.topMargin: UM.Theme.sizes.default_margin.height
+        width: parent.width - UM.Theme.sizes.default_margin.width
+        CheckBox
+        {
+            id: hotendCheckBox
+            text: catalog.i18nc("@option:check","Olsson Block")
+            checked: false
+        }
+    }
+
+    ExclusiveGroup { id: printerGroup; }
+}


### PR DESCRIPTION
Adds a "Select Upgraded Parts" wizard page when adding an UM2 or UM2 Extended, allowing the user to select the Olsson block upgrade. If the Olsson block is selected, the machine gets the same Nozzle options as the UM2+, but without the material options. For UM2 machines we still have the philosophy that material is chosen on the printer.

This PR also adds a set of ultimaker2_olsson profiles, which are based on the ultimaker2+ profiles but have the material-specific properties removed.

Also see https://github.com/Ultimaker/Uranium/pull/110
Fixes CURA-91