### PR TITLE
Show the warning color for unsupported materials/qualities

### DIFF
--- a/cura/QualityManager.py
+++ b/cura/QualityManager.py
@@ -20,9 +20,6 @@ class QualityManager:
 
     __instance = None
 
-    def __init__(self):
-        self._empty_quality_container = UM.Settings.ContainerRegistry.getInstance().findInstanceContainers(id = "empty_quality")[0]
-
     ##  Find a quality by name for a specific machine definition and materials.
     #
     #   \param quality_name
@@ -96,7 +93,7 @@ class QualityManager:
             basic_materials = self._getBasicMaterials(material_containers[0])
             result = self._getFilteredContainersForStack(machine_definition, basic_materials, **criteria)
 
-        return result[0] if result else self._empty_quality_container
+        return result[0] if result else None
 
     ##  Find all suitable qualities for a combination of machine and material.
     #
@@ -109,9 +106,6 @@ class QualityManager:
         if not result:
             basic_materials = self._getBasicMaterials(material_container)
             result = self._getFilteredContainersForStack(machine_definition, basic_materials, **criteria)
-
-        if not result:
-            result = [ self._empty_quality_container ]
 
         return result
 

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -3,6 +3,7 @@
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtProperty, pyqtSignal
 from PyQt5.QtWidgets import QMessageBox
+from UM import Util
 
 from UM.Application import Application
 from UM.Preferences import Preferences
@@ -503,6 +504,14 @@ class MachineManager(QObject):
                 return quality.getMetaDataEntry("quality_type")
         return ""
 
+    @pyqtProperty(bool, notify = activeQualityChanged)
+    def isActiveQualitySupported(self):
+        if self._active_container_stack:
+            quality = self._active_container_stack.findContainer(type = "quality")
+            if quality:
+                return Util.parseBool(quality.getMetaDataEntry("supported", True))
+        return ""
+
     ##  Get the Quality ID associated with the currently active extruder
     #   Note that this only returns the "quality", not the "quality_changes"
     #   \returns QualityID (string) if found, empty string otherwise
@@ -512,7 +521,7 @@ class MachineManager(QObject):
     @pyqtProperty(str, notify = activeQualityChanged)
     def activeQualityContainerId(self):
         # We're using the active stack instead of the global stack in case the list of qualities differs per extruder
-        if self._active_container_stack:
+        if self._global_container_stack:
             quality = self._active_container_stack.findContainer(type = "quality")
             if quality:
                 return quality.getId()

--- a/cura/Settings/QualitySettingsModel.py
+++ b/cura/Settings/QualitySettingsModel.py
@@ -120,11 +120,7 @@ class QualitySettingsModel(UM.Qt.ListModel.ListModel):
             quality_container = quality_container[0]
 
         quality_type = quality_container.getMetaDataEntry("quality_type")
-        definition = quality_container.getDefinition()
-        if definition:
-            definition_id = definition.getId()
-        else:
-            definition_id = "empty_quality"
+        definition_id = quality_container.getDefinition().getId()
 
         criteria = {"type": "quality", "quality_type": quality_type, "definition": definition_id}
 

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -137,7 +137,7 @@ Item
     Action
     {
         id: addProfileAction;
-        enabled: Cura.MachineManager.isActiveStackValid && Cura.MachineManager.hasUserSettings && Cura.MachineManager.activeQualityId != "empty_quality"
+        enabled: Cura.MachineManager.isActiveStackValid && Cura.MachineManager.hasUserSettings
         text: catalog.i18nc("@action:inmenu menubar:profile","&Create profile from current settings...");
     }
 

--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -62,7 +62,7 @@ UM.ManagementPage
         Button
         {
             text: catalog.i18nc("@label", "Create")
-            enabled: base.canCreateProfile() && Cura.MachineManager.activeQualityId != "empty_quality"
+            enabled: base.canCreateProfile()
             visible: base.canCreateProfile()
             iconName: "list-add";
 
@@ -78,7 +78,7 @@ UM.ManagementPage
         Button
         {
             text: catalog.i18nc("@label", "Duplicate")
-            enabled: ! base.canCreateProfile() && Cura.MachineManager.activeQualityId != "empty_quality"
+            enabled: ! base.canCreateProfile()
             visible: ! base.canCreateProfile()
             iconName: "list-add";
 

--- a/resources/qml/SidebarHeader.qml
+++ b/resources/qml/SidebarHeader.qml
@@ -244,7 +244,7 @@ Column
                     }
 
                 }
-                property var valueWarning: Cura.MachineManager.activeQualityContainerId == "empty_quality"
+                property var valueWarning: ! Cura.MachineManager.isActiveQualitySupported
 
                 enabled: !extrudersList.visible || base.currentExtruderIndex  > -1
 
@@ -292,7 +292,7 @@ Column
             height: UM.Theme.getSize("setting_control").height
             tooltip: Cura.MachineManager.activeQualityName
             style: UM.Theme.styles.sidebar_header_button
-            property var valueWarning: Cura.MachineManager.activeQualityId == "empty_quality"
+            property var valueWarning: ! Cura.MachineManager.isActiveQualitySupported
             menu: ProfileMenu { }
 
             UM.SimpleButton


### PR DESCRIPTION
Show the warning color for unsupported materials/qualities by using the new 'supported' metadata flag which is read from the quality profile.

CURA-2271
