### PR TITLE
CURA-2157: Adding an confirmation dialog

### DIFF
--- a/resources/qml/MonitorButton.qml
+++ b/resources/qml/MonitorButton.qml
@@ -4,6 +4,7 @@
 import QtQuick 2.2
 import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles 1.1
+import QtQuick.Dialogs 1.1
 import QtQuick.Layouts 1.1
 
 import UM 1.1 as UM
@@ -160,7 +161,7 @@ Rectangle
         anchors.rightMargin: UM.Theme.getSize("default_margin").width
 
         text: catalog.i18nc("@label:", "Abort Print")
-        onClicked: Cura.MachineManager.printerOutputDevices[0].setJobState("abort")
+        onClicked: confirmationDialog.visible = true
 
         style: ButtonStyle
         {
@@ -214,6 +215,18 @@ Rectangle
             }
         label: Item { }
         }
+    }
+
+    MessageDialog
+    {
+        id: confirmationDialog
+
+        title: catalog.i18nc("@text:MessageDialog", "Abort print")
+        icon: StandardIcon.Warning
+        text: catalog.i18nc("@text:MessageDialog", "Do you really want to abort the print?")
+        standardButtons: StandardButton.Yes | StandardButton.No
+        Component.onCompleted: visible = false
+        onYes: Cura.MachineManager.printerOutputDevices[0].setJobState("abort")
     }
 
     Button


### PR DESCRIPTION
Tested while starting two prints and aborting them. The buttons for
"Yes" and "No" are translated by Qt5.