### PR TITLE
Fix errors when switching from UM3 to UM2.

### DIFF
--- a/cura/QualityManager.py
+++ b/cura/QualityManager.py
@@ -161,7 +161,8 @@ class QualityManager:
     #   \return \type{List[InstanceContainer]} a list of the basic materials or an empty list if one could not be found.
     def _getBasicMaterials(self, material_container):
         base_material = material_container.getMetaDataEntry("material")
-        if material_container.getDefinition().getMetaDataEntry("has_machine_quality"):
+        material_container_definition = material_container.getDefinition()
+        if material_container_definition and material_container_definition.getMetaDataEntry("has_machine_quality"):
             definition_id = material_container.getDefinition().getMetaDataEntry("quality_definition", material_container.getDefinition().getId())
         else:
             definition_id = "fdmprinter"


### PR DESCRIPTION
This PR fixes "critical" errors caused (I think) by "empty_material" not having a definition. The error also happens in the 2.3 branch, so it should probably be cherry-picked.