### PR TITLE
QML: Remove name of application

### DIFF
--- a/resources/qml/AboutDialog.qml
+++ b/resources/qml/AboutDialog.qml
@@ -40,7 +40,7 @@ UM.Dialog
     {
         id: version
 
-        text: "Cura %1".arg(UM.Application.version)
+        text: catalog.i18nc("@label","version: %1").arg(UM.Application.version)
         font: UM.Theme.getFont("large")
         anchors.horizontalCenter : logo.horizontalCenter
         anchors.horizontalCenterOffset : (logo.width * 0.25)


### PR DESCRIPTION
For me having "Cura" under the logo actually doesn't make sense, as it is quite obvious by the logo that we are talking about _Cura_ here. So in my opinion we can prefix the application version here with "version: " instead.

Untested but it should work (fingers crossed)