### PR TITLE
Add mechanism for plugins to add controls to designated areas in the GUI

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -128,6 +128,8 @@ class CuraApplication(QtApplication):
         self._machine_action_manager = MachineActionManager.MachineActionManager()
         self._machine_manager = None    # This is initialized on demand.
 
+        self._additional_components = {} # Components to add to certain areas in the interface
+
         super().__init__(name = "cura", version = CuraVersion, buildtype = CuraBuildType)
 
         self.setWindowIcon(QIcon(Resources.getPath(Resources.Images, "cura-icon.png")))
@@ -877,3 +879,21 @@ class CuraApplication(QtApplication):
 
     def getBuildVolume(self):
         return self._volume
+
+    additionalComponentsChanged = pyqtSignal(str, arguments = ["areaId"])
+
+    @pyqtProperty("QVariantMap", notify = additionalComponentsChanged)
+    def additionalComponents(self):
+        return self._additional_components
+
+    ##  Add a component to a list of components to be reparented to another area in the GUI.
+    #   The actual reparenting is done by the area itself.
+    #   \param area_id \type{str} Identifying name of the area to which the component should be reparented
+    #   \param component \type{QQuickComponent} The component that should be reparented
+    @pyqtSlot(str, "QVariant")
+    def addAdditionalComponent(self, area_id, component):
+        if area_id not in self._additional_components:
+            self._additional_components[area_id] = []
+        self._additional_components[area_id].append(component)
+
+        self.additionalComponentsChanged.emit(area_id)

--- a/resources/qml/SaveButton.qml
+++ b/resources/qml/SaveButton.qml
@@ -84,6 +84,27 @@ Rectangle {
         anchors.topMargin: UM.Theme.getSize("default_margin").height
         anchors.left: parent.left
 
+        Row {
+            id: additionalComponentsRow
+            anchors.top: parent.top
+            anchors.right: saveToButton.visible ? saveToButton.left : parent.right
+            anchors.rightMargin: UM.Theme.getSize("default_margin").width
+
+            spacing: UM.Theme.getSize("default_margin").width
+        }
+
+        Connections {
+            target: Printer
+            onAdditionalComponentsChanged:
+            {
+                if(areaId == "saveButton") {
+                    for (var component in Printer.additionalComponents["saveButton"]) {
+                        Printer.additionalComponents["saveButton"][component].parent = additionalComponentsRow
+                    }
+                }
+            }
+        }
+
         Button {
             id: saveToButton
 
@@ -102,8 +123,7 @@ Rectangle {
             }
 
             style: ButtonStyle {
-                background:
-                Rectangle
+                background: Rectangle
                 {
                     border.width: UM.Theme.getSize("default_lining").width
                     border.color: !control.enabled ? UM.Theme.getColor("action_button_disabled_border") :
@@ -126,7 +146,7 @@ Rectangle {
                         text: control.text;
                     }
                 }
-            label: Item { }
+                label: Item { }
             }
         }
 


### PR DESCRIPTION
Contributes to CURA-271, but can hopefully be used to extend other areas of the gui in the future (eg plugin preferences on the general page, ...)