### PR TITLE
Allow postprocessing before sending data to the printer

### DIFF
--- a/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
@@ -532,6 +532,7 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
 
         Application.getInstance().showPrintMonitor.emit(True)
         self._print_finished = True
+        self.writeStarted.emit(self)
         self._gcode = getattr(Application.getInstance().getController().getScene(), "gcode_list")
 
         print_information = Application.getInstance().getPrintInformation()


### PR DESCRIPTION
When sending data to a UM3, gcode postprocessing is not performed because of a missing writeStarted emit.

From OutputDevice.py:
"output device subclasses are completely free to implement writing however they want, though you should emit writeStarted and related signals whenever certain events happen related to the write process."