### PR TITLE
New settings to allow control over automatic speed changes for merged infill lines

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2014,28 +2014,28 @@
                     "enabled": "jerk_enabled",
                     "settable_per_mesh": false
                 },
-                "speed_for_pressure_enabled":
+                "speed_equalize_flow_enabled":
                 {
-                    "label": "Equalize Nozzle Pressure",
-                    "description": "Attempt to dampen nozzle pressure changes by varying printing speed with extrusion width for narrow extrusions",
+                    "label": "Equalize Filament Flow",
+                    "description": "Print thinner than normal lines faster so that the amount of material extruded per second remains the same. Thin pieces in your model might require lines printed with smaller line width than provided in the settings. This setting controls the speed changes for such lines.",
                     "type": "bool",
                     "default_value": true,
                     "settable_per_mesh": false,
-                    "settable_per_extruder": false
+                    "settable_per_extruder": true
                 },
-                "speed_pressure_maximum":
+                "speed_equalize_flow_max":
                 {
-                    "label": "Maximum Speed for Pressure",
-                    "description": "Maximum print speed when adjusting to equalize nozzle pressure.",
+                    "label": "Maximum Speed for Flow Equalization",
+                    "description": "Maximum print speed when adjusting in order to equalize flow.",
                     "type": "float",
                     "unit": "mm/s",
-                    "enabled": "speed_for_pressure_enabled",
+                    "enabled": "speed_equalize_flow_enabled",
                     "default_value": 150,
                     "minimum_value": "0.1",
                     "maximum_value": "299792458000",
                     "maximum_value_warning": "150",
                     "settable_per_mesh": false,
-                    "settable_per_extruder": false
+                    "settable_per_extruder": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2013,6 +2013,29 @@
                     "value": "jerk_layer_0",
                     "enabled": "jerk_enabled",
                     "settable_per_mesh": false
+                },
+                "speed_for_pressure_enabled":
+                {
+                    "label": "Equalize Nozzle Pressure",
+                    "description": "Attempt to dampen nozzle pressure changes by varying printing speed with extrusion width for narrow extrusions",
+                    "type": "bool",
+                    "default_value": true,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
+                },
+                "speed_pressure_maximum":
+                {
+                    "label": "Maximum Speed for Pressure",
+                    "description": "Maximum print speed when adjusting to equalize nozzle pressure.",
+                    "type": "float",
+                    "unit": "mm/s",
+                    "enabled": "speed_for_pressure_enabled",
+                    "default_value": 150,
+                    "minimum_value": "0.1",
+                    "maximum_value": "299792458000",
+                    "maximum_value_warning": "150",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1577,6 +1577,29 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },
+                "speed_equalize_flow_enabled":
+                {
+                    "label": "Equalize Filament Flow",
+                    "description": "Print thinner than normal lines faster so that the amount of material extruded per second remains the same. Thin pieces in your model might require lines printed with smaller line width than provided in the settings. This setting controls the speed changes for such lines.",
+                    "type": "bool",
+                    "default_value": true,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
+                "speed_equalize_flow_max":
+                {
+                    "label": "Maximum Speed for Flow Equalization",
+                    "description": "Maximum print speed when adjusting the print speed in order to equalize flow.",
+                    "type": "float",
+                    "unit": "mm/s",
+                    "enabled": "speed_equalize_flow_enabled",
+                    "default_value": 150,
+                    "minimum_value": "0.1",
+                    "maximum_value": "299792458000",
+                    "maximum_value_warning": "150",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
 
 
                 "acceleration_enabled": {
@@ -2013,29 +2036,6 @@
                     "value": "jerk_layer_0",
                     "enabled": "jerk_enabled",
                     "settable_per_mesh": false
-                },
-                "speed_equalize_flow_enabled":
-                {
-                    "label": "Equalize Filament Flow",
-                    "description": "Print thinner than normal lines faster so that the amount of material extruded per second remains the same. Thin pieces in your model might require lines printed with smaller line width than provided in the settings. This setting controls the speed changes for such lines.",
-                    "type": "bool",
-                    "default_value": true,
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
-                },
-                "speed_equalize_flow_max":
-                {
-                    "label": "Maximum Speed for Flow Equalization",
-                    "description": "Maximum print speed when adjusting in order to equalize flow.",
-                    "type": "float",
-                    "unit": "mm/s",
-                    "enabled": "speed_equalize_flow_enabled",
-                    "default_value": 150,
-                    "minimum_value": "0.1",
-                    "maximum_value": "299792458000",
-                    "maximum_value_warning": "150",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
                 }
             }
         },


### PR DESCRIPTION
The settings are general enough to be used in other situations where Cura/CuraEngine may want to do autospeed computation.

These are the settings definitions that expose the settings introduced in Ultimaker/CuraEngine#376