### PR TITLE
Adding debian to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ resources/i18n/x-test
 *~
 *.qm
 .idea
+
+# Debian packaging
+debian/


### PR DESCRIPTION
Got a link here my packaging files. As Cura does not come with packaging
files itself, we can add this ignore here.