### PR TITLE
Fix printrbot simple mesh alignment to buildplate grid

### DIFF
--- a/resources/definitions/printrbot_simple.def.json
+++ b/resources/definitions/printrbot_simple.def.json
@@ -9,6 +9,7 @@
         "manufacturer": "PrintrBot",
         "category": "Other",
         "platform": "printrbot_simple_metal_platform.stl",
+        "platform_offset": [0, -3.45, 0],
         "file_formats": "text/x-gcode"
     },
 


### PR DESCRIPTION
Mesh is drawn too high. See https://ultimaker.com/en/community/23473-23-for-printrbot-cura-is-placing-the-model-too-low-and-i-cant-move-it