### PR TITLE
Make camera animation feel snappier

### DIFF
--- a/cura/CameraAnimation.py
+++ b/cura/CameraAnimation.py
@@ -11,8 +11,8 @@ class CameraAnimation(QVariantAnimation):
     def __init__(self, parent = None):
         super().__init__(parent)
         self._camera_tool = None
-        self.setDuration(500)
-        self.setEasingCurve(QEasingCurve.InOutQuad)
+        self.setDuration(300)
+        self.setEasingCurve(QEasingCurve.OutQuad)
 
     def setCameraTool(self, camera_tool):
         self._camera_tool = camera_tool


### PR DESCRIPTION
I've tweaked the camera animation a bit.
The difference is that it no longer eases into the animation, making it react more immediate. This makes it feel snappier. The duration is made a little shorter to make the ease-out feel approximately the same.

Let me know what you think.
