### PR TITLE
Speed up switching between multiextrusion machines

### DIFF
--- a/cura/Settings/ExtrudersModel.py
+++ b/cura/Settings/ExtrudersModel.py
@@ -52,7 +52,7 @@ class ExtrudersModel(UM.Qt.ListModel.ListModel):
 
         #Listen to changes.
         manager = ExtruderManager.getInstance()
-        manager.extrudersChanged.connect(self._updateExtruders) #When the list of extruders changes in general.
+        manager.globalContainerStackDefinitionChanged.connect(self._updateExtruders) #When the global stack changes to a printer with different extruders.
 
         self._updateExtruders()
 


### PR DESCRIPTION
ExtruderManager.addMachineExtruders is supposed to create a cache, but this cache was always rebuilt because of an indentation error.

This PR does a little refactoring on behavior that had grown because of the error; ExtrudersModel should not respond to the cache being rebuilt, but instead it should respond to when the global containerstack changes to a definition with different extruders.

I came across this when trying to figure out why the ExtrudersModel did not reset when selecting a single extrusion printer after selecting a multiextrusion printer. That is because for single extrusion printers the code was correctly using the cache, which resulted in not updating the ExtrudersModel.

This is in a PR because there is a non-negligible regression hazard, and there is no issue for it.