### PR TITLE
Initial support for elliptic build plate shape

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -183,7 +183,7 @@ class BuildVolume(SceneNode):
         min_d = -self._depth / 2
         max_d = self._depth / 2
 
-        if self._shape.lower() != "elliptic":
+        if self._shape != "elliptic":
             # Outline 'cube' of the build volume
             mb = MeshBuilder()
             mb.addLine(Vector(min_w, min_h, min_d), Vector(max_w, min_h, min_d), color = self.VolumeOutlineColor)
@@ -614,7 +614,8 @@ class BuildVolume(SceneNode):
                 bottom_unreachable_border = max(bottom_unreachable_border, other_offset_y - offset_y)
             half_machine_width = self._global_container_stack.getProperty("machine_width", "value") / 2
             half_machine_depth = self._global_container_stack.getProperty("machine_depth", "value") / 2
-            if self._shape.lower() != "elliptic":
+
+            if self._shape != "elliptic":
                 if border_size - left_unreachable_border > 0:
                     result[extruder_id].append(Polygon(numpy.array([
                         [-half_machine_width, -half_machine_depth],

--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -234,11 +234,14 @@ class BuildVolume(SceneNode):
 
             # Build plate grid mesh
             mb = MeshBuilder()
-            mb.addArc(max_w, Vector.Unit_Y, center = Vector(0, min_h - z_fight_distance, 0))
-            sections = mb.getVertexCount()
             mb.addVertex(0, min_h - z_fight_distance, 0)
-            for n in range(0, sections-1):
-                mb.addIndices([sections, n + 1, n])
+            mb.addArc(max_w, Vector.Unit_Y, center = Vector(0, min_h - z_fight_distance, 0))
+            sections = mb.getVertexCount() - 1 # Center point is not an arc section
+            indices = []
+            for n in range(0, sections - 1):
+                indices.append([0, n + 2, n + 1])
+            mb.addIndices(numpy.asarray(indices, dtype = numpy.int32))
+            mb.calculateNormals()
 
             for n in range(0, mb.getVertexCount()):
                 v = mb.getVertex(n)

--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -226,7 +226,7 @@ class BuildVolume(SceneNode):
             if self._width != 0:
                 # Scale circular meshes by aspect ratio if width != height
                 aspect = self._height / self._width
-                scale_matrix.compose(Vector(1, 1, aspect))
+                scale_matrix.compose(scale = Vector(1, 1, aspect))
             mb = MeshBuilder()
             mb.addArc(max_w, Vector.Unit_Y, center = (0, min_h - z_fight_distance, 0), color = self.VolumeOutlineColor)
             mb.addArc(max_w, Vector.Unit_Y, center = (0, max_h, 0),  color = self.VolumeOutlineColor)

--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -183,6 +183,8 @@ class BuildVolume(SceneNode):
         min_d = -self._depth / 2
         max_d = self._depth / 2
 
+        z_fight_distance = 0.2 # Distance between buildplate and disallowed area meshes to prevent z-fighting
+
         if self._shape != "elliptic":
             # Outline 'cube' of the build volume
             mb = MeshBuilder()
@@ -206,10 +208,10 @@ class BuildVolume(SceneNode):
             # Build plate grid mesh
             mb = MeshBuilder()
             mb.addQuad(
-                Vector(min_w, min_h - 0.2, min_d),
-                Vector(max_w, min_h - 0.2, min_d),
-                Vector(max_w, min_h - 0.2, max_d),
-                Vector(min_w, min_h - 0.2, max_d)
+                Vector(min_w, min_h - z_fight_distance, min_d),
+                Vector(max_w, min_h - z_fight_distance, min_d),
+                Vector(max_w, min_h - z_fight_distance, max_d),
+                Vector(min_w, min_h - z_fight_distance, max_d)
             )
 
             for n in range(0, 6):
@@ -226,15 +228,15 @@ class BuildVolume(SceneNode):
                 aspect = self._height / self._width
                 scale_matrix.compose(Vector(1, 1, aspect))
             mb = MeshBuilder()
-            mb.addArc(max_w, Vector.Unit_Y, center = (0, min_h - 0.2, 0), color = self.VolumeOutlineColor)
+            mb.addArc(max_w, Vector.Unit_Y, center = (0, min_h - z_fight_distance, 0), color = self.VolumeOutlineColor)
             mb.addArc(max_w, Vector.Unit_Y, center = (0, max_h, 0),  color = self.VolumeOutlineColor)
             self.setMeshData(mb.build().getTransformed(scale_matrix))
 
             # Build plate grid mesh
             mb = MeshBuilder()
-            mb.addArc(max_w, Vector.Unit_Y, center = Vector(0, min_h - 0.2, 0))
+            mb.addArc(max_w, Vector.Unit_Y, center = Vector(0, min_h - z_fight_distance, 0))
             sections = mb.getVertexCount()
-            mb.addVertex(0, min_h - 0.2, 0)
+            mb.addVertex(0, min_h - z_fight_distance, 0)
             for n in range(0, sections-1):
                 mb.addIndices([sections, n + 1, n])
 

--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -219,14 +219,14 @@ class BuildVolume(SceneNode):
             # Bottom and top 'ellipse' of the build volume
             mb = MeshBuilder()
             mb.addArc(max_w, Vector.Unit_Y, center = (0, min_h - 0.2, 0), color = self.VolumeOutlineColor)
-            mb.addArc(max_w, Vector.Unit_Y, center = (0, max_h, 0), color = self.VolumeOutlineColor)
+            mb.addArc(max_w, Vector.Unit_Y, center = (0, max_h, 0),  color = self.VolumeOutlineColor)
             self.setMeshData(mb.build())
 
             # Build plate grid mesh
             mb = MeshBuilder()
-            mb.addArc(max_w, Vector.Unit_Y)
+            mb.addArc(max_w, Vector.Unit_Y, center = Vector(0, min_h - 0.2, 0))
             sections = mb.getVertexCount()
-            mb.addVertex(0, 0, 0)
+            mb.addVertex(0, min_h - 0.2, 0)
             for n in range(0, sections-1):
                 mb.addIndices([sections, n + 1, n])
 

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -131,11 +131,20 @@ Cura.MachineAction
 
                             ComboBox
                             {
-                                model: ["Rectangular", "Elliptic"]
-                                currentIndex: machineShapeProvider.properties.value.toLowerCase() != model[1].toLowerCase() ? 0 : 1
+                                id: shapeComboBox
+                                model: ListModel
+                                {
+                                    id: shapesModel
+                                    Component.onCompleted:
+                                    {
+                                        shapesModel.append({ text: catalog.i18nc("@option:build plate shape", "Rectangular"), value: "rectangular" });
+                                        shapesModel.append({ text: catalog.i18nc("@option:build plate shape", "Elliptic"), value: "elliptic" });
+                                        shapeComboBox.currentIndex = machineShapeProvider.properties.value != shapesModel.get(1).value ? 0 : 1
+                                    }
+                                }
                                 onActivated:
                                 {
-                                    machineShapeProvider.setPropertyValue("value", model[index]);
+                                    machineShapeProvider.setPropertyValue("value", shapesModel.get(index).value);
                                     manager.forceUpdate();
                                 }
                             }

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -145,7 +145,11 @@ Cura.MachineAction
                             id: centerIsZeroCheckBox
                             text: catalog.i18nc("@option:check", "Machine Center is Zero")
                             checked: String(machineCenterIsZeroProvider.properties.value).toLowerCase() != 'false'
-                            onClicked: machineCenterIsZeroProvider.setPropertyValue("value", checked)
+                            onClicked:
+                            {
+                                    machineCenterIsZeroProvider.setPropertyValue("value", checked);
+                                    manager.forceUpdate();
+                            }
                         }
                         CheckBox
                         {

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -137,10 +137,31 @@ Cura.MachineAction
                                     id: shapesModel
                                     Component.onCompleted:
                                     {
-                                        shapesModel.append({ text: catalog.i18nc("@option:build plate shape", "Rectangular"), value: "rectangular" });
-                                        shapesModel.append({ text: catalog.i18nc("@option:build plate shape", "Elliptic"), value: "elliptic" });
-                                        shapeComboBox.currentIndex = machineShapeProvider.properties.value != shapesModel.get(1).value ? 0 : 1
+                                        // Options come in as a string-representation of an OrderedDict
+                                        var options = machineShapeProvider.properties.options.match(/^OrderedDict\(\[\((.*)\)\]\)$/);
+                                        if(options)
+                                        {
+                                            options = options[1].split("), (")
+                                            for(var i = 0; i < options.length; i++)
+                                            {
+                                                var option = options[i].substring(1, options[i].length - 1).split("', '")
+                                                shapesModel.append({text: option[1], value: option[0]});
+                                            }
+                                        }
                                     }
+                                }
+                                currentIndex:
+                                {
+                                    var currentValue = machineShapeProvider.properties.value;
+                                    var index = 0;
+                                    for(var i = 0; i < shapesModel.count; i++)
+                                    {
+                                        if(shapesModel.get(i).value == currentValue) {
+                                            index = i;
+                                            break;
+                                        }
+                                    }
+                                    return index
                                 }
                                 onActivated:
                                 {
@@ -467,7 +488,7 @@ Cura.MachineAction
 
         containerStackId: Cura.MachineManager.activeMachineId
         key: "machine_shape"
-        watchedProperties: [ "value" ]
+        watchedProperties: [ "value", "options" ]
         storeIndex: manager.containerIndex
     }
 

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -120,12 +120,25 @@ Cura.MachineAction
 
                     Column
                     {
-                        CheckBox
+                        Row
                         {
-                            id: heatedBedCheckBox
-                            text: catalog.i18nc("@option:check", "Heated Bed")
-                            checked: String(machineHeatedBedProvider.properties.value).toLowerCase() != 'false'
-                            onClicked: machineHeatedBedProvider.setPropertyValue("value", checked)
+                            spacing: UM.Theme.getSize("default_margin").width
+
+                            Label
+                            {
+                                text: catalog.i18nc("@label", "Build Plate Shape")
+                            }
+
+                            ComboBox
+                            {
+                                model: ["Rectangular", "Elliptic"]
+                                currentIndex: machineShapeProvider.properties.value.toLowerCase() != model[1].toLowerCase() ? 0 : 1
+                                onActivated:
+                                {
+                                    machineShapeProvider.setPropertyValue("value", model[index]);
+                                    manager.forceUpdate();
+                                }
+                            }
                         }
                         CheckBox
                         {
@@ -133,6 +146,13 @@ Cura.MachineAction
                             text: catalog.i18nc("@option:check", "Machine Center is Zero")
                             checked: String(machineCenterIsZeroProvider.properties.value).toLowerCase() != 'false'
                             onClicked: machineCenterIsZeroProvider.setPropertyValue("value", checked)
+                        }
+                        CheckBox
+                        {
+                            id: heatedBedCheckBox
+                            text: catalog.i18nc("@option:check", "Heated Bed")
+                            checked: String(machineHeatedBedProvider.properties.value).toLowerCase() != 'false'
+                            onClicked: machineHeatedBedProvider.setPropertyValue("value", checked)
                         }
                     }
 
@@ -424,6 +444,16 @@ Cura.MachineAction
 
         containerStackId: Cura.MachineManager.activeMachineId
         key: "machine_height"
+        watchedProperties: [ "value" ]
+        storeIndex: manager.containerIndex
+    }
+
+    UM.SettingPropertyProvider
+    {
+        id: machineShapeProvider
+
+        containerStackId: Cura.MachineManager.activeMachineId
+        key: "machine_shape"
         watchedProperties: [ "value" ]
         storeIndex: manager.containerIndex
     }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -137,6 +137,21 @@
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false
                 },
+                "machine_shape":
+                {
+                    "label": "Build plate shape",
+                    "description": "The shape of the build plate without taking unprintable areas into account.",
+                    "default_value": "Rectangular",
+                    "type": "enum",
+                    "options":
+                    {
+                        "rectangular": "Rectangular",
+                        "elliptic": "Elliptic"
+                    },
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false
+                },
                 "machine_height":
                 {
                     "label": "Machine height",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -141,7 +141,7 @@
                 {
                     "label": "Build plate shape",
                     "description": "The shape of the build plate without taking unprintable areas into account.",
-                    "default_value": "Rectangular",
+                    "default_value": "rectangular",
                     "type": "enum",
                     "options":
                     {


### PR DESCRIPTION
This PR provides an option to change the build plate shape to elliptic for polar printers.
![polar](https://cloud.githubusercontent.com/assets/143551/20705534/94d611e4-b623-11e6-8c74-cb061c8fd954.png)
An elliptic build volume is drawn, and disallowed area polygons are added so that only an elliptic area remains.
