### PR TITLE
Add start and end GCode to enable printing through WiFi

### DIFF
--- a/resources/machines/ultimaker2.json
+++ b/resources/machines/ultimaker2.json
@@ -34,8 +34,8 @@
         }
     ],
     "machine_settings": {
-        "machine_start_gcode" : { "default": "" },
-        "machine_end_gcode" : { "default": "" },
+        "machine_start_gcode" : { "default": "G21\nG90\nM107\nG28\nG1 Z15 F9000\nG92 E0\nG1 F9000" },
+        "machine_end_gcode" : { "default": "M107\nG91\nG1 E-1 F300\nG1 Z+5.5 E-5 X-20 Y-20 F9000\nG28\nM84\nG90" },
         "machine_width": { "default": 223 },
         "machine_depth": { "default": 223 },
         "machine_height": { "default": 205 },


### PR DESCRIPTION
The UltiGCode flavor does not use the "machine_start_gcode" and "machine_end_gcode". Adding this start and end gcode will enable us to print through USB and/or WiFi if we switch the printer flavor to RepRap before printing (through the use of plugins).