### PR TITLE
PrinterOutputDevice: Add isConnectionState

### DIFF
--- a/cura/PrinterOutputDevice.py
+++ b/cura/PrinterOutputDevice.py
@@ -366,6 +366,11 @@ class PrinterOutputDevice(QObject, OutputDevice):
             self._connection_state = connection_state
             self.connectionStateChanged.emit(self._id)
 
+    ##  Check the connection state of this output device.
+    #   /param connection_state ConnectionState enum.
+    def isConnectionState(self, connection_state):
+        return self._connection_state == connection_state
+
     @pyqtProperty(str, notify = connectionTextChanged)
     def connectionText(self):
         return self._connection_text


### PR DESCRIPTION
Adding isConnectionState here to make direct comparisons, whether the
current state is the correct one.
Looks better than `self._connection_state == <my_connection_state>`  in
my point of view.