### PR TITLE
Changed urllib import to be more restrictive

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -54,7 +54,7 @@ import sys
 import os.path
 import numpy
 import copy
-import urllib
+import urllib.parse
 import os
 
 


### PR DESCRIPTION
On certain Linux platforms, urllib in py3 no longer accepts a top-level module import. Restricting the imported modules to just "parse" fixes this issue.

This has been tested and is verified working on the following configuration:
Linux Mint 18 x86 Cinnamon