### PR TITLE
[CURA-1615] GCodeProfileReader/-Export: Rework

### DIFF
--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -75,15 +75,16 @@ class GCodeProfileReader(ProfileReader):
 
         # Create an empty profile - the id will be changed later
         profile = InstanceContainer("")
-        profile.addMetaDataEntry("type", "quality")
         try:
             profile.deserialize(serialized)
         except Exception as e:  # Not a valid g-code file.
             Logger.log("e", "Unable to serialise the profile: %s", str(e))
             return None
 
+        profile.addMetaDataEntry("type", "quality")
+
         #Creating a unique name using the filename of the GCode
-        new_name = catalog.i18nc("@label", "Custom profile (%s)") %(os.path.splitext(os.path.basename(file_name))[0])
+        new_name = catalog.i18nc("@label", "G-Code-imported profile")
         profile.setName(new_name)
         profile._id = new_name
 

--- a/plugins/GCodeProfileReader/GCodeProfileReader.py
+++ b/plugins/GCodeProfileReader/GCodeProfileReader.py
@@ -22,7 +22,7 @@ class GCodeProfileReader(ProfileReader):
     #   It can only read settings with the same version as the version it was
     #   written with. If the file format is changed in a way that breaks reverse
     #   compatibility, increment this version number!
-    version = 1
+    version = 2
 
     ##  Dictionary that defines how characters are escaped when embedded in
     #   g-code.

--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -69,8 +69,8 @@ class GCodeWriter(MeshWriter):
         prefix_length = len(prefix)
 
         global_stack = Application.getInstance().getGlobalContainerStack()
-        container_with_settings = global_stack.getContainers()[1]
-        serialized = container_with_settings.serialize()
+        container_with_profile = global_stack.findContainer({"type": "quality"})
+        serialized = container_with_profile.serialize()
 
         # Escape characters that have a special meaning in g-code comments.
         pattern = re.compile("|".join(GCodeWriter.escape_characters.keys()))


### PR DESCRIPTION
The exported data is now the same as you can find in .curaprofile files, but when deserializing the data back into a ContainerInstance and returning the new container like done in ```CuraProfileReader``` the imported profile still does not appear in the "settings window -> profiles".

I even get this error when "reimporting" the same container again:
```[35m2016-06-23 19:38:18,136[0m - [33mWARNING[0m - [37m.../UM/Settings/ContainerRegistry.py (addContainer [238]): Container of type <class 'UM.Settings.InstanceContainer.InstanceContainer'> and id BH2_SimpleCube_10mm already added[0m```

Would be great if someone could give me hints on that.
Thanks!