### PR TITLE
SliceInfo: Defining container_serialized as empty, before trying to s…

### DIFF
--- a/plugins/SliceInfoPlugin/SliceInfo.py
+++ b/plugins/SliceInfoPlugin/SliceInfo.py
@@ -119,6 +119,7 @@ class SliceInfo(Extension):
             }
             for container in global_container_stack.getContainers():
                 container_id = container.getId()
+                container_serialized = ""
                 try:
                     container_serialized = container.serialize()
                 except NotImplementedError:


### PR DESCRIPTION
…erialize

While discussing with Jordy about the code I just found a problematic case where sending slice info could fail.
(This shouldn't happen, but..) If the first container is not serializable, then the for-loop will crash because container_serialized is not set for the if clause.
Additionally the if-clause is at the moment useless, because it is always true, because the content of container_serialized gets never resetted.

Contributes to CURA-1445