### PR TITLE
BQ Hephestos2: Adding missing machine_preferences

### DIFF
--- a/resources/machines/bq_hephestos_2.json
+++ b/resources/machines/bq_hephestos_2.json
@@ -8,6 +8,12 @@
     "file_formats": "text/x-gcode",
     "inherits": "fdmprinter.json",
 
+    "machine_preferences": {
+        "prefered_profile": "Normal Quality",
+        "prefered_variant": "0.4 mm",
+        "prefered_material": "PLA"
+    },
+
     "overrides": {
         "machine_start_gcode": {
             "default": "; -- START GCODE --\nM800        ; Custom GCODE to fire start print procedure\n; -- end of START GCODE --"


### PR DESCRIPTION
Without that Cura will by default display "ABS" as material (first material in the list).
This will add the missing material setup to the JSON.