### PR TITLE
Use ListModel.setItems() instead of appending one item at a time

### DIFF
--- a/cura/Settings/ContainerSettingsModel.py
+++ b/cura/Settings/ContainerSettingsModel.py
@@ -31,7 +31,7 @@ class ContainerSettingsModel(ListModel):
             self._update()
 
     def _update(self):
-        self.clear()
+        items = []
 
         if len(self._container_ids) == 0:
             return
@@ -64,14 +64,15 @@ class ContainerSettingsModel(ListModel):
                 else:
                     values.append("")
 
-            self.appendItem({
+            items.append({
                 "key": key,
                 "values": values,
                 "label": definition.label,
                 "unit": definition.unit,
                 "category": category.label
             })
-        self.sort(lambda k: (k["category"], k["key"]))
+        items.sort(key = lambda k: (k["category"], k["key"]))
+        self.setItems(items)
 
     ##  Set the ids of the containers which have the settings this model should list.
     #   Also makes sure the model updates when the containers have property changes

--- a/cura/Settings/ExtrudersModel.py
+++ b/cura/Settings/ExtrudersModel.py
@@ -97,8 +97,9 @@ class ExtrudersModel(UM.Qt.ListModel.ListModel):
         changed = False
 
         if self.rowCount() != 0:
-            self.clear()
             changed = True
+
+        items = []
 
         global_container_stack = UM.Application.getInstance().getGlobalContainerStack()
         if global_container_stack:
@@ -111,7 +112,7 @@ class ExtrudersModel(UM.Qt.ListModel.ListModel):
                     "color": color,
                     "index": -1
                 }
-                self.appendItem(item)
+                items.append(item)
                 changed = True
 
             manager = ExtruderManager.getInstance()
@@ -133,9 +134,10 @@ class ExtrudersModel(UM.Qt.ListModel.ListModel):
                     "color": color,
                     "index": position
                 }
-                self.appendItem(item)
+                items.append(item)
                 changed = True
 
         if changed:
-            self.sort(lambda item: item["index"])
+            items.sort(key = lambda i: i["index"])
+            self.setItems(items)
             self.modelChanged.emit()

--- a/cura/Settings/QualitySettingsModel.py
+++ b/cura/Settings/QualitySettingsModel.py
@@ -70,7 +70,7 @@ class QualitySettingsModel(UM.Qt.ListModel.ListModel):
         if not self._quality:
             return
 
-        self.clear()
+        items = []
 
         settings = collections.OrderedDict()
         definition_container = UM.Application.getInstance().getGlobalContainerStack().getBottom()
@@ -163,7 +163,7 @@ class QualitySettingsModel(UM.Qt.ListModel.ListModel):
             if not profile_value and not user_value:
                 continue
 
-            self.appendItem({
+            items.append({
                 "key": definition.key,
                 "label": definition.label,
                 "unit": definition.unit,
@@ -171,3 +171,5 @@ class QualitySettingsModel(UM.Qt.ListModel.ListModel):
                 "user_value": "" if user_value is None else str(user_value),
                 "category": current_category
             })
+
+        self.setItems(items)


### PR DESCRIPTION
setItems sets the items to a (presorted) list of items instead of adding items one by one and then sorting the list. This way if an update to the model causes a signal storm at least it happens only once for an update.

Specifically this reduces switching to a dual extrusion printer by half.

Requires https://github.com/Ultimaker/Uranium/pull/163
Contributes to CURA-2193