### PR TITLE
Better call it "Print via USB"

### DIFF
--- a/plugins/USBPrinting/ControlWindow.qml
+++ b/plugins/USBPrinting/ControlWindow.qml
@@ -14,7 +14,7 @@ UM.Dialog
     height: 100 * Screen.devicePixelRatio;
     modality: Qt.NonModal
 
-    title: catalog.i18nc("@title:window", "Print with USB")
+    title: catalog.i18nc("@title:window", "Print via USB")
 
     Column
     {


### PR DESCRIPTION
I think this sounds better, because I understand "USB" as an technology. So you wouldn't say "Print with USB", but would fit if you say "Print with USB cable". So "Print via USB" should be more correct here.