### PR TITLE
Revert "global_profile" reference changes while refixing import

### DIFF
--- a/cura/QualityManager.py
+++ b/cura/QualityManager.py
@@ -44,9 +44,6 @@ class QualityManager:
         criteria = {"type": "quality_changes", "name": quality_changes_name}
         result = self._getFilteredContainersForStack(machine_definition, [], **criteria)
 
-        criteria = {"type": "quality_changes", "global_profile": quality_changes_name}
-        result.extend(self._getFilteredContainersForStack(machine_definition, [], **criteria))
-
         return result
 
     ##  Fetch the list of available quality types for this combination of machine definition and materials.

--- a/cura/Settings/QualitySettingsModel.py
+++ b/cura/Settings/QualitySettingsModel.py
@@ -154,7 +154,7 @@ class QualitySettingsModel(UM.Qt.ListModel.ListModel):
             criteria = {"type": "quality_changes", "quality_type": quality_type, "definition": definition_id, "name": quality_changes_container.getName()}
             if self._extruder_definition_id != "":
                 criteria["extruder"] = self._extruder_definition_id
-                criteria["name"] = "%s_%s" % (self._extruder_definition_id, quality_changes_container.getName())
+                criteria["name"] = quality_changes_container.getName()
             else:
                 criteria["extruder"] = None
 


### PR DESCRIPTION
This is a reimplementation of some problems I tried to fix by introducing a "global_profile" metadata entry on quality_changes profiles. In this PR I revert to the way @sedwards2009 implemented profiles (because I did not fully understand it before but it makes more sense to me now)

CURA-2518 and CURA-2478