### PR TITLE
Fix slow writing of gcode files to some usb sticks

### DIFF
--- a/plugins/GCodeWriter/GCodeWriter.py
+++ b/plugins/GCodeWriter/GCodeWriter.py
@@ -54,8 +54,7 @@ class GCodeWriter(MeshWriter):
         scene = Application.getInstance().getController().getScene()
         gcode_list = getattr(scene, "gcode_list")
         if gcode_list:
-            for gcode in gcode_list:
-                stream.write(gcode)
+            stream.write("\n".join(gcode_list))
             # Serialise the current container stack and put it at the end of the file.
             settings = self._serialiseSettings(Application.getInstance().getGlobalContainerStack())
             stream.write(settings)


### PR DESCRIPTION
The GCodeWriter writes to the USB drive line by line. On some USB drives this causes writing to take multiple minutes to write a file that takes tens of seconds on other USB drives. Writing the whole gcode string at once greatly reduces the total write-time.

CURA-2544