### PR TITLE
Remove unused required argument on _startCamera and _stopCamera

### DIFF
--- a/cura/PrinterOutputDevice.py
+++ b/cura/PrinterOutputDevice.py
@@ -138,14 +138,14 @@ class PrinterOutputDevice(QObject, OutputDevice):
     def startCamera(self):
         self._startCamera()
 
-    def _startCamera(self, job_state):
+    def _startCamera(self):
         Logger.log("w", "_startCamera is not implemented by this output device")
 
     @pyqtSlot()
     def stopCamera(self):
         self._stopCamera()
 
-    def _stopCamera(self, job_state):
+    def _stopCamera(self):
         Logger.log("w", "_stopCamera is not implemented by this output device")
 
     @pyqtProperty(str, notify = jobNameChanged)


### PR DESCRIPTION
This PR fixes the PrinterOutputDevice._startCamera and PrinterOutputDevice._stopCamera stubs, which have a unused and not supplied required argument. This results in a critical error being logged when a printeroutputdevice subclass does not override _startCamera and/or _stopCamera (eg USBPrinterOutputDevice, or OctoPrintOutputDevice)
 
CURA-2411