### PR TITLE
Scanning for CuraEngine and stop if it was not found

### DIFF
--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -13,7 +13,6 @@ from UM.Resources import Resources
 from UM.Settings.Validator import ValidatorState #To find if a setting is in an error state. We can't slice then.
 from UM.Platform import Platform
 
-
 import cura.Settings
 
 from cura.OneAtATimeIterator import OneAtATimeIterator
@@ -32,7 +31,6 @@ import Arcus
 
 from UM.i18n import i18nCatalog
 catalog = i18nCatalog("cura")
-
 
 class CuraEngineBackend(Backend):
     ##  Starts the back-end plug-in.

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -37,7 +37,6 @@ class CuraEngineBackend(Backend):
     #
     #   This registers all the signal listeners and prepares for communication
     #   with the back-end in general.
-    
     def __init__(self):
         super().__init__()
 

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -54,7 +54,7 @@ class CuraEngineBackend(Backend):
         if Platform.isWindows():
             default_engine_location += ".exe"
         if Platform.isLinux() and not default_engine_location:
-            if not os.getenv('PATH'):
+            if not os.getenv("PATH"):
                 raise OSError("There is something wrong with your Linux installation.")
             for pathdir in os.getenv('PATH').split(os.pathsep):
                 execpath = os.path.join(pathdir, executable_name)

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -56,7 +56,7 @@ class CuraEngineBackend(Backend):
         if Platform.isLinux() and not default_engine_location:
             if not os.getenv("PATH"):
                 raise OSError("There is something wrong with your Linux installation.")
-            for pathdir in os.getenv('PATH').split(os.pathsep):
+            for pathdir in os.getenv("PATH").split(os.pathsep):
                 execpath = os.path.join(pathdir, executable_name)
                 if os.path.exists(execpath):
                     default_engine_location = execpath

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -40,25 +40,24 @@ class CuraEngineBackend(Backend):
     #   This registers all the signal listeners and prepares for communication
     #   with the back-end in general.
     
-    executableName = "CuraEngine"
-    
     def __init__(self):
         super().__init__()
 
         # Find out where the engine is located, and how it is called.
         # This depends on how Cura is packaged and which OS we are running on.
+        executable_name = "CuraEngine"
         default_engine_location = None
-        if os.path.exists(os.path.join(Application.getInstallPrefix(), "bin", self.executableName)):
-            default_engine_location = os.path.join(Application.getInstallPrefix(), "bin", self.executableName)
+        if os.path.exists(os.path.join(Application.getInstallPrefix(), "bin", executable_name)):
+            default_engine_location = os.path.join(Application.getInstallPrefix(), "bin", executable_name)
         if hasattr(sys, "frozen"):
-            default_engine_location = os.path.join(os.path.dirname(os.path.abspath(sys.executable)), self.executableName)
+            default_engine_location = os.path.join(os.path.dirname(os.path.abspath(sys.executable)), executable_name)
         if Platform.isWindows():
             default_engine_location += ".exe"
         if Platform.isLinux() and not default_engine_location:
             if not os.getenv('PATH'):
                 raise OSError("There is something wrong with your Linux installation.")
             for pathdir in os.getenv('PATH').split(os.pathsep):
-                execpath = os.path.join(pathdir, self.executableName)
+                execpath = os.path.join(pathdir, executable_name)
                 if os.path.exists(execpath):
                     default_engine_location = execpath
                     break

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -48,10 +48,10 @@ class CuraEngineBackend(Backend):
         # Find out where the engine is located, and how it is called.
         # This depends on how Cura is packaged and which OS we are running on.
         default_engine_location = None
-        if os.path.exists(os.path.join(Application.getInstallPrefix(), "bin", "CuraEngine")):
-            default_engine_location = os.path.join(Application.getInstallPrefix(), "bin", "CuraEngine")
+        if os.path.exists(os.path.join(Application.getInstallPrefix(), "bin", self.executableName)):
+            default_engine_location = os.path.join(Application.getInstallPrefix(), "bin", self.executableName)
         if hasattr(sys, "frozen"):
-            default_engine_location = os.path.join(os.path.dirname(os.path.abspath(sys.executable)), "CuraEngine")
+            default_engine_location = os.path.join(os.path.dirname(os.path.abspath(sys.executable)), self.executableName)
         if Platform.isWindows():
             default_engine_location += ".exe"
         if Platform.isLinux() and not default_engine_location:


### PR DESCRIPTION
So far I ran 2 or 3 times into the problem that my engine was not up to
date. The bad thing here is that there is always an updated version from
my PPA on the PC. So first this commit gives the possibility to look for
CuraEngine in the $PATH directories. Before I had to copy it always
manually, eg. via "cp $(which CuraEngine) bin/CuraEngine" in my
workbench.

Second, people can get into the situation that CuraEngine is missing at
all. So before making Cura loop and try to use an executable that does
not exist, better raise an Exception here.
An additional info message tells about the location being used.

Does not contribute to any JIRA issue (I think), but makes my life
easier.