### PR TITLE
Use Global quality profiles for the Global Stack on Multiextrusion machines

### DIFF
--- a/cura/QualityManager.py
+++ b/cura/QualityManager.py
@@ -82,8 +82,9 @@ class QualityManager:
     #   \param material_containers (Optional) \type{List[ContainerInstance]} If nothing is specified then
     #                               the current set of selected materials is used.
     #   \return the matching quality container \type{ContainerInstance}
-    def findQualityByQualityType(self, quality_type, machine_definition=None, material_containers=None):
-        criteria = {"type": "quality"}
+    def findQualityByQualityType(self, quality_type, machine_definition=None, material_containers=None, **kwargs):
+        criteria = kwargs
+        criteria["type"] = "quality"
         if quality_type:
             criteria["quality_type"] = quality_type
         result = self._getFilteredContainersForStack(machine_definition, material_containers, **criteria)
@@ -218,7 +219,7 @@ class QualityManager:
         result = []
         for container in containers:
             # If the machine specifies we should filter by material, exclude containers that do not match any active material.
-            if filter_by_material and container.getMetaDataEntry("material") not in material_ids:
+            if filter_by_material and container.getMetaDataEntry("material") not in material_ids and not "global_quality" in kwargs:
                 continue
             result.append(container)
         return result

--- a/cura/QualityManager.py
+++ b/cura/QualityManager.py
@@ -81,6 +81,8 @@ class QualityManager:
     #                               specified then the currently selected machine definition is used.
     #   \param material_containers (Optional) \type{List[ContainerInstance]} If nothing is specified then
     #                               the current set of selected materials is used.
+    #   \param kwargs Keyword arguments. Passed along to ContainerRegistry and used as additional search
+    ##                              criteria when searching for quality profiles.
     #   \return the matching quality container \type{ContainerInstance}
     def findQualityByQualityType(self, quality_type, machine_definition=None, material_containers=None, **kwargs):
         criteria = kwargs

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -225,11 +225,26 @@ class MachineManager(QObject):
             self._global_container_stack.nameChanged.connect(self._onMachineNameChanged)
             self._global_container_stack.containersChanged.connect(self._onInstanceContainersChanged)
             self._global_container_stack.propertyChanged.connect(self._onPropertyChanged)
-            material = self._global_container_stack.findContainer({"type": "material"})
-            material.nameChanged.connect(self._onMaterialNameChanged)
 
-            quality = self._global_container_stack.findContainer({"type": "quality"})
-            quality.nameChanged.connect(self._onQualityNameChanged)
+            if self._global_container_stack.getProperty("machine_extruder_count", "value") > 1:
+                # For multi-extrusion machines, we do not want variant or material profiles in the stack,
+                # because these are extruder specific and may cause wrong values to be used for extruders
+                # that did not specify a value in the extruder.
+                global_variant = self._global_container_stack.findContainer(type = "variant")
+                if global_variant != self._empty_variant_container:
+                    self._global_container_stack.replaceContainer(self._global_container_stack.getContainerIndex(global_variant), self._empty_variant_container)
+
+                global_material = self._global_container_stack.findContainer(type = "material")
+                if global_material != self._empty_material_container:
+                    self._global_container_stack.replaceContainer(self._global_container_stack.getContainerIndex(global_material), self._empty_material_container)
+
+            else:
+                material = self._global_container_stack.findContainer({"type": "material"})
+                material.nameChanged.connect(self._onMaterialNameChanged)
+
+                quality = self._global_container_stack.findContainer({"type": "quality"})
+                quality.nameChanged.connect(self._onQualityNameChanged)
+
 
     def _onActiveExtruderStackChanged(self):
         self.blurSettings.emit()  # Ensure no-one has focus.

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -787,7 +787,10 @@ class MachineManager(QObject):
         # For the global stack, find a quality which matches the quality_type in
         # the quality changes profile and also satisfies any material constraints.
         quality_type = global_quality_changes.getMetaDataEntry("quality_type")
-        global_quality = quality_manager.findQualityByQualityType(quality_type, global_machine_definition, [material])
+        if global_container_stack.getProperty("machine_extruder_count", "value") > 1:
+            global_quality = quality_manager.findQualityByQualityType(quality_type, global_machine_definition, [], global_quality = True)
+        else:
+            global_quality = quality_manager.findQualityByQualityType(quality_type, global_machine_definition, [material])
 
         # Find the values for each extruder.
         extruder_stacks = ExtruderManager.getInstance().getActiveExtruderStacks()

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -793,9 +793,10 @@ class MachineManager(QObject):
             result.append({"stack": stack, "quality": quality, "quality_changes": quality_changes})
 
         if extruder_stacks:
-            # Duplicate the quality from the 1st extruder into the global stack. If anyone
-            # then looks in the global stack, they should get a reasonable view.
-            result.append({"stack": global_container_stack, "quality": result[0]["quality"], "quality_changes": global_quality_changes})
+            global_quality = quality_manager.findQualityByQualityType(quality_type, global_machine_definition, [material], global_quality = "True")
+            if not global_quality:
+                global_quality = self._empty_quality_container
+            result.append({"stack": global_container_stack, "quality": global_quality, "quality_changes": global_quality_changes})
         else:
             result.append({"stack": global_container_stack, "quality": global_quality, "quality_changes": global_quality_changes})
 

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -761,6 +761,7 @@ class MachineManager(QObject):
             global_quality = quality_manager.findQualityByQualityType(quality_type, global_machine_definition, [], global_quality = "True")
 
             if not global_quality:
+                Logger.log("w", "Could not find a global quality profile for quality type %s and machine %s, using empty", quality_type, global_container_stack.getId())
                 global_quality = self._empty_quality_container
 
             result.append({"stack": global_container_stack, "quality": global_quality, "quality_changes": empty_quality_changes})
@@ -813,6 +814,7 @@ class MachineManager(QObject):
         if extruder_stacks:
             global_quality = quality_manager.findQualityByQualityType(quality_type, global_machine_definition, [material], global_quality = "True")
             if not global_quality:
+                Logger.log("w", "Could not find a global quality profile for quality type %s and machine %s, using empty", quality_type, global_container_stack.getId())
                 global_quality = self._empty_quality_container
             result.append({"stack": global_container_stack, "quality": global_quality, "quality_changes": global_quality_changes})
         else:

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -743,8 +743,13 @@ class MachineManager(QObject):
 
         if extruder_stacks:
             # Add an extra entry for the global stack.
-            result.append({"stack": global_container_stack, "quality": result[0]["quality"],
-                           "quality_changes": empty_quality_changes})
+            global_quality = quality_manager.findQualityByQualityType(quality_type, global_machine_definition, [], global_quality = "True")
+
+            if not global_quality:
+                global_quality = self._empty_quality_container
+
+            result.append({"stack": global_container_stack, "quality": global_quality, "quality_changes": empty_quality_changes})
+
         return result
 
     ##  Determine the quality and quality changes settings for the current machine for a quality changes name.


### PR DESCRIPTION
This changes the behaviour related to the global stack to make sure that we use a global-container specific quality profile. In addition, we use an empty material and variant for the global stack. This fixes issues where values from the wrong profiles are used in another extruder, due to the primary extruder profile being used as global quality profile and the second extruder falling back to these values. The same would happen with materials and variants in that stack, which is why we are setting them to empty.

Ideally, we would simply use the empty quality container for the global stack, however, this interferes with the quality selection code, which depends on the quality_type being available. Since the empty container can only have one quality_type, using the empty profile would result in only having a single quality available.