### PR TITLE
[CURA-1223] 3MFReader: Doing selftest and fail on broken files

### DIFF
--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -27,7 +27,7 @@ except ImportError:
 ##    Base implementation for reading 3MF files. Has no support for textures. Only loads meshes!
 class ThreeMFReader(MeshReader):
     def __init__(self):
-        super(ThreeMFReader, self).__init__()
+        super().__init__()
         self._supported_extensions = [".3mf"]
 
         self._namespaces = {

--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -124,7 +124,8 @@ class ThreeMFReader(MeshReader):
             Logger.log("e", "exception occured in 3mf reader: %s", e)
 
         try: # Selftest - There might be more functions that should fail 
-            result.getBoundingBox()
+            boundingBox = result.getBoundingBox()
+            boundingBox.isValid()
         except:
             message = Message(catalog.i18nc("@info:status", "Your 3MF file seems to be broken. Please visit https://modelrepair.azurewebsites.net/ and try to repair your model!"), lifetime = 0)
             message.show()

--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -9,8 +9,12 @@ from UM.Math.Vector import Vector
 from UM.Scene.SceneNode import SceneNode
 from UM.Scene.GroupDecorator import GroupDecorator
 from UM.Math.Quaternion import Quaternion
-
 from UM.Job import Job
+
+from UM.Message import Message
+from UM.i18n import i18nCatalog
+catalog = i18nCatalog("cura")
+
 
 import math
 import zipfile
@@ -116,4 +120,11 @@ class ThreeMFReader(MeshReader):
         except Exception as e:
             Logger.log("e", "exception occured in 3mf reader: %s", e)
 
+        try: # Selftest - There might be more functions that should fail 
+            result.getBoundingBox()
+        except:
+            message = Message(catalog.i18nc("@info:status", "Your 3MF file seems to be broken. Please visit https://modelrepair.azurewebsites.net/ and try to repair your model!"), lifetime = 0)
+            message.show()
+            return None
+        
         return result  

--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -19,7 +19,10 @@ catalog = i18nCatalog("cura")
 import math
 import zipfile
 
-import xml.etree.ElementTree as ET
+try:
+    import xml.etree.cElementTree as ET
+except ImportError:
+    import xml.etree.ElementTree as ET
 
 ##    Base implementation for reading 3MF files. Has no support for textures. Only loads meshes!
 class ThreeMFReader(MeshReader):

--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -27,7 +27,7 @@ except ImportError:
 ##    Base implementation for reading 3MF files. Has no support for textures. Only loads meshes!
 class ThreeMFReader(MeshReader):
     def __init__(self):
-        super().__init__()
+        super(ThreeMFReader, self).__init__()
         self._supported_extensions = [".3mf"]
 
         self._namespaces = {


### PR DESCRIPTION
This commit adds a selftest before the "result" gets returned.
It should break on this/these functions and popup a message about using
the online repair tool.
I compared the content of both files for a long time, googled about the
format, but wasn't able to find a proper fix.
More routines will likely need to be added here, but with those I have
it is working so far very well.

Sadly it is not possible to override the default message, so two
messages will appear. Additionally, the URL of the link is not
clickable/executable from the UX. Just acting like normal text.

Contributes to CURA-1223