### PR TITLE
BQ Hephestos2 - Preheating temperature fix

### DIFF
--- a/resources/definitions/bq_hephestos_2.def.json
+++ b/resources/definitions/bq_hephestos_2.def.json
@@ -14,7 +14,7 @@
     },
 
     "overrides": {
-        "machine_start_gcode": { "default_value": "; -- START GCODE --\nM800        ; Custom GCODE to fire start print procedure\n; -- end of START GCODE --" },
+        "machine_start_gcode": { "default_value": "; -- START GCODE --\nM800        ; Custom GCODE to fire start print procedure\nM109 S{print_temperature} ;Makes sure the temperature is correct before printing\n; -- end of START GCODE --" },
         "machine_end_gcode": { "default_value": "; -- END GCODE --\nM801        ; Custom GCODE to fire end print procedure\n; -- end of END GCODE --" },
         "machine_width": { "default_value": 210 },
         "machine_depth": { "default_value": 297 },


### PR DESCRIPTION
When starting a print with the "custom" GCode by BQ, the printer resets
the nozzle temperature to 210°C when printing via SD card (no matter
what you set on Cura) and only preheats the nozzle to 180°C when
printing via USB.
So currently the printer begins to print via USB at 180°C and reaches
the correct temperature eg. while printing the brim.