### PR TITLE
Create shades of colors for each extruder

### DIFF
--- a/cura/Settings/ExtrudersModel.py
+++ b/cura/Settings/ExtrudersModel.py
@@ -155,9 +155,8 @@ class ExtrudersModel(UM.Qt.ListModel.ListModel):
     def _colorShade(self, base_color, shade):
         color_shade = base_color
         if shade > 0:
-            new_color = UM.Math.Color.Color.fromRGBString(base_color)
-            if (new_color.r + new_color.g + new_color.b) / 3 < .5:
-                mix = 1 # lighten the shade
+            new_color = UM.Math.Color.Color.fromHexString(base_color)
+            if (new_color.r + new_color.g + new_color.b) / 3 < .5:                mix = 1 # lighten the shade
             else:
                 mix = 0 # darken the shade
             new_color.setValues(
@@ -166,6 +165,5 @@ class ExtrudersModel(UM.Qt.ListModel.ListModel):
                 new_color.b * (1 - shade) + shade * mix,
                 1.0
             )
-            color_shade = new_color.toRGBString()
-
+            color_shade = new_color.toHexString()
         return color_shade

--- a/plugins/SolidView/SolidView.py
+++ b/plugins/SolidView/SolidView.py
@@ -7,6 +7,8 @@ from UM.Scene.Selection import Selection
 from UM.Resources import Resources
 from UM.Application import Application
 from UM.Preferences import Preferences
+from UM.Math.Color import Color
+
 from UM.View.Renderer import Renderer
 from UM.Settings.Validator import ValidatorState
 
@@ -34,6 +36,7 @@ class SolidView(View):
 
         if not self._enabled_shader:
             self._enabled_shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "overhang.shader"))
+            self._enabled_shader.setUniformValue("u_shininess", 50.0)
 
         if not self._disabled_shader:
             self._disabled_shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "striped.shader"))
@@ -76,14 +79,8 @@ class SolidView(View):
 
                         material_color = self._extruders_model.getItem(extruder_index)["color"]
                     try:
-                        # Colors are passed as rgb hex strings (eg "#ffffff"), and the shader needs
-                        # an rgba list of floats (eg [1.0, 1.0, 1.0, 1.0])
-                        uniforms["diffuse_color"] = [
-                            int(material_color[1:3], 16) / 255,
-                            int(material_color[3:5], 16) / 255,
-                            int(material_color[5:7], 16) / 255,
-                            1.0
-                        ]
+                        color = Color.fromRGBString(material_color)
+                        uniforms["diffuse_color"] = [color.r, color.g, color.b, color.a]
                     except ValueError:
                         pass
 
@@ -99,7 +96,3 @@ class SolidView(View):
 
     def endRendering(self):
         pass
-
-    #def _onPreferenceChanged(self, preference):
-        #if preference == "view/show_overhang": ## Todo: This a printer only setting. Should be removed from Uranium.
-            #self._enabled_material = None

--- a/plugins/SolidView/SolidView.py
+++ b/plugins/SolidView/SolidView.py
@@ -79,7 +79,7 @@ class SolidView(View):
 
                         material_color = self._extruders_model.getItem(extruder_index)["color"]
                     try:
-                        color = Color.fromRGBString(material_color)
+                        color = Color.fromHexString(material_color)
                         uniforms["diffuse_color"] = [color.r, color.g, color.b, color.a]
                     except ValueError:
                         pass


### PR DESCRIPTION
If two extruders have the same material it is impossible to see if multiple objects will print with the same extruder of with different extruders. This PR creates a shade of the material-color per extruder.

This PR relies on https://github.com/Ultimaker/Uranium/pull/155 for parsing and changing the rgb color strings used in the configuration files and qml.