### PR TITLE
Add a preference for scaling up tiny objects

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -115,6 +115,7 @@ class CuraApplication(QtApplication):
         Preferences.getInstance().addPreference("cura/categories_expanded", "")
         Preferences.getInstance().addPreference("view/center_on_select", True)
         Preferences.getInstance().addPreference("mesh/scale_to_fit", True)
+        Preferences.getInstance().addPreference("mesh/scale_tiny_meshes", True)
         Preferences.getInstance().setDefault("local_file/last_used_type", "text/x-gcode")
 
         JobQueue.getInstance().jobFinished.connect(self._onJobFinished)

--- a/resources/qml/GeneralPage.qml
+++ b/resources/qml/GeneralPage.qml
@@ -139,6 +139,20 @@ UM.PreferencesPage
         UM.TooltipArea {
             width: childrenRect.width
             height: childrenRect.height
+            text: catalog.i18nc("@info:tooltip","Should opened files be scaled up if they are extremely small?")
+
+            CheckBox
+            {
+                id: scaleTinyCheckbox
+                text: catalog.i18nc("@option:check","Scale extremely small files")
+                checked: boolCheck(UM.Preferences.getValue("mesh/scale_tiny_meshes"))
+                onCheckedChanged: UM.Preferences.setValue("mesh/scale_tiny_meshes", checked)
+            }
+        }
+
+        UM.TooltipArea {
+            width: childrenRect.width
+            height: childrenRect.height
             text: catalog.i18nc("@info:tooltip","Should anonymous data about your print be sent to Ultimaker? Note, no models, IP addresses or other personally identifiable information is sent or stored.")
 
             CheckBox


### PR DESCRIPTION
When objects have been modeled with meters as units, they become so tiny that the cannot be selected in Cura to be scaled up.

See https://github.com/Ultimaker/Cura/issues/697#issuecomment-209518061

Also see https://github.com/Ultimaker/Uranium/pull/132