### PR TITLE
BQ Hephestos2: Removing machine_gcode_flavor

### DIFF
--- a/resources/machines/bq_hephestos_2.json
+++ b/resources/machines/bq_hephestos_2.json
@@ -30,9 +30,6 @@
         "machine_center_is_zero": {
             "default": false
         },
-        "machine_gcode_flavor": {
-            "default": "RepRap"
-        },
         "machine_platform_offset": {
             "default": [6, 1320, 0]
         },


### PR DESCRIPTION
This is already default at https://github.com/Ultimaker/Cura/blob/master/resources/machines/fdmprinter.json#L115