### PR TITLE
Add link to OctoPrintPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Third party plugins
 * [Barbarian Plugin](https://github.com/nallath/BarbarianPlugin): Simple scale tool for imperial to metric.
 * [X3G Writer](https://github.com/Ghostkeeper/X3GWriter): Adds support for exporting X3G files.
 * [Auto orientation](https://github.com/nallath/CuraOrientationPlugin): Calculate the optimal orientation for a model.
+* [OctoPrint Plugin](https://github.com/fieldofview/OctoPrintPlugin): Send printjobs directly to OctoPrint and monitor their progress in Cura.
 
 Making profiles for other printers
 ----------------------------------


### PR DESCRIPTION
The readme contains a number of links to plugins, but the OctoPrint plugin is missing.