### PR TITLE
[CURA-1445] Sending bundle of serialized data

### DIFF
--- a/plugins/SliceInfoPlugin/SliceInfo.py
+++ b/plugins/SliceInfoPlugin/SliceInfo.py
@@ -109,7 +109,6 @@ class SliceInfo(Extension):
             containers = { "": global_container_stack.serialize() }
             for container in global_container_stack.getContainers():
                 container_id = container.getId()
-                container_serialized = ""
                 try:
                     container_serialized = container.serialize()
                 except NotImplementedError:


### PR DESCRIPTION
After an discussion with the developers at YM, we decided to send all data in one keyword.
So now all data is bundled into a JSON dictionary, where "" is the global_container_stack and it's containers go into the same JSON, too, by using their IDs as keywords.
More on JIRA...

Contributes to CURA-1445

Includes/Fixes #1013