### PR TITLE
Update Innovo Inventor JSON and STL files

### DIFF
--- a/resources/machines/innovo-inventor.json
+++ b/resources/machines/innovo-inventor.json
@@ -13,7 +13,7 @@
         "machine_height": {"default": 290},
         "machine_depth": {"default": 300},
         "machine_heated_bed": { "default": true},
-        "machine_center_is_zero": {"default": false},
+        "machine_center_is_zero": {"default": true},
         "machine_nozzle_size": {"default": 0.4},
         "machine_head_shape_min_x": {"default": 43.7},
         "machine_head_shape_min_y": {"default": 19.2},
@@ -24,16 +24,16 @@
         "machine_nozzle_offset_y_1": {"default": 15},
         "machine_gcode_flavor": {"default": "RepRap (Marlin/Sprinter)"},
         "machine_start_gcode": {"default": "G28 ; Home extruder\nM107 ; Turn off fan\nG90 ; Absolute positioning\nM82 ; Extruder in absolute mode\n{IF_BED}M190 S{BED}\n{IF_EXT0}M104 T0 S{TEMP0}\n{IF_EXT0}M109 T0 S{TEMP0}\n{IF_EXT1}M104 T1 S{TEMP1}\n{IF_EXT1}M109 T1 S{TEMP1}\nG32 S3 ; auto level\nG92 E0 ; Reset extruder position"},
-        "machine_end_gcode": {"default": "M104 S0\nG91 ; relative positioning\nG1 E-2 F5000; retract 2mm\nG28 Z; move bed down\nG90 ; absolute positioning\nM84   ; disable motors"},
+        "machine_end_gcode": {"default": "M104 S0\nM140 S0 ; heated bed heater off\nG91 ; relative positioning\nG1 E-2 F5000; retract 2mm\nG28 Z; move bed down\nG90 ; absolute positioning\nM84   ; disable motors"},
         "machine_platform_offset": {"default": [-180, -0.25, 160]}
     },
 
     "overrides": {
         "layer_height": { "default": 0.15},
         "wall_thickness": { "default": 0.8},
-        "top_bottom_thickness": { "default": 0.3, "visible": true},
+        "top_bottom_thickness": { "default": 1.2, "visible": true},
         "material_print_temperature": { "default": 215, "visible": true},
-        "material_bed_temperature": { "default": 60, "visible": true},
+        "material_bed_temperature": { "default": 0, "visible": true},
         "material_diameter": { "default": 1.75, "visible": true},
         "retraction_enable": { "default": true, "always_visible": true},
         "retraction_speed": { "default": 50.0, "visible": false},
@@ -45,5 +45,10 @@
         "speed_travel": { "default": 150.0, "visible": true},
         "speed_layer_0": { "min_value": "0.1", "default": 30.0, "visible": true},
         "infill_overlap": { "default": 10.0}
+    },
+        
+    "machine_preferences": {
+        "prefered_profile": "Normal Quality",
+        "prefered_material": "PLA"
     }
 }


### PR DESCRIPTION
Made some changes to the Inventor JSON file:
- made machine center is zero true
- added turn heated bed off to end g code
- changed top/bottom thickness from 0.30mm to 1.2mm (don’t know why I
put it to 0.3 in the first place!!)
- changed material bed temp to 0 by default

As for the STL file, it’s been updated to a much smaller file, 810kb
(down from 13mb).  I thought I updated this before but apparently not.

I hope this update can be merged soon, because I plan on launching a
makerspace with these printers and everyone will be using Cura so they
need these settings