### PR TITLE
Bugfix: Can't create shaders using Nvidia drivers on Linux Mint

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -61,7 +61,7 @@ numpy.seterr(all="ignore")
 #WORKAROUND: GITHUB-88 GITHUB-385 GITHUB-612
 if Platform.isLinux(): # Needed for platform.linux_distribution, which is not available on Windows and OSX
     # For Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
-    if platform.linux_distribution()[0] in ("Ubuntu", ): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
+    if platform.linux_distribution()[0] in ("Ubuntu", "LinuxMint"): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
         import ctypes
         from ctypes.util import find_library
         ctypes.CDLL(find_library('GL'), ctypes.RTLD_GLOBAL)

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -61,7 +61,7 @@ numpy.seterr(all="ignore")
 #WORKAROUND: GITHUB-88 GITHUB-385 GITHUB-612
 if Platform.isLinux(): # Needed for platform.linux_distribution, which is not available on Windows and OSX
     # For Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
-    if platform.linux_distribution()[0] in ("Ubuntu", "LinuxMint"): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
+    if platform.linux_distribution()[0] in ("Ubuntu", "LinuxMint", ): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
         import ctypes
         from ctypes.util import find_library
         ctypes.CDLL(find_library('GL'), ctypes.RTLD_GLOBAL)


### PR DESCRIPTION
Issue #88 is back again, this time on Linux Mint. This pull request adds it to the check in CuraApplication, which fixes the issue. Mint reports itself as "LinuxMint" in python, despite being an Ubuntu derivation.

I'm not all that good with Python, so I couldn't implement the more general fix suggested in the TODO comment.