### PR TITLE
Updating NVidia workaround

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -59,14 +59,6 @@ import copy
 import urllib
 numpy.seterr(all="ignore")
 
-#WORKAROUND: GITHUB-88 GITHUB-385 GITHUB-612
-if Platform.isLinux(): # Needed for platform.linux_distribution, which is not available on Windows and OSX
-    # For Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
-    if platform.linux_distribution()[0] in ("Ubuntu", ): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
-        import ctypes
-        from ctypes.util import find_library
-        ctypes.CDLL(find_library('GL'), ctypes.RTLD_GLOBAL)
-
 try:
     from cura.CuraVersion import CuraVersion, CuraBuildType
 except ImportError:

--- a/cura_app.py
+++ b/cura_app.py
@@ -5,6 +5,19 @@
 
 import os
 import sys
+import platform
+
+from UM.Platform import Platform
+
+#WORKAROUND: GITHUB-88 GITHUB-385 GITHUB-612
+if Platform.isLinux(): # Needed for platform.linux_distribution, which is not available on Windows and OSX
+    # For Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
+    print(platform.linux_distribution())
+    if platform.linux_distribution()[0] in ("debian", "Ubuntu", ): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
+        import ctypes
+        from ctypes.util import find_library
+        libGL = find_library("GL")
+        ctypes.CDLL(libGL, ctypes.RTLD_GLOBAL)
 
 #WORKAROUND: GITHUB-704 GITHUB-708
 # It looks like setuptools creates a .pth file in


### PR DESCRIPTION
Also needed for https://github.com/Ultimaker/cura-build/pull/68, as Python3 built in cura-build thinks it is on "debian".