### PR TITLE
[2.1] Set default version to 2.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GNUInstallDirs)
 
 set(URANIUM_SCRIPTS_DIR "${CMAKE_SOURCE_DIR}/../uranium/scripts" CACHE DIRECTORY "The location of the scripts directory of the Uranium repository")
 
-set(CURA_VERSION "master" CACHE STRING "Version name of Cura")
+set(CURA_VERSION "2.1.2" CACHE STRING "Version name of Cura")
 configure_file(cura/CuraVersion.py.in CuraVersion.py @ONLY)
 
 # Macro needed to list all sub-directory of a directory.


### PR DESCRIPTION
While discussing on #718 I noticed that the splash screen still shows "master" when built from [2.1].

This sets the version to 2.1.2.