### PR TITLE
BQ Hephestos2: Heat up nozzle while leveling

### DIFF
--- a/resources/definitions/bq_hephestos_2.def.json
+++ b/resources/definitions/bq_hephestos_2.def.json
@@ -14,7 +14,7 @@
     },
 
     "overrides": {
-        "machine_start_gcode": { "default_value": "; -- START GCODE --\nM800        ; Custom GCODE to fire start print procedure\nM109 S{material_print_temperature} ;Makes sure the temperature is correct before printing\n; -- end of START GCODE --" },
+        "machine_start_gcode": { "default_value": "; -- START GCODE --\nM104 S{material_print_temperature} ; Heat up extruder while leveling\nM800 ; Custom GCODE to fire start print procedure\nM109 S{material_print_temperature} ; Makes sure the temperature is correct before printing\n; -- end of START GCODE --" },
         "machine_end_gcode": { "default_value": "; -- END GCODE --\nM801        ; Custom GCODE to fire end print procedure\n; -- end of END GCODE --" },
         "machine_width": { "default_value": 210 },
         "machine_depth": { "default_value": 297 },


### PR DESCRIPTION
Saves time and preheats the nozzle to the correct temperature (set by Cura).
Btw. the BQ support explained me the reason why they are assuming 210°C needs to set here. The reason is that the printer is just meant to be used with PLA, so they are only expecting to use exactly 210°C. Just explained them why this is incorrect when think about the possibility that Cura can set the temperature on it's own.