### PR TITLE
USBPrinting: Adding entry for BQ Hephestos 2 firmware

### DIFF
--- a/plugins/USBPrinting/USBPrinterManager.py
+++ b/plugins/USBPrinting/USBPrinterManager.py
@@ -141,6 +141,7 @@ class USBPrinterManager(QObject, SignalEmitter, OutputDevicePlugin, Extension):
         # The *.hex files are stored at a seperate repository:
         # https://github.com/Ultimaker/cura-binary-data/tree/master/cura/resources/firmware
         machine_without_extras  = {"bq_witbox"                : "MarlinWitbox.hex",
+                                   "bq_hephestos_2"           : "MarlinHephestos2.hex",
                                    "ultimaker_original"       : "MarlinUltimaker-{baudrate}.hex",
                                    "ultimaker_original_plus"  : "MarlinUltimaker-UMOP-{baudrate}.hex",
                                    "ultimaker2"               : "MarlinUltimaker2.hex",


### PR DESCRIPTION
* Requires https://github.com/Ultimaker/cura-binary-data/pull/2