### PR TITLE
BQ Hephestos2: Removing override of support_enable

### DIFF
--- a/resources/machines/bq_hephestos_2.json
+++ b/resources/machines/bq_hephestos_2.json
@@ -58,6 +58,5 @@
         "skirt_minimal_length": { "default": 30.0, "visible": false },
         "skirt_gap": { "default": 6.0 },
         "cool_fan_full_at_height": { "default": 0.4, "visible": false },
-        "support_enable": { "default": false }
     }
 }


### PR DESCRIPTION
"support_enable" is already set as "enabled": false in fdmprinter.json.
So this line is unneeded here.