### PR TITLE
Fix blurSettings

### DIFF
--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -573,7 +573,7 @@ UM.MainWindow
         target: Cura.MachineManager
         onBlurSettings:
         {
-            forceActiveFocus()
+            contentItem.forceActiveFocus()
         }
     }
 


### PR DESCRIPTION
UM.MainWindow does not derive from QML Item, so it does not have a forceActiveFocus() method.

CURA-2835