### PR TITLE
Only reset the setting for the currently selected extruder.

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -387,7 +387,8 @@ class MachineManager(QObject):
         top_container.removeInstance(key, postpone_emit=True)
         send_emits_containers.append(top_container)
 
-        for stack in ExtruderManager.getInstance().getMachineExtruders(self._global_container_stack.getId()):
+        stack = ExtruderManager.getInstance().getActiveExtruderStack()
+        if stack:
             container = stack.getTop()
             container.removeInstance(key, postpone_emit=True)
             send_emits_containers.append(container)

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -387,8 +387,16 @@ class MachineManager(QObject):
         top_container.removeInstance(key, postpone_emit=True)
         send_emits_containers.append(top_container)
 
-        stack = ExtruderManager.getInstance().getActiveExtruderStack()
-        if stack:
+        linked = not self._global_container_stack.getProperty(key, "settable_per_extruder") or \
+                      self._global_container_stack.getProperty(key, "limit_to_extruder") != "-1"
+
+        if not linked:
+            stack = ExtruderManager.getInstance().getActiveExtruderStack()
+            stacks = [stack]
+        else:
+            stacks = ExtruderManager.getInstance().getMachineExtruders(self._global_container_stack.getId())
+
+        for stack in stacks:
             container = stack.getTop()
             container.removeInstance(key, postpone_emit=True)
             send_emits_containers.append(container)


### PR DESCRIPTION
When clicking on the little revert arrow for a setting in the UI, it reverts the setting for all extruders not just the one which is currently selected. This PR fixes this and just changes the current extruder.

CURA-2640 Restore to default not per extruder