### PR TITLE
[2.1] i18n: de: Correcting tooltip

### DIFF
--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: Cura 2.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-18 11:54+0100\n"
-"PO-Revision-Date: 2016-02-07 16:01+0100\n"
+"PO-Revision-Date: 2016-03-09 15:28+0100\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Last-Translator: Thomas Karl Pietrowski <thopiekar@googlemail.com>\n"
 "Language-Team: \n"
-"X-Generator: Poedit 1.8.4\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
 #: /home/tamara/2.1/Cura/cura/CrashHandler.py:26
 msgctxt "@title:window"
@@ -249,7 +249,7 @@ msgstr "Über USB drucken"
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/PrinterConnection.py:37
 msgctxt "@info:tooltip"
 msgid "Print with USB"
-msgstr "Über USB drucken"
+msgstr "Drucken über USB"
 
 #: /home/tamara/2.1/Cura/plugins/USBPrinting/__init__.py:13
 msgctxt "@label"


### PR DESCRIPTION
Just found another translation error.
This commit corrects "Bereit zum Über USB drucken" into "Bereit zum Drucken über USB".
It is almost related to another set of corrections I sent before, but didn't found this one as I didn't had my printer connected.

![cura](https://cloud.githubusercontent.com/assets/1847437/13638441/98516310-e60c-11e5-9b46-14e428dafc67.png)
