### PR TITLE
Adding "approximately equal" to the amount of material needed

### DIFF
--- a/resources/qml/JobSpecs.qml
+++ b/resources/qml/JobSpecs.qml
@@ -209,7 +209,7 @@ Rectangle {
                         lengths = ["0.00"];
                         weights = ["0"];
                     }
-                    return catalog.i18nc("@label", "%1 m / %2 g").arg(lengths.join(" + ")).arg(weights.join(" + "));
+                    return catalog.i18nc("@label", "≈ %1 m / %2 g").arg(lengths.join(" + ")).arg(weights.join(" + "));
                 }
             }
         }

--- a/resources/qml/JobSpecs.qml
+++ b/resources/qml/JobSpecs.qml
@@ -209,7 +209,7 @@ Rectangle {
                         lengths = ["0.00"];
                         weights = ["0"];
                     }
-                    return catalog.i18nc("@label", "≈ %1 m / %2 g").arg(lengths.join(" + ")).arg(weights.join(" + "));
+                    return catalog.i18nc("@label", "%1 m / ~ %2 g").arg(lengths.join(" + ")).arg(weights.join(" + "));
                 }
             }
         }


### PR DESCRIPTION
I think it makes sense to add this character here, because the amount needed is only a approximated value, and without the end-user might expect a more accurate value.