### PR TITLE
Remove duplicate translations causing failure to build on Linux

### DIFF
--- a/resources/i18n/de/cura.po
+++ b/resources/i18n/de/cura.po
@@ -2295,39 +2295,10 @@ msgid ""
 "Click to open the profile manager."
 msgstr "Einige Einstellungswerte unterscheiden sich von den im Profil gespeicherten Werten.\n\nKlicken Sie, um den Profilmanager zu öffnen."
 
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:24
-msgid "Modify G-Code"
-msgstr "G-Code ändern"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:12
-msgctxt "@label"
-msgid "Post Processing"
-msgstr "Nachbearbeitung"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:16
-msgctxt "Description of plugin"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr "Erweiterung, die eine Nachbearbeitung von Skripten ermöglicht, die von Benutzern erstellt wurden."
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:18
-msgctxt "@title:window"
-msgid "Post Processing Plugin"
-msgstr "Plugin Nachbearbeitung"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:49
-msgctxt "@label"
-msgid "Post Processing Scripts"
-msgstr "Skripts Nachbearbeitung"
-
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:218
 msgctxt "@action"
 msgid "Add a script"
 msgstr "Ein Skript hinzufügen"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:264
-msgctxt "@label"
-msgid "Settings"
-msgstr "Einstellungen"
 
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:456
 msgctxt "@info:tooltip"

--- a/resources/i18n/es/cura.po
+++ b/resources/i18n/es/cura.po
@@ -2295,39 +2295,10 @@ msgid ""
 "Click to open the profile manager."
 msgstr "Algunos valores son distintos de los valores almacenados en el perfil.\n\nHaga clic para abrir el administrador de perfiles."
 
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:24
-msgid "Modify G-Code"
-msgstr "Modificar GCode"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:12
-msgctxt "@label"
-msgid "Post Processing"
-msgstr "Posprocesamiento"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:16
-msgctxt "Description of plugin"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr "Extensión que permite el posprocesamiento de las secuencias de comandos creadas por los usuarios."
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:18
-msgctxt "@title:window"
-msgid "Post Processing Plugin"
-msgstr "Complemento de posprocesamiento"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:49
-msgctxt "@label"
-msgid "Post Processing Scripts"
-msgstr "Secuencias de comandos de posprocesamiento"
-
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:218
 msgctxt "@action"
 msgid "Add a script"
 msgstr "Añadir secuencia de comando"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:264
-msgctxt "@label"
-msgid "Settings"
-msgstr "Ajustes"
 
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:456
 msgctxt "@info:tooltip"

--- a/resources/i18n/fi/cura.po
+++ b/resources/i18n/fi/cura.po
@@ -2295,39 +2295,10 @@ msgid ""
 "Click to open the profile manager."
 msgstr "Jotkut asetusten arvot eroavat profiiliin tallennetuista arvoista.\n\nAvaa profiilin hallinta napsauttamalla."
 
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:24
-msgid "Modify G-Code"
-msgstr "Muokkaa GCode-arvoa"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:12
-msgctxt "@label"
-msgid "Post Processing"
-msgstr "Jälkikäsittely"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:16
-msgctxt "Description of plugin"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr "Lisäosa, jonka avulla käyttäjät voivat luoda komentosarjoja jälkikäsittelyä varten"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:18
-msgctxt "@title:window"
-msgid "Post Processing Plugin"
-msgstr "Jälkikäsittelylisäosa"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:49
-msgctxt "@label"
-msgid "Post Processing Scripts"
-msgstr "Jälkikäsittelykomentosarjat"
-
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:218
 msgctxt "@action"
 msgid "Add a script"
 msgstr "Lisää komentosarja"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:264
-msgctxt "@label"
-msgid "Settings"
-msgstr "Asetukset"
 
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:456
 msgctxt "@info:tooltip"

--- a/resources/i18n/fr/cura.po
+++ b/resources/i18n/fr/cura.po
@@ -2295,39 +2295,10 @@ msgid ""
 "Click to open the profile manager."
 msgstr "Certaines valeurs de paramètre sont différentes des valeurs enregistrées dans le profil.\n\nCliquez pour ouvrir le gestionnaire de profils."
 
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:24
-msgid "Modify G-Code"
-msgstr "Modifier le G-Code"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:12
-msgctxt "@label"
-msgid "Post Processing"
-msgstr "Post-traitement"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:16
-msgctxt "Description of plugin"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr "Extension qui permet le post-traitement des scripts créés par l'utilisateur"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:18
-msgctxt "@title:window"
-msgid "Post Processing Plugin"
-msgstr "Plug-in de post-traitement"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:49
-msgctxt "@label"
-msgid "Post Processing Scripts"
-msgstr "Scripts de post-traitement"
-
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:218
 msgctxt "@action"
 msgid "Add a script"
 msgstr "Ajouter un script"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:264
-msgctxt "@label"
-msgid "Settings"
-msgstr "Paramètres"
 
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:456
 msgctxt "@info:tooltip"

--- a/resources/i18n/it/cura.po
+++ b/resources/i18n/it/cura.po
@@ -2295,39 +2295,10 @@ msgid ""
 "Click to open the profile manager."
 msgstr "Alcuni valori di impostazione sono diversi dai valori memorizzati nel profilo.\n\nFare clic per aprire la gestione profili."
 
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:24
-msgid "Modify G-Code"
-msgstr "Modifica il codice G"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:12
-msgctxt "@label"
-msgid "Post Processing"
-msgstr "Post-elaborazione"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:16
-msgctxt "Description of plugin"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr "Estensione che consente la post-elaborazione degli script creati da utente"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:18
-msgctxt "@title:window"
-msgid "Post Processing Plugin"
-msgstr "Plug-in di post-elaborazione"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:49
-msgctxt "@label"
-msgid "Post Processing Scripts"
-msgstr "Script di post-elaborazione"
-
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:218
 msgctxt "@action"
 msgid "Add a script"
 msgstr "Aggiungi uno script"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:264
-msgctxt "@label"
-msgid "Settings"
-msgstr "Impostazioni"
 
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:456
 msgctxt "@info:tooltip"

--- a/resources/i18n/nl/cura.po
+++ b/resources/i18n/nl/cura.po
@@ -2295,39 +2295,10 @@ msgid ""
 "Click to open the profile manager."
 msgstr "Sommige instellingswaarden zijn anders dan de waarden die in het profiel zijn opgeslagen.\n\nKlik om het profielbeheer te openen."
 
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:24
-msgid "Modify G-Code"
-msgstr "G-code wijzigen"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:12
-msgctxt "@label"
-msgid "Post Processing"
-msgstr "Nabewerken"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:16
-msgctxt "Description of plugin"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr "Uitbreiding waarmee door de gebruiker gemaakte scripts voor nabewerking kunnen worden gebruikt"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:18
-msgctxt "@title:window"
-msgid "Post Processing Plugin"
-msgstr "Invoegtoepassing voor nabewerking"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:49
-msgctxt "@label"
-msgid "Post Processing Scripts"
-msgstr "Scripts voor nabewerking"
-
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:218
 msgctxt "@action"
 msgid "Add a script"
 msgstr "Een script toevoegen"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:264
-msgctxt "@label"
-msgid "Settings"
-msgstr "Instellingen"
 
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:456
 msgctxt "@info:tooltip"

--- a/resources/i18n/tr/cura.po
+++ b/resources/i18n/tr/cura.po
@@ -2295,39 +2295,10 @@ msgid ""
 "Click to open the profile manager."
 msgstr "Bazı ayar değerleri profilinizde saklanan değerlerden farklıdır.\n\nProfil yöneticisini açmak için tıklayın."
 
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:24
-msgid "Modify G-Code"
-msgstr "GCode Değiştir"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:12
-msgctxt "@label"
-msgid "Post Processing"
-msgstr "Son İşleme"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/__init__.py:16
-msgctxt "Description of plugin"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr "Kullanıcının oluşturduğu komut dosyalarına son işleme için izin veren uzantı"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:18
-msgctxt "@title:window"
-msgid "Post Processing Plugin"
-msgstr "Son İşleme Uzantısı"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:49
-msgctxt "@label"
-msgid "Post Processing Scripts"
-msgstr "Son İşleme Dosyaları"
-
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:218
 msgctxt "@action"
 msgid "Add a script"
 msgstr "Dosya ekle"
-
-#: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:264
-msgctxt "@label"
-msgid "Settings"
-msgstr "Ayarlar"
 
 #: /home/ruben/Projects/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:456
 msgctxt "@info:tooltip"


### PR DESCRIPTION
All of these lines exist higher in the file, and cause msgfmt to error out when building.