### PR TITLE
Add dialog to set number of copies when duplicating models

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -686,10 +686,9 @@ class CuraApplication(QtApplication):
             while current_node.getParent() and current_node.getParent().callDecoration("isGroup"):
                 current_node = current_node.getParent()
 
-            new_node = copy.deepcopy(current_node)
-
             op = GroupedOperation()
             for _ in range(count):
+                new_node = copy.deepcopy(current_node)
                 op.addOperation(AddSceneNodeOperation(new_node, current_node.getParent()))
             op.push()
 

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -232,7 +232,7 @@ Item
     Action
     {
         id: multiplyObjectAction;
-        text: catalog.i18nc("@action:inmenu","&Duplicate Model");
+        text: catalog.i18nc("@action:inmenu","&Duplicate Model...");
         iconName: "edit-duplicate"
     }
 

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -232,7 +232,7 @@ Item
     Action
     {
         id: multiplyObjectAction;
-        text: catalog.i18nc("@action:inmenu","&Duplicate Model...");
+        text: catalog.i18nc("@action:inmenu","&Multiply Model...");
         iconName: "edit-duplicate"
     }
 

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -605,6 +605,11 @@ UM.MainWindow
             }
         }
 
+        MultiplyObjectOptions
+        {
+            id: multiplyObjectOptions
+        }
+
         Connections
         {
             target: Cura.Actions.multiplyObject
@@ -612,7 +617,9 @@ UM.MainWindow
             {
                 if(objectContextMenu.objectId != 0)
                 {
-                    Printer.multiplyObject(objectContextMenu.objectId, 1);
+                    multiplyObjectOptions.objectId = objectContextMenu.objectId;
+                    multiplyObjectOptions.visible = true;
+                    multiplyObjectOptions.reset();
                     objectContextMenu.objectId = 0;
                 }
             }

--- a/resources/qml/MultiplyObjectOptions.qml
+++ b/resources/qml/MultiplyObjectOptions.qml
@@ -12,7 +12,7 @@ UM.Dialog
     id: base
 
     //: Dialog title
-    title: catalog.i18nc("@title:window", "Duplicate Model")
+    title: catalog.i18nc("@title:window", "Multiply Model")
 
     minimumWidth: 400 * Screen.devicePixelRatio
     minimumHeight: 80 * Screen.devicePixelRatio

--- a/resources/qml/MultiplyObjectOptions.qml
+++ b/resources/qml/MultiplyObjectOptions.qml
@@ -1,0 +1,66 @@
+// Copyright (c) 2015 Ultimaker B.V.
+// Cura is released under the terms of the AGPLv3 or higher.
+
+import QtQuick 2.2
+import QtQuick.Controls 1.1
+import QtQuick.Window 2.1
+
+import UM 1.1 as UM
+
+UM.Dialog
+{
+    id: base
+
+    //: Dialog title
+    title: catalog.i18nc("@title:window", "Duplicate Model")
+
+    minimumWidth: 400 * Screen.devicePixelRatio
+    minimumHeight: 80 * Screen.devicePixelRatio
+    width: minimumWidth
+    height: minimumHeight
+
+    property int objectId: 0;
+    onAccepted: Printer.multiplyObject(base.objectId, parseInt(copiesField.text))
+
+    property variant catalog: UM.I18nCatalog { name: "cura" }
+
+    signal reset()
+    onReset: {
+        copiesField.text = "1";
+        copiesField.selectAll();
+        copiesField.focus = true;
+    }
+
+    Row
+    {
+        spacing: UM.Theme.getSize("default_margin").width
+
+        Label {
+            text: "Number of copies:"
+            anchors.verticalCenter: copiesField.verticalCenter
+        }
+
+        TextField {
+            id: copiesField
+            validator: RegExpValidator { regExp: /^\d{0,2}/ }
+            maximumLength: 2
+        }
+    }
+
+
+    rightButtons:
+    [
+        Button
+        {
+            text: catalog.i18nc("@action:button","OK")
+            onClicked: base.accept()
+            enabled: base.objectId != 0 && parseInt(copiesField.text) > 0
+        },
+        Button
+        {
+            text: catalog.i18nc("@action:button","Cancel")
+            onClicked: base.reject()
+        }
+    ]
+}
+


### PR DESCRIPTION
This PR adds a dialog to allow the user to set the number of copies when duplicating models.

The copies are still naively set in the center of the buildplate, after which it is up to the buildplate physics to push them apart.