### PR TITLE
[CURA-1445] SliceInfo: Using HTTPS again

### DIFF
--- a/plugins/SliceInfoPlugin/SliceInfo.py
+++ b/plugins/SliceInfoPlugin/SliceInfo.py
@@ -61,7 +61,7 @@ class SliceInfoJob(Job):
 #       The data is only sent when the user in question gave permission to do so. All data is anonymous and
 #       no model files are being sent (Just a SHA256 hash of the model).
 class SliceInfo(Extension):
-    info_url = "http://stats.youmagine.com/curastats/slice"
+    info_url = "https://stats.youmagine.com/curastats/slice"
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
The problem seems to be related to our HTTP(S) server.
It is expected that the problem will be solved after the weekend.

Contributes to CURA-1445