### PR TITLE
CURA-1284: Changing icon for experimental category

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2987,7 +2987,7 @@
         {
             "label": "Experimental Modes",
             "type": "category",
-            "icon": "category_blackmagic",
+            "icon": "category_experimental",
             "description": "experimental!",
             "children":
             {


### PR DESCRIPTION
Needs an icon in resources/themes/cura/icons