### PR TITLE
[CURA-2079] Adding detailed error messages to firmware updater dialog

### DIFF
--- a/plugins/USBPrinting/FirmwareUpdateWindow.qml
+++ b/plugins/USBPrinting/FirmwareUpdateWindow.qml
@@ -37,6 +37,26 @@ UM.Dialog
                     //: Firmware update status label
                     return catalog.i18nc("@label","Firmware update completed.")
                 }
+                else if (manager.progress == -4)
+                {
+                    //: Firmware update status label
+                    return catalog.i18nc("@label","Firmware update failed due to missing firmware.")
+                }
+                else if (manager.progress == -3)
+                {
+                    //: Firmware update status label
+                    return catalog.i18nc("@label","Firmware update failed due to an input/output error.")
+                }
+                else if (manager.progress == -2)
+                {
+                    //: Firmware update status label
+                    return catalog.i18nc("@label","Firmware update failed due to an communication error.")
+                }
+                else if (manager.progress == -1)
+                {
+                    //: Firmware update status label
+                    return catalog.i18nc("@label","Firmware update failed due to an unknown error.")
+                }
                 else if (manager.progress == 0)
                 {
                     //: Firmware update status label

--- a/plugins/USBPrinting/FirmwareUpdateWindow.qml
+++ b/plugins/USBPrinting/FirmwareUpdateWindow.qml
@@ -32,7 +32,7 @@ UM.Dialog
             }
 
             text: {
-                if (manager.firmwareUpdateCompleteStatus)
+                if (manager.firmwareUpdateCompleteStatus && !manager.progress > 0)
                 {
                     //: Firmware update status label
                     return catalog.i18nc("@label","Firmware update completed.")

--- a/plugins/USBPrinting/FirmwareUpdateWindow.qml
+++ b/plugins/USBPrinting/FirmwareUpdateWindow.qml
@@ -32,40 +32,51 @@ UM.Dialog
             }
 
             text: {
-                if (manager.firmwareUpdateCompleteStatus && !manager.progress > 0)
+                if (manager.errorCode == 0)
                 {
-                    //: Firmware update status label
-                    return catalog.i18nc("@label","Firmware update completed.")
-                }
-                else if (manager.progress == -4)
+                    if (manager.firmwareUpdateCompleteStatus)
+                	{
+	                    //: Firmware update status label
+    	                return catalog.i18nc("@label","Firmware update completed.")
+        	        }
+        	        if (manager.progress == 0)
+                	{
+	                    //: Firmware update status label
+    	                return catalog.i18nc("@label","Starting firmware update, this may take a while.")
+                	}
+                	else
+                	{
+                    	//: Firmware update status label
+                    	return catalog.i18nc("@label","Updating firmware.")
+                    }
+        	    }
+                else 
                 {
-                    //: Firmware update status label
-                    return catalog.i18nc("@label","Firmware update failed due to missing firmware.")
-                }
-                else if (manager.progress == -3)
-                {
-                    //: Firmware update status label
-                    return catalog.i18nc("@label","Firmware update failed due to an input/output error.")
-                }
-                else if (manager.progress == -2)
-                {
-                    //: Firmware update status label
-                    return catalog.i18nc("@label","Firmware update failed due to an communication error.")
-                }
-                else if (manager.progress == -1)
-                {
-                    //: Firmware update status label
-                    return catalog.i18nc("@label","Firmware update failed due to an unknown error.")
-                }
-                else if (manager.progress == 0)
-                {
-                    //: Firmware update status label
-                    return catalog.i18nc("@label","Starting firmware update, this may take a while.")
-                }
-                else
-                {
-                    //: Firmware update status label
-                    return catalog.i18nc("@label","Updating firmware.")
+                	if (manager.errorCode == 1)
+                	{
+	                    //: Firmware update status label
+                    	return catalog.i18nc("@label","Firmware update failed due to an unknown error.")
+                	}
+                	else if (manager.errorCode == 2)
+                	{
+	                    //: Firmware update status label
+                    	return catalog.i18nc("@label","Firmware update failed due to an communication error.")
+                	}
+                	else if (manager.errorCode == 3)
+                	{
+	                    //: Firmware update status label
+                    	return catalog.i18nc("@label","Firmware update failed due to an input/output error.")
+                	}
+                	else if (manager.errorCode == 4)
+                	{
+	                    //: Firmware update status label
+                    	return catalog.i18nc("@label","Firmware update failed due to missing firmware.")
+                	}
+                	else
+                	{
+                    	//: Firmware update status label
+                    	return catalog.i18nc("@label", "Unknown error code: %1").arg(manager.errorCode)
+                    }
                 }
             }
 

--- a/plugins/USBPrinting/FirmwareUpdateWindow.qml
+++ b/plugins/USBPrinting/FirmwareUpdateWindow.qml
@@ -35,47 +35,45 @@ UM.Dialog
                 if (manager.errorCode == 0)
                 {
                     if (manager.firmwareUpdateCompleteStatus)
-                	{
-	                    //: Firmware update status label
-    	                return catalog.i18nc("@label","Firmware update completed.")
-        	        }
-        	        if (manager.progress == 0)
-                	{
-	                    //: Firmware update status label
-    	                return catalog.i18nc("@label","Starting firmware update, this may take a while.")
-                	}
-                	else
-                	{
-                    	//: Firmware update status label
-                    	return catalog.i18nc("@label","Updating firmware.")
+                    {
+                        //: Firmware update status label
+                        return catalog.i18nc("@label","Firmware update completed.")
                     }
-        	    }
+                    else if (manager.progress == 0)
+                    {
+                        //: Firmware update status label
+                        return catalog.i18nc("@label","Starting firmware update, this may take a while.")
+                    }
+                    else
+                    {
+                        //: Firmware update status label
+                        return catalog.i18nc("@label","Updating firmware.")
+                    }
+                }
                 else 
                 {
-                	if (manager.errorCode == 1)
-                	{
-	                    //: Firmware update status label
-                    	return catalog.i18nc("@label","Firmware update failed due to an unknown error.")
-                	}
-                	else if (manager.errorCode == 2)
-                	{
-	                    //: Firmware update status label
-                    	return catalog.i18nc("@label","Firmware update failed due to an communication error.")
-                	}
-                	else if (manager.errorCode == 3)
-                	{
-	                    //: Firmware update status label
-                    	return catalog.i18nc("@label","Firmware update failed due to an input/output error.")
-                	}
-                	else if (manager.errorCode == 4)
-                	{
-	                    //: Firmware update status label
-                    	return catalog.i18nc("@label","Firmware update failed due to missing firmware.")
-                	}
-                	else
-                	{
-                    	//: Firmware update status label
-                    	return catalog.i18nc("@label", "Unknown error code: %1").arg(manager.errorCode)
+                    switch (manager.errorCode)
+                    {
+                        case 1:
+                            //: Firmware update status label
+                            return catalog.i18nc("@label","Firmware update failed due to an unknown error.")
+
+                        case 2:
+                            //: Firmware update status label
+                            return catalog.i18nc("@label","Firmware update failed due to an communication error.")
+
+
+                        case 3:
+                            //: Firmware update status label
+                            return catalog.i18nc("@label","Firmware update failed due to an input/output error.")
+
+                        case 4:
+                            //: Firmware update status label
+                            return catalog.i18nc("@label","Firmware update failed due to missing firmware.")
+
+                        default:
+                            //: Firmware update status label
+                            return catalog.i18nc("@label", "Unknown error code: %1").arg(manager.errorCode)
                     }
                 }
             }

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -182,7 +182,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
 
         if len(hex_file) == 0:
             Logger.log("e", "Unable to read provided hex file. Could not update firmware")
-            self._updateFirmware_completed()
+            self._updateFirmware_completed_missing_firmware()
             return
 
         programmer = stk500v2.Stk500v2()
@@ -208,16 +208,39 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
             self._updating_firmware = False
         except Exception as e:
             Logger.log("e", "Exception while trying to update firmware %s" %e)
-            self._updateFirmware_completed()
+            self._updateFirmware_completed_unknown()
             return
         programmer.close()
 
         self._updateFirmware_completed()
         return
 
-    ##  Private function which makes sure that firmware update process has completed/ended
-    def _updateFirmware_completed(self):
-        self.setProgress(100, 100)
+    ##  Private function which makes sure that firmware update process has failed by missing firmware
+    def _updateFirmware_completed_missing_firmware(self):
+        return self._updateFirmware_common(progress = -4)
+    
+    ##  Private function which makes sure that firmware update process has failed by an IO error
+    def _updateFirmware_completed_io_error(self):
+        return self._updateFirmware_common(progress = -3)
+    
+    ##  Private function which makes sure that firmware update process has failed by a communication problem
+    def _updateFirmware_completed_communication_error(self):
+        return self._updateFirmware_common(progress = -2)
+    
+    ##  Private function which makes sure that firmware update process has failed by an unknown error
+    def _updateFirmware_completed_unknown(self):
+        return self._updateFirmware_common(progress = -1)
+    
+    ##  Private function which makes sure that firmware update process has sucessfully completed/ended
+    def _updateFirmware_completed_sucessfully(self):
+        return self._updateFirmware_common(progress = 100)
+    
+    ##  Private common function which makes sure that firmware update process has completed/ended with a set progress state
+    def _updateFirmware_completed_common(self, progress, max_progress = 100):
+        if not progress:
+            raise Exception("Progresss not set!")
+        
+        self.setProgress(progress, max_progress = max_progress)
         self._firmware_update_finished = True
         self.resetFirmwareUpdate(update_has_finished=True)
         self.firmwareUpdateComplete.emit()

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -242,7 +242,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
     ##  Private common function which makes sure that firmware update process has completed/ended with a set progress state
     def _updateFirmware_completed_common(self, progress, max_progress = 100):
         if not progress:
-            raise Exception("Progresss not set!")
+            raise Exception("Progress not set!")
         
         self.setProgress(progress, max_progress = max_progress)
         self._firmware_update_finished = True

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -14,7 +14,7 @@ from UM.Logger import Logger
 from cura.PrinterOutputDevice import PrinterOutputDevice, ConnectionState
 from UM.Message import Message
 
-from PyQt5.QtCore import QUrl, pyqtSlot, pyqtSignal
+from PyQt5.QtCore import QUrl, pyqtSlot, pyqtSignal, pyqtProperty
 
 from UM.i18n import i18nCatalog
 catalog = i18nCatalog("cura")
@@ -173,6 +173,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
 
     ##  Private function (threaded) that actually uploads the firmware.
     def _updateFirmware(self):
+        self._errorCode = 0
         self.setProgress(0, 100)
         self._firmware_update_finished = False
 
@@ -198,7 +199,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
 
         if not programmer.isConnected():
             Logger.log("e", "Unable to connect with serial. Could not update firmware")
-            self._updateFirmware_completed_communication_error()
+            self._updateFirmware_failed_communication_error()
             return 
 
         self._updating_firmware = True
@@ -208,11 +209,11 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
             self._updating_firmware = False
         except serial.SerialException as e:
             Logger.log("e", "SerialException while trying to update firmware: <%s>" %(repr(e)))
-            self._updateFirmware_completed_io_error()
+            self._updateFirmware_failed_io_error()
             return
         except Exception as e:
             Logger.log("e", "Exception while trying to update firmware: <%s>" %(repr(e)))
-            self._updateFirmware_completed_unknown()
+            self._updateFirmware_failed_unknown()
             return
         programmer.close()
 
@@ -220,35 +221,42 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
         return
 
     ##  Private function which makes sure that firmware update process has failed by missing firmware
-    def _updateFirmware_completed_missing_firmware(self):
-        return self._updateFirmware_completed_common(progress = -4)
+    def _updateFirmware_failed_missing_firmware(self):
+        return self._updateFirmware_failed_common(4)
     
     ##  Private function which makes sure that firmware update process has failed by an IO error
-    def _updateFirmware_completed_io_error(self):
-        return self._updateFirmware_completed_common(progress = -3)
+    def _updateFirmware_failed_io_error(self):
+        return self._updateFirmware_failed_common(3)
     
     ##  Private function which makes sure that firmware update process has failed by a communication problem
-    def _updateFirmware_completed_communication_error(self):
-        return self._updateFirmware_completed_common(progress = -2)
+    def _updateFirmware_failed_communication_error(self):
+        return self._updateFirmware_failed_common(2)
     
     ##  Private function which makes sure that firmware update process has failed by an unknown error
-    def _updateFirmware_completed_unknown(self):
-        return self._updateFirmware_completed_common(progress = -1)
+    def _updateFirmware_failed_unknown(self):
+        return self._updateFirmware_failed_common(1)
     
-    ##  Private function which makes sure that firmware update process has sucessfully completed/ended
+    ##  Private function which makes sure that firmware update process has successfully completed
     def _updateFirmware_completed_sucessfully(self):
-        return self._updateFirmware_completed_common(progress = 100)
-    
-    ##  Private common function which makes sure that firmware update process has completed/ended with a set progress state
-    def _updateFirmware_completed_common(self, progress, max_progress = 100):
-        if not progress:
-            raise Exception("Progress not set!")
-        
-        self.setProgress(progress, max_progress = max_progress)
+        self.setProgress(100, 100)
         self._firmware_update_finished = True
-        self.resetFirmwareUpdate(update_has_finished=True)
+        self.resetFirmwareUpdate(update_has_finished = True)
         self.firmwareUpdateComplete.emit()
-        
+
+        return
+
+    ##  Private common function which makes sure that firmware update process has completed/ended with a set progress state
+    def _updateFirmware_failed_common(self, code):
+        if not code:
+            raise Exception("Error code not set!")
+
+        self._errorCode = code
+
+        self._firmware_update_finished = True
+        self.resetFirmwareUpdate(update_has_finished = True)
+        self.progressChanged.emit()
+        self.firmwareUpdateComplete.emit()
+
         return
 
     ##  Upload new firmware to machine

--- a/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
+++ b/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
@@ -38,8 +38,6 @@ class USBPrinterOutputDeviceManager(QObject, OutputDevicePlugin, Extension):
         self._update_thread = threading.Thread(target = self._updateThread)
         self._update_thread.setDaemon(True)
 
-        self._errorCode = 0
-
         self._check_updates = True
         self._firmware_view = None
 
@@ -61,7 +59,10 @@ class USBPrinterOutputDeviceManager(QObject, OutputDevicePlugin, Extension):
 
     @pyqtProperty(int, notify = progressChanged)
     def errorCode(self):
-        return self._errorCode
+        for printer_name, device in self._usb_output_devices.items(): # TODO: @UnusedVariable "printer_name"
+            if device._error_code:
+                return device._error_code
+        return 0
 
     ##  Return True if all printers finished firmware update
     @pyqtProperty(float, notify = firmwareUpdateChange)

--- a/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
+++ b/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
@@ -38,6 +38,8 @@ class USBPrinterOutputDeviceManager(QObject, OutputDevicePlugin, Extension):
         self._update_thread = threading.Thread(target = self._updateThread)
         self._update_thread.setDaemon(True)
 
+        self._errorCode = 0
+
         self._check_updates = True
         self._firmware_view = None
 
@@ -56,6 +58,10 @@ class USBPrinterOutputDeviceManager(QObject, OutputDevicePlugin, Extension):
         for printer_name, device in self._usb_output_devices.items(): # TODO: @UnusedVariable "printer_name"
             progress += device.progress
         return progress / len(self._usb_output_devices)
+
+    @pyqtProperty(int, notify = progressChanged)
+    def errorCode(self):
+        return self._errorCode
 
     ##  Return True if all printers finished firmware update
     @pyqtProperty(float, notify = firmwareUpdateChange)


### PR DESCRIPTION
Just read https://github.com/Ultimaker/Cura/commit/0435706736b165cbb83b9a58c09dbc5ce2b21f06
and take a look at the code.

Short: Added different error messages, which appear whenever a exception was catched.