### PR TITLE
Show "ghosts" for all objects on the buildplate in layerview

### DIFF
--- a/plugins/LayerView/LayerView.py
+++ b/plugins/LayerView/LayerView.py
@@ -33,7 +33,7 @@ class LayerView(View):
     def __init__(self):
         super().__init__()
         self._shader = None
-        self._selection_shader = None
+        self._ghost_shader = None
         self._num_layers = 0
         self._layer_percentage = 0  # what percentage of layers need to be shown (Slider gives value between 0 - 100)
         self._proxy = LayerViewProxy.LayerViewProxy()
@@ -84,10 +84,9 @@ class LayerView(View):
         scene = self.getController().getScene()
         renderer = self.getRenderer()
 
-        if not self._selection_shader:
-            self._selection_shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "color.shader"))
-            self._selection_shader.setUniformValue("u_color", Color(32, 32, 32, 128))
-
+        if not self._ghost_shader:
+            self._ghost_shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "color.shader"))
+            self._ghost_shader.setUniformValue("u_color", Color(32, 32, 32, 96))
         for node in DepthFirstIterator(scene.getRoot()):
             # We do not want to render ConvexHullNode as it conflicts with the bottom layers.
             # However, it is somewhat relevant when the node is selected, so do render it then.
@@ -96,8 +95,7 @@ class LayerView(View):
 
             if not node.render(renderer):
                 if node.getMeshData() and node.isVisible():
-                    if Selection.isSelected(node):
-                        renderer.queueNode(node, transparent = True, shader = self._selection_shader)
+                    renderer.queueNode(node, transparent = True, shader = self._ghost_shader)
                     layer_data = node.callDecoration("getLayerData")
                     if not layer_data:
                         continue
@@ -113,13 +111,13 @@ class LayerView(View):
                             end += counts
 
                         # This uses glDrawRangeElements internally to only draw a certain range of lines.
-                        renderer.queueNode(node, mesh = layer_data, mode = RenderBatch.RenderMode.Lines, range = (start, end))
+                        renderer.queueNode(node, mesh = layer_data, mode = RenderBatch.RenderMode.Lines, overlay = True, range = (start, end))
 
                     if self._current_layer_mesh:
-                        renderer.queueNode(node, mesh = self._current_layer_mesh)
+                        renderer.queueNode(node, mesh = self._current_layer_mesh, overlay = True)
 
                     if self._current_layer_jumps:
-                        renderer.queueNode(node, mesh = self._current_layer_jumps)
+                        renderer.queueNode(node, mesh = self._current_layer_jumps, overlay = True)
 
     def setLayer(self, value):
         if self._current_layer_num != value:


### PR DESCRIPTION
The current implementation of layerview only shows a grey "ghost" of the currently selected object. If the user enters layerview without an object selected, she is presented with an empty buildplate until slicing is completed and layers are processed.

This PR shows a ghost for all objects instead of only for the selected object(s), this giving the user a decent view of where objects are located and where to click to select an object.

CURA-1601 is slated for a later sprint, but it seems such a shame to delay this now that we have made such great improvements to Layer View.