### PR TITLE
Fix error when starting with no active machine

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -566,7 +566,7 @@ class MachineManager(QObject):
             quality = self._active_container_stack.findContainer(type = "quality")
             if quality:
                 return Util.parseBool(quality.getMetaDataEntry("supported", True))
-        return ""
+        return False
 
     ##  Get the Quality ID associated with the currently active extruder
     #   Note that this only returns the "quality", not the "quality_changes"


### PR DESCRIPTION
This PR fixes an error when starting Cura without an active machine.

This should be applied to both the 2.3 and master branch; the "critical" unhandled exception error also happens with the released 2.3.0, but it only shows in the logs. Apropos, shouldn't a "critical" error trigger the CrashHandler instead of failing silently?