### PR TITLE
Add definition and bed mesh for Kossel Pro

### DIFF
--- a/resources/definitions/kossel_pro.def.json
+++ b/resources/definitions/kossel_pro.def.json
@@ -1,0 +1,56 @@
+{
+    "id": "kossel_pro",
+    "version": 2,
+    "name": "Kossel Pro",
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": true,
+        "author": "Chris Petersen",
+        "manufacturer": "OpenBeam",
+        "category": "Other",
+        "file_formats": "text/x-gcode",
+        "icon": "icon_ultimaker2",
+        "platform": "kossel_pro_build_platform.stl"
+    },
+    "overrides": {
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "machine_width": {
+            "default_value": 240
+        },
+        "machine_height": {
+            "default_value": 240
+        },
+        "machine_depth": {
+            "default_value": 240
+        },
+        "machine_center_is_zero": {
+            "default_value": true
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.35
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        },
+        "machine_nozzle_heat_up_speed": {
+            "default_value": 2
+        },
+        "machine_nozzle_cool_down_speed": {
+            "default_value": 2
+        },
+        "machine_gcode_flavor": {
+            "default_value": "RepRap (Marlin/Sprinter)"
+        },
+        "machine_start_gcode": {
+            "default_value": "; info: M303 E0 S200 C8 ; Pid auto-tune \n\nM140 S{{material_bed_temperature}}; Start heating up the base\nG28 ; Home to top 3 endstops\n; Autolevel and adjust first layer\n; Adjust this value to fit your own printer!  (positive is thicker)\n; This default value is intentionally very high to accommodate the\n; variety of print heads used with this printer.  Many of you will\n; need tiny values like Z0 or Z0.1.  Use feeler gauges to dial this\n; in as accurately as possible.\nG29 Z10\n\n; Squirt and wipe ;\nM109 S220 ; Wait for the temp to hit 220\nG00 X125 Y-60 Z0.1 ;\nG92 E0 ;\nG01 E25 F100 ; Extrude a little bit to replace oozage from auto levelling\nG01 X90 Y-50 F6000 ;\nG01 Z5 ;\n\n; Set the extruder to the requested print temperature\nM104 S{{material_print_temperature}}\n"
+        },
+        "machine_end_gcode": {
+            "default_value": "M104 S0 ; turn off temperature\nM140 S0 ; turn off bed\nG28 ; home all axes\nM84 ; disable motors\n"
+        },
+        "machine_disallowed_areas": {
+            "default_value": [[[125.0, 125.0], [125.0, 0.0], [120.741, 32.352]], [[-125.0, 125.0], [-125.0, 0.0], [-120.741, 32.352]], [[125.0, -125.0], [125.0, -0.0], [120.741, -32.352]], [[-125.0, -125.0], [-125.0, -0.0], [-120.741, -32.352]], [[125.0, 125.0], [120.741, 32.352], [108.253, 62.5]], [[-125.0, 125.0], [-120.741, 32.352], [-108.253, 62.5]], [[125.0, -125.0], [120.741, -32.352], [108.253, -62.5]], [[-125.0, -125.0], [-120.741, -32.352], [-108.253, -62.5]], [[125.0, 125.0], [108.253, 62.5], [88.388, 88.388]], [[-125.0, 125.0], [-108.253, 62.5], [-88.388, 88.388]], [[125.0, -125.0], [108.253, -62.5], [88.388, -88.388]], [[-125.0, -125.0], [-108.253, -62.5], [-88.388, -88.388]], [[125.0, 125.0], [88.388, 88.388], [62.5, 108.253]], [[-125.0, 125.0], [-88.388, 88.388], [-62.5, 108.253]], [[125.0, -125.0], [88.388, -88.388], [62.5, -108.253]], [[-125.0, -125.0], [-88.388, -88.388], [-62.5, -108.253]], [[125.0, 125.0], [62.5, 108.253], [32.352, 120.741]], [[-125.0, 125.0], [-62.5, 108.253], [-32.352, 120.741]], [[125.0, -125.0], [62.5, -108.253], [32.352, -120.741]], [[-125.0, -125.0], [-62.5, -108.253], [-32.352, -120.741]], [[125.0, 125.0], [32.352, 120.741], [0.0, 125.0]], [[-125.0, 125.0], [-32.352, 120.741], [-0.0, 125.0]], [[125.0, -125.0], [32.352, -120.741], [0.0, -125.0]], [[-125.0, -125.0], [-32.352, -120.741], [-0.0, -125.0]]]
+        }
+    }
+}

--- a/resources/meshes/kossel_pro_build_platform.stl
+++ b/resources/meshes/kossel_pro_build_platform.stl
@@ -1,0 +1,22822 @@
+solid OpenSCAD_Model
+  facet normal -0.866038 0.499978 0
+    outer loop
+      vertex -145.077 17.5082 -11.2
+      vertex -144.889 17.8338 -5.2
+      vertex -144.889 17.8338 -11.2
+    endloop
+  endfacet
+  facet normal -0.866038 0.499978 0
+    outer loop
+      vertex -144.889 17.8338 -5.2
+      vertex -145.077 17.5082 -11.2
+      vertex -145.077 17.5082 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -62.8667 105.571 -5.2
+      vertex -63.0358 105.655 -5.2
+      vertex -63.0269 105.671 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -62.5 -108.253 -5.2
+      vertex -60 -107.418 -5.2
+      vertex -60 -109.594 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -60 -107.418 -5.2
+      vertex -61.6374 102.266 -5.2
+      vertex -61.5276 103.01 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -60 -107.418 -5.2
+      vertex -61.9288 101.573 -5.2
+      vertex -61.6374 102.266 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -60 -107.418 -5.2
+      vertex -62.5 -108.253 -5.2
+      vertex -69.1739 -104.115 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -75.5749 -99.5662 -5.2
+      vertex -60 -107.418 -5.2
+      vertex -69.1739 -104.115 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -81.6776 -94.6244 -5.2
+      vertex -60 -107.418 -5.2
+      vertex -75.5749 -99.5662 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -87.4579 -89.3091 -5.2
+      vertex -60 -107.418 -5.2
+      vertex -81.6776 -94.6244 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -92.8931 -83.6413 -5.2
+      vertex -60 -107.418 -5.2
+      vertex -87.4579 -89.3091 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -60 -107.418 -5.2
+      vertex -92.8931 -83.6413 -5.2
+      vertex -118.929 2.84567 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -5.2
+      vertex -92.8931 -83.6413 -5.2
+      vertex -97.9617 -77.6435 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -5.2
+      vertex -97.9617 -77.6435 -5.2
+      vertex -102.644 -71.3392 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -5.2
+      vertex -102.644 -71.3392 -5.2
+      vertex -106.921 -64.7534 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -5.2
+      vertex -106.921 -64.7534 -5.2
+      vertex -110.775 -57.912 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -5.2
+      vertex -110.775 -57.912 -5.2
+      vertex -114.193 -50.8421 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -5.2
+      vertex -114.193 -50.8421 -5.2
+      vertex -117.16 -43.5715 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -60 -107.418 -5.2
+      vertex -118.929 2.84567 -5.2
+      vertex -61.9288 101.573 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.665 -36.129 -5.2
+      vertex -118.929 2.84567 -5.2
+      vertex -117.16 -43.5715 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -121.697 -28.5439 -5.2
+      vertex -118.929 2.84567 -5.2
+      vertex -119.665 -36.129 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -123.25 -20.8461 -5.2
+      vertex -118.929 2.84567 -5.2
+      vertex -121.697 -28.5439 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -124.315 -13.0661 -5.2
+      vertex -118.929 2.84567 -5.2
+      vertex -123.25 -20.8461 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -5.2
+      vertex -124.315 -13.0661 -5.2
+      vertex -119.384 2.24668 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.384 2.24668 -5.2
+      vertex -124.315 -13.0661 -5.2
+      vertex -119.973 1.77958 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -124.89 -5.23446 -5.2
+      vertex -119.973 1.77958 -5.2
+      vertex -124.315 -13.0661 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.973 1.77958 -5.2
+      vertex -124.89 -5.23446 -5.2
+      vertex -120.66 1.47371 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -120.66 1.47371 -5.2
+      vertex -124.89 -5.23446 -5.2
+      vertex -121.401 1.3483 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -121.401 1.3483 -5.2
+      vertex -124.89 -5.23446 -5.2
+      vertex -122.151 1.41123 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -122.151 1.41123 -5.2
+      vertex -124.89 -5.23446 -5.2
+      vertex -122.861 1.65854 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -123.027 1.7476 -5.2
+      vertex -122.861 1.65854 -5.2
+      vertex -124.89 -5.23446 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -122.861 1.65854 -5.2
+      vertex -123.027 1.7476 -5.2
+      vertex -123.018 1.76299 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -124.973 2.6178 -5.2
+      vertex -123.027 1.7476 -5.2
+      vertex -124.89 -5.23446 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -123.027 1.7476 -5.2
+      vertex -124.973 2.6178 -5.2
+      vertex -124.96 2.86349 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.9822 -107.418 -5.2
+      vertex -60 -107.418 -5.2
+      vertex -59.9941 -107.23 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 120.66 1.47371 -5.2
+      vertex 124.973 -2.6178 -5.2
+      vertex 124.562 -10.4597 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.384 2.24668 -5.2
+      vertex 124.562 -10.4597 -5.2
+      vertex 123.659 -18.2604 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 124.973 -2.6178 -5.2
+      vertex 123.027 1.7476 -5.2
+      vertex 124.915 2.83794 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 124.973 -2.6178 -5.2
+      vertex 122.861 1.65854 -5.2
+      vertex 123.027 1.7476 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 123.027 1.7476 -5.2
+      vertex 122.861 1.65854 -5.2
+      vertex 123.018 1.76299 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 118.929 2.84567 -5.2
+      vertex 123.659 -18.2604 -5.2
+      vertex 122.268 -25.989 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 124.973 -2.6178 -5.2
+      vertex 122.151 1.41123 -5.2
+      vertex 122.861 1.65854 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 124.973 -2.6178 -5.2
+      vertex 121.401 1.3483 -5.2
+      vertex 122.151 1.41123 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 124.973 -2.6178 -5.2
+      vertex 120.66 1.47371 -5.2
+      vertex 121.401 1.3483 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 118.929 2.84567 -5.2
+      vertex 122.268 -25.989 -5.2
+      vertex 120.395 -33.615 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 124.562 -10.4597 -5.2
+      vertex 119.973 1.77958 -5.2
+      vertex 120.66 1.47371 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 124.562 -10.4597 -5.2
+      vertex 119.384 2.24668 -5.2
+      vertex 119.973 1.77958 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 123.659 -18.2604 -5.2
+      vertex 118.929 2.84567 -5.2
+      vertex 119.384 2.24668 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 118.047 -41.1083 -5.2
+      vertex 118.929 2.84567 -5.2
+      vertex 120.395 -33.615 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 115.233 -48.4394 -5.2
+      vertex 118.929 2.84567 -5.2
+      vertex 118.047 -41.1083 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 111.964 -55.5794 -5.2
+      vertex 118.929 2.84567 -5.2
+      vertex 115.233 -48.4394 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108.253 -62.5 -5.2
+      vertex 118.929 2.84567 -5.2
+      vertex 111.964 -55.5794 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57 -104.418 -5.2
+      vertex 108.253 -62.5 -5.2
+      vertex 104.115 -69.1739 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57 -104.418 -5.2
+      vertex 104.115 -69.1739 -5.2
+      vertex 99.5662 -75.5749 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57 -104.418 -5.2
+      vertex 99.5662 -75.5749 -5.2
+      vertex 94.6244 -81.6776 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57 -104.418 -5.2
+      vertex 94.6244 -81.6776 -5.2
+      vertex 89.3091 -87.4579 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57 -104.418 -5.2
+      vertex 89.3091 -87.4579 -5.2
+      vertex 83.6413 -92.8931 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57 -104.418 -5.2
+      vertex 83.6413 -92.8931 -5.2
+      vertex 77.6435 -97.9617 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.7461 -104.512 -5.2
+      vertex 77.6435 -97.9617 -5.2
+      vertex 71.3392 -102.644 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.0536 -105.231 -5.2
+      vertex 71.3392 -102.644 -5.2
+      vertex 64.7534 -106.921 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 77.6435 -97.9617 -5.2
+      vertex 57.7461 -104.512 -5.2
+      vertex 57 -104.418 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 108.253 -62.5 -5.2
+      vertex 57 -104.418 -5.2
+      vertex 118.929 2.84567 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 118.929 2.84567 -5.2
+      vertex 57 -104.418 -5.2
+      vertex 61.9288 101.573 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 -107.418 -5.2
+      vertex 64.7534 -106.921 -5.2
+      vertex 60 -109.599 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 63.0358 105.655 -5.2
+      vertex 62.8667 105.571 -5.2
+      vertex 63.0269 105.671 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0269 105.671 -5.2
+      vertex 62.5 108.253 -5.2
+      vertex 64.9109 106.758 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.8667 105.571 -5.2
+      vertex 62.5 108.253 -5.2
+      vertex 63.0269 105.671 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.2975 105.08 -5.2
+      vertex 62.5 108.253 -5.2
+      vertex 62.8667 105.571 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.8683 104.462 -5.2
+      vertex 62.5 108.253 -5.2
+      vertex 62.2975 105.08 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.5794 111.964 -5.2
+      vertex 61.8683 104.462 -5.2
+      vertex 61.6062 103.758 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.9941 -107.23 -5.2
+      vertex 64.7534 -106.921 -5.2
+      vertex 60 -107.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.8532 -106.491 -5.2
+      vertex 64.7534 -106.921 -5.2
+      vertex 59.9941 -107.23 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.533 -105.811 -5.2
+      vertex 64.7534 -106.921 -5.2
+      vertex 59.8532 -106.491 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.0536 -105.231 -5.2
+      vertex 64.7534 -106.921 -5.2
+      vertex 59.533 -105.811 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.3392 -102.644 -5.2
+      vertex 59.0536 -105.231 -5.2
+      vertex 58.4453 -104.789 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 71.3392 -102.644 -5.2
+      vertex 58.4453 -104.789 -5.2
+      vertex 57.7461 -104.512 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex 61.9288 101.573 -5.2
+      vertex 57 -104.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 2.6178 124.973 -5.2
+      vertex 61.9288 101.573 -5.2
+      vertex -61.5276 103.01 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.8683 104.462 -5.2
+      vertex 55.5794 111.964 -5.2
+      vertex 62.5 108.253 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.5276 103.01 -5.2
+      vertex 55.5794 111.964 -5.2
+      vertex 61.6062 103.758 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 10.4597 124.562 -5.2
+      vertex 61.9288 101.573 -5.2
+      vertex 2.6178 124.973 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 18.2604 123.659 -5.2
+      vertex 61.9288 101.573 -5.2
+      vertex 10.4597 124.562 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.6374 102.266 -5.2
+      vertex 55.5794 111.964 -5.2
+      vertex 61.5276 103.01 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 55.5794 111.964 -5.2
+      vertex 61.6374 102.266 -5.2
+      vertex 48.4394 115.233 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9288 101.573 -5.2
+      vertex 48.4394 115.233 -5.2
+      vertex 61.6374 102.266 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 48.4394 115.233 -5.2
+      vertex 61.9288 101.573 -5.2
+      vertex 41.1083 118.047 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 41.1083 118.047 -5.2
+      vertex 61.9288 101.573 -5.2
+      vertex 33.615 120.395 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 33.615 120.395 -5.2
+      vertex 61.9288 101.573 -5.2
+      vertex 25.989 122.268 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 25.989 122.268 -5.2
+      vertex 61.9288 101.573 -5.2
+      vertex 18.2604 123.659 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.6178 124.973 -5.2
+      vertex -61.5276 103.01 -5.2
+      vertex -5.23446 124.89 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.23446 124.89 -5.2
+      vertex -61.5276 103.01 -5.2
+      vertex -13.0661 124.315 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.0661 124.315 -5.2
+      vertex -61.5276 103.01 -5.2
+      vertex -20.8461 123.25 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8461 123.25 -5.2
+      vertex -61.5276 103.01 -5.2
+      vertex -28.5439 121.697 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.5439 121.697 -5.2
+      vertex -61.5276 103.01 -5.2
+      vertex -36.129 119.665 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -36.129 119.665 -5.2
+      vertex -61.5276 103.01 -5.2
+      vertex -43.5715 117.16 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex 57 -104.418 -5.2
+      vertex -57 -104.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex -57 -104.418 -5.2
+      vertex -57.7461 -104.512 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -43.5715 117.16 -5.2
+      vertex -61.5276 103.01 -5.2
+      vertex -50.8421 114.193 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex -57.7461 -104.512 -5.2
+      vertex -58.4453 -104.789 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex -58.4453 -104.789 -5.2
+      vertex -59.0536 -105.231 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex -59.0536 -105.231 -5.2
+      vertex -59.533 -105.811 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex -59.533 -105.811 -5.2
+      vertex -59.8532 -106.491 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex -59.8532 -106.491 -5.2
+      vertex -59.9941 -107.23 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex -59.9941 -107.23 -5.2
+      vertex -60 -107.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -50.8421 114.193 -5.2
+      vertex -61.5276 103.01 -5.2
+      vertex -57.912 110.775 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.6062 103.758 -5.2
+      vertex -57.912 110.775 -5.2
+      vertex -61.5276 103.01 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.8683 104.462 -5.2
+      vertex -57.912 110.775 -5.2
+      vertex -61.6062 103.758 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -62.2975 105.08 -5.2
+      vertex -57.912 110.775 -5.2
+      vertex -61.8683 104.462 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -62.8667 105.571 -5.2
+      vertex -57.912 110.775 -5.2
+      vertex -62.2975 105.08 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -63.0269 105.671 -5.2
+      vertex -57.912 110.775 -5.2
+      vertex -62.8667 105.571 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -63.0269 105.671 -5.2
+      vertex -64.7534 106.921 -5.2
+      vertex -57.912 110.775 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -64.7534 106.921 -5.2
+      vertex -63.0269 105.671 -5.2
+      vertex -64.9597 106.787 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 -107.418 -5.2
+      vertex 59.9822 -107.418 -5.2
+      vertex 59.9941 -107.23 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.8115 117.671 -5.2
+      vertex -71.3392 102.644 -5.2
+      vertex -64.9597 106.787 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -83.8204 117.655 -5.2
+      vertex -71.3392 102.644 -5.2
+      vertex -83.8115 117.671 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -71.3392 102.644 -5.2
+      vertex -83.8204 117.655 -5.2
+      vertex -77.6435 97.9617 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -87.8891 116.561 -5.2
+      vertex -77.6435 97.9617 -5.2
+      vertex -83.8204 117.655 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -85.0605 118.062 -5.2
+      vertex -83.8204 117.655 -5.2
+      vertex -84.3249 117.906 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.8204 117.655 -5.2
+      vertex -85.0605 118.062 -5.2
+      vertex -87.8891 116.561 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.8891 116.561 -5.2
+      vertex -85.0605 118.062 -5.2
+      vertex -85.8118 118.031 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.8891 116.561 -5.2
+      vertex -85.8118 118.031 -5.2
+      vertex -86.5317 117.813 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.8891 116.561 -5.2
+      vertex -86.5317 117.813 -5.2
+      vertex -87.175 117.424 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.8891 116.561 -5.2
+      vertex -87.175 117.424 -5.2
+      vertex -87.7011 116.886 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.4144 93.77 -5.2
+      vertex -77.6435 97.9617 -5.2
+      vertex -87.8891 116.561 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -97.5198 96.6767 -5.2
+      vertex -87.8891 116.561 -5.2
+      vertex -87.9096 116.573 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -77.6435 97.9617 -5.2
+      vertex -92.4144 93.77 -5.2
+      vertex -83.6413 92.8931 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -91.4149 91.9961 -5.2
+      vertex -83.6413 92.8931 -5.2
+      vertex -91.4673 92.4947 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.6413 92.8931 -5.2
+      vertex -91.4149 91.9961 -5.2
+      vertex -89.3091 87.4579 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.6413 92.8931 -5.2
+      vertex -91.642 92.9645 -5.2
+      vertex -91.4673 92.4947 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.6413 92.8931 -5.2
+      vertex -91.9281 93.3762 -5.2
+      vertex -91.642 92.9645 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.6413 92.8931 -5.2
+      vertex -92.3076 93.7038 -5.2
+      vertex -91.9281 93.3762 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.6413 92.8931 -5.2
+      vertex -92.4144 93.77 -5.2
+      vertex -92.3076 93.7038 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.8891 116.561 -5.2
+      vertex -97.1776 96.52 -5.2
+      vertex -92.4144 93.77 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.8891 116.561 -5.2
+      vertex -97.5198 96.6767 -5.2
+      vertex -97.1776 96.52 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -97.1776 96.52 -5.2
+      vertex -97.5198 96.6767 -5.2
+      vertex -97.1835 96.5098 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.9096 116.573 -5.2
+      vertex -98.0102 96.7809 -5.2
+      vertex -97.5198 96.6767 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.9096 116.573 -5.2
+      vertex -98.5111 96.7599 -5.2
+      vertex -98.0102 96.7809 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.9096 116.573 -5.2
+      vertex -98.991 96.6151 -5.2
+      vertex -98.5111 96.7599 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.9096 116.573 -5.2
+      vertex -99.4199 96.3553 -5.2
+      vertex -98.991 96.6151 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.9096 116.573 -5.2
+      vertex -99.7706 95.9972 -5.2
+      vertex -99.4199 96.3553 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.9096 95.788 -5.2
+      vertex -99.7706 95.9972 -5.2
+      vertex -87.9096 116.573 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.7706 95.9972 -5.2
+      vertex -99.9096 95.788 -5.2
+      vertex -99.896 95.7801 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -91.4881 91.5001 -5.2
+      vertex -89.3091 87.4579 -5.2
+      vertex -91.4149 91.9961 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -91.6824 91.038 -5.2
+      vertex -89.3091 87.4579 -5.2
+      vertex -91.4881 91.5001 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.6824 91.038 -5.2
+      vertex -94.6244 81.6776 -5.2
+      vertex -89.3091 87.4579 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.6824 91.038 -5.2
+      vertex -99.5662 75.5749 -5.2
+      vertex -94.6244 81.6776 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.6824 91.038 -5.2
+      vertex -104.115 69.1739 -5.2
+      vertex -99.5662 75.5749 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -104.115 69.1739 -5.2
+      vertex -91.6824 91.038 -5.2
+      vertex -106.882 64.7122 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.3076 93.7038 -5.2
+      vertex -92.4144 93.77 -5.2
+      vertex -92.4203 93.7598 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.484 36.1163 -5.2
+      vertex 132.172 35.9085 -5.2
+      vertex 132.178 35.8982 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 143.803 13.763 -5.2
+      vertex 144.775 14.6335 -5.2
+      vertex 144.889 17.8338 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.775 14.6335 -5.2
+      vertex 143.803 13.763 -5.2
+      vertex 144.272 14.0747 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 132.82 36.4889 -5.2
+      vertex 144.91 17.8457 -5.2
+      vertex 133.052 36.9331 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 133.052 36.9331 -5.2
+      vertex 144.91 17.8457 -5.2
+      vertex 133.167 37.4212 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.91 17.8457 -5.2
+      vertex 133.156 37.9224 -5.2
+      vertex 133.167 37.4212 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.91 17.8457 -5.2
+      vertex 133.021 38.4053 -5.2
+      vertex 133.156 37.9224 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.91 38.6303 -5.2
+      vertex 133.021 38.4053 -5.2
+      vertex 144.91 17.8457 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 133.021 38.4053 -5.2
+      vertex 132.91 38.6303 -5.2
+      vertex 132.896 38.6224 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.889 17.8338 -5.2
+      vertex 145.295 16.0321 -5.2
+      vertex 145.279 16.7839 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.889 17.8338 -5.2
+      vertex 145.279 16.7839 -5.2
+      vertex 145.077 17.5082 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 145.295 16.0321 -5.2
+      vertex 144.889 17.8338 -5.2
+      vertex 145.123 15.3 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 145.123 15.3 -5.2
+      vertex 144.889 17.8338 -5.2
+      vertex 144.775 14.6335 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 132.484 36.1163 -5.2
+      vertex 144.91 17.8457 -5.2
+      vertex 132.82 36.4889 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.91 17.8457 -5.2
+      vertex 132.484 36.1163 -5.2
+      vertex 144.889 17.8338 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 132.178 35.8982 -5.2
+      vertex 144.889 17.8338 -5.2
+      vertex 132.484 36.1163 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 127.414 33.1482 -5.2
+      vertex 144.889 17.8338 -5.2
+      vertex 132.178 35.8982 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 123.25 20.8461 -5.2
+      vertex 144.889 17.8338 -5.2
+      vertex 127.414 33.1482 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.889 17.8338 -5.2
+      vertex 123.25 20.8461 -5.2
+      vertex 143.803 13.763 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 127.304 33.0889 -5.2
+      vertex 127.414 33.1482 -5.2
+      vertex 127.408 33.1585 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 123.25 20.8461 -5.2
+      vertex 127.414 33.1482 -5.2
+      vertex 127.304 33.0889 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 123.25 20.8461 -5.2
+      vertex 127.304 33.0889 -5.2
+      vertex 126.83 32.924 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.697 28.5439 -5.2
+      vertex 126.83 32.924 -5.2
+      vertex 126.331 32.882 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.697 28.5439 -5.2
+      vertex 126.331 32.882 -5.2
+      vertex 125.836 32.9656 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.697 28.5439 -5.2
+      vertex 125.836 32.9656 -5.2
+      vertex 125.378 33.1696 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.697 28.5439 -5.2
+      vertex 125.378 33.1696 -5.2
+      vertex 124.985 33.481 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 124.315 13.0661 -5.2
+      vertex 143.803 13.763 -5.2
+      vertex 123.25 20.8461 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 143.812 13.7476 -5.2
+      vertex 124.89 5.23446 -5.2
+      vertex 124.915 2.83794 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.697 28.5439 -5.2
+      vertex 124.985 33.481 -5.2
+      vertex 124.682 33.8803 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 143.803 13.763 -5.2
+      vertex 124.89 5.23446 -5.2
+      vertex 143.812 13.7476 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 124.89 5.23446 -5.2
+      vertex 143.803 13.763 -5.2
+      vertex 124.315 13.0661 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 126.83 32.924 -5.2
+      vertex 121.697 28.5439 -5.2
+      vertex 123.25 20.8461 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 124.682 33.8803 -5.2
+      vertex 119.665 36.129 -5.2
+      vertex 121.697 28.5439 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 124.682 33.8803 -5.2
+      vertex 117.16 43.5715 -5.2
+      vertex 119.665 36.129 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 124.682 33.8803 -5.2
+      vertex 114.193 50.8421 -5.2
+      vertex 117.16 43.5715 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 124.682 33.8803 -5.2
+      vertex 110.775 57.912 -5.2
+      vertex 114.193 50.8421 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 110.775 57.912 -5.2
+      vertex 124.682 33.8803 -5.2
+      vertex 109.468 60.232 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.5715 -117.16 -5.2
+      vertex 34.9961 -126.793 -5.2
+      vertex 35 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.5715 -117.16 -5.2
+      vertex 34.9021 -126.3 -5.2
+      vertex 34.9961 -126.793 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.129 -119.665 -5.2
+      vertex 34.6887 -125.847 -5.2
+      vertex 34.9021 -126.3 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.129 -119.665 -5.2
+      vertex 34.3691 -125.46 -5.2
+      vertex 34.6887 -125.847 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.129 -119.665 -5.2
+      vertex 33.9635 -125.166 -5.2
+      vertex 34.3691 -125.46 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.129 -119.665 -5.2
+      vertex 33.4974 -124.981 -5.2
+      vertex 33.9635 -125.166 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 36.129 -119.665 -5.2
+      vertex 33 -124.918 -5.2
+      vertex 33.4974 -124.981 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.5439 -121.697 -5.2
+      vertex 33 -124.918 -5.2
+      vertex 36.129 -119.665 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.8461 -123.25 -5.2
+      vertex 33 -124.918 -5.2
+      vertex 28.5439 -121.697 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.0661 -124.315 -5.2
+      vertex 33 -124.918 -5.2
+      vertex 20.8461 -123.25 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.23446 -124.89 -5.2
+      vertex 33 -124.918 -5.2
+      vertex 13.0661 -124.315 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33 -124.918 -5.2
+      vertex 5.23446 -124.89 -5.2
+      vertex 2.57163 -124.918 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 57.912 -110.775 -5.2
+      vertex 60 -131.418 -5.2
+      vertex 60 -109.599 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -131.418 -5.2
+      vertex 57.912 -110.775 -5.2
+      vertex 59.9822 -131.418 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 50.8421 -114.193 -5.2
+      vertex 59.9822 -131.418 -5.2
+      vertex 57.912 -110.775 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 43.5715 -117.16 -5.2
+      vertex 59.9822 -131.418 -5.2
+      vertex 50.8421 -114.193 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 59.7145 -132.696 -5.2
+      vertex 59.9822 -131.418 -5.2
+      vertex 57 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.9822 -131.418 -5.2
+      vertex 59.7145 -132.696 -5.2
+      vertex 59.9469 -131.98 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.7145 -132.696 -5.2
+      vertex 57 -134.395 -5.2
+      vertex 59.3115 -133.331 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.3115 -133.331 -5.2
+      vertex 57 -134.395 -5.2
+      vertex 58.7634 -133.845 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.7634 -133.845 -5.2
+      vertex 57 -134.395 -5.2
+      vertex 58.1044 -134.208 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.1044 -134.208 -5.2
+      vertex 57 -134.395 -5.2
+      vertex 57.376 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.9822 -131.418 -5.2
+      vertex 43.5715 -117.16 -5.2
+      vertex 57 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35 -126.918 -5.2
+      vertex 57 -134.395 -5.2
+      vertex 43.5715 -117.16 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.9021 -126.3 -5.2
+      vertex 43.5715 -117.16 -5.2
+      vertex 36.129 -119.665 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35 -132.418 -5.2
+      vertex 57 -134.395 -5.2
+      vertex 35 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.9646 -132.793 -5.2
+      vertex 57 -134.395 -5.2
+      vertex 35 -132.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.9646 -132.793 -5.2
+      vertex 35 -132.418 -5.2
+      vertex 34.9882 -132.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57 -134.395 -5.2
+      vertex 34.9646 -132.793 -5.2
+      vertex 57 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.8097 -133.27 -5.2
+      vertex 57 -134.418 -5.2
+      vertex 34.9646 -132.793 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.541 -133.693 -5.2
+      vertex 57 -134.418 -5.2
+      vertex 34.8097 -133.27 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.1756 -134.036 -5.2
+      vertex 57 -134.418 -5.2
+      vertex 34.541 -133.693 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 33.7362 -134.278 -5.2
+      vertex 57 -134.418 -5.2
+      vertex 34.1756 -134.036 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 33.2507 -134.402 -5.2
+      vertex 57 -134.418 -5.2
+      vertex 33.7362 -134.278 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33 -134.418 -5.2
+      vertex 33.2507 -134.402 -5.2
+      vertex 33 -134.402 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.2507 -134.402 -5.2
+      vertex 33 -134.418 -5.2
+      vertex 57 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35 -126.918 -5.2
+      vertex 34.9961 -126.793 -5.2
+      vertex 34.9882 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.4597 -124.562 -5.2
+      vertex -33 -124.918 -5.2
+      vertex -3.65479 -124.918 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2604 -123.659 -5.2
+      vertex -33 -124.918 -5.2
+      vertex -10.4597 -124.562 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.989 -122.268 -5.2
+      vertex -33 -124.918 -5.2
+      vertex -18.2604 -123.659 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.615 -120.395 -5.2
+      vertex -33 -124.918 -5.2
+      vertex -25.989 -122.268 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33 -124.918 -5.2
+      vertex -33.615 -120.395 -5.2
+      vertex -33.4974 -124.981 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.615 -120.395 -5.2
+      vertex -33.9635 -125.166 -5.2
+      vertex -33.4974 -124.981 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.615 -120.395 -5.2
+      vertex -34.3691 -125.46 -5.2
+      vertex -33.9635 -125.166 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -41.1083 -118.047 -5.2
+      vertex -34.3691 -125.46 -5.2
+      vertex -33.615 -120.395 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.3691 -125.46 -5.2
+      vertex -41.1083 -118.047 -5.2
+      vertex -34.6887 -125.847 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57 -134.395 -5.2
+      vertex -35 -126.918 -5.2
+      vertex -41.1083 -118.047 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9961 -126.793 -5.2
+      vertex -41.1083 -118.047 -5.2
+      vertex -35 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9021 -126.3 -5.2
+      vertex -41.1083 -118.047 -5.2
+      vertex -34.9961 -126.793 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.6887 -125.847 -5.2
+      vertex -41.1083 -118.047 -5.2
+      vertex -34.9021 -126.3 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9882 -126.918 -5.2
+      vertex -34.9961 -126.793 -5.2
+      vertex -35 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -33.2507 -134.402 -5.2
+      vertex -33 -134.418 -5.2
+      vertex -33 -134.402 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35 -132.418 -5.2
+      vertex -34.9646 -132.793 -5.2
+      vertex -34.9882 -132.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35 -126.918 -5.2
+      vertex -57 -134.395 -5.2
+      vertex -35 -132.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -35 -132.418 -5.2
+      vertex -57 -134.395 -5.2
+      vertex -34.9646 -132.793 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57 -134.395 -5.2
+      vertex -41.1083 -118.047 -5.2
+      vertex -48.4394 -115.233 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57 -134.418 -5.2
+      vertex -34.9646 -132.793 -5.2
+      vertex -57 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.9822 -131.418 -5.2
+      vertex -48.4394 -115.233 -5.2
+      vertex -55.5794 -111.964 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9646 -132.793 -5.2
+      vertex -57 -134.418 -5.2
+      vertex -34.8097 -133.27 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.8097 -133.27 -5.2
+      vertex -57 -134.418 -5.2
+      vertex -34.541 -133.693 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.541 -133.693 -5.2
+      vertex -57 -134.418 -5.2
+      vertex -34.1756 -134.036 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.1756 -134.036 -5.2
+      vertex -57 -134.418 -5.2
+      vertex -33.7362 -134.278 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.7362 -134.278 -5.2
+      vertex -57 -134.418 -5.2
+      vertex -33.2507 -134.402 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33.2507 -134.402 -5.2
+      vertex -57 -134.418 -5.2
+      vertex -33 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -48.4394 -115.233 -5.2
+      vertex -59.9822 -131.418 -5.2
+      vertex -57 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -58.7634 -133.845 -5.2
+      vertex -57 -134.395 -5.2
+      vertex -59.9822 -131.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57 -134.395 -5.2
+      vertex -58.1044 -134.208 -5.2
+      vertex -57.376 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57 -134.395 -5.2
+      vertex -58.7634 -133.845 -5.2
+      vertex -58.1044 -134.208 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.7634 -133.845 -5.2
+      vertex -59.9822 -131.418 -5.2
+      vertex -59.3115 -133.331 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3115 -133.331 -5.2
+      vertex -59.9822 -131.418 -5.2
+      vertex -59.7145 -132.696 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.7145 -132.696 -5.2
+      vertex -59.9822 -131.418 -5.2
+      vertex -59.9469 -131.98 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60 -131.418 -5.2
+      vertex -55.5794 -111.964 -5.2
+      vertex -60 -109.594 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -55.5794 -111.964 -5.2
+      vertex -60 -131.418 -5.2
+      vertex -59.9822 -131.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.9096 95.788 -5.2
+      vertex 99.7706 95.9972 -5.2
+      vertex 99.896 95.7801 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.5198 96.6767 -5.2
+      vertex 97.1776 96.52 -5.2
+      vertex 97.1835 96.5098 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.9281 93.3762 -5.2
+      vertex 81.6776 94.6244 -5.2
+      vertex 91.642 92.9645 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92.3076 93.7038 -5.2
+      vertex 81.6776 94.6244 -5.2
+      vertex 91.9281 93.3762 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92.4144 93.77 -5.2
+      vertex 81.6776 94.6244 -5.2
+      vertex 92.3076 93.7038 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 81.6776 94.6244 -5.2
+      vertex 92.4144 93.77 -5.2
+      vertex 87.8891 116.561 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.1776 96.52 -5.2
+      vertex 87.8891 116.561 -5.2
+      vertex 92.4144 93.77 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.5198 96.6767 -5.2
+      vertex 87.8891 116.561 -5.2
+      vertex 97.1776 96.52 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 87.8891 116.561 -5.2
+      vertex 97.5198 96.6767 -5.2
+      vertex 87.9096 116.573 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 98.0102 96.7809 -5.2
+      vertex 87.9096 116.573 -5.2
+      vertex 97.5198 96.6767 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 98.5111 96.7599 -5.2
+      vertex 87.9096 116.573 -5.2
+      vertex 98.0102 96.7809 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 98.991 96.6151 -5.2
+      vertex 87.9096 116.573 -5.2
+      vertex 98.5111 96.7599 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.4199 96.3553 -5.2
+      vertex 87.9096 116.573 -5.2
+      vertex 98.991 96.6151 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.7706 95.9972 -5.2
+      vertex 87.9096 116.573 -5.2
+      vertex 99.4199 96.3553 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.9096 116.573 -5.2
+      vertex 99.7706 95.9972 -5.2
+      vertex 99.9096 95.788 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92.4203 93.7598 -5.2
+      vertex 92.4144 93.77 -5.2
+      vertex 92.3076 93.7038 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.6824 91.038 -5.2
+      vertex 102.644 71.3392 -5.2
+      vertex 106.355 65.6243 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.6824 91.038 -5.2
+      vertex 97.9617 77.6435 -5.2
+      vertex 102.644 71.3392 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.6824 91.038 -5.2
+      vertex 92.8931 83.6413 -5.2
+      vertex 97.9617 77.6435 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.4579 89.3091 -5.2
+      vertex 91.6824 91.038 -5.2
+      vertex 91.4881 91.5001 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.642 92.9645 -5.2
+      vertex 81.6776 94.6244 -5.2
+      vertex 91.4673 92.4947 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.175 117.424 -5.2
+      vertex 87.8891 116.561 -5.2
+      vertex 87.7011 116.886 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 87.4579 89.3091 -5.2
+      vertex 91.4673 92.4947 -5.2
+      vertex 81.6776 94.6244 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.6824 91.038 -5.2
+      vertex 87.4579 89.3091 -5.2
+      vertex 92.8931 83.6413 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.4673 92.4947 -5.2
+      vertex 87.4579 89.3091 -5.2
+      vertex 91.4149 91.9961 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 86.5317 117.813 -5.2
+      vertex 87.8891 116.561 -5.2
+      vertex 87.175 117.424 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.8891 116.561 -5.2
+      vertex 86.5317 117.813 -5.2
+      vertex 83.8204 117.655 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 83.8204 117.655 -5.2
+      vertex 86.5317 117.813 -5.2
+      vertex 85.8118 118.031 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 83.8204 117.655 -5.2
+      vertex 85.8118 118.031 -5.2
+      vertex 85.0605 118.062 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 83.8204 117.655 -5.2
+      vertex 85.0605 118.062 -5.2
+      vertex 84.3249 117.906 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.8891 116.561 -5.2
+      vertex 83.8204 117.655 -5.2
+      vertex 75.5749 99.5662 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 69.1739 104.115 -5.2
+      vertex 83.8204 117.655 -5.2
+      vertex 83.8115 117.671 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.4149 91.9961 -5.2
+      vertex 87.4579 89.3091 -5.2
+      vertex 91.4881 91.5001 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.8891 116.561 -5.2
+      vertex 75.5749 99.5662 -5.2
+      vertex 81.6776 94.6244 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 83.8204 117.655 -5.2
+      vertex 69.1739 104.115 -5.2
+      vertex 75.5749 99.5662 -5.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 69.1739 104.115 -5.2
+      vertex 83.8115 117.671 -5.2
+      vertex 64.9109 106.758 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -132.91 38.6303 -5.2
+      vertex -133.021 38.4053 -5.2
+      vertex -132.896 38.6224 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -144.91 17.8457 -5.2
+      vertex -133.167 37.4212 -5.2
+      vertex -133.156 37.9224 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -144.91 17.8457 -5.2
+      vertex -133.156 37.9224 -5.2
+      vertex -133.021 38.4053 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -133.167 37.4212 -5.2
+      vertex -144.889 17.8338 -5.2
+      vertex -143.803 13.763 -5.2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -144.775 14.6335 -5.2
+      vertex -143.803 13.763 -5.2
+      vertex -144.889 17.8338 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.803 13.763 -5.2
+      vertex -144.775 14.6335 -5.2
+      vertex -144.272 14.0747 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -144.91 17.8457 -5.2
+      vertex -133.021 38.4053 -5.2
+      vertex -132.91 38.6303 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -133.167 37.4212 -5.2
+      vertex -144.91 17.8457 -5.2
+      vertex -144.889 17.8338 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -132.172 35.9085 -5.2
+      vertex -132.484 36.1163 -5.2
+      vertex -132.178 35.8982 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -124.682 33.8803 -5.2
+      vertex -111.964 55.5794 -5.2
+      vertex -109.483 60.206 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -124.682 33.8803 -5.2
+      vertex -115.233 48.4394 -5.2
+      vertex -111.964 55.5794 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -124.682 33.8803 -5.2
+      vertex -118.047 41.1083 -5.2
+      vertex -115.233 48.4394 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -124.682 33.8803 -5.2
+      vertex -120.395 33.615 -5.2
+      vertex -118.047 41.1083 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -124.985 33.481 -5.2
+      vertex -120.395 33.615 -5.2
+      vertex -124.682 33.8803 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -120.395 33.615 -5.2
+      vertex -124.985 33.481 -5.2
+      vertex -122.268 25.989 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -125.378 33.1696 -5.2
+      vertex -122.268 25.989 -5.2
+      vertex -124.985 33.481 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -125.836 32.9656 -5.2
+      vertex -122.268 25.989 -5.2
+      vertex -125.378 33.1696 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -126.331 32.882 -5.2
+      vertex -122.268 25.989 -5.2
+      vertex -125.836 32.9656 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -126.83 32.924 -5.2
+      vertex -122.268 25.989 -5.2
+      vertex -126.331 32.882 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -127.304 33.0889 -5.2
+      vertex -122.268 25.989 -5.2
+      vertex -126.83 32.924 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -127.414 33.1482 -5.2
+      vertex -122.268 25.989 -5.2
+      vertex -127.304 33.0889 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -122.268 25.989 -5.2
+      vertex -127.414 33.1482 -5.2
+      vertex -123.659 18.2604 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -123.659 18.2604 -5.2
+      vertex -143.803 13.763 -5.2
+      vertex -124.562 10.4597 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -127.414 33.1482 -5.2
+      vertex -127.304 33.0889 -5.2
+      vertex -127.408 33.1585 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -123.659 18.2604 -5.2
+      vertex -127.414 33.1482 -5.2
+      vertex -143.803 13.763 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.803 13.763 -5.2
+      vertex -127.414 33.1482 -5.2
+      vertex -132.178 35.8982 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.803 13.763 -5.2
+      vertex -132.178 35.8982 -5.2
+      vertex -132.484 36.1163 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.803 13.763 -5.2
+      vertex -132.484 36.1163 -5.2
+      vertex -132.82 36.4889 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.803 13.763 -5.2
+      vertex -132.82 36.4889 -5.2
+      vertex -133.052 36.9331 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.803 13.763 -5.2
+      vertex -133.052 36.9331 -5.2
+      vertex -133.167 37.4212 -5.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -143.812 13.7476 -5.2
+      vertex -124.562 10.4597 -5.2
+      vertex -143.803 13.763 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -124.562 10.4597 -5.2
+      vertex -143.812 13.7476 -5.2
+      vertex -124.96 2.86349 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -145.279 16.7839 -5.2
+      vertex -144.889 17.8338 -5.2
+      vertex -145.077 17.5082 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -144.889 17.8338 -5.2
+      vertex -145.123 15.3 -5.2
+      vertex -144.775 14.6335 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -145.295 16.0321 -5.2
+      vertex -144.889 17.8338 -5.2
+      vertex -145.279 16.7839 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -144.889 17.8338 -5.2
+      vertex -145.295 16.0321 -5.2
+      vertex -145.123 15.3 -5.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.6374 102.266 -11.2
+      vertex -61.6062 103.758 -11.2
+      vertex -61.5276 103.01 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.6374 102.266 -11.2
+      vertex -61.8683 104.462 -11.2
+      vertex -61.6062 103.758 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.9288 101.573 -11.2
+      vertex -61.8683 104.462 -11.2
+      vertex -61.6374 102.266 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -63.0358 105.655 -11.2
+      vertex -61.8683 104.462 -11.2
+      vertex -61.9288 101.573 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.8683 104.462 -11.2
+      vertex -63.0358 105.655 -11.2
+      vertex -62.2975 105.08 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -62.2975 105.08 -11.2
+      vertex -63.0358 105.655 -11.2
+      vertex -62.8667 105.571 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -61.9288 101.573 -11.2
+      vertex -73.4192 111.671 -11.2
+      vertex -63.0358 105.655 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -11.2
+      vertex -73.4192 111.671 -11.2
+      vertex -61.9288 101.573 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -123.018 1.76299 -11.2
+      vertex -118.929 2.84567 -11.2
+      vertex -119.384 2.24668 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -123.018 1.76299 -11.2
+      vertex -119.384 2.24668 -11.2
+      vertex -119.973 1.77958 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -123.018 1.76299 -11.2
+      vertex -119.973 1.77958 -11.2
+      vertex -120.66 1.47371 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -123.018 1.76299 -11.2
+      vertex -120.66 1.47371 -11.2
+      vertex -121.401 1.3483 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -123.018 1.76299 -11.2
+      vertex -121.401 1.3483 -11.2
+      vertex -122.151 1.41123 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -123.018 1.76299 -11.2
+      vertex -122.151 1.41123 -11.2
+      vertex -122.861 1.65854 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -11.2
+      vertex -123.018 1.76299 -11.2
+      vertex -133.419 7.7476 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -133.419 7.7476 -11.2
+      vertex -123.018 1.76299 -11.2
+      vertex -123.027 1.7476 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -118.929 2.84567 -11.2
+      vertex -133.419 7.7476 -11.2
+      vertex -73.4192 111.671 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -63.0269 105.671 -11.2
+      vertex -63.0358 105.655 -11.2
+      vertex -73.4192 111.671 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.8115 117.671 -11.2
+      vertex -22.1465 219.478 -11.2
+      vertex -26.9096 222.228 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.1465 219.478 -11.2
+      vertex -83.8115 117.671 -11.2
+      vertex -81.6465 116.421 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -84.3249 117.906 -11.2
+      vertex -83.8115 117.671 -11.2
+      vertex -26.9096 222.228 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.8115 117.671 -11.2
+      vertex -84.3249 117.906 -11.2
+      vertex -83.8204 117.655 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.9096 222.228 -11.2
+      vertex -85.0605 118.062 -11.2
+      vertex -84.3249 117.906 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.9096 222.228 -11.2
+      vertex -85.8118 118.031 -11.2
+      vertex -85.0605 118.062 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.9096 222.228 -11.2
+      vertex -86.5317 117.813 -11.2
+      vertex -85.8118 118.031 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.9096 222.228 -11.2
+      vertex -87.175 117.424 -11.2
+      vertex -86.5317 117.813 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.9096 222.228 -11.2
+      vertex -87.7011 116.886 -11.2
+      vertex -87.175 117.424 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.9096 116.573 -11.2
+      vertex -87.7011 116.886 -11.2
+      vertex -26.9096 222.228 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.7011 116.886 -11.2
+      vertex -87.9096 116.573 -11.2
+      vertex -87.8891 116.561 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.803 13.763 -11.2
+      vertex -144.272 14.0747 -11.2
+      vertex -143.812 13.7476 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.812 13.7476 -11.2
+      vertex -201.146 -90.5594 -11.2
+      vertex -141.646 12.4976 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -205.91 -87.8094 -11.2
+      vertex -143.812 13.7476 -11.2
+      vertex -144.272 14.0747 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -205.91 -87.8094 -11.2
+      vertex -144.272 14.0747 -11.2
+      vertex -144.775 14.6335 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -205.91 -87.8094 -11.2
+      vertex -144.775 14.6335 -11.2
+      vertex -145.123 15.3 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -205.91 -87.8094 -11.2
+      vertex -145.123 15.3 -11.2
+      vertex -145.295 16.0321 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -144.91 17.8457 -11.2
+      vertex -145.077 17.5082 -11.2
+      vertex -144.889 17.8338 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -205.91 -87.8094 -11.2
+      vertex -145.295 16.0321 -11.2
+      vertex -145.279 16.7839 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -205.91 -87.8094 -11.2
+      vertex -145.279 16.7839 -11.2
+      vertex -145.077 17.5082 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -205.91 -87.8094 -11.2
+      vertex -145.077 17.5082 -11.2
+      vertex -144.91 17.8457 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -143.812 13.7476 -11.2
+      vertex -205.91 -87.8094 -11.2
+      vertex -201.146 -90.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -138.182 10.4976 -11.2
+      vertex -192.919 -95.3094 -11.2
+      vertex -133.419 7.7476 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -192.919 -95.3094 -11.2
+      vertex -138.182 10.4976 -11.2
+      vertex -197.682 -92.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6824 217.478 -11.2
+      vertex -73.4192 111.671 -11.2
+      vertex -13.9192 214.728 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -73.4192 111.671 -11.2
+      vertex -18.6824 217.478 -11.2
+      vertex -78.1824 114.421 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -138.182 10.4976 -11.2
+      vertex -81.6465 116.421 -11.2
+      vertex -78.1824 114.421 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -81.6465 116.421 -11.2
+      vertex -138.182 10.4976 -11.2
+      vertex -141.646 12.4976 -11.2
+    endloop
+  endfacet
+  facet normal -0.886201 -0.463302 0
+    outer loop
+      vertex -144.775 14.6335 -11.2
+      vertex -145.123 15.3 -5.2
+      vertex -145.123 15.3 -11.2
+    endloop
+  endfacet
+  facet normal -0.886201 -0.463302 0
+    outer loop
+      vertex -145.123 15.3 -5.2
+      vertex -144.775 14.6335 -11.2
+      vertex -144.775 14.6335 -5.2
+    endloop
+  endfacet
+  facet normal -0.973578 -0.228354 0
+    outer loop
+      vertex -145.123 15.3 -11.2
+      vertex -145.295 16.0321 -5.2
+      vertex -145.295 16.0321 -11.2
+    endloop
+  endfacet
+  facet normal -0.973578 -0.228354 0
+    outer loop
+      vertex -145.295 16.0321 -5.2
+      vertex -145.123 15.3 -11.2
+      vertex -145.123 15.3 -5.2
+    endloop
+  endfacet
+  facet normal -0.553391 -0.832922 0
+    outer loop
+      vertex -144.272 14.0747 -11.2
+      vertex -143.803 13.763 -5.2
+      vertex -144.272 14.0747 -5.2
+    endloop
+  endfacet
+  facet normal -0.553391 -0.832922 -0
+    outer loop
+      vertex -143.803 13.763 -5.2
+      vertex -144.272 14.0747 -11.2
+      vertex -143.803 13.763 -11.2
+    endloop
+  endfacet
+  facet normal -0.99978 0.0209605 0
+    outer loop
+      vertex -145.295 16.0321 -11.2
+      vertex -145.279 16.7839 -5.2
+      vertex -145.279 16.7839 -11.2
+    endloop
+  endfacet
+  facet normal -0.99978 0.0209605 0
+    outer loop
+      vertex -145.279 16.7839 -5.2
+      vertex -145.295 16.0321 -11.2
+      vertex -145.295 16.0321 -5.2
+    endloop
+  endfacet
+  facet normal -0.963164 0.268916 0
+    outer loop
+      vertex -145.279 16.7839 -11.2
+      vertex -145.077 17.5082 -5.2
+      vertex -145.077 17.5082 -11.2
+    endloop
+  endfacet
+  facet normal -0.963164 0.268916 0
+    outer loop
+      vertex -145.077 17.5082 -5.2
+      vertex -145.279 16.7839 -11.2
+      vertex -145.279 16.7839 -5.2
+    endloop
+  endfacet
+  facet normal -0.743143 -0.669133 0
+    outer loop
+      vertex -144.272 14.0747 -11.2
+      vertex -144.775 14.6335 -5.2
+      vertex -144.775 14.6335 -11.2
+    endloop
+  endfacet
+  facet normal -0.743143 -0.669133 0
+    outer loop
+      vertex -144.775 14.6335 -5.2
+      vertex -144.272 14.0747 -11.2
+      vertex -144.272 14.0747 -5.2
+    endloop
+  endfacet
+  facet normal -0.866033 0.499987 0
+    outer loop
+      vertex -87.8891 116.561 -11.2
+      vertex -87.7011 116.886 -5.2
+      vertex -87.7011 116.886 -11.2
+    endloop
+  endfacet
+  facet normal -0.866033 0.499987 0
+    outer loop
+      vertex -87.7011 116.886 -5.2
+      vertex -87.8891 116.561 -11.2
+      vertex -87.8891 116.561 -5.2
+    endloop
+  endfacet
+  facet normal 0.444633 0.895713 -0
+    outer loop
+      vertex -83.8204 117.655 -11.2
+      vertex -84.3249 117.906 -5.2
+      vertex -83.8204 117.655 -5.2
+    endloop
+  endfacet
+  facet normal 0.444633 0.895713 0
+    outer loop
+      vertex -84.3249 117.906 -5.2
+      vertex -83.8204 117.655 -11.2
+      vertex -84.3249 117.906 -11.2
+    endloop
+  endfacet
+  facet normal -0.289032 0.957319 0
+    outer loop
+      vertex -85.8118 118.031 -11.2
+      vertex -86.5317 117.813 -5.2
+      vertex -85.8118 118.031 -5.2
+    endloop
+  endfacet
+  facet normal -0.289032 0.957319 0
+    outer loop
+      vertex -86.5317 117.813 -5.2
+      vertex -85.8118 118.031 -11.2
+      vertex -86.5317 117.813 -11.2
+    endloop
+  endfacet
+  facet normal -0.0418707 0.999123 0
+    outer loop
+      vertex -85.0605 118.062 -11.2
+      vertex -85.8118 118.031 -5.2
+      vertex -85.0605 118.062 -5.2
+    endloop
+  endfacet
+  facet normal -0.0418707 0.999123 0
+    outer loop
+      vertex -85.8118 118.031 -5.2
+      vertex -85.0605 118.062 -11.2
+      vertex -85.8118 118.031 -11.2
+    endloop
+  endfacet
+  facet normal -0.518027 0.855364 0
+    outer loop
+      vertex -86.5317 117.813 -11.2
+      vertex -87.175 117.424 -5.2
+      vertex -86.5317 117.813 -5.2
+    endloop
+  endfacet
+  facet normal -0.518027 0.855364 0
+    outer loop
+      vertex -87.175 117.424 -5.2
+      vertex -86.5317 117.813 -11.2
+      vertex -87.175 117.424 -11.2
+    endloop
+  endfacet
+  facet normal -0.714469 0.699667 0
+    outer loop
+      vertex -87.7011 116.886 -11.2
+      vertex -87.175 117.424 -5.2
+      vertex -87.175 117.424 -11.2
+    endloop
+  endfacet
+  facet normal -0.714469 0.699667 0
+    outer loop
+      vertex -87.175 117.424 -5.2
+      vertex -87.7011 116.886 -11.2
+      vertex -87.7011 116.886 -5.2
+    endloop
+  endfacet
+  facet normal 0.207912 0.978148 -0
+    outer loop
+      vertex -84.3249 117.906 -11.2
+      vertex -85.0605 118.062 -5.2
+      vertex -84.3249 117.906 -5.2
+    endloop
+  endfacet
+  facet normal 0.207912 0.978148 0
+    outer loop
+      vertex -85.0605 118.062 -5.2
+      vertex -84.3249 117.906 -11.2
+      vertex -85.0605 118.062 -11.2
+    endloop
+  endfacet
+  facet normal -0.328866 -0.944377 0
+    outer loop
+      vertex -122.861 1.65854 -11.2
+      vertex -122.151 1.41123 -5.2
+      vertex -122.861 1.65854 -5.2
+    endloop
+  endfacet
+  facet normal -0.328866 -0.944377 -0
+    outer loop
+      vertex -122.151 1.41123 -5.2
+      vertex -122.861 1.65854 -11.2
+      vertex -122.151 1.41123 -11.2
+    endloop
+  endfacet
+  facet normal 0.406734 -0.913546 0
+    outer loop
+      vertex -120.66 1.47371 -11.2
+      vertex -119.973 1.77958 -5.2
+      vertex -120.66 1.47371 -5.2
+    endloop
+  endfacet
+  facet normal 0.406734 -0.913546 0
+    outer loop
+      vertex -119.973 1.77958 -5.2
+      vertex -120.66 1.47371 -11.2
+      vertex -119.973 1.77958 -11.2
+    endloop
+  endfacet
+  facet normal 0.621151 -0.783691 0
+    outer loop
+      vertex -119.973 1.77958 -11.2
+      vertex -119.384 2.24668 -5.2
+      vertex -119.973 1.77958 -5.2
+    endloop
+  endfacet
+  facet normal 0.621151 -0.783691 0
+    outer loop
+      vertex -119.384 2.24668 -5.2
+      vertex -119.973 1.77958 -11.2
+      vertex -119.384 2.24668 -11.2
+    endloop
+  endfacet
+  facet normal -0.0836772 -0.996493 0
+    outer loop
+      vertex -122.151 1.41123 -11.2
+      vertex -121.401 1.3483 -5.2
+      vertex -122.151 1.41123 -5.2
+    endloop
+  endfacet
+  facet normal -0.0836772 -0.996493 -0
+    outer loop
+      vertex -121.401 1.3483 -5.2
+      vertex -122.151 1.41123 -11.2
+      vertex -121.401 1.3483 -11.2
+    endloop
+  endfacet
+  facet normal 0.796529 -0.6046 0
+    outer loop
+      vertex -119.384 2.24668 -5.2
+      vertex -118.929 2.84567 -11.2
+      vertex -118.929 2.84567 -5.2
+    endloop
+  endfacet
+  facet normal 0.796529 -0.6046 0
+    outer loop
+      vertex -118.929 2.84567 -11.2
+      vertex -119.384 2.24668 -5.2
+      vertex -119.384 2.24668 -11.2
+    endloop
+  endfacet
+  facet normal -0.553402 -0.832914 0
+    outer loop
+      vertex -123.018 1.76299 -11.2
+      vertex -122.861 1.65854 -5.2
+      vertex -123.018 1.76299 -5.2
+    endloop
+  endfacet
+  facet normal -0.553402 -0.832914 -0
+    outer loop
+      vertex -122.861 1.65854 -5.2
+      vertex -123.018 1.76299 -11.2
+      vertex -122.861 1.65854 -11.2
+    endloop
+  endfacet
+  facet normal 0.166768 -0.985996 0
+    outer loop
+      vertex -121.401 1.3483 -11.2
+      vertex -120.66 1.47371 -5.2
+      vertex -121.401 1.3483 -5.2
+    endloop
+  endfacet
+  facet normal 0.166768 -0.985996 0
+    outer loop
+      vertex -120.66 1.47371 -5.2
+      vertex -121.401 1.3483 -11.2
+      vertex -120.66 1.47371 -11.2
+    endloop
+  endfacet
+  facet normal 0.921862 -0.387518 0
+    outer loop
+      vertex -61.9288 101.573 -5.2
+      vertex -61.6374 102.266 -11.2
+      vertex -61.6374 102.266 -5.2
+    endloop
+  endfacet
+  facet normal 0.921862 -0.387518 0
+    outer loop
+      vertex -61.6374 102.266 -11.2
+      vertex -61.9288 101.573 -5.2
+      vertex -61.9288 101.573 -11.2
+    endloop
+  endfacet
+  facet normal 0.444608 0.895725 -0
+    outer loop
+      vertex -62.8667 105.571 -11.2
+      vertex -63.0358 105.655 -5.2
+      vertex -62.8667 105.571 -5.2
+    endloop
+  endfacet
+  facet normal 0.444608 0.895725 0
+    outer loop
+      vertex -63.0358 105.655 -5.2
+      vertex -62.8667 105.571 -11.2
+      vertex -63.0358 105.655 -11.2
+    endloop
+  endfacet
+  facet normal 0.937281 0.348574 0
+    outer loop
+      vertex -61.6062 103.758 -5.2
+      vertex -61.8683 104.462 -11.2
+      vertex -61.8683 104.462 -5.2
+    endloop
+  endfacet
+  facet normal 0.937281 0.348574 0
+    outer loop
+      vertex -61.8683 104.462 -11.2
+      vertex -61.6062 103.758 -5.2
+      vertex -61.6062 103.758 -11.2
+    endloop
+  endfacet
+  facet normal 0.989272 -0.146084 0
+    outer loop
+      vertex -61.6374 102.266 -5.2
+      vertex -61.5276 103.01 -11.2
+      vertex -61.5276 103.01 -5.2
+    endloop
+  endfacet
+  facet normal 0.989272 -0.146084 0
+    outer loop
+      vertex -61.5276 103.01 -11.2
+      vertex -61.6374 102.266 -5.2
+      vertex -61.6374 102.266 -11.2
+    endloop
+  endfacet
+  facet normal 0.821148 0.570716 0
+    outer loop
+      vertex -61.8683 104.462 -5.2
+      vertex -62.2975 105.08 -11.2
+      vertex -62.2975 105.08 -5.2
+    endloop
+  endfacet
+  facet normal 0.821148 0.570716 0
+    outer loop
+      vertex -62.2975 105.08 -11.2
+      vertex -61.8683 104.462 -5.2
+      vertex -61.8683 104.462 -11.2
+    endloop
+  endfacet
+  facet normal 0.994522 0.104529 0
+    outer loop
+      vertex -61.5276 103.01 -5.2
+      vertex -61.6062 103.758 -11.2
+      vertex -61.6062 103.758 -5.2
+    endloop
+  endfacet
+  facet normal 0.994522 0.104529 0
+    outer loop
+      vertex -61.6062 103.758 -11.2
+      vertex -61.5276 103.01 -5.2
+      vertex -61.5276 103.01 -11.2
+    endloop
+  endfacet
+  facet normal 0.653426 0.75699 -0
+    outer loop
+      vertex -62.2975 105.08 -11.2
+      vertex -62.8667 105.571 -5.2
+      vertex -62.2975 105.08 -5.2
+    endloop
+  endfacet
+  facet normal 0.653426 0.75699 0
+    outer loop
+      vertex -62.8667 105.571 -5.2
+      vertex -62.2975 105.08 -11.2
+      vertex -62.8667 105.571 -11.2
+    endloop
+  endfacet
+  facet normal -0.86579 0.500408 0
+    outer loop
+      vertex -143.812 13.7476 -11.2
+      vertex -143.803 13.763 -5.2
+      vertex -143.803 13.763 -11.2
+    endloop
+  endfacet
+  facet normal -0.86579 0.500408 0
+    outer loop
+      vertex -143.803 13.763 -5.2
+      vertex -143.812 13.7476 -11.2
+      vertex -143.812 13.7476 -5.2
+    endloop
+  endfacet
+  facet normal -0.866043 0.49997 0
+    outer loop
+      vertex -83.8204 117.655 -11.2
+      vertex -83.8115 117.671 -5.2
+      vertex -83.8115 117.671 -11.2
+    endloop
+  endfacet
+  facet normal -0.866043 0.49997 0
+    outer loop
+      vertex -83.8115 117.671 -5.2
+      vertex -83.8204 117.655 -11.2
+      vertex -83.8204 117.655 -5.2
+    endloop
+  endfacet
+  facet normal 0.865966 -0.500104 0
+    outer loop
+      vertex -123.027 1.7476 -5.2
+      vertex -123.018 1.76299 -11.2
+      vertex -123.018 1.76299 -5.2
+    endloop
+  endfacet
+  facet normal 0.865966 -0.500104 0
+    outer loop
+      vertex -123.018 1.76299 -11.2
+      vertex -123.027 1.7476 -5.2
+      vertex -123.027 1.7476 -11.2
+    endloop
+  endfacet
+  facet normal 0.866136 -0.499809 0
+    outer loop
+      vertex -63.0358 105.655 -5.2
+      vertex -63.0269 105.671 -11.2
+      vertex -63.0269 105.671 -5.2
+    endloop
+  endfacet
+  facet normal 0.866136 -0.499809 0
+    outer loop
+      vertex -63.0269 105.671 -11.2
+      vertex -63.0358 105.655 -5.2
+      vertex -63.0358 105.655 -11.2
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 -0
+    outer loop
+      vertex -63.0269 105.671 -11.2
+      vertex -64.9597 106.787 -5.2
+      vertex -63.0269 105.671 -5.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 5.20318e-07
+    outer loop
+      vertex -64.9597 106.787 -5.2
+      vertex -63.0269 105.671 -11.2
+      vertex -73.4192 111.671 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 2.86832e-07
+    outer loop
+      vertex -64.9597 106.787 -5.2
+      vertex -73.4192 111.671 -11.2
+      vertex -83.8115 117.671 -5.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 2.31194e-07
+    outer loop
+      vertex -78.1824 114.421 -11.2
+      vertex -83.8115 117.671 -5.2
+      vertex -73.4192 111.671 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866026 -2.38418e-07
+    outer loop
+      vertex -81.6465 116.421 -11.2
+      vertex -83.8115 117.671 -5.2
+      vertex -78.1824 114.421 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -83.8115 117.671 -5.2
+      vertex -81.6465 116.421 -11.2
+      vertex -83.8115 117.671 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 3.17324e-07
+    outer loop
+      vertex -133.419 7.7476 -11.2
+      vertex -124.96 2.86349 -5.2
+      vertex -143.812 13.7476 -5.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex -141.646 12.4976 -11.2
+      vertex -143.812 13.7476 -5.2
+      vertex -143.812 13.7476 -11.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 -7.9473e-07
+    outer loop
+      vertex -138.182 10.4976 -11.2
+      vertex -143.812 13.7476 -5.2
+      vertex -141.646 12.4976 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 -1.49855e-07
+    outer loop
+      vertex -133.419 7.7476 -11.2
+      vertex -143.812 13.7476 -5.2
+      vertex -138.182 10.4976 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 1.14117e-07
+    outer loop
+      vertex -123.027 1.7476 -11.2
+      vertex -124.96 2.86349 -5.2
+      vertex -133.419 7.7476 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex -124.96 2.86349 -5.2
+      vertex -123.027 1.7476 -11.2
+      vertex -123.027 1.7476 -5.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -87.9096 116.573 -11.2
+      vertex -99.9096 95.788 -5.2
+      vertex -87.9096 116.573 -5.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -99.9096 95.788 -5.2
+      vertex -132.91 38.6303 -5.2
+      vertex -99.9096 95.788 -0.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 4.04589e-07
+    outer loop
+      vertex -87.9096 116.573 -11.2
+      vertex -132.91 38.6303 -5.2
+      vertex -99.9096 95.788 -5.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 1.42215e-07
+    outer loop
+      vertex -144.91 17.8457 -11.2
+      vertex -132.91 38.6303 -5.2
+      vertex -87.9096 116.573 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -132.91 38.6303 -5.2
+      vertex -144.91 17.8457 -11.2
+      vertex -144.91 17.8457 -5.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -99.9096 95.788 -0.2
+      vertex -132.91 38.6303 -5.2
+      vertex -132.91 38.6303 -0.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -118.929 2.84567 -5.2
+      vertex -61.9288 101.573 -11.2
+      vertex -61.9288 101.573 -5.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -61.9288 101.573 -11.2
+      vertex -118.929 2.84567 -5.2
+      vertex -118.929 2.84567 -11.2
+    endloop
+  endfacet
+  facet normal 0.500197 0.865912 -0
+    outer loop
+      vertex -87.8891 116.561 -11.2
+      vertex -87.9096 116.573 -5.2
+      vertex -87.8891 116.561 -5.2
+    endloop
+  endfacet
+  facet normal 0.500197 0.865912 0
+    outer loop
+      vertex -87.9096 116.573 -5.2
+      vertex -87.8891 116.561 -11.2
+      vertex -87.9096 116.573 -11.2
+    endloop
+  endfacet
+  facet normal -0.500155 -0.865936 0
+    outer loop
+      vertex -144.91 17.8457 -11.2
+      vertex -144.889 17.8338 -5.2
+      vertex -144.91 17.8457 -5.2
+    endloop
+  endfacet
+  facet normal -0.500155 -0.865936 -0
+    outer loop
+      vertex -144.889 17.8338 -5.2
+      vertex -144.91 17.8457 -11.2
+      vertex -144.889 17.8338 -11.2
+    endloop
+  endfacet
+  facet normal -0.866021 0.500008 0
+    outer loop
+      vertex -133.021 38.4053 -5.2
+      vertex -132.896 38.6224 -0.2
+      vertex -132.896 38.6224 -5.2
+    endloop
+  endfacet
+  facet normal -0.866021 0.500008 0
+    outer loop
+      vertex -132.896 38.6224 -0.2
+      vertex -133.021 38.4053 -5.2
+      vertex -133.021 38.4053 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.4144 93.77 -0.2
+      vertex -97.1776 96.52 -0.2
+      vertex -92.4203 93.7598 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.4673 92.4947 -0.2
+      vertex -91.4881 91.5001 -0.2
+      vertex -91.4149 91.9961 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.642 92.9645 -0.2
+      vertex -91.4881 91.5001 -0.2
+      vertex -91.4673 92.4947 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.642 92.9645 -0.2
+      vertex -91.6824 91.038 -0.2
+      vertex -91.4881 91.5001 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.4203 93.7598 -0.2
+      vertex -91.642 92.9645 -0.2
+      vertex -91.9281 93.3762 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.4203 93.7598 -0.2
+      vertex -91.9281 93.3762 -0.2
+      vertex -92.3076 93.7038 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.642 92.9645 -0.2
+      vertex -92.4203 93.7598 -0.2
+      vertex -91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -97.1835 96.5098 -0.2
+      vertex -92.4203 93.7598 -0.2
+      vertex -97.1776 96.52 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.4203 93.7598 -0.2
+      vertex -97.1835 96.5098 -0.2
+      vertex -91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -98.0102 96.7809 -0.2
+      vertex -97.1835 96.5098 -0.2
+      vertex -97.5198 96.6767 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -97.1835 96.5098 -0.2
+      vertex -98.0102 96.7809 -0.2
+      vertex -99.896 95.7801 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.896 95.7801 -0.2
+      vertex -98.0102 96.7809 -0.2
+      vertex -98.5111 96.7599 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.896 95.7801 -0.2
+      vertex -98.5111 96.7599 -0.2
+      vertex -98.991 96.6151 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.896 95.7801 -0.2
+      vertex -98.991 96.6151 -0.2
+      vertex -99.4199 96.3553 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.896 95.7801 -0.2
+      vertex -99.4199 96.3553 -0.2
+      vertex -99.7706 95.9972 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -97.1835 96.5098 -0.2
+      vertex -99.896 95.7801 -0.2
+      vertex -91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -106.882 64.7122 -0.2
+      vertex -99.896 95.7801 -0.2
+      vertex -99.9096 95.788 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.896 95.7801 -0.2
+      vertex -106.882 64.7122 -0.2
+      vertex -91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -106.882 64.7122 -0.2
+      vertex -109.483 60.206 -0.2
+      vertex -106.921 -64.7534 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.9096 95.788 -0.2
+      vertex -109.483 60.206 -0.2
+      vertex -106.882 64.7122 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -132.91 38.6303 -0.2
+      vertex -109.483 60.206 -0.2
+      vertex -99.9096 95.788 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -109.483 60.206 -0.2
+      vertex -132.896 38.6224 -0.2
+      vertex -124.682 33.8803 -0.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -127.408 33.1585 -0.2
+      vertex -124.682 33.8803 -0.2
+      vertex -132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -124.682 33.8803 -0.2
+      vertex -127.408 33.1585 -0.2
+      vertex -124.985 33.481 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -124.985 33.481 -0.2
+      vertex -127.408 33.1585 -0.2
+      vertex -125.378 33.1696 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -125.378 33.1696 -0.2
+      vertex -127.408 33.1585 -0.2
+      vertex -125.836 32.9656 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -125.836 32.9656 -0.2
+      vertex -127.408 33.1585 -0.2
+      vertex -126.331 32.882 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -126.331 32.882 -0.2
+      vertex -127.408 33.1585 -0.2
+      vertex -126.83 32.924 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -126.83 32.924 -0.2
+      vertex -127.408 33.1585 -0.2
+      vertex -127.304 33.0889 -0.2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -132.172 35.9085 -0.2
+      vertex -127.408 33.1585 -0.2
+      vertex -132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -127.408 33.1585 -0.2
+      vertex -132.172 35.9085 -0.2
+      vertex -127.414 33.1482 -0.2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -132.82 36.4889 -0.2
+      vertex -132.172 35.9085 -0.2
+      vertex -132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -132.172 35.9085 -0.2
+      vertex -132.82 36.4889 -0.2
+      vertex -132.484 36.1163 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -109.483 60.206 -0.2
+      vertex -132.91 38.6303 -0.2
+      vertex -132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -34.9882 -132.418 -0.2
+      vertex -33 -134.402 -0.2
+      vertex -33 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9882 -126.918 -0.2
+      vertex -33 -124.918 -0.2
+      vertex -33.4974 -124.981 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9882 -132.418 -0.2
+      vertex -33 -124.918 -0.2
+      vertex -34.9882 -126.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9882 -126.918 -0.2
+      vertex -33.4974 -124.981 -0.2
+      vertex -33.9635 -125.166 -0.2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -34.1756 -134.036 -0.2
+      vertex -33 -134.402 -0.2
+      vertex -34.9882 -132.418 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9882 -126.918 -0.2
+      vertex -33.9635 -125.166 -0.2
+      vertex -34.3691 -125.46 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33 -134.402 -0.2
+      vertex -33.7362 -134.278 -0.2
+      vertex -33.2507 -134.402 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9882 -126.918 -0.2
+      vertex -34.3691 -125.46 -0.2
+      vertex -34.6887 -125.847 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33 -134.402 -0.2
+      vertex -34.1756 -134.036 -0.2
+      vertex -33.7362 -134.278 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9882 -126.918 -0.2
+      vertex -34.6887 -125.847 -0.2
+      vertex -34.9021 -126.3 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.1756 -134.036 -0.2
+      vertex -34.9882 -132.418 -0.2
+      vertex -34.541 -133.693 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.541 -133.693 -0.2
+      vertex -34.9882 -132.418 -0.2
+      vertex -34.8097 -133.27 -0.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -34.9882 -126.918 -0.2
+      vertex -34.9021 -126.3 -0.2
+      vertex -34.9961 -126.793 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.1776 96.52 -0.2
+      vertex 92.4144 93.77 -0.2
+      vertex 92.4203 93.7598 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.172 35.9085 -0.2
+      vertex 132.82 36.4889 -0.2
+      vertex 132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.82 36.4889 -0.2
+      vertex 132.172 35.9085 -0.2
+      vertex 132.484 36.1163 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 127.408 33.1585 -0.2
+      vertex 132.172 35.9085 -0.2
+      vertex 132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.172 35.9085 -0.2
+      vertex 127.408 33.1585 -0.2
+      vertex 127.414 33.1482 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 124.682 33.8803 -0.2
+      vertex 127.408 33.1585 -0.2
+      vertex 132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 126.331 32.882 -0.2
+      vertex 127.408 33.1585 -0.2
+      vertex 124.682 33.8803 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 127.408 33.1585 -0.2
+      vertex 126.83 32.924 -0.2
+      vertex 127.304 33.0889 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 127.408 33.1585 -0.2
+      vertex 126.331 32.882 -0.2
+      vertex 126.83 32.924 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 126.331 32.882 -0.2
+      vertex 124.682 33.8803 -0.2
+      vertex 125.836 32.9656 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 125.836 32.9656 -0.2
+      vertex 124.682 33.8803 -0.2
+      vertex 125.378 33.1696 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 125.378 33.1696 -0.2
+      vertex 124.682 33.8803 -0.2
+      vertex 124.985 33.481 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.468 60.232 -0.2
+      vertex 132.896 38.6224 -0.2
+      vertex 132.91 38.6303 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.896 38.6224 -0.2
+      vertex 109.468 60.232 -0.2
+      vertex 124.682 33.8803 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.468 60.232 -0.2
+      vertex 106.355 65.6243 -0.2
+      vertex 108.253 -62.5 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.9096 95.788 -0.2
+      vertex 109.468 60.232 -0.2
+      vertex 132.91 38.6303 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.468 60.232 -0.2
+      vertex 99.9096 95.788 -0.2
+      vertex 106.355 65.6243 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 99.896 95.7801 -0.2
+      vertex 106.355 65.6243 -0.2
+      vertex 99.9096 95.788 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.4199 96.3553 -0.2
+      vertex 99.896 95.7801 -0.2
+      vertex 99.7706 95.9972 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 98.991 96.6151 -0.2
+      vertex 99.896 95.7801 -0.2
+      vertex 99.4199 96.3553 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.896 95.7801 -0.2
+      vertex 98.991 96.6151 -0.2
+      vertex 97.1835 96.5098 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.1835 96.5098 -0.2
+      vertex 98.991 96.6151 -0.2
+      vertex 98.5111 96.7599 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.1835 96.5098 -0.2
+      vertex 98.5111 96.7599 -0.2
+      vertex 98.0102 96.7809 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.1835 96.5098 -0.2
+      vertex 98.0102 96.7809 -0.2
+      vertex 97.5198 96.6767 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.896 95.7801 -0.2
+      vertex 97.1835 96.5098 -0.2
+      vertex 91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92.4203 93.7598 -0.2
+      vertex 97.1835 96.5098 -0.2
+      vertex 97.1776 96.52 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.1835 96.5098 -0.2
+      vertex 92.4203 93.7598 -0.2
+      vertex 91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.9281 93.3762 -0.2
+      vertex 92.4203 93.7598 -0.2
+      vertex 92.3076 93.7038 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.642 92.9645 -0.2
+      vertex 92.4203 93.7598 -0.2
+      vertex 91.9281 93.3762 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.896 95.7801 -0.2
+      vertex 91.6824 91.038 -0.2
+      vertex 106.355 65.6243 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92.4203 93.7598 -0.2
+      vertex 91.642 92.9645 -0.2
+      vertex 91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.642 92.9645 -0.2
+      vertex 91.4881 91.5001 -0.2
+      vertex 91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 91.4673 92.4947 -0.2
+      vertex 91.4881 91.5001 -0.2
+      vertex 91.642 92.9645 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 91.4881 91.5001 -0.2
+      vertex 91.4673 92.4947 -0.2
+      vertex 91.4149 91.9961 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.896 38.6224 -0.2
+      vertex 133.167 37.4212 -0.2
+      vertex 133.156 37.9224 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.896 38.6224 -0.2
+      vertex 133.156 37.9224 -0.2
+      vertex 133.021 38.4053 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 133.167 37.4212 -0.2
+      vertex 132.896 38.6224 -0.2
+      vertex 133.052 36.9331 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 133.052 36.9331 -0.2
+      vertex 132.896 38.6224 -0.2
+      vertex 132.82 36.4889 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 132.178 35.8982 -0.2
+      vertex 132.172 35.9085 -0.2
+      vertex 127.414 33.1482 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 124.89 5.23446 -0.2
+      vertex 124.562 -10.4597 -0.2
+      vertex 124.973 -2.6178 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 124.315 13.0661 -0.2
+      vertex 124.562 -10.4597 -0.2
+      vertex 124.89 5.23446 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 124.315 13.0661 -0.2
+      vertex 123.659 -18.2604 -0.2
+      vertex 124.562 -10.4597 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 123.25 20.8461 -0.2
+      vertex 123.659 -18.2604 -0.2
+      vertex 124.315 13.0661 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 123.25 20.8461 -0.2
+      vertex 122.268 -25.989 -0.2
+      vertex 123.659 -18.2604 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.697 28.5439 -0.2
+      vertex 122.268 -25.989 -0.2
+      vertex 123.25 20.8461 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 121.697 28.5439 -0.2
+      vertex 120.395 -33.615 -0.2
+      vertex 122.268 -25.989 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.665 36.129 -0.2
+      vertex 120.395 -33.615 -0.2
+      vertex 121.697 28.5439 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.665 36.129 -0.2
+      vertex 118.047 -41.1083 -0.2
+      vertex 120.395 -33.615 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 117.16 43.5715 -0.2
+      vertex 118.047 -41.1083 -0.2
+      vertex 119.665 36.129 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 117.16 43.5715 -0.2
+      vertex 115.233 -48.4394 -0.2
+      vertex 118.047 -41.1083 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 114.193 50.8421 -0.2
+      vertex 115.233 -48.4394 -0.2
+      vertex 117.16 43.5715 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 114.193 50.8421 -0.2
+      vertex 111.964 -55.5794 -0.2
+      vertex 115.233 -48.4394 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 109.468 60.232 -0.2
+      vertex 114.193 50.8421 -0.2
+      vertex 110.775 57.912 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 114.193 50.8421 -0.2
+      vertex 109.468 60.232 -0.2
+      vertex 111.964 -55.5794 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 111.964 -55.5794 -0.2
+      vertex 109.468 60.232 -0.2
+      vertex 108.253 -62.5 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 106.355 65.6243 -0.2
+      vertex 104.115 -69.1739 -0.2
+      vertex 108.253 -62.5 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 102.644 71.3392 -0.2
+      vertex 104.115 -69.1739 -0.2
+      vertex 106.355 65.6243 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 102.644 71.3392 -0.2
+      vertex 99.5662 -75.5749 -0.2
+      vertex 104.115 -69.1739 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.9617 77.6435 -0.2
+      vertex 99.5662 -75.5749 -0.2
+      vertex 102.644 71.3392 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.9617 77.6435 -0.2
+      vertex 94.6244 -81.6776 -0.2
+      vertex 99.5662 -75.5749 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92.8931 83.6413 -0.2
+      vertex 94.6244 -81.6776 -0.2
+      vertex 97.9617 77.6435 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92.8931 83.6413 -0.2
+      vertex 89.3091 -87.4579 -0.2
+      vertex 94.6244 -81.6776 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.4579 89.3091 -0.2
+      vertex 89.3091 -87.4579 -0.2
+      vertex 92.8931 83.6413 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.4579 89.3091 -0.2
+      vertex 83.6413 -92.8931 -0.2
+      vertex 89.3091 -87.4579 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 81.6776 94.6244 -0.2
+      vertex 83.6413 -92.8931 -0.2
+      vertex 87.4579 89.3091 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 81.6776 94.6244 -0.2
+      vertex 77.6435 -97.9617 -0.2
+      vertex 83.6413 -92.8931 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5749 99.5662 -0.2
+      vertex 77.6435 -97.9617 -0.2
+      vertex 81.6776 94.6244 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 75.5749 99.5662 -0.2
+      vertex 71.3392 -102.644 -0.2
+      vertex 77.6435 -97.9617 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 69.1739 104.115 -0.2
+      vertex 71.3392 -102.644 -0.2
+      vertex 75.5749 99.5662 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 69.1739 104.115 -0.2
+      vertex 64.7534 -106.921 -0.2
+      vertex 71.3392 -102.644 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5 108.253 -0.2
+      vertex 64.7534 -106.921 -0.2
+      vertex 69.1739 104.115 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.5 108.253 -0.2
+      vertex 57.912 -110.775 -0.2
+      vertex 64.7534 -106.921 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5794 111.964 -0.2
+      vertex 57.912 -110.775 -0.2
+      vertex 62.5 108.253 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 55.5794 111.964 -0.2
+      vertex 50.8421 -114.193 -0.2
+      vertex 57.912 -110.775 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.4394 115.233 -0.2
+      vertex 50.8421 -114.193 -0.2
+      vertex 55.5794 111.964 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 48.4394 115.233 -0.2
+      vertex 43.5715 -117.16 -0.2
+      vertex 50.8421 -114.193 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.1083 118.047 -0.2
+      vertex 43.5715 -117.16 -0.2
+      vertex 48.4394 115.233 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.1083 118.047 -0.2
+      vertex 36.129 -119.665 -0.2
+      vertex 43.5715 -117.16 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.615 120.395 -0.2
+      vertex 36.129 -119.665 -0.2
+      vertex 41.1083 118.047 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.615 120.395 -0.2
+      vertex 28.5439 -121.697 -0.2
+      vertex 36.129 -119.665 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.989 122.268 -0.2
+      vertex 28.5439 -121.697 -0.2
+      vertex 33.615 120.395 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.989 122.268 -0.2
+      vertex 20.8461 -123.25 -0.2
+      vertex 28.5439 -121.697 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2604 123.659 -0.2
+      vertex 20.8461 -123.25 -0.2
+      vertex 25.989 122.268 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2604 123.659 -0.2
+      vertex 13.0661 -124.315 -0.2
+      vertex 20.8461 -123.25 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.4597 124.562 -0.2
+      vertex 13.0661 -124.315 -0.2
+      vertex 18.2604 123.659 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.57163 -124.918 -0.2
+      vertex 13.0661 -124.315 -0.2
+      vertex 10.4597 124.562 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.57163 -124.918 -0.2
+      vertex 10.4597 124.562 -0.2
+      vertex 2.6178 124.973 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0661 -124.315 -0.2
+      vertex 2.57163 -124.918 -0.2
+      vertex 5.23446 -124.89 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.6178 124.973 -0.2
+      vertex -3.65479 -124.918 -0.2
+      vertex 2.57163 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.23446 124.89 -0.2
+      vertex -3.65479 -124.918 -0.2
+      vertex 2.6178 124.973 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.23446 124.89 -0.2
+      vertex -10.4597 -124.562 -0.2
+      vertex -3.65479 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.0661 124.315 -0.2
+      vertex -10.4597 -124.562 -0.2
+      vertex -5.23446 124.89 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0661 124.315 -0.2
+      vertex -18.2604 -123.659 -0.2
+      vertex -10.4597 -124.562 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8461 123.25 -0.2
+      vertex -18.2604 -123.659 -0.2
+      vertex -13.0661 124.315 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.8461 123.25 -0.2
+      vertex -25.989 -122.268 -0.2
+      vertex -18.2604 -123.659 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -28.5439 121.697 -0.2
+      vertex -25.989 -122.268 -0.2
+      vertex -20.8461 123.25 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.5439 121.697 -0.2
+      vertex -33.615 -120.395 -0.2
+      vertex -25.989 -122.268 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -36.129 119.665 -0.2
+      vertex -33.615 -120.395 -0.2
+      vertex -28.5439 121.697 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -36.129 119.665 -0.2
+      vertex -41.1083 -118.047 -0.2
+      vertex -33.615 -120.395 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -43.5715 117.16 -0.2
+      vertex -41.1083 -118.047 -0.2
+      vertex -36.129 119.665 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.5715 117.16 -0.2
+      vertex -48.4394 -115.233 -0.2
+      vertex -41.1083 -118.047 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -50.8421 114.193 -0.2
+      vertex -48.4394 -115.233 -0.2
+      vertex -43.5715 117.16 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -50.8421 114.193 -0.2
+      vertex -55.5794 -111.964 -0.2
+      vertex -48.4394 -115.233 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.912 110.775 -0.2
+      vertex -55.5794 -111.964 -0.2
+      vertex -50.8421 114.193 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57.912 110.775 -0.2
+      vertex -62.5 -108.253 -0.2
+      vertex -55.5794 -111.964 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -64.7534 106.921 -0.2
+      vertex -62.5 -108.253 -0.2
+      vertex -57.912 110.775 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -64.7534 106.921 -0.2
+      vertex -69.1739 -104.115 -0.2
+      vertex -62.5 -108.253 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -71.3392 102.644 -0.2
+      vertex -69.1739 -104.115 -0.2
+      vertex -64.7534 106.921 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -71.3392 102.644 -0.2
+      vertex -75.5749 -99.5662 -0.2
+      vertex -69.1739 -104.115 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -77.6435 97.9617 -0.2
+      vertex -75.5749 -99.5662 -0.2
+      vertex -71.3392 102.644 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -77.6435 97.9617 -0.2
+      vertex -81.6776 -94.6244 -0.2
+      vertex -75.5749 -99.5662 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -83.6413 92.8931 -0.2
+      vertex -81.6776 -94.6244 -0.2
+      vertex -77.6435 97.9617 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -83.6413 92.8931 -0.2
+      vertex -87.4579 -89.3091 -0.2
+      vertex -81.6776 -94.6244 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -89.3091 87.4579 -0.2
+      vertex -87.4579 -89.3091 -0.2
+      vertex -83.6413 92.8931 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -89.3091 87.4579 -0.2
+      vertex -92.8931 -83.6413 -0.2
+      vertex -87.4579 -89.3091 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -94.6244 81.6776 -0.2
+      vertex -92.8931 -83.6413 -0.2
+      vertex -89.3091 87.4579 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -94.6244 81.6776 -0.2
+      vertex -97.9617 -77.6435 -0.2
+      vertex -92.8931 -83.6413 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -99.5662 75.5749 -0.2
+      vertex -97.9617 -77.6435 -0.2
+      vertex -94.6244 81.6776 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.5662 75.5749 -0.2
+      vertex -102.644 -71.3392 -0.2
+      vertex -97.9617 -77.6435 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -106.882 64.7122 -0.2
+      vertex -99.5662 75.5749 -0.2
+      vertex -104.115 69.1739 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -99.5662 75.5749 -0.2
+      vertex -106.882 64.7122 -0.2
+      vertex -102.644 -71.3392 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -102.644 -71.3392 -0.2
+      vertex -106.882 64.7122 -0.2
+      vertex -106.921 -64.7534 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33 -134.402 -0.2
+      vertex 34.9882 -132.418 -0.2
+      vertex 34.9882 -126.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.9021 -126.3 -0.2
+      vertex 34.9882 -126.918 -0.2
+      vertex 34.9961 -126.793 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.6887 -125.847 -0.2
+      vertex 34.9882 -126.918 -0.2
+      vertex 34.9021 -126.3 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33 -134.402 -0.2
+      vertex 34.9882 -126.918 -0.2
+      vertex 33 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.9882 -126.918 -0.2
+      vertex 34.6887 -125.847 -0.2
+      vertex 33 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 34.8097 -133.27 -0.2
+      vertex 34.9882 -132.418 -0.2
+      vertex 33 -134.402 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33 -124.918 -0.2
+      vertex 34.6887 -125.847 -0.2
+      vertex 34.3691 -125.46 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.9882 -132.418 -0.2
+      vertex 34.8097 -133.27 -0.2
+      vertex 34.9646 -132.793 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33 -124.918 -0.2
+      vertex 34.3691 -125.46 -0.2
+      vertex 33.9635 -125.166 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.8097 -133.27 -0.2
+      vertex 33 -134.402 -0.2
+      vertex 34.541 -133.693 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33 -124.918 -0.2
+      vertex 33.9635 -125.166 -0.2
+      vertex 33.4974 -124.981 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.541 -133.693 -0.2
+      vertex 33 -134.402 -0.2
+      vertex 34.1756 -134.036 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 34.1756 -134.036 -0.2
+      vertex 33 -134.402 -0.2
+      vertex 33.7362 -134.278 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33.7362 -134.278 -0.2
+      vertex 33 -134.402 -0.2
+      vertex 33.2507 -134.402 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.57163 -124.918 -0.2
+      vertex 33 -134.402 -0.2
+      vertex 33 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 33 -134.402 -0.2
+      vertex 2.57163 -124.918 -0.2
+      vertex 33 -134.418 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33 -134.418 -0.2
+      vertex 2.57163 -124.918 -0.2
+      vertex -3.65479 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33 -134.402 -0.2
+      vertex -3.65479 -124.918 -0.2
+      vertex -33 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -33 -134.418 -0.2
+      vertex -3.65479 -124.918 -0.2
+      vertex -33 -134.402 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.57163 -124.918 -0.2
+      vertex -33 -134.418 -0.2
+      vertex 33 -134.418 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 34.9882 -126.918 -0.2
+      vertex 35 -132.418 -0.2
+      vertex 35 -126.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35 -132.418 -0.2
+      vertex 34.9882 -126.918 -0.2
+      vertex 34.9882 -132.418 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.8097 -133.27 -0.2
+      vertex -34.9882 -132.418 -0.2
+      vertex -34.9646 -132.793 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -35 -126.918 -0.2
+      vertex -34.9882 -132.418 -0.2
+      vertex -34.9882 -126.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -34.9882 -132.418 -0.2
+      vertex -35 -126.918 -0.2
+      vertex -35 -132.418 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -109.483 60.206 -0.2
+      vertex -110.775 -57.912 -0.2
+      vertex -106.921 -64.7534 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -114.193 -50.8421 -0.2
+      vertex -109.483 60.206 -0.2
+      vertex -111.964 55.5794 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -109.483 60.206 -0.2
+      vertex -114.193 -50.8421 -0.2
+      vertex -110.775 -57.912 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -115.233 48.4394 -0.2
+      vertex -114.193 -50.8421 -0.2
+      vertex -111.964 55.5794 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -115.233 48.4394 -0.2
+      vertex -117.16 -43.5715 -0.2
+      vertex -114.193 -50.8421 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -118.047 41.1083 -0.2
+      vertex -117.16 -43.5715 -0.2
+      vertex -115.233 48.4394 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -118.047 41.1083 -0.2
+      vertex -119.665 -36.129 -0.2
+      vertex -117.16 -43.5715 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -120.395 33.615 -0.2
+      vertex -119.665 -36.129 -0.2
+      vertex -118.047 41.1083 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -120.395 33.615 -0.2
+      vertex -121.697 -28.5439 -0.2
+      vertex -119.665 -36.129 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -122.268 25.989 -0.2
+      vertex -121.697 -28.5439 -0.2
+      vertex -120.395 33.615 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -122.268 25.989 -0.2
+      vertex -123.25 -20.8461 -0.2
+      vertex -121.697 -28.5439 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -123.659 18.2604 -0.2
+      vertex -123.25 -20.8461 -0.2
+      vertex -122.268 25.989 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -123.659 18.2604 -0.2
+      vertex -124.315 -13.0661 -0.2
+      vertex -123.25 -20.8461 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -124.562 10.4597 -0.2
+      vertex -124.315 -13.0661 -0.2
+      vertex -123.659 18.2604 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -124.562 10.4597 -0.2
+      vertex -124.89 -5.23446 -0.2
+      vertex -124.315 -13.0661 -0.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -124.89 -5.23446 -0.2
+      vertex -124.562 10.4597 -0.2
+      vertex -124.973 2.6178 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -127.414 33.1482 -0.2
+      vertex -132.172 35.9085 -0.2
+      vertex -132.178 35.8982 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -133.156 37.9224 -0.2
+      vertex -132.896 38.6224 -0.2
+      vertex -133.021 38.4053 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -132.896 38.6224 -0.2
+      vertex -133.052 36.9331 -0.2
+      vertex -132.82 36.4889 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -133.167 37.4212 -0.2
+      vertex -132.896 38.6224 -0.2
+      vertex -133.156 37.9224 -0.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -132.896 38.6224 -0.2
+      vertex -133.167 37.4212 -0.2
+      vertex -133.052 36.9331 -0.2
+    endloop
+  endfacet
+  facet normal -0.973583 -0.228335 0
+    outer loop
+      vertex -133.052 36.9331 -5.2
+      vertex -133.167 37.4212 -0.2
+      vertex -133.167 37.4212 -5.2
+    endloop
+  endfacet
+  facet normal -0.973583 -0.228335 0
+    outer loop
+      vertex -133.167 37.4212 -0.2
+      vertex -133.052 36.9331 -5.2
+      vertex -133.052 36.9331 -0.2
+    endloop
+  endfacet
+  facet normal -0.553375 -0.832932 0
+    outer loop
+      vertex -132.484 36.1163 -5.2
+      vertex -132.172 35.9085 -0.2
+      vertex -132.484 36.1163 -0.2
+    endloop
+  endfacet
+  facet normal -0.553375 -0.832932 -0
+    outer loop
+      vertex -132.172 35.9085 -0.2
+      vertex -132.484 36.1163 -5.2
+      vertex -132.172 35.9085 -5.2
+    endloop
+  endfacet
+  facet normal -0.8862 -0.463302 0
+    outer loop
+      vertex -132.82 36.4889 -5.2
+      vertex -133.052 36.9331 -0.2
+      vertex -133.052 36.9331 -5.2
+    endloop
+  endfacet
+  facet normal -0.8862 -0.463302 0
+    outer loop
+      vertex -133.052 36.9331 -0.2
+      vertex -132.82 36.4889 -5.2
+      vertex -132.82 36.4889 -0.2
+    endloop
+  endfacet
+  facet normal -0.743152 -0.669122 0
+    outer loop
+      vertex -132.484 36.1163 -5.2
+      vertex -132.82 36.4889 -0.2
+      vertex -132.82 36.4889 -5.2
+    endloop
+  endfacet
+  facet normal -0.743152 -0.669122 0
+    outer loop
+      vertex -132.82 36.4889 -0.2
+      vertex -132.484 36.1163 -5.2
+      vertex -132.484 36.1163 -0.2
+    endloop
+  endfacet
+  facet normal -0.999781 0.0209402 0
+    outer loop
+      vertex -133.167 37.4212 -5.2
+      vertex -133.156 37.9224 -0.2
+      vertex -133.156 37.9224 -5.2
+    endloop
+  endfacet
+  facet normal -0.999781 0.0209402 0
+    outer loop
+      vertex -133.156 37.9224 -0.2
+      vertex -133.167 37.4212 -5.2
+      vertex -133.167 37.4212 -0.2
+    endloop
+  endfacet
+  facet normal -0.963166 0.268907 0
+    outer loop
+      vertex -133.156 37.9224 -5.2
+      vertex -133.021 38.4053 -0.2
+      vertex -133.021 38.4053 -5.2
+    endloop
+  endfacet
+  facet normal -0.963166 0.268907 0
+    outer loop
+      vertex -133.021 38.4053 -0.2
+      vertex -133.156 37.9224 -5.2
+      vertex -133.156 37.9224 -0.2
+    endloop
+  endfacet
+  facet normal -0.86603 0.499992 0
+    outer loop
+      vertex -99.896 95.7801 -5.2
+      vertex -99.7706 95.9972 -0.2
+      vertex -99.7706 95.9972 -5.2
+    endloop
+  endfacet
+  facet normal -0.86603 0.499992 0
+    outer loop
+      vertex -99.7706 95.9972 -0.2
+      vertex -99.896 95.7801 -5.2
+      vertex -99.896 95.7801 -0.2
+    endloop
+  endfacet
+  facet normal 0.444627 0.895716 -0
+    outer loop
+      vertex -97.1835 96.5098 -5.2
+      vertex -97.5198 96.6767 -0.2
+      vertex -97.1835 96.5098 -0.2
+    endloop
+  endfacet
+  facet normal 0.444627 0.895716 0
+    outer loop
+      vertex -97.5198 96.6767 -0.2
+      vertex -97.1835 96.5098 -5.2
+      vertex -97.5198 96.6767 -5.2
+    endloop
+  endfacet
+  facet normal -0.289021 0.957323 0
+    outer loop
+      vertex -98.5111 96.7599 -5.2
+      vertex -98.991 96.6151 -0.2
+      vertex -98.5111 96.7599 -0.2
+    endloop
+  endfacet
+  facet normal -0.289021 0.957323 0
+    outer loop
+      vertex -98.991 96.6151 -0.2
+      vertex -98.5111 96.7599 -5.2
+      vertex -98.991 96.6151 -5.2
+    endloop
+  endfacet
+  facet normal -0.0418806 0.999123 0
+    outer loop
+      vertex -98.0102 96.7809 -5.2
+      vertex -98.5111 96.7599 -0.2
+      vertex -98.0102 96.7809 -0.2
+    endloop
+  endfacet
+  facet normal -0.0418806 0.999123 0
+    outer loop
+      vertex -98.5111 96.7599 -0.2
+      vertex -98.0102 96.7809 -5.2
+      vertex -98.5111 96.7599 -5.2
+    endloop
+  endfacet
+  facet normal -0.518032 0.855361 0
+    outer loop
+      vertex -98.991 96.6151 -5.2
+      vertex -99.4199 96.3553 -0.2
+      vertex -98.991 96.6151 -0.2
+    endloop
+  endfacet
+  facet normal -0.518032 0.855361 0
+    outer loop
+      vertex -99.4199 96.3553 -0.2
+      vertex -98.991 96.6151 -5.2
+      vertex -99.4199 96.3553 -5.2
+    endloop
+  endfacet
+  facet normal -0.714472 0.699664 0
+    outer loop
+      vertex -99.7706 95.9972 -5.2
+      vertex -99.4199 96.3553 -0.2
+      vertex -99.4199 96.3553 -5.2
+    endloop
+  endfacet
+  facet normal -0.714472 0.699664 0
+    outer loop
+      vertex -99.4199 96.3553 -0.2
+      vertex -99.7706 95.9972 -5.2
+      vertex -99.7706 95.9972 -0.2
+    endloop
+  endfacet
+  facet normal 0.207914 0.978147 -0
+    outer loop
+      vertex -97.5198 96.6767 -5.2
+      vertex -98.0102 96.7809 -0.2
+      vertex -97.5198 96.6767 -0.2
+    endloop
+  endfacet
+  facet normal 0.207914 0.978147 0
+    outer loop
+      vertex -98.0102 96.7809 -0.2
+      vertex -97.5198 96.6767 -5.2
+      vertex -98.0102 96.7809 -5.2
+    endloop
+  endfacet
+  facet normal -0.328876 -0.944373 0
+    outer loop
+      vertex -127.304 33.0889 -5.2
+      vertex -126.83 32.924 -0.2
+      vertex -127.304 33.0889 -0.2
+    endloop
+  endfacet
+  facet normal -0.328876 -0.944373 -0
+    outer loop
+      vertex -126.83 32.924 -0.2
+      vertex -127.304 33.0889 -5.2
+      vertex -126.83 32.924 -5.2
+    endloop
+  endfacet
+  facet normal 0.621148 -0.783694 0
+    outer loop
+      vertex -125.378 33.1696 -5.2
+      vertex -124.985 33.481 -0.2
+      vertex -125.378 33.1696 -0.2
+    endloop
+  endfacet
+  facet normal 0.621148 -0.783694 0
+    outer loop
+      vertex -124.985 33.481 -0.2
+      vertex -125.378 33.1696 -5.2
+      vertex -124.985 33.481 -5.2
+    endloop
+  endfacet
+  facet normal 0.796527 -0.604603 0
+    outer loop
+      vertex -124.985 33.481 -0.2
+      vertex -124.682 33.8803 -5.2
+      vertex -124.682 33.8803 -0.2
+    endloop
+  endfacet
+  facet normal 0.796527 -0.604603 0
+    outer loop
+      vertex -124.682 33.8803 -5.2
+      vertex -124.985 33.481 -0.2
+      vertex -124.985 33.481 -5.2
+    endloop
+  endfacet
+  facet normal 0.406736 -0.913546 0
+    outer loop
+      vertex -125.836 32.9656 -5.2
+      vertex -125.378 33.1696 -0.2
+      vertex -125.836 32.9656 -0.2
+    endloop
+  endfacet
+  facet normal 0.406736 -0.913546 0
+    outer loop
+      vertex -125.378 33.1696 -0.2
+      vertex -125.836 32.9656 -5.2
+      vertex -125.378 33.1696 -5.2
+    endloop
+  endfacet
+  facet normal -0.553377 -0.832931 0
+    outer loop
+      vertex -127.408 33.1585 -5.2
+      vertex -127.304 33.0889 -0.2
+      vertex -127.408 33.1585 -0.2
+    endloop
+  endfacet
+  facet normal -0.553377 -0.832931 -0
+    outer loop
+      vertex -127.304 33.0889 -0.2
+      vertex -127.408 33.1585 -5.2
+      vertex -127.304 33.0889 -5.2
+    endloop
+  endfacet
+  facet normal 0.166763 -0.985997 0
+    outer loop
+      vertex -126.331 32.882 -5.2
+      vertex -125.836 32.9656 -0.2
+      vertex -126.331 32.882 -0.2
+    endloop
+  endfacet
+  facet normal 0.166763 -0.985997 0
+    outer loop
+      vertex -125.836 32.9656 -0.2
+      vertex -126.331 32.882 -5.2
+      vertex -125.836 32.9656 -5.2
+    endloop
+  endfacet
+  facet normal -0.0836689 -0.996494 0
+    outer loop
+      vertex -126.83 32.924 -5.2
+      vertex -126.331 32.882 -0.2
+      vertex -126.83 32.924 -0.2
+    endloop
+  endfacet
+  facet normal -0.0836689 -0.996494 -0
+    outer loop
+      vertex -126.331 32.882 -0.2
+      vertex -126.83 32.924 -5.2
+      vertex -126.331 32.882 -5.2
+    endloop
+  endfacet
+  facet normal 0.921868 -0.387505 0
+    outer loop
+      vertex -91.6824 91.038 -0.2
+      vertex -91.4881 91.5001 -5.2
+      vertex -91.4881 91.5001 -0.2
+    endloop
+  endfacet
+  facet normal 0.921868 -0.387505 0
+    outer loop
+      vertex -91.4881 91.5001 -5.2
+      vertex -91.6824 91.038 -0.2
+      vertex -91.6824 91.038 -5.2
+    endloop
+  endfacet
+  facet normal 0.444689 0.895685 -0
+    outer loop
+      vertex -92.3076 93.7038 -5.2
+      vertex -92.4203 93.7598 -0.2
+      vertex -92.3076 93.7038 -0.2
+    endloop
+  endfacet
+  facet normal 0.444689 0.895685 0
+    outer loop
+      vertex -92.4203 93.7598 -0.2
+      vertex -92.3076 93.7038 -5.2
+      vertex -92.4203 93.7598 -5.2
+    endloop
+  endfacet
+  facet normal 0.937281 0.348575 0
+    outer loop
+      vertex -91.4673 92.4947 -0.2
+      vertex -91.642 92.9645 -5.2
+      vertex -91.642 92.9645 -0.2
+    endloop
+  endfacet
+  facet normal 0.937281 0.348575 0
+    outer loop
+      vertex -91.642 92.9645 -5.2
+      vertex -91.4673 92.4947 -0.2
+      vertex -91.4673 92.4947 -5.2
+    endloop
+  endfacet
+  facet normal 0.821153 0.570709 0
+    outer loop
+      vertex -91.642 92.9645 -0.2
+      vertex -91.9281 93.3762 -5.2
+      vertex -91.9281 93.3762 -0.2
+    endloop
+  endfacet
+  facet normal 0.821153 0.570709 0
+    outer loop
+      vertex -91.9281 93.3762 -5.2
+      vertex -91.642 92.9645 -0.2
+      vertex -91.642 92.9645 -5.2
+    endloop
+  endfacet
+  facet normal 0.994521 0.104533 0
+    outer loop
+      vertex -91.4149 91.9961 -0.2
+      vertex -91.4673 92.4947 -5.2
+      vertex -91.4673 92.4947 -0.2
+    endloop
+  endfacet
+  facet normal 0.994521 0.104533 0
+    outer loop
+      vertex -91.4673 92.4947 -5.2
+      vertex -91.4149 91.9961 -0.2
+      vertex -91.4149 91.9961 -5.2
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -91.4881 91.5001 -0.2
+      vertex -91.4149 91.9961 -5.2
+      vertex -91.4149 91.9961 -0.2
+    endloop
+  endfacet
+  facet normal 0.989271 -0.146094 0
+    outer loop
+      vertex -91.4149 91.9961 -5.2
+      vertex -91.4881 91.5001 -0.2
+      vertex -91.4881 91.5001 -5.2
+    endloop
+  endfacet
+  facet normal 0.653412 0.757003 -0
+    outer loop
+      vertex -91.9281 93.3762 -5.2
+      vertex -92.3076 93.7038 -0.2
+      vertex -91.9281 93.3762 -0.2
+    endloop
+  endfacet
+  facet normal 0.653412 0.757003 0
+    outer loop
+      vertex -92.3076 93.7038 -0.2
+      vertex -91.9281 93.3762 -5.2
+      vertex -92.3076 93.7038 -5.2
+    endloop
+  endfacet
+  facet normal -0.866175 0.499741 0
+    outer loop
+      vertex -132.178 35.8982 -5.2
+      vertex -132.172 35.9085 -0.2
+      vertex -132.172 35.9085 -5.2
+    endloop
+  endfacet
+  facet normal -0.866175 0.499741 0
+    outer loop
+      vertex -132.172 35.9085 -0.2
+      vertex -132.178 35.8982 -5.2
+      vertex -132.178 35.8982 -0.2
+    endloop
+  endfacet
+  facet normal -0.866175 0.499741 0
+    outer loop
+      vertex -97.1835 96.5098 -5.2
+      vertex -97.1776 96.52 -0.2
+      vertex -97.1776 96.52 -5.2
+    endloop
+  endfacet
+  facet normal -0.866175 0.499741 0
+    outer loop
+      vertex -97.1776 96.52 -0.2
+      vertex -97.1835 96.5098 -5.2
+      vertex -97.1835 96.5098 -0.2
+    endloop
+  endfacet
+  facet normal 0.865815 -0.500363 0
+    outer loop
+      vertex -127.414 33.1482 -0.2
+      vertex -127.408 33.1585 -5.2
+      vertex -127.408 33.1585 -0.2
+    endloop
+  endfacet
+  facet normal 0.865815 -0.500363 0
+    outer loop
+      vertex -127.408 33.1585 -5.2
+      vertex -127.414 33.1482 -0.2
+      vertex -127.414 33.1482 -5.2
+    endloop
+  endfacet
+  facet normal 0.866175 -0.499741 0
+    outer loop
+      vertex -92.4203 93.7598 -0.2
+      vertex -92.4144 93.77 -5.2
+      vertex -92.4144 93.77 -0.2
+    endloop
+  endfacet
+  facet normal 0.866175 -0.499741 0
+    outer loop
+      vertex -92.4144 93.77 -5.2
+      vertex -92.4203 93.7598 -0.2
+      vertex -92.4203 93.7598 -5.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -132.178 35.8982 -5.2
+      vertex -127.414 33.1482 -0.2
+      vertex -132.178 35.8982 -0.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 -0
+    outer loop
+      vertex -127.414 33.1482 -0.2
+      vertex -132.178 35.8982 -5.2
+      vertex -127.414 33.1482 -5.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -92.4144 93.77 -5.2
+      vertex -97.1776 96.52 -0.2
+      vertex -92.4144 93.77 -0.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -97.1776 96.52 -0.2
+      vertex -92.4144 93.77 -5.2
+      vertex -97.1776 96.52 -5.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -106.882 64.7122 -0.2
+      vertex -91.6824 91.038 -5.2
+      vertex -91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -91.6824 91.038 -5.2
+      vertex -106.882 64.7122 -0.2
+      vertex -106.882 64.7122 -5.2
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex -124.682 33.8803 -0.2
+      vertex -109.483 60.206 -5.2
+      vertex -109.483 60.206 -0.2
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex -109.483 60.206 -5.2
+      vertex -124.682 33.8803 -0.2
+      vertex -124.682 33.8803 -5.2
+    endloop
+  endfacet
+  facet normal -0.500016 -0.866016 0
+    outer loop
+      vertex -132.91 38.6303 -5.2
+      vertex -132.896 38.6224 -0.2
+      vertex -132.91 38.6303 -0.2
+    endloop
+  endfacet
+  facet normal -0.500016 -0.866016 -0
+    outer loop
+      vertex -132.896 38.6224 -0.2
+      vertex -132.91 38.6303 -5.2
+      vertex -132.896 38.6224 -5.2
+    endloop
+  endfacet
+  facet normal 0.499834 0.866121 -0
+    outer loop
+      vertex -99.896 95.7801 -5.2
+      vertex -99.9096 95.788 -0.2
+      vertex -99.896 95.7801 -0.2
+    endloop
+  endfacet
+  facet normal 0.499834 0.866121 0
+    outer loop
+      vertex -99.9096 95.788 -0.2
+      vertex -99.896 95.7801 -5.2
+      vertex -99.9096 95.788 -5.2
+    endloop
+  endfacet
+  facet normal -0.838668 -0.544643 -3.1646e-06
+    outer loop
+      vertex -201.322 -120.579 -26.3675
+      vertex -203.374 -117.418 -30.997
+      vertex -203.212 -117.668 -31.4178
+    endloop
+  endfacet
+  facet normal -0.83867 -0.54464 0
+    outer loop
+      vertex -203.374 -117.418 -30.997
+      vertex -201.322 -120.579 -26.3675
+      vertex -203.374 -117.418 -11.2
+    endloop
+  endfacet
+  facet normal -0.83867 -0.54464 0
+    outer loop
+      vertex -203.374 -117.418 -11.2
+      vertex -201.322 -120.579 -26.3675
+      vertex -201.322 -120.579 -11.2
+    endloop
+  endfacet
+  facet normal -0.83867 -0.54464 0
+    outer loop
+      vertex -201.322 -120.579 -39.7633
+      vertex -203.374 -117.418 -35.0844
+      vertex -203.374 -117.418 -56.2
+    endloop
+  endfacet
+  facet normal -0.83867 -0.54464 -0
+    outer loop
+      vertex -201.322 -120.579 -39.7633
+      vertex -203.374 -117.418 -56.2
+      vertex -201.322 -120.579 -56.2
+    endloop
+  endfacet
+  facet normal -0.838672 -0.544637 -2.58821e-06
+    outer loop
+      vertex -203.374 -117.418 -35.0844
+      vertex -201.322 -120.579 -39.7633
+      vertex -203.219 -117.657 -34.6777
+    endloop
+  endfacet
+  facet normal -0.838669 -0.544642 -0
+    outer loop
+      vertex -201.322 -120.579 -30.2508
+      vertex -202.4 -118.918 -33.0068
+      vertex -201.322 -120.579 -35.8086
+    endloop
+  endfacet
+  facet normal -0.629319 -0.777147 0
+    outer loop
+      vertex -196.286 -126.171 -56.2
+      vertex -193.358 -128.543 -11.2
+      vertex -196.286 -126.171 -11.2
+    endloop
+  endfacet
+  facet normal -0.629319 -0.777147 -0
+    outer loop
+      vertex -193.358 -128.543 -11.2
+      vertex -196.286 -126.171 -56.2
+      vertex -193.358 -128.543 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179.992 -134.549 -56.2
+      vertex -183.322 -133.656 -56.2
+      vertex -179.992 -118.918 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.37 -118.918 -56.2
+      vertex -134.255 -114.917 -56.2
+      vertex -119.37 -114.917 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.37 -118.918 -56.2
+      vertex -135.751 -114.76 -56.2
+      vertex -134.255 -114.917 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -148.658 -113.205 -56.2
+      vertex -139.379 -112.239 -56.2
+      vertex -138.396 -113.377 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -149.856 -114.114 -56.2
+      vertex -138.396 -113.377 -56.2
+      vertex -137.161 -114.235 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -139.379 -112.239 -56.2
+      vertex -147.112 -110.652 -56.2
+      vertex -146.861 -109.169 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -151.243 -114.697 -56.2
+      vertex -137.161 -114.235 -56.2
+      vertex -135.751 -114.76 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -139.379 -112.239 -56.2
+      vertex -147.724 -112.026 -56.2
+      vertex -147.112 -110.652 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -152.731 -114.917 -56.2
+      vertex -135.751 -114.76 -56.2
+      vertex -119.37 -118.918 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -139.379 -112.239 -56.2
+      vertex -148.658 -113.205 -56.2
+      vertex -147.724 -112.026 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -138.396 -113.377 -56.2
+      vertex -149.856 -114.114 -56.2
+      vertex -148.658 -113.205 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -137.161 -114.235 -56.2
+      vertex -151.243 -114.697 -56.2
+      vertex -149.856 -114.114 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -135.751 -114.76 -56.2
+      vertex -152.731 -114.917 -56.2
+      vertex -151.243 -114.697 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -152.731 -114.917 -56.2
+      vertex -119.37 -118.918 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -152.731 -114.917 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -171.206 -114.917 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -172.702 -114.76 -56.2
+      vertex -171.206 -114.917 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -174.111 -114.235 -56.2
+      vertex -172.702 -114.76 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -175.346 -113.377 -56.2
+      vertex -174.111 -114.235 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -176.329 -112.239 -56.2
+      vertex -175.346 -113.377 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -184.989 -97.2386 -56.2
+      vertex -176.329 -112.239 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -186.84 -132.306 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -183.322 -133.656 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -190.197 -130.595 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -186.84 -132.306 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -193.358 -128.543 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -190.197 -130.595 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -196.286 -126.171 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -193.358 -128.543 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -146.987 -107.671 -56.2
+      vertex -139.379 -112.239 -56.2
+      vertex -146.861 -109.169 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -147.482 -106.25 -56.2
+      vertex -139.379 -112.239 -56.2
+      vertex -146.987 -107.671 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -165.38 -75.2504 -56.2
+      vertex -139.379 -112.239 -56.2
+      vertex -147.482 -106.25 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -166.514 -65.2386 -56.2
+      vertex -165.38 -75.2504 -56.2
+      vertex -166.212 -73.9977 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -165.38 -75.2504 -56.2
+      vertex -166.514 -65.2386 -56.2
+      vertex -139.379 -112.239 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -167.33 -72.9913 -56.2
+      vertex -166.514 -65.2386 -56.2
+      vertex -166.212 -73.9977 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -168.663 -72.2945 -56.2
+      vertex -166.514 -65.2386 -56.2
+      vertex -167.33 -72.9913 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -170.127 -71.9511 -56.2
+      vertex -166.514 -65.2386 -56.2
+      vertex -168.663 -72.2945 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -171.631 -71.9826 -56.2
+      vertex -166.514 -65.2386 -56.2
+      vertex -170.127 -71.9511 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -166.998 -59.4778 -56.2
+      vertex -162.671 -43.9182 -56.2
+      vertex -159.179 -45.9347 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -175.456 -74.1914 -56.2
+      vertex -166.998 -59.4778 -56.2
+      vertex -167.432 -60.9176 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -166.514 -65.2386 -56.2
+      vertex -171.631 -71.9826 -56.2
+      vertex -167.183 -63.8914 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -173.079 -72.3871 -56.2
+      vertex -167.183 -63.8914 -56.2
+      vertex -171.631 -71.9826 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -167.183 -63.8914 -56.2
+      vertex -173.079 -72.3871 -56.2
+      vertex -167.495 -62.4203 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -174.382 -73.1391 -56.2
+      vertex -167.495 -62.4203 -56.2
+      vertex -173.079 -72.3871 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -167.495 -62.4203 -56.2
+      vertex -174.382 -73.1391 -56.2
+      vertex -167.432 -60.9176 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -175.456 -74.1914 -56.2
+      vertex -167.432 -60.9176 -56.2
+      vertex -174.382 -73.1391 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -166.998 -59.4778 -56.2
+      vertex -175.456 -74.1914 -56.2
+      vertex -162.671 -43.9182 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -176.235 -75.4778 -56.2
+      vertex -162.671 -43.9182 -56.2
+      vertex -175.456 -74.1914 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -192.982 -96.4182 -56.2
+      vertex -176.235 -75.4778 -56.2
+      vertex -185.473 -91.4778 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -198.951 -123.507 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -196.286 -126.171 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -201.322 -120.579 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -198.951 -123.507 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -176.235 -75.4778 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -162.671 -43.9182 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -185.908 -92.9176 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -185.473 -91.4778 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -185.971 -94.4203 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -185.908 -92.9176 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -203.374 -117.418 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -201.322 -120.579 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -185.658 -95.8914 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -185.971 -94.4203 -56.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -192.982 -96.4182 -56.2
+      vertex -179.992 -118.918 -56.2
+      vertex -203.374 -117.418 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -184.989 -97.2386 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -185.658 -95.8914 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -184.989 -97.2386 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -205.085 -114.061 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -203.374 -117.418 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -206.435 -110.543 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -205.085 -114.061 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -207.411 -106.903 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -206.435 -110.543 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -208 -103.181 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -207.411 -106.903 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -192.982 -96.4182 -56.2
+      vertex -207.411 -91.9334 -56.2
+      vertex -206.518 -88.603 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -208.197 -99.4182 -56.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -208 -103.181 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -192.982 -96.4182 -56.2
+      vertex -208 -95.6552 -56.2
+      vertex -207.411 -91.9334 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -192.982 -96.4182 -56.2
+      vertex -208.197 -99.4182 -56.2
+      vertex -208 -95.6552 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -195.281 -110.436 -11.2
+      vertex -196.745 -115.9 -11.2
+      vertex -193.281 -113.9 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -196.745 -115.9 -11.2
+      vertex -195.281 -110.436 -11.2
+      vertex -198.745 -112.436 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -187.768 -112.449 -11.2
+      vertex -191.232 -114.449 -11.2
+      vertex -189.232 -117.913 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -192.982 -96.4182 -11.2
+      vertex -185.658 -95.8914 -11.2
+      vertex -185.971 -94.4203 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -185.658 -95.8914 -11.2
+      vertex -188.505 -100.173 -11.2
+      vertex -185.755 -104.936 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -162.671 -43.9182 -11.2
+      vertex -166.998 -59.4778 -11.2
+      vertex -159.179 -45.9347 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -175.456 -74.1914 -11.2
+      vertex -166.998 -59.4778 -11.2
+      vertex -162.671 -43.9182 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -174.382 -73.1391 -11.2
+      vertex -167.495 -62.4203 -11.2
+      vertex -167.432 -60.9176 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -167.495 -62.4203 -11.2
+      vertex -170.127 -71.9511 -11.2
+      vertex -168.663 -72.2945 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -167.495 -62.4203 -11.2
+      vertex -171.631 -71.9826 -11.2
+      vertex -170.127 -71.9511 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -166.998 -59.4778 -11.2
+      vertex -175.456 -74.1914 -11.2
+      vertex -167.432 -60.9176 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -167.495 -62.4203 -11.2
+      vertex -173.079 -72.3871 -11.2
+      vertex -171.631 -71.9826 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -167.495 -62.4203 -11.2
+      vertex -174.382 -73.1391 -11.2
+      vertex -173.079 -72.3871 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -167.432 -60.9176 -11.2
+      vertex -175.456 -74.1914 -11.2
+      vertex -174.382 -73.1391 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -162.671 -43.9182 -11.2
+      vertex -176.235 -75.4778 -11.2
+      vertex -175.456 -74.1914 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -192.982 -96.4182 -11.2
+      vertex -176.235 -75.4778 -11.2
+      vertex -162.671 -43.9182 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -192.982 -96.4182 -11.2
+      vertex -185.971 -94.4203 -11.2
+      vertex -185.908 -92.9176 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -192.982 -96.4182 -11.2
+      vertex -185.908 -92.9176 -11.2
+      vertex -185.473 -91.4778 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -176.235 -75.4778 -11.2
+      vertex -192.982 -96.4182 -11.2
+      vertex -185.473 -91.4778 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -185.658 -95.8914 -11.2
+      vertex -192.982 -96.4182 -11.2
+      vertex -188.505 -100.173 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -192.982 -96.4182 -11.2
+      vertex -193.268 -102.923 -11.2
+      vertex -188.505 -100.173 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -196.732 -104.923 -11.2
+      vertex -193.268 -102.923 -11.2
+      vertex -192.982 -96.4182 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -193.268 -102.923 -11.2
+      vertex -196.732 -104.923 -11.2
+      vertex -194.732 -108.387 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -208.197 -99.4182 -11.2
+      vertex -196.732 -104.923 -11.2
+      vertex -192.982 -96.4182 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -198.745 -112.436 -11.2
+      vertex -205.085 -114.061 -11.2
+      vertex -203.374 -117.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -201.495 -107.673 -11.2
+      vertex -206.435 -110.543 -11.2
+      vertex -205.085 -114.061 -11.2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex -208 -103.181 -11.2
+      vertex -196.732 -104.923 -11.2
+      vertex -208.197 -99.4182 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -207.411 -91.9334 -11.2
+      vertex -192.982 -96.4182 -11.2
+      vertex -206.518 -88.603 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -208 -95.6552 -11.2
+      vertex -192.982 -96.4182 -11.2
+      vertex -207.411 -91.9334 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -201.495 -107.673 -11.2
+      vertex -207.411 -106.903 -11.2
+      vertex -206.435 -110.543 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -208.197 -99.4182 -11.2
+      vertex -192.982 -96.4182 -11.2
+      vertex -208 -95.6552 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -201.495 -107.673 -11.2
+      vertex -208 -103.181 -11.2
+      vertex -207.411 -106.903 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -196.732 -104.923 -11.2
+      vertex -208 -103.181 -11.2
+      vertex -201.495 -107.673 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -139.379 -112.239 -11.2
+      vertex -146.987 -107.671 -11.2
+      vertex -146.861 -109.169 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -139.379 -112.239 -11.2
+      vertex -147.482 -106.25 -11.2
+      vertex -146.987 -107.671 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -139.379 -112.239 -11.2
+      vertex -165.38 -75.2504 -11.2
+      vertex -147.482 -106.25 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -166.514 -65.2386 -11.2
+      vertex -165.38 -75.2504 -11.2
+      vertex -139.379 -112.239 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -165.38 -75.2504 -11.2
+      vertex -166.514 -65.2386 -11.2
+      vertex -166.212 -73.9977 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -168.663 -72.2945 -11.2
+      vertex -166.514 -65.2386 -11.2
+      vertex -167.183 -63.8914 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -166.514 -65.2386 -11.2
+      vertex -167.33 -72.9913 -11.2
+      vertex -166.212 -73.9977 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -168.663 -72.2945 -11.2
+      vertex -167.183 -63.8914 -11.2
+      vertex -167.495 -62.4203 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -166.514 -65.2386 -11.2
+      vertex -168.663 -72.2945 -11.2
+      vertex -167.33 -72.9913 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -134.255 -114.917 -11.2
+      vertex -119.37 -118.918 -11.2
+      vertex -119.37 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -135.751 -114.76 -11.2
+      vertex -119.37 -118.918 -11.2
+      vertex -134.255 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -147.112 -110.652 -11.2
+      vertex -139.379 -112.239 -11.2
+      vertex -146.861 -109.169 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -147.724 -112.026 -11.2
+      vertex -139.379 -112.239 -11.2
+      vertex -147.112 -110.652 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -148.658 -113.205 -11.2
+      vertex -139.379 -112.239 -11.2
+      vertex -147.724 -112.026 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -139.379 -112.239 -11.2
+      vertex -148.658 -113.205 -11.2
+      vertex -138.396 -113.377 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -149.856 -114.114 -11.2
+      vertex -138.396 -113.377 -11.2
+      vertex -148.658 -113.205 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -138.396 -113.377 -11.2
+      vertex -149.856 -114.114 -11.2
+      vertex -137.161 -114.235 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -151.243 -114.697 -11.2
+      vertex -137.161 -114.235 -11.2
+      vertex -149.856 -114.114 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -137.161 -114.235 -11.2
+      vertex -151.243 -114.697 -11.2
+      vertex -135.751 -114.76 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -152.731 -114.917 -11.2
+      vertex -135.751 -114.76 -11.2
+      vertex -151.243 -114.697 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -135.751 -114.76 -11.2
+      vertex -152.731 -114.917 -11.2
+      vertex -119.37 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -179.992 -118.918 -11.2
+      vertex -152.731 -114.917 -11.2
+      vertex -171.206 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -152.731 -114.917 -11.2
+      vertex -179.992 -118.918 -11.2
+      vertex -119.37 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -172.702 -114.76 -11.2
+      vertex -179.992 -118.918 -11.2
+      vertex -171.206 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -174.111 -114.235 -11.2
+      vertex -179.992 -118.918 -11.2
+      vertex -172.702 -114.76 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -175.346 -113.377 -11.2
+      vertex -179.992 -118.918 -11.2
+      vertex -174.111 -114.235 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -181.005 -113.163 -11.2
+      vertex -175.346 -113.377 -11.2
+      vertex -176.329 -112.239 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -185.768 -115.913 -11.2
+      vertex -179.992 -118.918 -11.2
+      vertex -181.005 -113.163 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -175.346 -113.377 -11.2
+      vertex -181.005 -113.163 -11.2
+      vertex -179.992 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -176.329 -112.239 -11.2
+      vertex -183.755 -108.4 -11.2
+      vertex -181.005 -113.163 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -184.989 -97.2386 -11.2
+      vertex -183.755 -108.4 -11.2
+      vertex -176.329 -112.239 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -185.755 -104.936 -11.2
+      vertex -184.989 -97.2386 -11.2
+      vertex -185.658 -95.8914 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -184.989 -97.2386 -11.2
+      vertex -185.755 -104.936 -11.2
+      vertex -183.755 -108.4 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -185.755 -104.936 -11.2
+      vertex -187.219 -110.4 -11.2
+      vertex -183.755 -108.4 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -187.219 -110.4 -11.2
+      vertex -185.755 -104.936 -11.2
+      vertex -189.219 -106.936 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -189.232 -117.913 -11.2
+      vertex -179.992 -118.918 -11.2
+      vertex -185.768 -115.913 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -179.992 -118.918 -11.2
+      vertex -183.322 -133.656 -11.2
+      vertex -179.992 -134.549 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -179.992 -118.918 -11.2
+      vertex -186.84 -132.306 -11.2
+      vertex -183.322 -133.656 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -189.232 -117.913 -11.2
+      vertex -185.768 -115.913 -11.2
+      vertex -187.768 -112.449 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -190.197 -130.595 -11.2
+      vertex -179.992 -118.918 -11.2
+      vertex -189.232 -117.913 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -179.992 -118.918 -11.2
+      vertex -190.197 -130.595 -11.2
+      vertex -186.84 -132.306 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -189.232 -117.913 -11.2
+      vertex -193.358 -128.543 -11.2
+      vertex -190.197 -130.595 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -193.995 -120.663 -11.2
+      vertex -193.358 -128.543 -11.2
+      vertex -189.232 -117.913 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -193.995 -120.663 -11.2
+      vertex -196.286 -126.171 -11.2
+      vertex -193.358 -128.543 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -201.322 -120.579 -11.2
+      vertex -193.995 -120.663 -11.2
+      vertex -196.745 -115.9 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -203.374 -117.418 -11.2
+      vertex -196.745 -115.9 -11.2
+      vertex -198.745 -112.436 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -193.995 -120.663 -11.2
+      vertex -198.951 -123.507 -11.2
+      vertex -196.286 -126.171 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -193.995 -120.663 -11.2
+      vertex -201.322 -120.579 -11.2
+      vertex -198.951 -123.507 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -205.085 -114.061 -11.2
+      vertex -198.745 -112.436 -11.2
+      vertex -201.495 -107.673 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -196.745 -115.9 -11.2
+      vertex -203.374 -117.418 -11.2
+      vertex -201.322 -120.579 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -191.268 -106.387 -11.2
+      vertex -193.268 -102.923 -11.2
+      vertex -194.732 -108.387 -11.2
+    endloop
+  endfacet
+  facet normal -0.965926 0.258817 0
+    outer loop
+      vertex -207.411 -91.9334 -56.2
+      vertex -206.518 -88.603 -11.2
+      vertex -206.518 -88.603 -56.2
+    endloop
+  endfacet
+  facet normal -0.965926 0.258817 0
+    outer loop
+      vertex -206.518 -88.603 -11.2
+      vertex -207.411 -91.9334 -56.2
+      vertex -207.411 -91.9334 -11.2
+    endloop
+  endfacet
+  facet normal -0.777147 -0.62932 0
+    outer loop
+      vertex -201.322 -120.579 -56.2
+      vertex -199.892 -122.344 -43.0438
+      vertex -201.322 -120.579 -39.7633
+    endloop
+  endfacet
+  facet normal -0.777146 -0.62932 -9.39395e-08
+    outer loop
+      vertex -198.951 -123.507 -56.2
+      vertex -199.892 -122.344 -43.0438
+      vertex -201.322 -120.579 -56.2
+    endloop
+  endfacet
+  facet normal -0.777146 -0.629321 0
+    outer loop
+      vertex -199.892 -122.344 -43.0438
+      vertex -198.951 -123.507 -56.2
+      vertex -198.951 -123.507 -43.0438
+    endloop
+  endfacet
+  facet normal -0.777147 -0.629319 0
+    outer loop
+      vertex -200.246 -121.907 -23.9078
+      vertex -201.322 -120.579 -11.2
+      vertex -201.322 -120.579 -26.3675
+    endloop
+  endfacet
+  facet normal -0.777145 -0.629321 -0
+    outer loop
+      vertex -198.951 -123.507 -11.2
+      vertex -200.246 -121.907 -23.9078
+      vertex -198.951 -123.507 -23.9078
+    endloop
+  endfacet
+  facet normal -0.777146 -0.62932 1.96737e-07
+    outer loop
+      vertex -200.246 -121.907 -23.9078
+      vertex -198.951 -123.507 -11.2
+      vertex -201.322 -120.579 -11.2
+    endloop
+  endfacet
+  facet normal -0.777146 -0.629321 0
+    outer loop
+      vertex -199.548 -122.77 -39.7551
+      vertex -201.322 -120.579 -30.2508
+      vertex -201.322 -120.579 -35.8086
+    endloop
+  endfacet
+  facet normal -0.777148 -0.629318 -0
+    outer loop
+      vertex -198.951 -123.507 -25.0624
+      vertex -199.548 -122.77 -39.7551
+      vertex -198.951 -123.507 -41.0833
+    endloop
+  endfacet
+  facet normal -0.777146 -0.62932 -1.63917e-07
+    outer loop
+      vertex -199.548 -122.77 -39.7551
+      vertex -198.951 -123.507 -25.0624
+      vertex -201.322 -120.579 -30.2508
+    endloop
+  endfacet
+  facet normal -0.258821 -0.965925 0
+    outer loop
+      vertex -183.322 -133.656 -56.2
+      vertex -179.992 -134.549 -11.2
+      vertex -183.322 -133.656 -11.2
+    endloop
+  endfacet
+  facet normal -0.258821 -0.965925 -0
+    outer loop
+      vertex -179.992 -134.549 -11.2
+      vertex -183.322 -133.656 -56.2
+      vertex -179.992 -134.549 -56.2
+    endloop
+  endfacet
+  facet normal -0.544639 -0.838671 0
+    outer loop
+      vertex -193.358 -128.543 -56.2
+      vertex -190.197 -130.595 -11.2
+      vertex -193.358 -128.543 -11.2
+    endloop
+  endfacet
+  facet normal -0.544639 -0.838671 -0
+    outer loop
+      vertex -190.197 -130.595 -11.2
+      vertex -193.358 -128.543 -56.2
+      vertex -190.197 -130.595 -56.2
+    endloop
+  endfacet
+  facet normal -0.453992 -0.891006 0
+    outer loop
+      vertex -190.197 -130.595 -56.2
+      vertex -186.84 -132.306 -11.2
+      vertex -190.197 -130.595 -11.2
+    endloop
+  endfacet
+  facet normal -0.453992 -0.891006 -0
+    outer loop
+      vertex -186.84 -132.306 -11.2
+      vertex -190.197 -130.595 -56.2
+      vertex -186.84 -132.306 -56.2
+    endloop
+  endfacet
+  facet normal -0.358365 -0.933582 0
+    outer loop
+      vertex -186.84 -132.306 -56.2
+      vertex -183.322 -133.656 -11.2
+      vertex -186.84 -132.306 -11.2
+    endloop
+  endfacet
+  facet normal -0.358365 -0.933582 -0
+    outer loop
+      vertex -183.322 -133.656 -11.2
+      vertex -186.84 -132.306 -56.2
+      vertex -183.322 -133.656 -56.2
+    endloop
+  endfacet
+  facet normal -0.891006 -0.453992 -0
+    outer loop
+      vertex -203.374 -117.418 -11.2
+      vertex -205.085 -114.061 -25.6679
+      vertex -203.374 -117.418 -30.997
+    endloop
+  endfacet
+  facet normal -0.891006 -0.453992 0
+    outer loop
+      vertex -205.085 -114.061 -25.6679
+      vertex -203.374 -117.418 -11.2
+      vertex -205.085 -114.061 -11.2
+    endloop
+  endfacet
+  facet normal -0.891006 -0.453992 0
+    outer loop
+      vertex -203.374 -117.418 -56.2
+      vertex -205.085 -114.061 -40.4704
+      vertex -205.085 -114.061 -56.2
+    endloop
+  endfacet
+  facet normal -0.891006 -0.453992 0
+    outer loop
+      vertex -205.085 -114.061 -40.4704
+      vertex -203.374 -117.418 -56.2
+      vertex -203.374 -117.418 -35.0844
+    endloop
+  endfacet
+  facet normal -0.891004 -0.453995 0
+    outer loop
+      vertex -204.662 -114.891 -35.3861
+      vertex -205.085 -114.061 -29.5395
+      vertex -205.085 -114.061 -36.6604
+    endloop
+  endfacet
+  facet normal -0.891006 -0.453992 -6.04943e-07
+    outer loop
+      vertex -205.085 -114.061 -29.5395
+      vertex -204.662 -114.891 -35.3861
+      vertex -203.904 -116.378 -33.1028
+    endloop
+  endfacet
+  facet normal -0.99863 -0.052334 0
+    outer loop
+      vertex -208 -103.181 -56.2
+      vertex -208.197 -99.4182 -11.2
+      vertex -208.197 -99.4182 -56.2
+    endloop
+  endfacet
+  facet normal -0.99863 -0.052334 0
+    outer loop
+      vertex -208.197 -99.4182 -11.2
+      vertex -208 -103.181 -56.2
+      vertex -208 -103.181 -11.2
+    endloop
+  endfacet
+  facet normal -0.99863 0.0523341 0
+    outer loop
+      vertex -208.197 -99.4182 -56.2
+      vertex -208 -95.6552 -11.2
+      vertex -208 -95.6552 -56.2
+    endloop
+  endfacet
+  facet normal -0.99863 0.0523341 0
+    outer loop
+      vertex -208 -95.6552 -11.2
+      vertex -208.197 -99.4182 -56.2
+      vertex -208.197 -99.4182 -11.2
+    endloop
+  endfacet
+  facet normal -0.987688 0.156435 0
+    outer loop
+      vertex -208 -95.6552 -56.2
+      vertex -207.411 -91.9334 -11.2
+      vertex -207.411 -91.9334 -56.2
+    endloop
+  endfacet
+  facet normal -0.987688 0.156435 0
+    outer loop
+      vertex -207.411 -91.9334 -11.2
+      vertex -208 -95.6552 -56.2
+      vertex -208 -95.6552 -11.2
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -198.951 -123.507 -56.2
+      vertex -197.938 -124.52 -43.0438
+      vertex -198.951 -123.507 -43.0438
+    endloop
+  endfacet
+  facet normal -0.707108 -0.707106 1.55837e-07
+    outer loop
+      vertex -197.938 -124.52 -43.0438
+      vertex -198.951 -123.507 -56.2
+      vertex -196.286 -126.171 -56.2
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -198.951 -123.507 -41.0833
+      vertex -198.344 -124.113 -23.9078
+      vertex -198.951 -123.507 -25.0624
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -198.344 -124.113 -23.9078
+      vertex -198.951 -123.507 -41.0833
+      vertex -197.938 -124.52 -43.0438
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -198.344 -124.113 -23.9078
+      vertex -198.951 -123.507 -11.2
+      vertex -198.951 -123.507 -23.9078
+    endloop
+  endfacet
+  facet normal -0.707108 -0.707105 -0
+    outer loop
+      vertex -196.286 -126.171 -11.2
+      vertex -197.938 -124.52 -43.0438
+      vertex -196.286 -126.171 -56.2
+    endloop
+  endfacet
+  facet normal -0.707108 -0.707106 -4.92008e-08
+    outer loop
+      vertex -197.938 -124.52 -43.0438
+      vertex -196.286 -126.171 -11.2
+      vertex -198.344 -124.113 -23.9078
+    endloop
+  endfacet
+  facet normal -0.707108 -0.707106 -9.6606e-08
+    outer loop
+      vertex -198.344 -124.113 -23.9078
+      vertex -196.286 -126.171 -11.2
+      vertex -198.951 -123.507 -11.2
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 -1.02299e-07
+    outer loop
+      vertex -206.435 -110.543 -41.7587
+      vertex -206.538 -110.16 -23.9078
+      vertex -206.687 -109.605 -43.0438
+    endloop
+  endfacet
+  facet normal -0.965925 -0.258824 0
+    outer loop
+      vertex -206.538 -110.16 -23.9078
+      vertex -206.435 -110.543 -41.7587
+      vertex -206.435 -110.543 -24.4333
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 0
+    outer loop
+      vertex -207.411 -106.903 -56.2
+      vertex -206.687 -109.605 -43.0438
+      vertex -207.411 -106.903 -11.2
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 -1.82929e-09
+    outer loop
+      vertex -206.435 -110.543 -56.2
+      vertex -206.687 -109.605 -43.0438
+      vertex -207.411 -106.903 -56.2
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 0
+    outer loop
+      vertex -206.687 -109.605 -43.0438
+      vertex -206.435 -110.543 -56.2
+      vertex -206.435 -110.543 -43.0438
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 -7.24614e-08
+    outer loop
+      vertex -206.538 -110.16 -23.9078
+      vertex -207.411 -106.903 -11.2
+      vertex -206.687 -109.605 -43.0438
+    endloop
+  endfacet
+  facet normal -0.965925 -0.258824 -0
+    outer loop
+      vertex -206.435 -110.543 -11.2
+      vertex -206.538 -110.16 -23.9078
+      vertex -206.435 -110.543 -23.9078
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 1.487e-07
+    outer loop
+      vertex -206.538 -110.16 -23.9078
+      vertex -206.435 -110.543 -11.2
+      vertex -207.411 -106.903 -11.2
+    endloop
+  endfacet
+  facet normal -0.93358 -0.358369 0
+    outer loop
+      vertex -205.536 -112.886 -23.9078
+      vertex -206.435 -110.543 -11.2
+      vertex -206.435 -110.543 -23.9078
+    endloop
+  endfacet
+  facet normal -0.933584 -0.358359 -0
+    outer loop
+      vertex -205.085 -114.061 -11.2
+      vertex -205.536 -112.886 -23.9078
+      vertex -205.085 -114.061 -25.6679
+    endloop
+  endfacet
+  facet normal -0.933581 -0.358366 -7.43373e-07
+    outer loop
+      vertex -205.536 -112.886 -23.9078
+      vertex -205.085 -114.061 -11.2
+      vertex -206.435 -110.543 -11.2
+    endloop
+  endfacet
+  facet normal -0.933581 -0.358366 0
+    outer loop
+      vertex -206.435 -110.543 -56.2
+      vertex -205.737 -112.361 -43.0438
+      vertex -206.435 -110.543 -43.0438
+    endloop
+  endfacet
+  facet normal -0.933581 -0.358366 2.13457e-09
+    outer loop
+      vertex -205.085 -114.061 -56.2
+      vertex -205.737 -112.361 -43.0438
+      vertex -206.435 -110.543 -56.2
+    endloop
+  endfacet
+  facet normal -0.933581 -0.358366 0
+    outer loop
+      vertex -205.737 -112.361 -43.0438
+      vertex -205.085 -114.061 -56.2
+      vertex -205.085 -114.061 -40.4704
+    endloop
+  endfacet
+  facet normal -0.933581 -0.358366 0
+    outer loop
+      vertex -205.085 -114.061 -36.6604
+      vertex -206.435 -110.543 -24.4333
+      vertex -206.435 -110.543 -41.7587
+    endloop
+  endfacet
+  facet normal -0.933581 -0.358366 0
+    outer loop
+      vertex -206.435 -110.543 -24.4333
+      vertex -205.085 -114.061 -36.6604
+      vertex -205.085 -114.061 -29.5395
+    endloop
+  endfacet
+  facet normal -0.987688 -0.156435 0
+    outer loop
+      vertex -207.411 -106.903 -56.2
+      vertex -208 -103.181 -11.2
+      vertex -208 -103.181 -56.2
+    endloop
+  endfacet
+  facet normal -0.987688 -0.156435 0
+    outer loop
+      vertex -208 -103.181 -11.2
+      vertex -207.411 -106.903 -56.2
+      vertex -207.411 -106.903 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -179.992 -134.549 -11.2
+      vertex -179.992 -118.918 -56.2
+      vertex -179.992 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -179.992 -134.549 -11.2
+      vertex -179.992 -134.549 -56.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866026 -0
+    outer loop
+      vertex -192.982 -96.4182 -56.2
+      vertex -206.518 -88.603 -11.2
+      vertex -192.982 -96.4182 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866026 0
+    outer loop
+      vertex -206.518 -88.603 -11.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -206.518 -88.603 -56.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179.992 -118.918 -56.2
+      vertex -119.37 -118.918 -11.2
+      vertex -179.992 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -119.37 -118.918 -11.2
+      vertex -179.992 -118.918 -56.2
+      vertex -119.37 -118.918 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -192.982 -96.4182 -56.2
+      vertex -162.671 -43.9182 -11.2
+      vertex -162.671 -43.9182 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -162.671 -43.9182 -11.2
+      vertex -192.982 -96.4182 -56.2
+      vertex -192.982 -96.4182 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -119.37 -118.918 -11.2
+      vertex -119.37 -114.917 -56.2
+      vertex -119.37 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -119.37 -114.917 -56.2
+      vertex -119.37 -118.918 -11.2
+      vertex -119.37 -118.918 -56.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866026 -0
+    outer loop
+      vertex -159.179 -45.9347 -56.2
+      vertex -162.671 -43.9182 -11.2
+      vertex -159.179 -45.9347 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866026 0
+    outer loop
+      vertex -162.671 -43.9182 -11.2
+      vertex -159.179 -45.9347 -56.2
+      vertex -162.671 -43.9182 -56.2
+    endloop
+  endfacet
+  facet normal -0.913543 0.406742 0
+    outer loop
+      vertex -147.724 -112.026 -56.2
+      vertex -147.112 -110.652 -11.2
+      vertex -147.112 -110.652 -56.2
+    endloop
+  endfacet
+  facet normal -0.913543 0.406742 0
+    outer loop
+      vertex -147.112 -110.652 -11.2
+      vertex -147.724 -112.026 -56.2
+      vertex -147.724 -112.026 -11.2
+    endloop
+  endfacet
+  facet normal 0.699662 -0.714474 0
+    outer loop
+      vertex -175.456 -74.1914 -56.2
+      vertex -174.382 -73.1391 -11.2
+      vertex -175.456 -74.1914 -11.2
+    endloop
+  endfacet
+  facet normal 0.699662 -0.714474 0
+    outer loop
+      vertex -174.382 -73.1391 -11.2
+      vertex -175.456 -74.1914 -56.2
+      vertex -174.382 -73.1391 -56.2
+    endloop
+  endfacet
+  facet normal 0.500003 -0.866024 0
+    outer loop
+      vertex -174.382 -73.1391 -56.2
+      vertex -173.079 -72.3871 -11.2
+      vertex -174.382 -73.1391 -11.2
+    endloop
+  endfacet
+  facet normal 0.500003 -0.866024 0
+    outer loop
+      vertex -173.079 -72.3871 -11.2
+      vertex -174.382 -73.1391 -56.2
+      vertex -173.079 -72.3871 -56.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -185.473 -91.4778 -11.2
+      vertex -176.235 -75.4778 -56.2
+      vertex -176.235 -75.4778 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -176.235 -75.4778 -56.2
+      vertex -185.473 -91.4778 -11.2
+      vertex -185.473 -91.4778 -56.2
+    endloop
+  endfacet
+  facet normal -0.832919 -0.553395 0
+    outer loop
+      vertex -165.38 -75.2504 -56.2
+      vertex -166.212 -73.9977 -11.2
+      vertex -166.212 -73.9977 -56.2
+    endloop
+  endfacet
+  facet normal -0.832919 -0.553395 0
+    outer loop
+      vertex -166.212 -73.9977 -11.2
+      vertex -165.38 -75.2504 -56.2
+      vertex -165.38 -75.2504 -11.2
+    endloop
+  endfacet
+  facet normal 0.268921 -0.963162 0
+    outer loop
+      vertex -173.079 -72.3871 -56.2
+      vertex -171.631 -71.9826 -11.2
+      vertex -173.079 -72.3871 -11.2
+    endloop
+  endfacet
+  facet normal 0.268921 -0.963162 0
+    outer loop
+      vertex -171.631 -71.9826 -11.2
+      vertex -173.079 -72.3871 -56.2
+      vertex -171.631 -71.9826 -56.2
+    endloop
+  endfacet
+  facet normal 0.855364 -0.518027 0
+    outer loop
+      vertex -176.235 -75.4778 -11.2
+      vertex -175.456 -74.1914 -56.2
+      vertex -175.456 -74.1914 -11.2
+    endloop
+  endfacet
+  facet normal 0.855364 -0.518027 0
+    outer loop
+      vertex -175.456 -74.1914 -56.2
+      vertex -176.235 -75.4778 -11.2
+      vertex -176.235 -75.4778 -56.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -152.731 -114.917 -56.2
+      vertex -171.206 -114.917 -11.2
+      vertex -152.731 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -171.206 -114.917 -11.2
+      vertex -152.731 -114.917 -56.2
+      vertex -171.206 -114.917 -56.2
+    endloop
+  endfacet
+  facet normal -0.66913 -0.743146 0
+    outer loop
+      vertex -167.33 -72.9913 -56.2
+      vertex -166.212 -73.9977 -11.2
+      vertex -167.33 -72.9913 -11.2
+    endloop
+  endfacet
+  facet normal -0.66913 -0.743146 -0
+    outer loop
+      vertex -166.212 -73.9977 -11.2
+      vertex -167.33 -72.9913 -56.2
+      vertex -166.212 -73.9977 -56.2
+    endloop
+  endfacet
+  facet normal 0.999123 -0.0418806 0
+    outer loop
+      vertex -185.971 -94.4203 -11.2
+      vertex -185.908 -92.9176 -56.2
+      vertex -185.908 -92.9176 -11.2
+    endloop
+  endfacet
+  facet normal 0.999123 -0.0418806 0
+    outer loop
+      vertex -185.908 -92.9176 -56.2
+      vertex -185.971 -94.4203 -11.2
+      vertex -185.971 -94.4203 -56.2
+    endloop
+  endfacet
+  facet normal 0.957321 -0.289026 0
+    outer loop
+      vertex -185.908 -92.9176 -11.2
+      vertex -185.473 -91.4778 -56.2
+      vertex -185.473 -91.4778 -11.2
+    endloop
+  endfacet
+  facet normal 0.957321 -0.289026 0
+    outer loop
+      vertex -185.473 -91.4778 -56.2
+      vertex -185.908 -92.9176 -11.2
+      vertex -185.908 -92.9176 -56.2
+    endloop
+  endfacet
+  facet normal -0.6046 0.796529 0
+    outer loop
+      vertex -148.658 -113.205 -56.2
+      vertex -149.856 -114.114 -11.2
+      vertex -148.658 -113.205 -11.2
+    endloop
+  endfacet
+  facet normal -0.6046 0.796529 0
+    outer loop
+      vertex -149.856 -114.114 -11.2
+      vertex -148.658 -113.205 -56.2
+      vertex -149.856 -114.114 -56.2
+    endloop
+  endfacet
+  facet normal -0.4633 -0.886201 0
+    outer loop
+      vertex -168.663 -72.2945 -56.2
+      vertex -167.33 -72.9913 -11.2
+      vertex -168.663 -72.2945 -11.2
+    endloop
+  endfacet
+  facet normal -0.4633 -0.886201 -0
+    outer loop
+      vertex -167.33 -72.9913 -11.2
+      vertex -168.663 -72.2945 -56.2
+      vertex -167.33 -72.9913 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex -147.482 -106.25 -56.2
+      vertex -165.38 -75.2504 -11.2
+      vertex -165.38 -75.2504 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex -165.38 -75.2504 -11.2
+      vertex -147.482 -106.25 -56.2
+      vertex -147.482 -106.25 -11.2
+    endloop
+  endfacet
+  facet normal -0.996493 -0.0836798 0
+    outer loop
+      vertex -146.861 -109.169 -56.2
+      vertex -146.987 -107.671 -11.2
+      vertex -146.987 -107.671 -56.2
+    endloop
+  endfacet
+  facet normal -0.996493 -0.0836798 0
+    outer loop
+      vertex -146.987 -107.671 -11.2
+      vertex -146.861 -109.169 -56.2
+      vertex -146.861 -109.169 -11.2
+    endloop
+  endfacet
+  facet normal 0.756995 0.65342 0
+    outer loop
+      vertex -175.346 -113.377 -11.2
+      vertex -176.329 -112.239 -56.2
+      vertex -176.329 -112.239 -11.2
+    endloop
+  endfacet
+  facet normal 0.756995 0.65342 0
+    outer loop
+      vertex -176.329 -112.239 -56.2
+      vertex -175.346 -113.377 -11.2
+      vertex -175.346 -113.377 -56.2
+    endloop
+  endfacet
+  facet normal -0.146084 0.989272 0
+    outer loop
+      vertex -151.243 -114.697 -56.2
+      vertex -152.731 -114.917 -11.2
+      vertex -151.243 -114.697 -11.2
+    endloop
+  endfacet
+  facet normal -0.146084 0.989272 0
+    outer loop
+      vertex -152.731 -114.917 -11.2
+      vertex -151.243 -114.697 -56.2
+      vertex -152.731 -114.917 -56.2
+    endloop
+  endfacet
+  facet normal -0.783696 0.621145 0
+    outer loop
+      vertex -148.658 -113.205 -56.2
+      vertex -147.724 -112.026 -11.2
+      vertex -147.724 -112.026 -56.2
+    endloop
+  endfacet
+  facet normal -0.783696 0.621145 0
+    outer loop
+      vertex -147.724 -112.026 -11.2
+      vertex -148.658 -113.205 -56.2
+      vertex -148.658 -113.205 -11.2
+    endloop
+  endfacet
+  facet normal 0.0209402 -0.999781 0
+    outer loop
+      vertex -171.631 -71.9826 -56.2
+      vertex -170.127 -71.9511 -11.2
+      vertex -171.631 -71.9826 -11.2
+    endloop
+  endfacet
+  facet normal 0.0209402 -0.999781 0
+    outer loop
+      vertex -170.127 -71.9511 -11.2
+      vertex -171.631 -71.9826 -56.2
+      vertex -170.127 -71.9511 -56.2
+    endloop
+  endfacet
+  facet normal -0.228349 -0.973579 0
+    outer loop
+      vertex -170.127 -71.9511 -56.2
+      vertex -168.663 -72.2945 -11.2
+      vertex -170.127 -71.9511 -11.2
+    endloop
+  endfacet
+  facet normal -0.228349 -0.973579 -0
+    outer loop
+      vertex -168.663 -72.2945 -11.2
+      vertex -170.127 -71.9511 -56.2
+      vertex -168.663 -72.2945 -56.2
+    endloop
+  endfacet
+  facet normal -0.944377 -0.328866 0
+    outer loop
+      vertex -146.987 -107.671 -56.2
+      vertex -147.482 -106.25 -11.2
+      vertex -147.482 -106.25 -56.2
+    endloop
+  endfacet
+  facet normal -0.944377 -0.328866 0
+    outer loop
+      vertex -147.482 -106.25 -11.2
+      vertex -146.987 -107.671 -56.2
+      vertex -146.987 -107.671 -11.2
+    endloop
+  endfacet
+  facet normal 0.978148 0.207911 0
+    outer loop
+      vertex -185.658 -95.8914 -11.2
+      vertex -185.971 -94.4203 -56.2
+      vertex -185.971 -94.4203 -11.2
+    endloop
+  endfacet
+  facet normal 0.978148 0.207911 0
+    outer loop
+      vertex -185.971 -94.4203 -56.2
+      vertex -185.658 -95.8914 -11.2
+      vertex -185.658 -95.8914 -56.2
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -176.329 -112.239 -11.2
+      vertex -184.989 -97.2386 -56.2
+      vertex -184.989 -97.2386 -11.2
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -184.989 -97.2386 -56.2
+      vertex -176.329 -112.239 -11.2
+      vertex -176.329 -112.239 -56.2
+    endloop
+  endfacet
+  facet normal 0.348574 0.937281 -0
+    outer loop
+      vertex -172.702 -114.76 -56.2
+      vertex -174.111 -114.235 -11.2
+      vertex -172.702 -114.76 -11.2
+    endloop
+  endfacet
+  facet normal 0.348574 0.937281 0
+    outer loop
+      vertex -174.111 -114.235 -11.2
+      vertex -172.702 -114.76 -56.2
+      vertex -174.111 -114.235 -56.2
+    endloop
+  endfacet
+  facet normal 0.104529 0.994522 -0
+    outer loop
+      vertex -171.206 -114.917 -56.2
+      vertex -172.702 -114.76 -11.2
+      vertex -171.206 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal 0.104529 0.994522 0
+    outer loop
+      vertex -172.702 -114.76 -11.2
+      vertex -171.206 -114.917 -56.2
+      vertex -172.702 -114.76 -56.2
+    endloop
+  endfacet
+  facet normal -0.985996 0.166772 0
+    outer loop
+      vertex -147.112 -110.652 -56.2
+      vertex -146.861 -109.169 -11.2
+      vertex -146.861 -109.169 -56.2
+    endloop
+  endfacet
+  facet normal -0.985996 0.166772 0
+    outer loop
+      vertex -146.861 -109.169 -11.2
+      vertex -147.112 -110.652 -56.2
+      vertex -147.112 -110.652 -11.2
+    endloop
+  endfacet
+  facet normal 0.895711 0.444637 0
+    outer loop
+      vertex -184.989 -97.2386 -11.2
+      vertex -185.658 -95.8914 -56.2
+      vertex -185.658 -95.8914 -11.2
+    endloop
+  endfacet
+  facet normal 0.895711 0.444637 0
+    outer loop
+      vertex -185.658 -95.8914 -56.2
+      vertex -184.989 -97.2386 -11.2
+      vertex -184.989 -97.2386 -56.2
+    endloop
+  endfacet
+  facet normal 0.570711 0.821151 -0
+    outer loop
+      vertex -174.111 -114.235 -56.2
+      vertex -175.346 -113.377 -11.2
+      vertex -174.111 -114.235 -11.2
+    endloop
+  endfacet
+  facet normal 0.570711 0.821151 0
+    outer loop
+      vertex -175.346 -113.377 -11.2
+      vertex -174.111 -114.235 -56.2
+      vertex -175.346 -113.377 -56.2
+    endloop
+  endfacet
+  facet normal -0.387514 0.921864 0
+    outer loop
+      vertex -149.856 -114.114 -56.2
+      vertex -151.243 -114.697 -11.2
+      vertex -149.856 -114.114 -11.2
+    endloop
+  endfacet
+  facet normal -0.387514 0.921864 0
+    outer loop
+      vertex -151.243 -114.697 -11.2
+      vertex -149.856 -114.114 -56.2
+      vertex -151.243 -114.697 -56.2
+    endloop
+  endfacet
+  facet normal 0.999123 -0.0418806 0
+    outer loop
+      vertex -167.495 -62.4203 -11.2
+      vertex -167.432 -60.9176 -56.2
+      vertex -167.432 -60.9176 -11.2
+    endloop
+  endfacet
+  facet normal 0.999123 -0.0418806 0
+    outer loop
+      vertex -167.432 -60.9176 -56.2
+      vertex -167.495 -62.4203 -11.2
+      vertex -167.495 -62.4203 -56.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -166.998 -59.4778 -11.2
+      vertex -159.179 -45.9347 -56.2
+      vertex -159.179 -45.9347 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -159.179 -45.9347 -56.2
+      vertex -166.998 -59.4778 -11.2
+      vertex -166.998 -59.4778 -56.2
+    endloop
+  endfacet
+  facet normal 0.957319 -0.289034 0
+    outer loop
+      vertex -167.432 -60.9176 -11.2
+      vertex -166.998 -59.4778 -56.2
+      vertex -166.998 -59.4778 -11.2
+    endloop
+  endfacet
+  facet normal 0.957319 -0.289034 0
+    outer loop
+      vertex -166.998 -59.4778 -56.2
+      vertex -167.432 -60.9176 -11.2
+      vertex -167.432 -60.9176 -56.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -119.37 -114.917 -56.2
+      vertex -134.255 -114.917 -11.2
+      vertex -119.37 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -134.255 -114.917 -11.2
+      vertex -119.37 -114.917 -56.2
+      vertex -134.255 -114.917 -56.2
+    endloop
+  endfacet
+  facet normal 0.756995 0.65342 0
+    outer loop
+      vertex -138.396 -113.377 -11.2
+      vertex -139.379 -112.239 -56.2
+      vertex -139.379 -112.239 -11.2
+    endloop
+  endfacet
+  facet normal 0.756995 0.65342 0
+    outer loop
+      vertex -139.379 -112.239 -56.2
+      vertex -138.396 -113.377 -11.2
+      vertex -138.396 -113.377 -56.2
+    endloop
+  endfacet
+  facet normal 0.895711 0.444637 0
+    outer loop
+      vertex -166.514 -65.2386 -11.2
+      vertex -167.183 -63.8914 -56.2
+      vertex -167.183 -63.8914 -11.2
+    endloop
+  endfacet
+  facet normal 0.895711 0.444637 0
+    outer loop
+      vertex -167.183 -63.8914 -56.2
+      vertex -166.514 -65.2386 -11.2
+      vertex -166.514 -65.2386 -56.2
+    endloop
+  endfacet
+  facet normal 0.978148 0.207911 0
+    outer loop
+      vertex -167.183 -63.8914 -11.2
+      vertex -167.495 -62.4203 -56.2
+      vertex -167.495 -62.4203 -11.2
+    endloop
+  endfacet
+  facet normal 0.978148 0.207911 0
+    outer loop
+      vertex -167.495 -62.4203 -56.2
+      vertex -167.183 -63.8914 -11.2
+      vertex -167.183 -63.8914 -56.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex -139.379 -112.239 -11.2
+      vertex -166.514 -65.2386 -56.2
+      vertex -166.514 -65.2386 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex -166.514 -65.2386 -56.2
+      vertex -139.379 -112.239 -11.2
+      vertex -139.379 -112.239 -56.2
+    endloop
+  endfacet
+  facet normal 0.348571 0.937283 -0
+    outer loop
+      vertex -135.751 -114.76 -56.2
+      vertex -137.161 -114.235 -11.2
+      vertex -135.751 -114.76 -11.2
+    endloop
+  endfacet
+  facet normal 0.348571 0.937283 0
+    outer loop
+      vertex -137.161 -114.235 -11.2
+      vertex -135.751 -114.76 -56.2
+      vertex -137.161 -114.235 -56.2
+    endloop
+  endfacet
+  facet normal 0.104529 0.994522 -0
+    outer loop
+      vertex -134.255 -114.917 -56.2
+      vertex -135.751 -114.76 -11.2
+      vertex -134.255 -114.917 -11.2
+    endloop
+  endfacet
+  facet normal 0.104529 0.994522 0
+    outer loop
+      vertex -135.751 -114.76 -11.2
+      vertex -134.255 -114.917 -56.2
+      vertex -135.751 -114.76 -56.2
+    endloop
+  endfacet
+  facet normal 0.570716 0.821148 -0
+    outer loop
+      vertex -137.161 -114.235 -56.2
+      vertex -138.396 -113.377 -11.2
+      vertex -137.161 -114.235 -11.2
+    endloop
+  endfacet
+  facet normal 0.570716 0.821148 0
+    outer loop
+      vertex -138.396 -113.377 -11.2
+      vertex -137.161 -114.235 -56.2
+      vertex -138.396 -113.377 -56.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 4.52954e-07
+    outer loop
+      vertex -197.185 -120.139 -23.9078
+      vertex -199.017 -116.965 -33.0068
+      vertex -195.754 -122.618 -23.9078
+    endloop
+  endfacet
+  facet normal -0.866027 -0.499997 1.53958e-06
+    outer loop
+      vertex -197.185 -120.139 -23.9078
+      vertex -199.762 -115.676 -31.4178
+      vertex -199.017 -116.965 -33.0068
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 4.41666e-07
+    outer loop
+      vertex -202.413 -111.083 -23.9078
+      vertex -203.844 -108.604 -23.9078
+      vertex -200.493 -114.409 -33.1028
+    endloop
+  endfacet
+  facet normal -0.866025 -0.500001 5.73415e-07
+    outer loop
+      vertex -199.762 -115.676 -31.4178
+      vertex -202.413 -111.083 -23.9078
+      vertex -200.493 -114.409 -33.1028
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 1.15653e-06
+    outer loop
+      vertex -202.691 -110.602 -43.0438
+      vertex -200.493 -114.409 -33.1028
+      vertex -204.122 -108.124 -43.0438
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 6.43548e-07
+    outer loop
+      vertex -199.768 -115.664 -34.6777
+      vertex -200.493 -114.409 -33.1028
+      vertex -202.691 -110.602 -43.0438
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499998 -1.34666e-06
+    outer loop
+      vertex -199.017 -116.965 -33.0068
+      vertex -200.493 -114.409 -33.1028
+      vertex -199.768 -115.664 -34.6777
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499998 2.99673e-06
+    outer loop
+      vertex -200.493 -114.409 -33.1028
+      vertex -199.017 -116.965 -33.0068
+      vertex -199.762 -115.676 -31.4178
+    endloop
+  endfacet
+  facet normal -0.866027 -0.499998 -8.89281e-07
+    outer loop
+      vertex -196.907 -120.621 -43.0438
+      vertex -199.017 -116.965 -33.0068
+      vertex -199.768 -115.664 -34.6777
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 1.29657e-07
+    outer loop
+      vertex -199.017 -116.965 -33.0068
+      vertex -196.907 -120.621 -43.0438
+      vertex -195.476 -123.098 -43.0438
+    endloop
+  endfacet
+  facet normal 0.412678 -0.714782 0.56461
+    outer loop
+      vertex -201.322 -120.579 -39.7633
+      vertex -199.768 -115.664 -34.6777
+      vertex -203.219 -117.657 -34.6777
+    endloop
+  endfacet
+  facet normal 0.412679 -0.714782 0.564609
+    outer loop
+      vertex -196.907 -120.621 -43.0438
+      vertex -201.322 -120.579 -39.7633
+      vertex -199.892 -122.344 -43.0438
+    endloop
+  endfacet
+  facet normal 0.412679 -0.714781 0.564609
+    outer loop
+      vertex -201.322 -120.579 -39.7633
+      vertex -196.907 -120.621 -43.0438
+      vertex -199.768 -115.664 -34.6777
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -198.951 -123.507 -43.0438
+      vertex -195.476 -123.098 -43.0438
+      vertex -196.907 -120.621 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -195.476 -123.098 -43.0438
+      vertex -198.951 -123.507 -43.0438
+      vertex -197.938 -124.52 -43.0438
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -198.951 -123.507 -43.0438
+      vertex -196.907 -120.621 -43.0438
+      vertex -199.892 -122.344 -43.0438
+    endloop
+  endfacet
+  facet normal -0.408541 0.707612 -0.576524
+    outer loop
+      vertex -195.476 -123.098 -43.0438
+      vertex -199.548 -122.77 -39.7551
+      vertex -199.017 -116.965 -33.0068
+    endloop
+  endfacet
+  facet normal -0.408541 0.707611 -0.576524
+    outer loop
+      vertex -199.548 -122.77 -39.7551
+      vertex -195.476 -123.098 -43.0438
+      vertex -198.951 -123.507 -41.0833
+    endloop
+  endfacet
+  facet normal -0.408541 0.707613 -0.576522
+    outer loop
+      vertex -198.951 -123.507 -41.0833
+      vertex -195.476 -123.098 -43.0438
+      vertex -197.938 -124.52 -43.0438
+    endloop
+  endfacet
+  facet normal -0.40854 0.707612 -0.576524
+    outer loop
+      vertex -199.017 -116.965 -33.0068
+      vertex -201.322 -120.579 -35.8086
+      vertex -202.4 -118.918 -33.0068
+    endloop
+  endfacet
+  facet normal -0.40854 0.707612 -0.576524
+    outer loop
+      vertex -201.322 -120.579 -35.8086
+      vertex -199.017 -116.965 -33.0068
+      vertex -199.548 -122.77 -39.7551
+    endloop
+  endfacet
+  facet normal -0.406281 0.703698 0.582876
+    outer loop
+      vertex -195.754 -122.618 -23.9078
+      vertex -198.951 -123.507 -25.0624
+      vertex -198.344 -124.113 -23.9078
+    endloop
+  endfacet
+  facet normal -0.406281 0.703698 0.582876
+    outer loop
+      vertex -199.017 -116.965 -33.0068
+      vertex -198.951 -123.507 -25.0624
+      vertex -195.754 -122.618 -23.9078
+    endloop
+  endfacet
+  facet normal -0.40628 0.703698 0.582877
+    outer loop
+      vertex -198.951 -123.507 -25.0624
+      vertex -199.017 -116.965 -33.0068
+      vertex -201.322 -120.579 -30.2508
+    endloop
+  endfacet
+  facet normal -0.406281 0.703698 0.582876
+    outer loop
+      vertex -201.322 -120.579 -30.2508
+      vertex -199.017 -116.965 -33.0068
+      vertex -202.4 -118.918 -33.0068
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -198.951 -123.507 -23.9078
+      vertex -195.754 -122.618 -23.9078
+      vertex -198.344 -124.113 -23.9078
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -195.754 -122.618 -23.9078
+      vertex -198.951 -123.507 -23.9078
+      vertex -197.185 -120.139 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -197.185 -120.139 -23.9078
+      vertex -198.951 -123.507 -23.9078
+      vertex -200.246 -121.907 -23.9078
+    endloop
+  endfacet
+  facet normal 0.412255 -0.714045 -0.565849
+    outer loop
+      vertex -201.322 -120.579 -26.3675
+      vertex -197.185 -120.139 -23.9078
+      vertex -200.246 -121.907 -23.9078
+    endloop
+  endfacet
+  facet normal 0.412254 -0.714046 -0.565849
+    outer loop
+      vertex -199.762 -115.676 -31.4178
+      vertex -201.322 -120.579 -26.3675
+      vertex -203.212 -117.668 -31.4178
+    endloop
+  endfacet
+  facet normal 0.412255 -0.714046 -0.565849
+    outer loop
+      vertex -201.322 -120.579 -26.3675
+      vertex -199.762 -115.676 -31.4178
+      vertex -197.185 -120.139 -23.9078
+    endloop
+  endfacet
+  facet normal -0.408438 0.707435 -0.576813
+    outer loop
+      vertex -202.413 -111.083 -23.9078
+      vertex -205.085 -114.061 -25.6679
+      vertex -205.536 -112.886 -23.9078
+    endloop
+  endfacet
+  facet normal -0.408438 0.707435 -0.576814
+    outer loop
+      vertex -202.413 -111.083 -23.9078
+      vertex -203.374 -117.418 -30.997
+      vertex -205.085 -114.061 -25.6679
+    endloop
+  endfacet
+  facet normal -0.408437 0.707435 -0.576814
+    outer loop
+      vertex -199.762 -115.676 -31.4178
+      vertex -203.374 -117.418 -30.997
+      vertex -202.413 -111.083 -23.9078
+    endloop
+  endfacet
+  facet normal -0.408436 0.707431 -0.57682
+    outer loop
+      vertex -203.374 -117.418 -30.997
+      vertex -199.762 -115.676 -31.4178
+      vertex -203.212 -117.668 -31.4178
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -206.435 -110.543 -23.9078
+      vertex -202.413 -111.083 -23.9078
+      vertex -205.536 -112.886 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -202.413 -111.083 -23.9078
+      vertex -206.435 -110.543 -23.9078
+      vertex -203.844 -108.604 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -203.844 -108.604 -23.9078
+      vertex -206.435 -110.543 -23.9078
+      vertex -206.538 -110.16 -23.9078
+    endloop
+  endfacet
+  facet normal 0.404058 -0.69985 0.589022
+    outer loop
+      vertex -206.435 -110.543 -24.4333
+      vertex -203.844 -108.604 -23.9078
+      vertex -206.538 -110.16 -23.9078
+    endloop
+  endfacet
+  facet normal 0.404061 -0.699852 0.589017
+    outer loop
+      vertex -205.085 -114.061 -29.5395
+      vertex -203.844 -108.604 -23.9078
+      vertex -206.435 -110.543 -24.4333
+    endloop
+  endfacet
+  facet normal 0.404059 -0.699854 0.589018
+    outer loop
+      vertex -200.493 -114.409 -33.1028
+      vertex -205.085 -114.061 -29.5395
+      vertex -203.904 -116.378 -33.1028
+    endloop
+  endfacet
+  facet normal 0.404059 -0.699853 0.589018
+    outer loop
+      vertex -205.085 -114.061 -29.5395
+      vertex -200.493 -114.409 -33.1028
+      vertex -203.844 -108.604 -23.9078
+    endloop
+  endfacet
+  facet normal 0.403841 -0.699476 -0.589615
+    outer loop
+      vertex -204.662 -114.891 -35.3861
+      vertex -200.493 -114.409 -33.1028
+      vertex -203.904 -116.378 -33.1028
+    endloop
+  endfacet
+  facet normal 0.403841 -0.699475 -0.589616
+    outer loop
+      vertex -200.493 -114.409 -33.1028
+      vertex -204.662 -114.891 -35.3861
+      vertex -204.122 -108.124 -43.0438
+    endloop
+  endfacet
+  facet normal 0.403844 -0.699474 -0.589615
+    outer loop
+      vertex -204.122 -108.124 -43.0438
+      vertex -205.085 -114.061 -36.6604
+      vertex -206.435 -110.543 -41.7587
+    endloop
+  endfacet
+  facet normal 0.403842 -0.699474 -0.589617
+    outer loop
+      vertex -204.122 -108.124 -43.0438
+      vertex -206.435 -110.543 -41.7587
+      vertex -206.687 -109.605 -43.0438
+    endloop
+  endfacet
+  facet normal 0.40384 -0.699475 -0.589616
+    outer loop
+      vertex -205.085 -114.061 -36.6604
+      vertex -204.122 -108.124 -43.0438
+      vertex -204.662 -114.891 -35.3861
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -206.435 -110.543 -43.0438
+      vertex -202.691 -110.602 -43.0438
+      vertex -204.122 -108.124 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -202.691 -110.602 -43.0438
+      vertex -206.435 -110.543 -43.0438
+      vertex -205.737 -112.361 -43.0438
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -206.435 -110.543 -43.0438
+      vertex -204.122 -108.124 -43.0438
+      vertex -206.687 -109.605 -43.0438
+    endloop
+  endfacet
+  facet normal -0.409871 0.709919 0.572731
+    outer loop
+      vertex -199.768 -115.664 -34.6777
+      vertex -203.374 -117.418 -35.0844
+      vertex -203.219 -117.657 -34.6777
+    endloop
+  endfacet
+  facet normal -0.409872 0.709924 0.572724
+    outer loop
+      vertex -199.768 -115.664 -34.6777
+      vertex -205.085 -114.061 -40.4704
+      vertex -203.374 -117.418 -35.0844
+    endloop
+  endfacet
+  facet normal -0.409873 0.709923 0.572724
+    outer loop
+      vertex -202.691 -110.602 -43.0438
+      vertex -205.085 -114.061 -40.4704
+      vertex -199.768 -115.664 -34.6777
+    endloop
+  endfacet
+  facet normal -0.409873 0.709923 0.572725
+    outer loop
+      vertex -205.085 -114.061 -40.4704
+      vertex -202.691 -110.602 -43.0438
+      vertex -205.737 -112.361 -43.0438
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -194.732 -108.387 249.8
+      vertex -193.281 -113.9 249.8
+      vertex -191.268 -106.387 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -194.732 -108.387 249.8
+      vertex -195.281 -110.436 249.8
+      vertex -193.281 -113.9 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -201.495 -107.673 249.8
+      vertex -194.732 -108.387 249.8
+      vertex -196.732 -104.923 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -194.732 -108.387 249.8
+      vertex -201.495 -107.673 249.8
+      vertex -195.281 -110.436 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -195.281 -110.436 249.8
+      vertex -201.495 -107.673 249.8
+      vertex -198.745 -112.436 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -188.505 -100.173 249.8
+      vertex -189.219 -106.936 249.8
+      vertex -185.755 -104.936 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -191.268 -106.387 249.8
+      vertex -189.219 -106.936 249.8
+      vertex -188.505 -100.173 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -189.219 -106.936 249.8
+      vertex -191.268 -106.387 249.8
+      vertex -191.232 -114.449 249.8
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -191.268 -106.387 249.8
+      vertex -188.505 -100.173 249.8
+      vertex -193.268 -102.923 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -187.219 -110.4 249.8
+      vertex -181.005 -113.163 249.8
+      vertex -183.755 -108.4 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -187.768 -112.449 249.8
+      vertex -181.005 -113.163 249.8
+      vertex -187.219 -110.4 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -181.005 -113.163 249.8
+      vertex -187.768 -112.449 249.8
+      vertex -185.768 -115.913 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -189.219 -106.936 249.8
+      vertex -187.768 -112.449 249.8
+      vertex -187.219 -110.4 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -187.768 -112.449 249.8
+      vertex -189.219 -106.936 249.8
+      vertex -191.232 -114.449 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -193.281 -113.9 249.8
+      vertex -191.232 -114.449 249.8
+      vertex -191.268 -106.387 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -193.995 -120.663 249.8
+      vertex -191.232 -114.449 249.8
+      vertex -193.281 -113.9 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -191.232 -114.449 249.8
+      vertex -193.995 -120.663 249.8
+      vertex -189.232 -117.913 249.8
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -193.995 -120.663 249.8
+      vertex -193.281 -113.9 249.8
+      vertex -196.745 -115.9 249.8
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -189.232 -117.913 249.8
+      vertex -191.232 -114.449 -11.2
+      vertex -191.232 -114.449 249.8
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -191.232 -114.449 -11.2
+      vertex -189.232 -117.913 249.8
+      vertex -189.232 -117.913 -11.2
+    endloop
+  endfacet
+  facet normal 0.499999 -0.866026 0
+    outer loop
+      vertex -191.232 -114.449 -11.2
+      vertex -187.768 -112.449 249.8
+      vertex -191.232 -114.449 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 -0.866026 0
+    outer loop
+      vertex -187.768 -112.449 249.8
+      vertex -191.232 -114.449 -11.2
+      vertex -187.768 -112.449 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex -185.768 -115.913 -11.2
+      vertex -187.768 -112.449 249.8
+      vertex -187.768 -112.449 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex -187.768 -112.449 249.8
+      vertex -185.768 -115.913 -11.2
+      vertex -185.768 -115.913 249.8
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex -185.768 -115.913 -11.2
+      vertex -181.005 -113.163 249.8
+      vertex -185.768 -115.913 249.8
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex -181.005 -113.163 249.8
+      vertex -185.768 -115.913 -11.2
+      vertex -181.005 -113.163 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex -181.005 -113.163 249.8
+      vertex -183.755 -108.4 -11.2
+      vertex -183.755 -108.4 249.8
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex -183.755 -108.4 -11.2
+      vertex -181.005 -113.163 249.8
+      vertex -181.005 -113.163 -11.2
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex -183.755 -108.4 -11.2
+      vertex -187.219 -110.4 249.8
+      vertex -183.755 -108.4 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex -187.219 -110.4 249.8
+      vertex -183.755 -108.4 -11.2
+      vertex -187.219 -110.4 -11.2
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -187.219 -110.4 249.8
+      vertex -189.219 -106.936 -11.2
+      vertex -189.219 -106.936 249.8
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -189.219 -106.936 -11.2
+      vertex -187.219 -110.4 249.8
+      vertex -187.219 -110.4 -11.2
+    endloop
+  endfacet
+  facet normal 0.499999 -0.866026 0
+    outer loop
+      vertex -189.219 -106.936 -11.2
+      vertex -185.755 -104.936 249.8
+      vertex -189.219 -106.936 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 -0.866026 0
+    outer loop
+      vertex -185.755 -104.936 249.8
+      vertex -189.219 -106.936 -11.2
+      vertex -185.755 -104.936 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex -185.755 -104.936 249.8
+      vertex -188.505 -100.173 -11.2
+      vertex -188.505 -100.173 249.8
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex -188.505 -100.173 -11.2
+      vertex -185.755 -104.936 249.8
+      vertex -185.755 -104.936 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex -188.505 -100.173 -11.2
+      vertex -193.268 -102.923 249.8
+      vertex -188.505 -100.173 249.8
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex -193.268 -102.923 249.8
+      vertex -188.505 -100.173 -11.2
+      vertex -193.268 -102.923 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex -191.268 -106.387 -11.2
+      vertex -193.268 -102.923 249.8
+      vertex -193.268 -102.923 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex -193.268 -102.923 249.8
+      vertex -191.268 -106.387 -11.2
+      vertex -191.268 -106.387 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex -191.268 -106.387 -11.2
+      vertex -194.732 -108.387 249.8
+      vertex -191.268 -106.387 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex -194.732 -108.387 249.8
+      vertex -191.268 -106.387 -11.2
+      vertex -194.732 -108.387 -11.2
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -194.732 -108.387 249.8
+      vertex -196.732 -104.923 -11.2
+      vertex -196.732 -104.923 249.8
+    endloop
+  endfacet
+  facet normal 0.866026 0.5 0
+    outer loop
+      vertex -196.732 -104.923 -11.2
+      vertex -194.732 -108.387 249.8
+      vertex -194.732 -108.387 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex -196.732 -104.923 -11.2
+      vertex -201.495 -107.673 249.8
+      vertex -196.732 -104.923 249.8
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex -201.495 -107.673 249.8
+      vertex -196.732 -104.923 -11.2
+      vertex -201.495 -107.673 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex -198.745 -112.436 -11.2
+      vertex -201.495 -107.673 249.8
+      vertex -201.495 -107.673 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex -201.495 -107.673 249.8
+      vertex -198.745 -112.436 -11.2
+      vertex -198.745 -112.436 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 -0.866026 0
+    outer loop
+      vertex -198.745 -112.436 -11.2
+      vertex -195.281 -110.436 249.8
+      vertex -198.745 -112.436 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 -0.866026 0
+    outer loop
+      vertex -195.281 -110.436 249.8
+      vertex -198.745 -112.436 -11.2
+      vertex -195.281 -110.436 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex -193.281 -113.9 -11.2
+      vertex -195.281 -110.436 249.8
+      vertex -195.281 -110.436 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex -195.281 -110.436 249.8
+      vertex -193.281 -113.9 -11.2
+      vertex -193.281 -113.9 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex -193.281 -113.9 -11.2
+      vertex -196.745 -115.9 249.8
+      vertex -193.281 -113.9 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex -196.745 -115.9 249.8
+      vertex -193.281 -113.9 -11.2
+      vertex -196.745 -115.9 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex -193.995 -120.663 -11.2
+      vertex -196.745 -115.9 249.8
+      vertex -196.745 -115.9 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex -196.745 -115.9 249.8
+      vertex -193.995 -120.663 -11.2
+      vertex -193.995 -120.663 249.8
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex -193.995 -120.663 -11.2
+      vertex -189.232 -117.913 249.8
+      vertex -193.995 -120.663 249.8
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex -189.232 -117.913 249.8
+      vertex -193.995 -120.663 -11.2
+      vertex -189.232 -117.913 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 -8.03094e-07
+    outer loop
+      vertex -196.383 -93.3094 -46.7
+      vertex -192.919 -95.3094 -41.2
+      vertex -197.682 -92.5594 -45.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -192.919 -95.3094 -46.7
+      vertex -192.919 -95.3094 -41.2
+      vertex -196.383 -93.3094 -46.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex -201.146 -90.5594 -45.2
+      vertex -201.146 -90.5594 -41.2
+      vertex -205.91 -87.8094 -41.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex -192.919 -95.3094 -41.2
+      vertex -197.682 -92.5594 -41.2
+      vertex -197.682 -92.5594 -45.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -197.682 -92.5594 -52.2
+      vertex -197.682 -92.5594 -45.2
+      vertex -201.146 -90.5594 -52.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex -197.682 -92.5594 -52.2
+      vertex -196.383 -93.3094 -46.7
+      vertex -197.682 -92.5594 -45.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex -197.682 -92.5594 -52.2
+      vertex -196.383 -93.3094 -50.7
+      vertex -196.383 -93.3094 -46.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 8.03094e-07
+    outer loop
+      vertex -192.919 -95.3094 -56.2
+      vertex -196.383 -93.3094 -50.7
+      vertex -197.682 -92.5594 -52.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex -192.919 -95.3094 -56.2
+      vertex -197.682 -92.5594 -52.2
+      vertex -197.682 -92.5594 -56.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -196.383 -93.3094 -50.7
+      vertex -192.919 -95.3094 -56.2
+      vertex -192.919 -95.3094 -50.7
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -197.682 -92.5594 -45.2
+      vertex -201.146 -90.5594 -45.2
+      vertex -201.146 -90.5594 -52.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -205.91 -87.8094 -56.2
+      vertex -202.446 -89.8094 -50.7
+      vertex -205.91 -87.8094 -50.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 -8.03094e-07
+    outer loop
+      vertex -202.446 -89.8094 -50.7
+      vertex -205.91 -87.8094 -56.2
+      vertex -201.146 -90.5594 -52.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 -0
+    outer loop
+      vertex -201.146 -90.5594 -52.2
+      vertex -205.91 -87.8094 -56.2
+      vertex -201.146 -90.5594 -56.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -202.446 -89.8094 -46.7
+      vertex -205.91 -87.8094 -41.2
+      vertex -205.91 -87.8094 -46.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 8.03094e-07
+    outer loop
+      vertex -205.91 -87.8094 -41.2
+      vertex -202.446 -89.8094 -46.7
+      vertex -201.146 -90.5594 -45.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex -202.446 -89.8094 -50.7
+      vertex -201.146 -90.5594 -45.2
+      vertex -202.446 -89.8094 -46.7
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 -0
+    outer loop
+      vertex -201.146 -90.5594 -45.2
+      vertex -202.446 -89.8094 -50.7
+      vertex -201.146 -90.5594 -52.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -13.9192 214.728 -41.2
+      vertex -18.6824 217.478 -45.2
+      vertex -18.6824 217.478 -41.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -3.34623e-08
+    outer loop
+      vertex -13.9192 214.728 -41.2
+      vertex -17.3833 216.728 -46.7
+      vertex -18.6824 217.478 -45.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -17.3833 216.728 -46.7
+      vertex -13.9192 214.728 -41.2
+      vertex -13.9192 214.728 -46.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -22.1465 219.478 -45.2
+      vertex -26.9096 222.228 -41.2
+      vertex -22.1465 219.478 -41.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -7.94729e-08
+    outer loop
+      vertex -18.6824 217.478 -45.2
+      vertex -17.3833 216.728 -46.7
+      vertex -22.1465 219.478 -45.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 4.54131e-08
+    outer loop
+      vertex -23.4455 220.228 -46.7
+      vertex -22.1465 219.478 -45.2
+      vertex -17.3833 216.728 -46.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 3.34623e-08
+    outer loop
+      vertex -23.4455 220.228 -46.7
+      vertex -26.9096 222.228 -41.2
+      vertex -22.1465 219.478 -45.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -26.9096 222.228 -41.2
+      vertex -23.4455 220.228 -46.7
+      vertex -26.9096 222.228 -46.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -13.9192 214.728 -56.2
+      vertex -17.3833 216.728 -50.7
+      vertex -13.9192 214.728 -50.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 4.54131e-08
+    outer loop
+      vertex -17.3833 216.728 -50.7
+      vertex -18.6824 217.478 -52.2
+      vertex -23.4455 220.228 -50.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -7.94729e-08
+    outer loop
+      vertex -22.1465 219.478 -52.2
+      vertex -23.4455 220.228 -50.7
+      vertex -18.6824 217.478 -52.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 3.34623e-08
+    outer loop
+      vertex -17.3833 216.728 -50.7
+      vertex -13.9192 214.728 -56.2
+      vertex -18.6824 217.478 -52.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -18.6824 217.478 -52.2
+      vertex -13.9192 214.728 -56.2
+      vertex -18.6824 217.478 -56.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -17.3833 216.728 -50.7
+      vertex -23.4455 220.228 -46.7
+      vertex -17.3833 216.728 -46.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -23.4455 220.228 -46.7
+      vertex -17.3833 216.728 -50.7
+      vertex -23.4455 220.228 -50.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -3.34623e-08
+    outer loop
+      vertex -26.9096 222.228 -56.2
+      vertex -23.4455 220.228 -50.7
+      vertex -22.1465 219.478 -52.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -26.9096 222.228 -56.2
+      vertex -22.1465 219.478 -52.2
+      vertex -22.1465 219.478 -56.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -23.4455 220.228 -50.7
+      vertex -26.9096 222.228 -56.2
+      vertex -26.9096 222.228 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.9096 222.228 -50.7
+      vertex -202.446 -89.8094 -50.7
+      vertex -23.4455 220.228 -50.7
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -202.446 -89.8094 -50.7
+      vertex -26.9096 222.228 -50.7
+      vertex -205.91 -87.8094 -50.7
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -202.446 -89.8094 -50.7
+      vertex -23.4455 220.228 -46.7
+      vertex -23.4455 220.228 -50.7
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -23.4455 220.228 -46.7
+      vertex -202.446 -89.8094 -50.7
+      vertex -202.446 -89.8094 -46.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -202.446 -89.8094 -46.7
+      vertex -26.9096 222.228 -46.7
+      vertex -23.4455 220.228 -46.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.9096 222.228 -46.7
+      vertex -202.446 -89.8094 -46.7
+      vertex -205.91 -87.8094 -46.7
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -205.91 -87.8094 -46.7
+      vertex -26.9096 222.228 -41.2
+      vertex -26.9096 222.228 -46.7
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -26.9096 222.228 -41.2
+      vertex -205.91 -87.8094 -46.7
+      vertex -205.91 -87.8094 -41.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.9096 222.228 -41.2
+      vertex -201.146 -90.5594 -41.2
+      vertex -22.1465 219.478 -41.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -201.146 -90.5594 -41.2
+      vertex -26.9096 222.228 -41.2
+      vertex -205.91 -87.8094 -41.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -201.146 -90.5594 -45.2
+      vertex -22.1465 219.478 -41.2
+      vertex -201.146 -90.5594 -41.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -22.1465 219.478 -45.2
+      vertex -22.1465 219.478 -41.2
+      vertex -201.146 -90.5594 -45.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.1465 219.478 -45.2
+      vertex -197.682 -92.5594 -45.2
+      vertex -18.6824 217.478 -45.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -197.682 -92.5594 -45.2
+      vertex -22.1465 219.478 -45.2
+      vertex -201.146 -90.5594 -45.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -197.682 -92.5594 -45.2
+      vertex -18.6824 217.478 -41.2
+      vertex -18.6824 217.478 -45.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -18.6824 217.478 -41.2
+      vertex -197.682 -92.5594 -45.2
+      vertex -197.682 -92.5594 -41.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6824 217.478 -41.2
+      vertex -192.919 -95.3094 -41.2
+      vertex -13.9192 214.728 -41.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -192.919 -95.3094 -41.2
+      vertex -18.6824 217.478 -41.2
+      vertex -197.682 -92.5594 -41.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -192.919 -95.3094 -41.2
+      vertex -13.9192 214.728 -46.7
+      vertex -13.9192 214.728 -41.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -13.9192 214.728 -46.7
+      vertex -192.919 -95.3094 -41.2
+      vertex -192.919 -95.3094 -46.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -192.919 -95.3094 -46.7
+      vertex -17.3833 216.728 -46.7
+      vertex -13.9192 214.728 -46.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3833 216.728 -46.7
+      vertex -192.919 -95.3094 -46.7
+      vertex -196.383 -93.3094 -46.7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -196.383 -93.3094 -46.7
+      vertex -17.3833 216.728 -50.7
+      vertex -17.3833 216.728 -46.7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -17.3833 216.728 -50.7
+      vertex -196.383 -93.3094 -46.7
+      vertex -196.383 -93.3094 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.3833 216.728 -50.7
+      vertex -192.919 -95.3094 -50.7
+      vertex -13.9192 214.728 -50.7
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -192.919 -95.3094 -50.7
+      vertex -17.3833 216.728 -50.7
+      vertex -196.383 -93.3094 -50.7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -192.919 -95.3094 -50.7
+      vertex -13.9192 214.728 -56.2
+      vertex -13.9192 214.728 -50.7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -13.9192 214.728 -56.2
+      vertex -192.919 -95.3094 -50.7
+      vertex -192.919 -95.3094 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -192.919 -95.3094 -56.2
+      vertex -18.6824 217.478 -56.2
+      vertex -13.9192 214.728 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6824 217.478 -56.2
+      vertex -192.919 -95.3094 -56.2
+      vertex -197.682 -92.5594 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -197.682 -92.5594 -56.2
+      vertex -18.6824 217.478 -52.2
+      vertex -18.6824 217.478 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -18.6824 217.478 -52.2
+      vertex -197.682 -92.5594 -56.2
+      vertex -197.682 -92.5594 -52.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -197.682 -92.5594 -52.2
+      vertex -22.1465 219.478 -52.2
+      vertex -18.6824 217.478 -52.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.1465 219.478 -52.2
+      vertex -197.682 -92.5594 -52.2
+      vertex -201.146 -90.5594 -52.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -201.146 -90.5594 -52.2
+      vertex -22.1465 219.478 -56.2
+      vertex -22.1465 219.478 -52.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -22.1465 219.478 -56.2
+      vertex -201.146 -90.5594 -52.2
+      vertex -201.146 -90.5594 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -201.146 -90.5594 -56.2
+      vertex -26.9096 222.228 -56.2
+      vertex -22.1465 219.478 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.9096 222.228 -56.2
+      vertex -201.146 -90.5594 -56.2
+      vertex -205.91 -87.8094 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -205.91 -87.8094 -56.2
+      vertex -26.9096 222.228 -50.7
+      vertex -26.9096 222.228 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -26.9096 222.228 -50.7
+      vertex -205.91 -87.8094 -56.2
+      vertex -205.91 -87.8094 -50.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 -8.03093e-07
+    outer loop
+      vertex -196.383 -93.3094 -16.7
+      vertex -192.919 -95.3094 -11.2
+      vertex -197.682 -92.5594 -15.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -192.919 -95.3094 -16.7
+      vertex -192.919 -95.3094 -11.2
+      vertex -196.383 -93.3094 -16.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex -201.146 -90.5594 -15.2
+      vertex -201.146 -90.5594 -11.2
+      vertex -205.91 -87.8094 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex -192.919 -95.3094 -11.2
+      vertex -197.682 -92.5594 -11.2
+      vertex -197.682 -92.5594 -15.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -197.682 -92.5594 -22.2
+      vertex -197.682 -92.5594 -15.2
+      vertex -201.146 -90.5594 -22.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex -197.682 -92.5594 -22.2
+      vertex -196.383 -93.3094 -16.7
+      vertex -197.682 -92.5594 -15.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex -197.682 -92.5594 -22.2
+      vertex -196.383 -93.3094 -20.7
+      vertex -196.383 -93.3094 -16.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 8.03094e-07
+    outer loop
+      vertex -192.919 -95.3094 -26.2
+      vertex -196.383 -93.3094 -20.7
+      vertex -197.682 -92.5594 -22.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex -192.919 -95.3094 -26.2
+      vertex -197.682 -92.5594 -22.2
+      vertex -197.682 -92.5594 -26.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -196.383 -93.3094 -20.7
+      vertex -192.919 -95.3094 -26.2
+      vertex -192.919 -95.3094 -20.7
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -197.682 -92.5594 -15.2
+      vertex -201.146 -90.5594 -15.2
+      vertex -201.146 -90.5594 -22.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -205.91 -87.8094 -26.2
+      vertex -202.446 -89.8094 -20.7
+      vertex -205.91 -87.8094 -20.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 -8.03094e-07
+    outer loop
+      vertex -202.446 -89.8094 -20.7
+      vertex -205.91 -87.8094 -26.2
+      vertex -201.146 -90.5594 -22.2
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 -0
+    outer loop
+      vertex -201.146 -90.5594 -22.2
+      vertex -205.91 -87.8094 -26.2
+      vertex -201.146 -90.5594 -26.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -202.446 -89.8094 -16.7
+      vertex -205.91 -87.8094 -11.2
+      vertex -205.91 -87.8094 -16.7
+    endloop
+  endfacet
+  facet normal -0.5 -0.866026 8.03093e-07
+    outer loop
+      vertex -205.91 -87.8094 -11.2
+      vertex -202.446 -89.8094 -16.7
+      vertex -201.146 -90.5594 -15.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex -202.446 -89.8094 -20.7
+      vertex -201.146 -90.5594 -15.2
+      vertex -202.446 -89.8094 -16.7
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 -0
+    outer loop
+      vertex -201.146 -90.5594 -15.2
+      vertex -202.446 -89.8094 -20.7
+      vertex -201.146 -90.5594 -22.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -13.9192 214.728 -11.2
+      vertex -18.6824 217.478 -15.2
+      vertex -18.6824 217.478 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -3.34622e-08
+    outer loop
+      vertex -13.9192 214.728 -11.2
+      vertex -17.3833 216.728 -16.7
+      vertex -18.6824 217.478 -15.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -17.3833 216.728 -16.7
+      vertex -13.9192 214.728 -11.2
+      vertex -13.9192 214.728 -16.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -22.1465 219.478 -15.2
+      vertex -26.9096 222.228 -11.2
+      vertex -22.1465 219.478 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -7.94728e-08
+    outer loop
+      vertex -18.6824 217.478 -15.2
+      vertex -17.3833 216.728 -16.7
+      vertex -22.1465 219.478 -15.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 4.5413e-08
+    outer loop
+      vertex -23.4455 220.228 -16.7
+      vertex -22.1465 219.478 -15.2
+      vertex -17.3833 216.728 -16.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 3.34622e-08
+    outer loop
+      vertex -23.4455 220.228 -16.7
+      vertex -26.9096 222.228 -11.2
+      vertex -22.1465 219.478 -15.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -26.9096 222.228 -11.2
+      vertex -23.4455 220.228 -16.7
+      vertex -26.9096 222.228 -16.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -13.9192 214.728 -26.2
+      vertex -17.3833 216.728 -20.7
+      vertex -13.9192 214.728 -20.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 4.54131e-08
+    outer loop
+      vertex -17.3833 216.728 -20.7
+      vertex -18.6824 217.478 -22.2
+      vertex -23.4455 220.228 -20.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -7.94729e-08
+    outer loop
+      vertex -22.1465 219.478 -22.2
+      vertex -23.4455 220.228 -20.7
+      vertex -18.6824 217.478 -22.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 3.34623e-08
+    outer loop
+      vertex -17.3833 216.728 -20.7
+      vertex -13.9192 214.728 -26.2
+      vertex -18.6824 217.478 -22.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -18.6824 217.478 -22.2
+      vertex -13.9192 214.728 -26.2
+      vertex -18.6824 217.478 -26.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -17.3833 216.728 -20.7
+      vertex -23.4455 220.228 -16.7
+      vertex -17.3833 216.728 -16.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -23.4455 220.228 -16.7
+      vertex -17.3833 216.728 -20.7
+      vertex -23.4455 220.228 -20.7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -3.34623e-08
+    outer loop
+      vertex -26.9096 222.228 -26.2
+      vertex -23.4455 220.228 -20.7
+      vertex -22.1465 219.478 -22.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -26.9096 222.228 -26.2
+      vertex -22.1465 219.478 -22.2
+      vertex -22.1465 219.478 -26.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -23.4455 220.228 -20.7
+      vertex -26.9096 222.228 -26.2
+      vertex -26.9096 222.228 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.9096 222.228 -20.7
+      vertex -202.446 -89.8094 -20.7
+      vertex -23.4455 220.228 -20.7
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -202.446 -89.8094 -20.7
+      vertex -26.9096 222.228 -20.7
+      vertex -205.91 -87.8094 -20.7
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -202.446 -89.8094 -20.7
+      vertex -23.4455 220.228 -16.7
+      vertex -23.4455 220.228 -20.7
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -23.4455 220.228 -16.7
+      vertex -202.446 -89.8094 -20.7
+      vertex -202.446 -89.8094 -16.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -202.446 -89.8094 -16.7
+      vertex -26.9096 222.228 -16.7
+      vertex -23.4455 220.228 -16.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.9096 222.228 -16.7
+      vertex -202.446 -89.8094 -16.7
+      vertex -205.91 -87.8094 -16.7
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -26.9096 222.228 -16.7
+      vertex -87.9096 116.573 -11.2
+      vertex -26.9096 222.228 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 -9.07354e-07
+    outer loop
+      vertex -26.9096 222.228 -16.7
+      vertex -144.91 17.8457 -11.2
+      vertex -87.9096 116.573 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 1.44001e-07
+    outer loop
+      vertex -205.91 -87.8094 -16.7
+      vertex -144.91 17.8457 -11.2
+      vertex -26.9096 222.228 -16.7
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -144.91 17.8457 -11.2
+      vertex -205.91 -87.8094 -16.7
+      vertex -205.91 -87.8094 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 -7.76847e-07
+    outer loop
+      vertex -201.146 -90.5594 -15.2
+      vertex -81.6465 116.421 -11.2
+      vertex -141.646 12.4976 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -201.146 -90.5594 -15.2
+      vertex -141.646 12.4976 -11.2
+      vertex -201.146 -90.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 2.2199e-06
+    outer loop
+      vertex -81.6465 116.421 -11.2
+      vertex -201.146 -90.5594 -15.2
+      vertex -22.1465 219.478 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -22.1465 219.478 -15.2
+      vertex -22.1465 219.478 -11.2
+      vertex -201.146 -90.5594 -15.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.1465 219.478 -15.2
+      vertex -197.682 -92.5594 -15.2
+      vertex -18.6824 217.478 -15.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -197.682 -92.5594 -15.2
+      vertex -22.1465 219.478 -15.2
+      vertex -201.146 -90.5594 -15.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -18.6824 217.478 -15.2
+      vertex -78.1824 114.421 -11.2
+      vertex -18.6824 217.478 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 5.58897e-07
+    outer loop
+      vertex -18.6824 217.478 -15.2
+      vertex -138.182 10.4976 -11.2
+      vertex -78.1824 114.421 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 -3.89156e-07
+    outer loop
+      vertex -197.682 -92.5594 -15.2
+      vertex -138.182 10.4976 -11.2
+      vertex -18.6824 217.478 -15.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -138.182 10.4976 -11.2
+      vertex -197.682 -92.5594 -15.2
+      vertex -197.682 -92.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -73.4192 111.671 -11.2
+      vertex -13.9192 214.728 -16.7
+      vertex -13.9192 214.728 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 -1.49129e-07
+    outer loop
+      vertex -133.419 7.7476 -11.2
+      vertex -13.9192 214.728 -16.7
+      vertex -73.4192 111.671 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -192.919 -95.3094 -16.7
+      vertex -133.419 7.7476 -11.2
+      vertex -192.919 -95.3094 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 4.26202e-07
+    outer loop
+      vertex -133.419 7.7476 -11.2
+      vertex -192.919 -95.3094 -16.7
+      vertex -13.9192 214.728 -16.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -192.919 -95.3094 -16.7
+      vertex -17.3833 216.728 -16.7
+      vertex -13.9192 214.728 -16.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.3833 216.728 -16.7
+      vertex -192.919 -95.3094 -16.7
+      vertex -196.383 -93.3094 -16.7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -196.383 -93.3094 -16.7
+      vertex -17.3833 216.728 -20.7
+      vertex -17.3833 216.728 -16.7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -17.3833 216.728 -20.7
+      vertex -196.383 -93.3094 -16.7
+      vertex -196.383 -93.3094 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.3833 216.728 -20.7
+      vertex -192.919 -95.3094 -20.7
+      vertex -13.9192 214.728 -20.7
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -192.919 -95.3094 -20.7
+      vertex -17.3833 216.728 -20.7
+      vertex -196.383 -93.3094 -20.7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -192.919 -95.3094 -20.7
+      vertex -13.9192 214.728 -26.2
+      vertex -13.9192 214.728 -20.7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -13.9192 214.728 -26.2
+      vertex -192.919 -95.3094 -20.7
+      vertex -192.919 -95.3094 -26.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -192.919 -95.3094 -26.2
+      vertex -18.6824 217.478 -26.2
+      vertex -13.9192 214.728 -26.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6824 217.478 -26.2
+      vertex -192.919 -95.3094 -26.2
+      vertex -197.682 -92.5594 -26.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -197.682 -92.5594 -26.2
+      vertex -18.6824 217.478 -22.2
+      vertex -18.6824 217.478 -26.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -18.6824 217.478 -22.2
+      vertex -197.682 -92.5594 -26.2
+      vertex -197.682 -92.5594 -22.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -197.682 -92.5594 -22.2
+      vertex -22.1465 219.478 -22.2
+      vertex -18.6824 217.478 -22.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.1465 219.478 -22.2
+      vertex -197.682 -92.5594 -22.2
+      vertex -201.146 -90.5594 -22.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -201.146 -90.5594 -22.2
+      vertex -22.1465 219.478 -26.2
+      vertex -22.1465 219.478 -22.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -22.1465 219.478 -26.2
+      vertex -201.146 -90.5594 -22.2
+      vertex -201.146 -90.5594 -26.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -201.146 -90.5594 -26.2
+      vertex -26.9096 222.228 -26.2
+      vertex -22.1465 219.478 -26.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.9096 222.228 -26.2
+      vertex -201.146 -90.5594 -26.2
+      vertex -205.91 -87.8094 -26.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -205.91 -87.8094 -26.2
+      vertex -26.9096 222.228 -20.7
+      vertex -26.9096 222.228 -26.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -26.9096 222.228 -20.7
+      vertex -205.91 -87.8094 -26.2
+      vertex -205.91 -87.8094 -20.7
+    endloop
+  endfacet
+  facet normal 0.866033 0.499987 0
+    outer loop
+      vertex 87.8891 116.561 -5.2
+      vertex 87.7011 116.886 -11.2
+      vertex 87.7011 116.886 -5.2
+    endloop
+  endfacet
+  facet normal 0.866033 0.499987 0
+    outer loop
+      vertex 87.7011 116.886 -11.2
+      vertex 87.8891 116.561 -5.2
+      vertex 87.8891 116.561 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 123.018 1.76299 -11.2
+      vertex 133.419 7.74759 -11.2
+      vertex 123.027 1.7476 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 122.151 1.41123 -11.2
+      vertex 123.018 1.76299 -11.2
+      vertex 122.861 1.65854 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 121.401 1.3483 -11.2
+      vertex 123.018 1.76299 -11.2
+      vertex 122.151 1.41123 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 123.018 1.76299 -11.2
+      vertex 121.401 1.3483 -11.2
+      vertex 118.929 2.84567 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 118.929 2.84567 -11.2
+      vertex 121.401 1.3483 -11.2
+      vertex 120.66 1.47371 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 118.929 2.84567 -11.2
+      vertex 120.66 1.47371 -11.2
+      vertex 119.973 1.77958 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 118.929 2.84567 -11.2
+      vertex 119.973 1.77958 -11.2
+      vertex 119.384 2.24668 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 123.018 1.76299 -11.2
+      vertex 118.929 2.84567 -11.2
+      vertex 133.419 7.74759 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 118.929 2.84567 -11.2
+      vertex 73.4192 111.671 -11.2
+      vertex 133.419 7.74759 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9288 101.573 -11.2
+      vertex 73.4192 111.671 -11.2
+      vertex 118.929 2.84567 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.4192 111.671 -11.2
+      vertex 61.9288 101.573 -11.2
+      vertex 63.0358 105.655 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.8683 104.462 -11.2
+      vertex 63.0358 105.655 -11.2
+      vertex 61.9288 101.573 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0358 105.655 -11.2
+      vertex 62.2975 105.08 -11.2
+      vertex 62.8667 105.571 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0358 105.655 -11.2
+      vertex 61.8683 104.462 -11.2
+      vertex 62.2975 105.08 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.6374 102.266 -11.2
+      vertex 61.8683 104.462 -11.2
+      vertex 61.9288 101.573 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.6374 102.266 -11.2
+      vertex 61.6062 103.758 -11.2
+      vertex 61.8683 104.462 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 61.6062 103.758 -11.2
+      vertex 61.6374 102.266 -11.2
+      vertex 61.5276 103.01 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 73.4192 111.671 -11.2
+      vertex 63.0358 105.655 -11.2
+      vertex 63.0269 105.671 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.272 14.0747 -11.2
+      vertex 143.803 13.763 -11.2
+      vertex 143.812 13.7476 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 145.123 15.3 -11.2
+      vertex 205.91 -87.8094 -11.2
+      vertex 145.295 16.0321 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 205.91 -87.8094 -11.2
+      vertex 145.279 16.7839 -11.2
+      vertex 145.295 16.0321 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 205.91 -87.8094 -11.2
+      vertex 145.077 17.5082 -11.2
+      vertex 145.279 16.7839 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 144.91 17.8457 -11.2
+      vertex 145.077 17.5082 -11.2
+      vertex 205.91 -87.8094 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 145.077 17.5082 -11.2
+      vertex 144.91 17.8457 -11.2
+      vertex 144.889 17.8338 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 144.775 14.6335 -11.2
+      vertex 205.91 -87.8094 -11.2
+      vertex 145.123 15.3 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 144.272 14.0747 -11.2
+      vertex 205.91 -87.8094 -11.2
+      vertex 144.775 14.6335 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 143.812 13.7476 -11.2
+      vertex 205.91 -87.8094 -11.2
+      vertex 144.272 14.0747 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 205.91 -87.8094 -11.2
+      vertex 143.812 13.7476 -11.2
+      vertex 201.146 -90.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 201.146 -90.5594 -11.2
+      vertex 143.812 13.7476 -11.2
+      vertex 141.646 12.4976 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 87.9096 116.573 -11.2
+      vertex 87.7011 116.886 -11.2
+      vertex 87.8891 116.561 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 84.3249 117.906 -11.2
+      vertex 83.8115 117.671 -11.2
+      vertex 83.8204 117.655 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 87.7011 116.886 -11.2
+      vertex 87.9096 116.573 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 87.175 117.424 -11.2
+      vertex 87.7011 116.886 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 86.5317 117.813 -11.2
+      vertex 87.175 117.424 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 85.8118 118.031 -11.2
+      vertex 86.5317 117.813 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 85.0605 118.062 -11.2
+      vertex 85.8118 118.031 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 84.3249 117.906 -11.2
+      vertex 85.0605 118.062 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 83.8115 117.671 -11.2
+      vertex 84.3249 117.906 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.1465 219.478 -11.2
+      vertex 83.8115 117.671 -11.2
+      vertex 26.9096 222.228 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 83.8115 117.671 -11.2
+      vertex 22.1465 219.478 -11.2
+      vertex 81.6465 116.421 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6824 217.478 -11.2
+      vertex 73.4192 111.671 -11.2
+      vertex 78.1824 114.421 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 73.4192 111.671 -11.2
+      vertex 18.6824 217.478 -11.2
+      vertex 13.9192 214.728 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 138.182 10.4976 -11.2
+      vertex 192.919 -95.3094 -11.2
+      vertex 197.682 -92.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.919 -95.3094 -11.2
+      vertex 138.182 10.4976 -11.2
+      vertex 133.419 7.74759 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 138.182 10.4976 -11.2
+      vertex 81.6465 116.421 -11.2
+      vertex 141.646 12.4976 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 81.6465 116.421 -11.2
+      vertex 138.182 10.4976 -11.2
+      vertex 78.1824 114.421 -11.2
+    endloop
+  endfacet
+  facet normal 0.0418707 0.999123 -0
+    outer loop
+      vertex 85.8118 118.031 -11.2
+      vertex 85.0605 118.062 -5.2
+      vertex 85.8118 118.031 -5.2
+    endloop
+  endfacet
+  facet normal 0.0418707 0.999123 0
+    outer loop
+      vertex 85.0605 118.062 -5.2
+      vertex 85.8118 118.031 -11.2
+      vertex 85.0605 118.062 -11.2
+    endloop
+  endfacet
+  facet normal 0.289032 0.957319 -0
+    outer loop
+      vertex 86.5317 117.813 -11.2
+      vertex 85.8118 118.031 -5.2
+      vertex 86.5317 117.813 -5.2
+    endloop
+  endfacet
+  facet normal 0.289032 0.957319 0
+    outer loop
+      vertex 85.8118 118.031 -5.2
+      vertex 86.5317 117.813 -11.2
+      vertex 85.8118 118.031 -11.2
+    endloop
+  endfacet
+  facet normal -0.444633 0.895713 0
+    outer loop
+      vertex 84.3249 117.906 -11.2
+      vertex 83.8204 117.655 -5.2
+      vertex 84.3249 117.906 -5.2
+    endloop
+  endfacet
+  facet normal -0.444633 0.895713 0
+    outer loop
+      vertex 83.8204 117.655 -5.2
+      vertex 84.3249 117.906 -11.2
+      vertex 83.8204 117.655 -11.2
+    endloop
+  endfacet
+  facet normal 0.518027 0.855364 -0
+    outer loop
+      vertex 87.175 117.424 -11.2
+      vertex 86.5317 117.813 -5.2
+      vertex 87.175 117.424 -5.2
+    endloop
+  endfacet
+  facet normal 0.518027 0.855364 0
+    outer loop
+      vertex 86.5317 117.813 -5.2
+      vertex 87.175 117.424 -11.2
+      vertex 86.5317 117.813 -11.2
+    endloop
+  endfacet
+  facet normal 0.714469 0.699667 0
+    outer loop
+      vertex 87.7011 116.886 -5.2
+      vertex 87.175 117.424 -11.2
+      vertex 87.175 117.424 -5.2
+    endloop
+  endfacet
+  facet normal 0.714469 0.699667 0
+    outer loop
+      vertex 87.175 117.424 -11.2
+      vertex 87.7011 116.886 -5.2
+      vertex 87.7011 116.886 -11.2
+    endloop
+  endfacet
+  facet normal -0.207912 0.978148 0
+    outer loop
+      vertex 85.0605 118.062 -11.2
+      vertex 84.3249 117.906 -5.2
+      vertex 85.0605 118.062 -5.2
+    endloop
+  endfacet
+  facet normal -0.207912 0.978148 0
+    outer loop
+      vertex 84.3249 117.906 -5.2
+      vertex 85.0605 118.062 -11.2
+      vertex 84.3249 117.906 -11.2
+    endloop
+  endfacet
+  facet normal 0.866038 0.499978 0
+    outer loop
+      vertex 145.077 17.5082 -5.2
+      vertex 144.889 17.8338 -11.2
+      vertex 144.889 17.8338 -5.2
+    endloop
+  endfacet
+  facet normal 0.866038 0.499978 0
+    outer loop
+      vertex 144.889 17.8338 -11.2
+      vertex 145.077 17.5082 -5.2
+      vertex 145.077 17.5082 -11.2
+    endloop
+  endfacet
+  facet normal 0.553391 -0.832922 0
+    outer loop
+      vertex 143.803 13.763 -11.2
+      vertex 144.272 14.0747 -5.2
+      vertex 143.803 13.763 -5.2
+    endloop
+  endfacet
+  facet normal 0.553391 -0.832922 0
+    outer loop
+      vertex 144.272 14.0747 -5.2
+      vertex 143.803 13.763 -11.2
+      vertex 144.272 14.0747 -11.2
+    endloop
+  endfacet
+  facet normal 0.973578 -0.228354 0
+    outer loop
+      vertex 145.123 15.3 -5.2
+      vertex 145.295 16.0321 -11.2
+      vertex 145.295 16.0321 -5.2
+    endloop
+  endfacet
+  facet normal 0.973578 -0.228354 0
+    outer loop
+      vertex 145.295 16.0321 -11.2
+      vertex 145.123 15.3 -5.2
+      vertex 145.123 15.3 -11.2
+    endloop
+  endfacet
+  facet normal 0.886201 -0.463302 0
+    outer loop
+      vertex 144.775 14.6335 -5.2
+      vertex 145.123 15.3 -11.2
+      vertex 145.123 15.3 -5.2
+    endloop
+  endfacet
+  facet normal 0.886201 -0.463302 0
+    outer loop
+      vertex 145.123 15.3 -11.2
+      vertex 144.775 14.6335 -5.2
+      vertex 144.775 14.6335 -11.2
+    endloop
+  endfacet
+  facet normal 0.99978 0.0209605 0
+    outer loop
+      vertex 145.295 16.0321 -5.2
+      vertex 145.279 16.7839 -11.2
+      vertex 145.279 16.7839 -5.2
+    endloop
+  endfacet
+  facet normal 0.99978 0.0209605 0
+    outer loop
+      vertex 145.279 16.7839 -11.2
+      vertex 145.295 16.0321 -5.2
+      vertex 145.295 16.0321 -11.2
+    endloop
+  endfacet
+  facet normal 0.963164 0.268916 0
+    outer loop
+      vertex 145.279 16.7839 -5.2
+      vertex 145.077 17.5082 -11.2
+      vertex 145.077 17.5082 -5.2
+    endloop
+  endfacet
+  facet normal 0.963164 0.268916 0
+    outer loop
+      vertex 145.077 17.5082 -11.2
+      vertex 145.279 16.7839 -5.2
+      vertex 145.279 16.7839 -11.2
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669133 0
+    outer loop
+      vertex 144.272 14.0747 -5.2
+      vertex 144.775 14.6335 -11.2
+      vertex 144.775 14.6335 -5.2
+    endloop
+  endfacet
+  facet normal 0.743143 -0.669133 0
+    outer loop
+      vertex 144.775 14.6335 -11.2
+      vertex 144.272 14.0747 -5.2
+      vertex 144.272 14.0747 -11.2
+    endloop
+  endfacet
+  facet normal -0.653426 0.75699 0
+    outer loop
+      vertex 62.8667 105.571 -11.2
+      vertex 62.2975 105.08 -5.2
+      vertex 62.8667 105.571 -5.2
+    endloop
+  endfacet
+  facet normal -0.653426 0.75699 0
+    outer loop
+      vertex 62.2975 105.08 -5.2
+      vertex 62.8667 105.571 -11.2
+      vertex 62.2975 105.08 -11.2
+    endloop
+  endfacet
+  facet normal -0.994522 0.104529 0
+    outer loop
+      vertex 61.5276 103.01 -11.2
+      vertex 61.6062 103.758 -5.2
+      vertex 61.6062 103.758 -11.2
+    endloop
+  endfacet
+  facet normal -0.994522 0.104529 0
+    outer loop
+      vertex 61.6062 103.758 -5.2
+      vertex 61.5276 103.01 -11.2
+      vertex 61.5276 103.01 -5.2
+    endloop
+  endfacet
+  facet normal -0.989272 -0.146084 0
+    outer loop
+      vertex 61.6374 102.266 -11.2
+      vertex 61.5276 103.01 -5.2
+      vertex 61.5276 103.01 -11.2
+    endloop
+  endfacet
+  facet normal -0.989272 -0.146084 0
+    outer loop
+      vertex 61.5276 103.01 -5.2
+      vertex 61.6374 102.266 -11.2
+      vertex 61.6374 102.266 -5.2
+    endloop
+  endfacet
+  facet normal -0.821148 0.570716 0
+    outer loop
+      vertex 61.8683 104.462 -11.2
+      vertex 62.2975 105.08 -5.2
+      vertex 62.2975 105.08 -11.2
+    endloop
+  endfacet
+  facet normal -0.821148 0.570716 0
+    outer loop
+      vertex 62.2975 105.08 -5.2
+      vertex 61.8683 104.462 -11.2
+      vertex 61.8683 104.462 -5.2
+    endloop
+  endfacet
+  facet normal -0.921862 -0.387518 0
+    outer loop
+      vertex 61.9288 101.573 -11.2
+      vertex 61.6374 102.266 -5.2
+      vertex 61.6374 102.266 -11.2
+    endloop
+  endfacet
+  facet normal -0.921862 -0.387518 0
+    outer loop
+      vertex 61.6374 102.266 -5.2
+      vertex 61.9288 101.573 -11.2
+      vertex 61.9288 101.573 -5.2
+    endloop
+  endfacet
+  facet normal -0.444608 0.895725 0
+    outer loop
+      vertex 63.0358 105.655 -11.2
+      vertex 62.8667 105.571 -5.2
+      vertex 63.0358 105.655 -5.2
+    endloop
+  endfacet
+  facet normal -0.444608 0.895725 0
+    outer loop
+      vertex 62.8667 105.571 -5.2
+      vertex 63.0358 105.655 -11.2
+      vertex 62.8667 105.571 -11.2
+    endloop
+  endfacet
+  facet normal -0.937281 0.348574 0
+    outer loop
+      vertex 61.6062 103.758 -11.2
+      vertex 61.8683 104.462 -5.2
+      vertex 61.8683 104.462 -11.2
+    endloop
+  endfacet
+  facet normal -0.937281 0.348574 0
+    outer loop
+      vertex 61.8683 104.462 -5.2
+      vertex 61.6062 103.758 -11.2
+      vertex 61.6062 103.758 -5.2
+    endloop
+  endfacet
+  facet normal -0.796529 -0.6046 0
+    outer loop
+      vertex 119.384 2.24668 -11.2
+      vertex 118.929 2.84567 -5.2
+      vertex 118.929 2.84567 -11.2
+    endloop
+  endfacet
+  facet normal -0.796529 -0.6046 0
+    outer loop
+      vertex 118.929 2.84567 -5.2
+      vertex 119.384 2.24668 -11.2
+      vertex 119.384 2.24668 -5.2
+    endloop
+  endfacet
+  facet normal 0.553402 -0.832914 0
+    outer loop
+      vertex 122.861 1.65854 -11.2
+      vertex 123.018 1.76299 -5.2
+      vertex 122.861 1.65854 -5.2
+    endloop
+  endfacet
+  facet normal 0.553402 -0.832914 0
+    outer loop
+      vertex 123.018 1.76299 -5.2
+      vertex 122.861 1.65854 -11.2
+      vertex 123.018 1.76299 -11.2
+    endloop
+  endfacet
+  facet normal -0.166768 -0.985996 0
+    outer loop
+      vertex 120.66 1.47371 -11.2
+      vertex 121.401 1.3483 -5.2
+      vertex 120.66 1.47371 -5.2
+    endloop
+  endfacet
+  facet normal -0.166768 -0.985996 -0
+    outer loop
+      vertex 121.401 1.3483 -5.2
+      vertex 120.66 1.47371 -11.2
+      vertex 121.401 1.3483 -11.2
+    endloop
+  endfacet
+  facet normal -0.621151 -0.783691 0
+    outer loop
+      vertex 119.384 2.24668 -11.2
+      vertex 119.973 1.77958 -5.2
+      vertex 119.384 2.24668 -5.2
+    endloop
+  endfacet
+  facet normal -0.621151 -0.783691 -0
+    outer loop
+      vertex 119.973 1.77958 -5.2
+      vertex 119.384 2.24668 -11.2
+      vertex 119.973 1.77958 -11.2
+    endloop
+  endfacet
+  facet normal 0.0836772 -0.996493 0
+    outer loop
+      vertex 121.401 1.3483 -11.2
+      vertex 122.151 1.41123 -5.2
+      vertex 121.401 1.3483 -5.2
+    endloop
+  endfacet
+  facet normal 0.0836772 -0.996493 0
+    outer loop
+      vertex 122.151 1.41123 -5.2
+      vertex 121.401 1.3483 -11.2
+      vertex 122.151 1.41123 -11.2
+    endloop
+  endfacet
+  facet normal -0.406734 -0.913546 0
+    outer loop
+      vertex 119.973 1.77958 -11.2
+      vertex 120.66 1.47371 -5.2
+      vertex 119.973 1.77958 -5.2
+    endloop
+  endfacet
+  facet normal -0.406734 -0.913546 -0
+    outer loop
+      vertex 120.66 1.47371 -5.2
+      vertex 119.973 1.77958 -11.2
+      vertex 120.66 1.47371 -11.2
+    endloop
+  endfacet
+  facet normal 0.328866 -0.944377 0
+    outer loop
+      vertex 122.151 1.41123 -11.2
+      vertex 122.861 1.65854 -5.2
+      vertex 122.151 1.41123 -5.2
+    endloop
+  endfacet
+  facet normal 0.328866 -0.944377 0
+    outer loop
+      vertex 122.861 1.65854 -5.2
+      vertex 122.151 1.41123 -11.2
+      vertex 122.861 1.65854 -11.2
+    endloop
+  endfacet
+  facet normal 0.866043 0.49997 0
+    outer loop
+      vertex 83.8204 117.655 -5.2
+      vertex 83.8115 117.671 -11.2
+      vertex 83.8115 117.671 -5.2
+    endloop
+  endfacet
+  facet normal 0.866043 0.49997 0
+    outer loop
+      vertex 83.8115 117.671 -11.2
+      vertex 83.8204 117.655 -5.2
+      vertex 83.8204 117.655 -11.2
+    endloop
+  endfacet
+  facet normal 0.86579 0.500408 0
+    outer loop
+      vertex 143.812 13.7476 -5.2
+      vertex 143.803 13.763 -11.2
+      vertex 143.803 13.763 -5.2
+    endloop
+  endfacet
+  facet normal 0.86579 0.500408 0
+    outer loop
+      vertex 143.803 13.763 -11.2
+      vertex 143.812 13.7476 -5.2
+      vertex 143.812 13.7476 -11.2
+    endloop
+  endfacet
+  facet normal -0.866136 -0.499809 0
+    outer loop
+      vertex 63.0358 105.655 -11.2
+      vertex 63.0269 105.671 -5.2
+      vertex 63.0269 105.671 -11.2
+    endloop
+  endfacet
+  facet normal -0.866136 -0.499809 0
+    outer loop
+      vertex 63.0269 105.671 -5.2
+      vertex 63.0358 105.655 -11.2
+      vertex 63.0358 105.655 -5.2
+    endloop
+  endfacet
+  facet normal -0.865966 -0.500104 0
+    outer loop
+      vertex 123.027 1.7476 -11.2
+      vertex 123.018 1.76299 -5.2
+      vertex 123.018 1.76299 -11.2
+    endloop
+  endfacet
+  facet normal -0.865966 -0.500104 0
+    outer loop
+      vertex 123.018 1.76299 -5.2
+      vertex 123.027 1.7476 -11.2
+      vertex 123.027 1.7476 -5.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 123.027 1.7476 -11.2
+      vertex 124.915 2.83794 -5.2
+      vertex 123.027 1.7476 -5.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 4.47465e-08
+    outer loop
+      vertex 124.915 2.83794 -5.2
+      vertex 123.027 1.7476 -11.2
+      vertex 133.419 7.74759 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 3.41703e-07
+    outer loop
+      vertex 124.915 2.83794 -5.2
+      vertex 133.419 7.74759 -11.2
+      vertex 143.812 13.7476 -5.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 -2.31194e-07
+    outer loop
+      vertex 138.182 10.4976 -11.2
+      vertex 143.812 13.7476 -5.2
+      vertex 133.419 7.74759 -11.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 -7.9473e-07
+    outer loop
+      vertex 141.646 12.4976 -11.2
+      vertex 143.812 13.7476 -5.2
+      vertex 138.182 10.4976 -11.2
+    endloop
+  endfacet
+  facet normal 0.499999 -0.866026 0
+    outer loop
+      vertex 143.812 13.7476 -5.2
+      vertex 141.646 12.4976 -11.2
+      vertex 143.812 13.7476 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 3.54201e-07
+    outer loop
+      vertex 73.4192 111.671 -11.2
+      vertex 64.9109 106.758 -5.2
+      vertex 83.8115 117.671 -5.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 81.6465 116.421 -11.2
+      vertex 83.8115 117.671 -5.2
+      vertex 83.8115 117.671 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 -2.38418e-07
+    outer loop
+      vertex 78.1824 114.421 -11.2
+      vertex 83.8115 117.671 -5.2
+      vertex 81.6465 116.421 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 2.31194e-07
+    outer loop
+      vertex 73.4192 111.671 -11.2
+      vertex 83.8115 117.671 -5.2
+      vertex 78.1824 114.421 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 6.44191e-07
+    outer loop
+      vertex 63.0269 105.671 -11.2
+      vertex 64.9109 106.758 -5.2
+      vertex 73.4192 111.671 -11.2
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex 64.9109 106.758 -5.2
+      vertex 63.0269 105.671 -11.2
+      vertex 63.0269 105.671 -5.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 99.9096 95.788 -0.2
+      vertex 132.91 38.6303 -0.2
+      vertex 99.9096 95.788 -5.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 99.9096 95.788 -5.2
+      vertex 87.9096 116.573 -11.2
+      vertex 87.9096 116.573 -5.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 -0
+    outer loop
+      vertex 132.91 38.6303 -5.2
+      vertex 99.9096 95.788 -5.2
+      vertex 132.91 38.6303 -0.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 4.04589e-07
+    outer loop
+      vertex 99.9096 95.788 -5.2
+      vertex 132.91 38.6303 -5.2
+      vertex 87.9096 116.573 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 -0
+    outer loop
+      vertex 144.91 17.8457 -11.2
+      vertex 132.91 38.6303 -5.2
+      vertex 144.91 17.8457 -5.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 1.42215e-07
+    outer loop
+      vertex 132.91 38.6303 -5.2
+      vertex 144.91 17.8457 -11.2
+      vertex 87.9096 116.573 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 118.929 2.84567 -11.2
+      vertex 61.9288 101.573 -5.2
+      vertex 61.9288 101.573 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 61.9288 101.573 -5.2
+      vertex 118.929 2.84567 -11.2
+      vertex 118.929 2.84567 -5.2
+    endloop
+  endfacet
+  facet normal 0.500155 -0.865936 0
+    outer loop
+      vertex 144.889 17.8338 -11.2
+      vertex 144.91 17.8457 -5.2
+      vertex 144.889 17.8338 -5.2
+    endloop
+  endfacet
+  facet normal 0.500155 -0.865936 0
+    outer loop
+      vertex 144.91 17.8457 -5.2
+      vertex 144.889 17.8338 -11.2
+      vertex 144.91 17.8457 -11.2
+    endloop
+  endfacet
+  facet normal -0.500197 0.865912 0
+    outer loop
+      vertex 87.9096 116.573 -11.2
+      vertex 87.8891 116.561 -5.2
+      vertex 87.9096 116.573 -5.2
+    endloop
+  endfacet
+  facet normal -0.500197 0.865912 0
+    outer loop
+      vertex 87.8891 116.561 -5.2
+      vertex 87.9096 116.573 -11.2
+      vertex 87.8891 116.561 -11.2
+    endloop
+  endfacet
+  facet normal 0.86603 0.499992 0
+    outer loop
+      vertex 99.896 95.7801 -0.2
+      vertex 99.7706 95.9972 -5.2
+      vertex 99.7706 95.9972 -0.2
+    endloop
+  endfacet
+  facet normal 0.86603 0.499992 0
+    outer loop
+      vertex 99.7706 95.9972 -5.2
+      vertex 99.896 95.7801 -0.2
+      vertex 99.896 95.7801 -5.2
+    endloop
+  endfacet
+  facet normal 0.289021 0.957323 -0
+    outer loop
+      vertex 98.991 96.6151 -5.2
+      vertex 98.5111 96.7599 -0.2
+      vertex 98.991 96.6151 -0.2
+    endloop
+  endfacet
+  facet normal 0.289021 0.957323 0
+    outer loop
+      vertex 98.5111 96.7599 -0.2
+      vertex 98.991 96.6151 -5.2
+      vertex 98.5111 96.7599 -5.2
+    endloop
+  endfacet
+  facet normal -0.444627 0.895716 0
+    outer loop
+      vertex 97.5198 96.6767 -5.2
+      vertex 97.1835 96.5098 -0.2
+      vertex 97.5198 96.6767 -0.2
+    endloop
+  endfacet
+  facet normal -0.444627 0.895716 0
+    outer loop
+      vertex 97.1835 96.5098 -0.2
+      vertex 97.5198 96.6767 -5.2
+      vertex 97.1835 96.5098 -5.2
+    endloop
+  endfacet
+  facet normal 0.0418806 0.999123 -0
+    outer loop
+      vertex 98.5111 96.7599 -5.2
+      vertex 98.0102 96.7809 -0.2
+      vertex 98.5111 96.7599 -0.2
+    endloop
+  endfacet
+  facet normal 0.0418806 0.999123 0
+    outer loop
+      vertex 98.0102 96.7809 -0.2
+      vertex 98.5111 96.7599 -5.2
+      vertex 98.0102 96.7809 -5.2
+    endloop
+  endfacet
+  facet normal -0.207914 0.978147 0
+    outer loop
+      vertex 98.0102 96.7809 -5.2
+      vertex 97.5198 96.6767 -0.2
+      vertex 98.0102 96.7809 -0.2
+    endloop
+  endfacet
+  facet normal -0.207914 0.978147 0
+    outer loop
+      vertex 97.5198 96.6767 -0.2
+      vertex 98.0102 96.7809 -5.2
+      vertex 97.5198 96.6767 -5.2
+    endloop
+  endfacet
+  facet normal 0.518032 0.855361 -0
+    outer loop
+      vertex 99.4199 96.3553 -5.2
+      vertex 98.991 96.6151 -0.2
+      vertex 99.4199 96.3553 -0.2
+    endloop
+  endfacet
+  facet normal 0.518032 0.855361 0
+    outer loop
+      vertex 98.991 96.6151 -0.2
+      vertex 99.4199 96.3553 -5.2
+      vertex 98.991 96.6151 -5.2
+    endloop
+  endfacet
+  facet normal 0.714472 0.699664 0
+    outer loop
+      vertex 99.7706 95.9972 -0.2
+      vertex 99.4199 96.3553 -5.2
+      vertex 99.4199 96.3553 -0.2
+    endloop
+  endfacet
+  facet normal 0.714472 0.699664 0
+    outer loop
+      vertex 99.4199 96.3553 -5.2
+      vertex 99.7706 95.9972 -0.2
+      vertex 99.7706 95.9972 -5.2
+    endloop
+  endfacet
+  facet normal 0.866021 0.500008 0
+    outer loop
+      vertex 133.021 38.4053 -0.2
+      vertex 132.896 38.6224 -5.2
+      vertex 132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal 0.866021 0.500008 0
+    outer loop
+      vertex 132.896 38.6224 -5.2
+      vertex 133.021 38.4053 -0.2
+      vertex 133.021 38.4053 -5.2
+    endloop
+  endfacet
+  facet normal 0.553375 -0.832932 0
+    outer loop
+      vertex 132.172 35.9085 -5.2
+      vertex 132.484 36.1163 -0.2
+      vertex 132.172 35.9085 -0.2
+    endloop
+  endfacet
+  facet normal 0.553375 -0.832932 0
+    outer loop
+      vertex 132.484 36.1163 -0.2
+      vertex 132.172 35.9085 -5.2
+      vertex 132.484 36.1163 -5.2
+    endloop
+  endfacet
+  facet normal 0.973583 -0.228335 0
+    outer loop
+      vertex 133.052 36.9331 -0.2
+      vertex 133.167 37.4212 -5.2
+      vertex 133.167 37.4212 -0.2
+    endloop
+  endfacet
+  facet normal 0.973583 -0.228335 0
+    outer loop
+      vertex 133.167 37.4212 -5.2
+      vertex 133.052 36.9331 -0.2
+      vertex 133.052 36.9331 -5.2
+    endloop
+  endfacet
+  facet normal 0.8862 -0.463302 0
+    outer loop
+      vertex 132.82 36.4889 -0.2
+      vertex 133.052 36.9331 -5.2
+      vertex 133.052 36.9331 -0.2
+    endloop
+  endfacet
+  facet normal 0.8862 -0.463302 0
+    outer loop
+      vertex 133.052 36.9331 -5.2
+      vertex 132.82 36.4889 -0.2
+      vertex 132.82 36.4889 -5.2
+    endloop
+  endfacet
+  facet normal 0.999781 0.0209402 0
+    outer loop
+      vertex 133.167 37.4212 -0.2
+      vertex 133.156 37.9224 -5.2
+      vertex 133.156 37.9224 -0.2
+    endloop
+  endfacet
+  facet normal 0.999781 0.0209402 0
+    outer loop
+      vertex 133.156 37.9224 -5.2
+      vertex 133.167 37.4212 -0.2
+      vertex 133.167 37.4212 -5.2
+    endloop
+  endfacet
+  facet normal 0.963166 0.268907 0
+    outer loop
+      vertex 133.156 37.9224 -0.2
+      vertex 133.021 38.4053 -5.2
+      vertex 133.021 38.4053 -0.2
+    endloop
+  endfacet
+  facet normal 0.963166 0.268907 0
+    outer loop
+      vertex 133.021 38.4053 -5.2
+      vertex 133.156 37.9224 -0.2
+      vertex 133.156 37.9224 -5.2
+    endloop
+  endfacet
+  facet normal 0.743152 -0.669122 0
+    outer loop
+      vertex 132.484 36.1163 -0.2
+      vertex 132.82 36.4889 -5.2
+      vertex 132.82 36.4889 -0.2
+    endloop
+  endfacet
+  facet normal 0.743152 -0.669122 0
+    outer loop
+      vertex 132.82 36.4889 -5.2
+      vertex 132.484 36.1163 -0.2
+      vertex 132.484 36.1163 -5.2
+    endloop
+  endfacet
+  facet normal -0.653412 0.757003 0
+    outer loop
+      vertex 92.3076 93.7038 -5.2
+      vertex 91.9281 93.3762 -0.2
+      vertex 92.3076 93.7038 -0.2
+    endloop
+  endfacet
+  facet normal -0.653412 0.757003 0
+    outer loop
+      vertex 91.9281 93.3762 -0.2
+      vertex 92.3076 93.7038 -5.2
+      vertex 91.9281 93.3762 -5.2
+    endloop
+  endfacet
+  facet normal -0.989271 -0.146094 0
+    outer loop
+      vertex 91.4881 91.5001 -5.2
+      vertex 91.4149 91.9961 -0.2
+      vertex 91.4149 91.9961 -5.2
+    endloop
+  endfacet
+  facet normal -0.989271 -0.146094 0
+    outer loop
+      vertex 91.4149 91.9961 -0.2
+      vertex 91.4881 91.5001 -5.2
+      vertex 91.4881 91.5001 -0.2
+    endloop
+  endfacet
+  facet normal -0.921868 -0.387505 0
+    outer loop
+      vertex 91.6824 91.038 -5.2
+      vertex 91.4881 91.5001 -0.2
+      vertex 91.4881 91.5001 -5.2
+    endloop
+  endfacet
+  facet normal -0.921868 -0.387505 0
+    outer loop
+      vertex 91.4881 91.5001 -0.2
+      vertex 91.6824 91.038 -5.2
+      vertex 91.6824 91.038 -0.2
+    endloop
+  endfacet
+  facet normal -0.994521 0.104533 0
+    outer loop
+      vertex 91.4149 91.9961 -5.2
+      vertex 91.4673 92.4947 -0.2
+      vertex 91.4673 92.4947 -5.2
+    endloop
+  endfacet
+  facet normal -0.994521 0.104533 0
+    outer loop
+      vertex 91.4673 92.4947 -0.2
+      vertex 91.4149 91.9961 -5.2
+      vertex 91.4149 91.9961 -0.2
+    endloop
+  endfacet
+  facet normal -0.444689 0.895685 0
+    outer loop
+      vertex 92.4203 93.7598 -5.2
+      vertex 92.3076 93.7038 -0.2
+      vertex 92.4203 93.7598 -0.2
+    endloop
+  endfacet
+  facet normal -0.444689 0.895685 0
+    outer loop
+      vertex 92.3076 93.7038 -0.2
+      vertex 92.4203 93.7598 -5.2
+      vertex 92.3076 93.7038 -5.2
+    endloop
+  endfacet
+  facet normal -0.937281 0.348575 0
+    outer loop
+      vertex 91.4673 92.4947 -5.2
+      vertex 91.642 92.9645 -0.2
+      vertex 91.642 92.9645 -5.2
+    endloop
+  endfacet
+  facet normal -0.937281 0.348575 0
+    outer loop
+      vertex 91.642 92.9645 -0.2
+      vertex 91.4673 92.4947 -5.2
+      vertex 91.4673 92.4947 -0.2
+    endloop
+  endfacet
+  facet normal -0.821153 0.570709 0
+    outer loop
+      vertex 91.642 92.9645 -5.2
+      vertex 91.9281 93.3762 -0.2
+      vertex 91.9281 93.3762 -5.2
+    endloop
+  endfacet
+  facet normal -0.821153 0.570709 0
+    outer loop
+      vertex 91.9281 93.3762 -0.2
+      vertex 91.642 92.9645 -5.2
+      vertex 91.642 92.9645 -0.2
+    endloop
+  endfacet
+  facet normal -0.796527 -0.604603 0
+    outer loop
+      vertex 124.985 33.481 -5.2
+      vertex 124.682 33.8803 -0.2
+      vertex 124.682 33.8803 -5.2
+    endloop
+  endfacet
+  facet normal -0.796527 -0.604603 0
+    outer loop
+      vertex 124.682 33.8803 -0.2
+      vertex 124.985 33.481 -5.2
+      vertex 124.985 33.481 -0.2
+    endloop
+  endfacet
+  facet normal 0.553377 -0.832931 0
+    outer loop
+      vertex 127.304 33.0889 -5.2
+      vertex 127.408 33.1585 -0.2
+      vertex 127.304 33.0889 -0.2
+    endloop
+  endfacet
+  facet normal 0.553377 -0.832931 0
+    outer loop
+      vertex 127.408 33.1585 -0.2
+      vertex 127.304 33.0889 -5.2
+      vertex 127.408 33.1585 -5.2
+    endloop
+  endfacet
+  facet normal -0.166763 -0.985997 0
+    outer loop
+      vertex 125.836 32.9656 -5.2
+      vertex 126.331 32.882 -0.2
+      vertex 125.836 32.9656 -0.2
+    endloop
+  endfacet
+  facet normal -0.166763 -0.985997 -0
+    outer loop
+      vertex 126.331 32.882 -0.2
+      vertex 125.836 32.9656 -5.2
+      vertex 126.331 32.882 -5.2
+    endloop
+  endfacet
+  facet normal 0.0836689 -0.996494 0
+    outer loop
+      vertex 126.331 32.882 -5.2
+      vertex 126.83 32.924 -0.2
+      vertex 126.331 32.882 -0.2
+    endloop
+  endfacet
+  facet normal 0.0836689 -0.996494 0
+    outer loop
+      vertex 126.83 32.924 -0.2
+      vertex 126.331 32.882 -5.2
+      vertex 126.83 32.924 -5.2
+    endloop
+  endfacet
+  facet normal -0.406736 -0.913546 0
+    outer loop
+      vertex 125.378 33.1696 -5.2
+      vertex 125.836 32.9656 -0.2
+      vertex 125.378 33.1696 -0.2
+    endloop
+  endfacet
+  facet normal -0.406736 -0.913546 -0
+    outer loop
+      vertex 125.836 32.9656 -0.2
+      vertex 125.378 33.1696 -5.2
+      vertex 125.836 32.9656 -5.2
+    endloop
+  endfacet
+  facet normal -0.621148 -0.783694 0
+    outer loop
+      vertex 124.985 33.481 -5.2
+      vertex 125.378 33.1696 -0.2
+      vertex 124.985 33.481 -0.2
+    endloop
+  endfacet
+  facet normal -0.621148 -0.783694 -0
+    outer loop
+      vertex 125.378 33.1696 -0.2
+      vertex 124.985 33.481 -5.2
+      vertex 125.378 33.1696 -5.2
+    endloop
+  endfacet
+  facet normal 0.328876 -0.944373 0
+    outer loop
+      vertex 126.83 32.924 -5.2
+      vertex 127.304 33.0889 -0.2
+      vertex 126.83 32.924 -0.2
+    endloop
+  endfacet
+  facet normal 0.328876 -0.944373 0
+    outer loop
+      vertex 127.304 33.0889 -0.2
+      vertex 126.83 32.924 -5.2
+      vertex 127.304 33.0889 -5.2
+    endloop
+  endfacet
+  facet normal 0.866175 0.499741 0
+    outer loop
+      vertex 97.1835 96.5098 -0.2
+      vertex 97.1776 96.52 -5.2
+      vertex 97.1776 96.52 -0.2
+    endloop
+  endfacet
+  facet normal 0.866175 0.499741 0
+    outer loop
+      vertex 97.1776 96.52 -5.2
+      vertex 97.1835 96.5098 -0.2
+      vertex 97.1835 96.5098 -5.2
+    endloop
+  endfacet
+  facet normal 0.866175 0.499741 0
+    outer loop
+      vertex 132.178 35.8982 -0.2
+      vertex 132.172 35.9085 -5.2
+      vertex 132.172 35.9085 -0.2
+    endloop
+  endfacet
+  facet normal 0.866175 0.499741 0
+    outer loop
+      vertex 132.172 35.9085 -5.2
+      vertex 132.178 35.8982 -0.2
+      vertex 132.178 35.8982 -5.2
+    endloop
+  endfacet
+  facet normal -0.866175 -0.499741 0
+    outer loop
+      vertex 92.4203 93.7598 -5.2
+      vertex 92.4144 93.77 -0.2
+      vertex 92.4144 93.77 -5.2
+    endloop
+  endfacet
+  facet normal -0.866175 -0.499741 0
+    outer loop
+      vertex 92.4144 93.77 -0.2
+      vertex 92.4203 93.7598 -5.2
+      vertex 92.4203 93.7598 -0.2
+    endloop
+  endfacet
+  facet normal -0.865815 -0.500363 0
+    outer loop
+      vertex 127.414 33.1482 -5.2
+      vertex 127.408 33.1585 -0.2
+      vertex 127.408 33.1585 -5.2
+    endloop
+  endfacet
+  facet normal -0.865815 -0.500363 0
+    outer loop
+      vertex 127.408 33.1585 -0.2
+      vertex 127.414 33.1482 -5.2
+      vertex 127.414 33.1482 -0.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 97.1776 96.52 -5.2
+      vertex 92.4144 93.77 -0.2
+      vertex 97.1776 96.52 -0.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 92.4144 93.77 -0.2
+      vertex 97.1776 96.52 -5.2
+      vertex 92.4144 93.77 -5.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 127.414 33.1482 -5.2
+      vertex 132.178 35.8982 -0.2
+      vertex 127.414 33.1482 -0.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 132.178 35.8982 -0.2
+      vertex 127.414 33.1482 -5.2
+      vertex 132.178 35.8982 -5.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 124.682 33.8803 -5.2
+      vertex 109.468 60.232 -0.2
+      vertex 109.468 60.232 -5.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 109.468 60.232 -0.2
+      vertex 124.682 33.8803 -5.2
+      vertex 124.682 33.8803 -0.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 106.355 65.6243 -5.2
+      vertex 91.6824 91.038 -0.2
+      vertex 91.6824 91.038 -5.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 91.6824 91.038 -0.2
+      vertex 106.355 65.6243 -5.2
+      vertex 106.355 65.6243 -0.2
+    endloop
+  endfacet
+  facet normal -0.499834 0.866121 0
+    outer loop
+      vertex 99.9096 95.788 -5.2
+      vertex 99.896 95.7801 -0.2
+      vertex 99.9096 95.788 -0.2
+    endloop
+  endfacet
+  facet normal -0.499834 0.866121 0
+    outer loop
+      vertex 99.896 95.7801 -0.2
+      vertex 99.9096 95.788 -5.2
+      vertex 99.896 95.7801 -5.2
+    endloop
+  endfacet
+  facet normal 0.500016 -0.866016 0
+    outer loop
+      vertex 132.896 38.6224 -5.2
+      vertex 132.91 38.6303 -0.2
+      vertex 132.896 38.6224 -0.2
+    endloop
+  endfacet
+  facet normal 0.500016 -0.866016 0
+    outer loop
+      vertex 132.91 38.6303 -0.2
+      vertex 132.896 38.6224 -5.2
+      vertex 132.91 38.6303 -5.2
+    endloop
+  endfacet
+  facet normal -0.0523341 0.99863 0
+    outer loop
+      vertex -1.44666e-15 234.836 -23.9078
+      vertex -3.76302 234.639 -11.2
+      vertex -1.44666e-15 234.836 -11.2
+    endloop
+  endfacet
+  facet normal -0.0523341 0.99863 0
+    outer loop
+      vertex -3.76302 234.639 -11.2
+      vertex -1.44666e-15 234.836 -23.9078
+      vertex -3.76302 234.639 -23.9078
+    endloop
+  endfacet
+  facet normal -0.0523341 0.99863 0
+    outer loop
+      vertex -1.44666e-15 234.836 -56.2
+      vertex -3.76302 234.639 -43.0438
+      vertex -1.44666e-15 234.836 -43.0438
+    endloop
+  endfacet
+  facet normal -0.0523341 0.99863 0
+    outer loop
+      vertex -3.76302 234.639 -43.0438
+      vertex -1.44666e-15 234.836 -56.2
+      vertex -3.76302 234.639 -56.2
+    endloop
+  endfacet
+  facet normal -0.0523341 0.99863 0
+    outer loop
+      vertex -1.44666e-15 234.836 -26.0238
+      vertex -3.76302 234.639 -26.6258
+      vertex -3.76302 234.639 -26.0238
+    endloop
+  endfacet
+  facet normal -0.052334 0.99863 -6.43119e-07
+    outer loop
+      vertex -1.44666e-15 234.836 -26.0238
+      vertex -1.69455 234.748 -29.3078
+      vertex -3.76302 234.639 -26.6258
+    endloop
+  endfacet
+  facet normal -0.0523352 0.99863 0
+    outer loop
+      vertex -1.69455 234.748 -29.3078
+      vertex -1.44666e-15 234.836 -26.0238
+      vertex -1.44666e-15 234.836 -31.505
+    endloop
+  endfacet
+  facet normal -0.0523341 0.99863 0
+    outer loop
+      vertex -3.76302 234.639 -40.9277
+      vertex -1.44666e-15 234.836 -35.1236
+      vertex -1.44666e-15 234.836 -40.9277
+    endloop
+  endfacet
+  facet normal -0.0523341 0.99863 0
+    outer loop
+      vertex -1.44666e-15 234.836 -35.1236
+      vertex -3.76302 234.639 -40.9277
+      vertex -3.76302 234.639 -30.2272
+    endloop
+  endfacet
+  facet normal -0.358365 0.933581 0
+    outer loop
+      vertex -11.1246 233.075 -56.2
+      vertex -14.6425 231.724 -11.2
+      vertex -11.1246 233.075 -11.2
+    endloop
+  endfacet
+  facet normal -0.358365 0.933581 0
+    outer loop
+      vertex -14.6425 231.724 -11.2
+      vertex -11.1246 233.075 -56.2
+      vertex -14.6425 231.724 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 28.2598 176.73 -56.2
+      vertex 23.4765 184.628 -56.2
+      vertex 23.8505 186.084 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7587 176.825 -56.2
+      vertex 22.752 183.31 -56.2
+      vertex 23.4765 184.628 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7587 176.825 -56.2
+      vertex 21.7224 182.213 -56.2
+      vertex 22.752 183.31 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7587 176.825 -56.2
+      vertex 20.4525 181.408 -56.2
+      vertex 21.7224 182.213 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7587 176.825 -56.2
+      vertex 19.0221 180.943 -56.2
+      vertex 20.4525 181.408 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7587 176.825 -56.2
+      vertex 17.5211 180.848 -56.2
+      vertex 19.0221 180.943 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7587 176.825 -56.2
+      vertex -18.2746 180.848 -56.2
+      vertex 17.5211 180.848 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.9896 176.543 -56.2
+      vertex -23.7094 185.344 -56.2
+      vertex -27.5122 176.825 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.1557 183.946 -56.2
+      vertex -27.5122 176.825 -56.2
+      vertex -23.7094 185.344 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.2717 182.729 -56.2
+      vertex -27.5122 176.825 -56.2
+      vertex -23.1557 183.946 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.1128 181.771 -56.2
+      vertex -27.5122 176.825 -56.2
+      vertex -22.2717 182.729 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.752 181.13 -56.2
+      vertex -27.5122 176.825 -56.2
+      vertex -21.1128 181.771 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -18.2746 180.848 -56.2
+      vertex -27.5122 176.825 -56.2
+      vertex -19.752 181.13 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.5122 176.825 -56.2
+      vertex -18.2746 180.848 -56.2
+      vertex 26.7587 176.825 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.9896 174.363 -56.2
+      vertex 43.3013 162.836 -56.2
+      vertex 39.8087 160.82 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.4765 189.045 -56.2
+      vertex 31.9896 174.363 -56.2
+      vertex 30.96 175.46 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.4765 184.628 -56.2
+      vertex 28.2598 176.73 -56.2
+      vertex 26.7587 176.825 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.8505 186.084 -56.2
+      vertex 29.6901 176.265 -56.2
+      vertex 28.2598 176.73 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.8505 187.588 -56.2
+      vertex 29.6901 176.265 -56.2
+      vertex 23.8505 186.084 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29.6901 176.265 -56.2
+      vertex 23.8505 187.588 -56.2
+      vertex 30.96 175.46 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 23.4765 189.045 -56.2
+      vertex 30.96 175.46 -56.2
+      vertex 23.8505 187.588 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 31.9896 174.363 -56.2
+      vertex 23.4765 189.045 -56.2
+      vertex 43.3013 162.836 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.752 190.363 -56.2
+      vertex 43.3013 162.836 -56.2
+      vertex 23.4765 189.045 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex 22.752 190.363 -56.2
+      vertex 13.5144 206.363 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 22.752 190.363 -56.2
+      vertex 12.9904 215.336 -56.2
+      vertex 43.3013 162.836 -56.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex 13.5144 206.363 -56.2
+      vertex 12.4848 207.46 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex 24.0887 225.59 -56.2
+      vertex 26.5267 223.152 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 24.0887 225.59 -56.2
+      vertex 12.9904 215.336 -56.2
+      vertex 21.1603 227.961 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 21.1603 227.961 -56.2
+      vertex 12.9904 215.336 -56.2
+      vertex 18 230.013 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18 230.013 -56.2
+      vertex 12.9904 215.336 -56.2
+      vertex 14.6425 231.724 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.2149 208.265 -56.2
+      vertex 12.9904 215.336 -56.2
+      vertex 12.4848 207.46 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.78454 208.73 -56.2
+      vertex 12.9904 215.336 -56.2
+      vertex 11.2149 208.265 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.28351 208.825 -56.2
+      vertex 12.9904 215.336 -56.2
+      vertex 9.78454 208.73 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.9904 215.336 -56.2
+      vertex 12.9904 215.336 -56.2
+      vertex 8.28351 208.825 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex 11.1246 233.075 -56.2
+      vertex 14.6425 231.724 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex 7.48482 234.05 -56.2
+      vertex 11.1246 233.075 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex 3.76302 234.639 -56.2
+      vertex 7.48482 234.05 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex -1.44666e-15 234.836 -56.2
+      vertex 3.76302 234.639 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex -12.9904 215.336 -56.2
+      vertex -1.44666e-15 234.836 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.44666e-15 234.836 -56.2
+      vertex -12.9904 215.336 -56.2
+      vertex -3.76302 234.639 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.9904 215.336 -56.2
+      vertex 8.28351 208.825 -56.2
+      vertex -9.037 208.825 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.9904 215.336 -56.2
+      vertex -9.037 208.825 -56.2
+      vertex -10.5144 208.543 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.76302 234.639 -56.2
+      vertex -12.9904 215.336 -56.2
+      vertex -7.48482 234.05 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.9904 215.336 -56.2
+      vertex -10.5144 208.543 -56.2
+      vertex -11.8752 207.902 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.48482 234.05 -56.2
+      vertex -12.9904 215.336 -56.2
+      vertex -11.1246 233.075 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.9904 215.336 -56.2
+      vertex -14.6425 231.724 -56.2
+      vertex -11.1246 233.075 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.9904 215.336 -56.2
+      vertex -18 230.013 -56.2
+      vertex -14.6425 231.724 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.9904 215.336 -56.2
+      vertex -21.1603 227.961 -56.2
+      vertex -18 230.013 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.9904 215.336 -56.2
+      vertex -24.0887 225.59 -56.2
+      vertex -21.1603 227.961 -56.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -24.0887 225.59 -56.2
+      vertex -12.9904 215.336 -56.2
+      vertex -26.5267 223.152 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.0341 206.944 -56.2
+      vertex -12.9904 215.336 -56.2
+      vertex -11.8752 207.902 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.9181 205.727 -56.2
+      vertex -12.9904 215.336 -56.2
+      vertex -13.0341 206.944 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1557 189.727 -56.2
+      vertex -12.9904 215.336 -56.2
+      vertex -13.9181 205.727 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.7094 185.344 -56.2
+      vertex -28.9896 176.543 -56.2
+      vertex -23.8979 186.836 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.3504 175.902 -56.2
+      vertex -23.8979 186.836 -56.2
+      vertex -28.9896 176.543 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.8979 186.836 -56.2
+      vertex -30.3504 175.902 -56.2
+      vertex -23.7094 188.329 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.5093 174.944 -56.2
+      vertex -23.7094 188.329 -56.2
+      vertex -30.3504 175.902 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.7094 188.329 -56.2
+      vertex -31.5093 174.944 -56.2
+      vertex -23.1557 189.727 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -43.3013 162.836 -56.2
+      vertex -23.1557 189.727 -56.2
+      vertex -31.5093 174.944 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -43.3013 162.836 -56.2
+      vertex -31.5093 174.944 -56.2
+      vertex -32.3933 173.727 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -43.3013 162.836 -56.2
+      vertex -32.3933 173.727 -56.2
+      vertex -39.836 160.836 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.1557 189.727 -56.2
+      vertex -43.3013 162.836 -56.2
+      vertex -12.9904 215.336 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.76302 234.639 -11.2
+      vertex -2 228.336 -11.2
+      vertex -1.44666e-15 234.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.5 228.336 -11.2
+      vertex -3.76302 234.639 -11.2
+      vertex -7.48482 234.05 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.76302 234.639 -11.2
+      vertex -7.5 228.336 -11.2
+      vertex -2 228.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.6425 231.724 -11.2
+      vertex -7.5 222.836 -11.2
+      vertex -7.5 228.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -12.9904 215.336 -11.2
+      vertex -7.5 222.836 -11.2
+      vertex -18 230.013 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.5 218.836 -11.2
+      vertex -12.9904 215.336 -11.2
+      vertex -7.5 213.336 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.1246 233.075 -11.2
+      vertex -7.5 228.336 -11.2
+      vertex -7.48482 234.05 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -10.5144 208.543 -11.2
+      vertex -7.5 213.336 -11.2
+      vertex -12.9904 215.336 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.6425 231.724 -11.2
+      vertex -7.5 228.336 -11.2
+      vertex -11.1246 233.075 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.5 213.336 -11.2
+      vertex -10.5144 208.543 -11.2
+      vertex -9.037 208.825 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5144 208.543 -11.2
+      vertex -12.9904 215.336 -11.2
+      vertex -11.8752 207.902 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.5 222.836 -11.2
+      vertex -14.6425 231.724 -11.2
+      vertex -18 230.013 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.5 222.836 -11.2
+      vertex -12.9904 215.336 -11.2
+      vertex -7.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.1603 227.961 -11.2
+      vertex -12.9904 215.336 -11.2
+      vertex -18 230.013 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -24.0887 225.59 -11.2
+      vertex -12.9904 215.336 -11.2
+      vertex -21.1603 227.961 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.9904 215.336 -11.2
+      vertex -24.0887 225.59 -11.2
+      vertex -26.5267 223.152 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 217.336 -11.2
+      vertex -2 217.336 -11.2
+      vertex 2 213.336 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.5 222.836 -11.2
+      vertex 7.5 218.836 -11.2
+      vertex 7.5 222.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 218.836 -11.2
+      vertex 3.5 222.836 -11.2
+      vertex 3.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.9904 215.336 -11.2
+      vertex 24.0887 225.59 -11.2
+      vertex 21.1603 227.961 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.9904 215.336 -11.2
+      vertex 21.1603 227.961 -11.2
+      vertex 18 230.013 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 222.836 -11.2
+      vertex 18 230.013 -11.2
+      vertex 14.6425 231.724 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 24.0887 225.59 -11.2
+      vertex 12.9904 215.336 -11.2
+      vertex 26.5267 223.152 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.9904 215.336 -11.2
+      vertex 11.2149 208.265 -11.2
+      vertex 12.4848 207.46 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18 230.013 -11.2
+      vertex 7.5 222.836 -11.2
+      vertex 12.9904 215.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 228.336 -11.2
+      vertex 14.6425 231.724 -11.2
+      vertex 11.1246 233.075 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 213.336 -11.2
+      vertex 12.9904 215.336 -11.2
+      vertex 7.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 9.78454 208.73 -11.2
+      vertex 12.9904 215.336 -11.2
+      vertex 7.5 213.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6425 231.724 -11.2
+      vertex 7.5 228.336 -11.2
+      vertex 7.5 222.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.48482 234.05 -11.2
+      vertex 7.5 228.336 -11.2
+      vertex 11.1246 233.075 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.76302 234.639 -11.2
+      vertex 7.5 228.336 -11.2
+      vertex 7.48482 234.05 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.76302 234.639 -11.2
+      vertex 2 228.336 -11.2
+      vertex 7.5 228.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44666e-15 234.836 -11.2
+      vertex 2 228.336 -11.2
+      vertex 3.76302 234.639 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 228.336 -11.2
+      vertex 2 228.336 -11.2
+      vertex -1.44666e-15 234.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 228.336 -11.2
+      vertex -2 228.336 -11.2
+      vertex 2 224.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 224.336 -11.2
+      vertex -2 228.336 -11.2
+      vertex -2 224.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.3013 162.836 -11.2
+      vertex 31.9896 174.363 -11.2
+      vertex 39.8087 160.82 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 23.4765 189.045 -11.2
+      vertex 31.9896 174.363 -11.2
+      vertex 43.3013 162.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.6901 176.265 -11.2
+      vertex 23.8505 186.084 -11.2
+      vertex 28.2598 176.73 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.8505 186.084 -11.2
+      vertex 29.6901 176.265 -11.2
+      vertex 23.8505 187.588 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.96 175.46 -11.2
+      vertex 23.8505 187.588 -11.2
+      vertex 29.6901 176.265 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 31.9896 174.363 -11.2
+      vertex 23.4765 189.045 -11.2
+      vertex 30.96 175.46 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.96 175.46 -11.2
+      vertex 23.4765 189.045 -11.2
+      vertex 23.8505 187.588 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 43.3013 162.836 -11.2
+      vertex 22.752 190.363 -11.2
+      vertex 23.4765 189.045 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.9904 215.336 -11.2
+      vertex 22.752 190.363 -11.2
+      vertex 43.3013 162.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.752 190.363 -11.2
+      vertex 12.9904 215.336 -11.2
+      vertex 13.5144 206.363 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5144 206.363 -11.2
+      vertex 12.9904 215.336 -11.2
+      vertex 12.4848 207.46 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 23.4765 184.628 -11.2
+      vertex 28.2598 176.73 -11.2
+      vertex 23.8505 186.084 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 28.2598 176.73 -11.2
+      vertex 23.4765 184.628 -11.2
+      vertex 26.7587 176.825 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.752 183.31 -11.2
+      vertex 26.7587 176.825 -11.2
+      vertex 23.4765 184.628 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 21.7224 182.213 -11.2
+      vertex 26.7587 176.825 -11.2
+      vertex 22.752 183.31 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.4525 181.408 -11.2
+      vertex 26.7587 176.825 -11.2
+      vertex 21.7224 182.213 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.0221 180.943 -11.2
+      vertex 26.7587 176.825 -11.2
+      vertex 20.4525 181.408 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.5211 180.848 -11.2
+      vertex 26.7587 176.825 -11.2
+      vertex 19.0221 180.943 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.2746 180.848 -11.2
+      vertex 26.7587 176.825 -11.2
+      vertex 17.5211 180.848 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2746 180.848 -11.2
+      vertex -27.5122 176.825 -11.2
+      vertex 26.7587 176.825 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.752 181.13 -11.2
+      vertex -27.5122 176.825 -11.2
+      vertex -18.2746 180.848 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.1128 181.771 -11.2
+      vertex -27.5122 176.825 -11.2
+      vertex -19.752 181.13 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.2717 182.729 -11.2
+      vertex -27.5122 176.825 -11.2
+      vertex -21.1128 181.771 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1557 183.946 -11.2
+      vertex -27.5122 176.825 -11.2
+      vertex -22.2717 182.729 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.7094 185.344 -11.2
+      vertex -27.5122 176.825 -11.2
+      vertex -23.1557 183.946 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -28.9896 176.543 -11.2
+      vertex -23.7094 185.344 -11.2
+      vertex -23.8979 186.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.9904 215.336 -11.2
+      vertex 7.5 222.836 -11.2
+      vertex 7.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.9904 215.336 -11.2
+      vertex 9.78454 208.73 -11.2
+      vertex 11.2149 208.265 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.78454 208.73 -11.2
+      vertex 7.5 213.336 -11.2
+      vertex 8.28351 208.825 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2 213.336 -11.2
+      vertex 8.28351 208.825 -11.2
+      vertex 7.5 213.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 213.336 -11.2
+      vertex 2 213.336 -11.2
+      vertex -2 217.336 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2 213.336 -11.2
+      vertex 8.28351 208.825 -11.2
+      vertex 2 213.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.037 208.825 -11.2
+      vertex -2 213.336 -11.2
+      vertex -7.5 213.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 213.336 -11.2
+      vertex -9.037 208.825 -11.2
+      vertex 8.28351 208.825 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.5 222.836 -11.2
+      vertex -3.5 218.836 -11.2
+      vertex -3.5 222.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.5 218.836 -11.2
+      vertex -7.5 222.836 -11.2
+      vertex -7.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.9904 215.336 -11.2
+      vertex -13.0341 206.944 -11.2
+      vertex -11.8752 207.902 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.9904 215.336 -11.2
+      vertex -13.9181 205.727 -11.2
+      vertex -13.0341 206.944 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.9904 215.336 -11.2
+      vertex -23.1557 189.727 -11.2
+      vertex -13.9181 205.727 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -30.3504 175.902 -11.2
+      vertex -23.8979 186.836 -11.2
+      vertex -23.7094 188.329 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.7094 185.344 -11.2
+      vertex -28.9896 176.543 -11.2
+      vertex -27.5122 176.825 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.5093 174.944 -11.2
+      vertex -23.7094 188.329 -11.2
+      vertex -23.1557 189.727 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -43.3013 162.836 -11.2
+      vertex -23.1557 189.727 -11.2
+      vertex -12.9904 215.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8979 186.836 -11.2
+      vertex -30.3504 175.902 -11.2
+      vertex -28.9896 176.543 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.7094 188.329 -11.2
+      vertex -31.5093 174.944 -11.2
+      vertex -30.3504 175.902 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1557 189.727 -11.2
+      vertex -43.3013 162.836 -11.2
+      vertex -31.5093 174.944 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -31.5093 174.944 -11.2
+      vertex -43.3013 162.836 -11.2
+      vertex -32.3933 173.727 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -32.3933 173.727 -11.2
+      vertex -43.3013 162.836 -11.2
+      vertex -39.836 160.836 -11.2
+    endloop
+  endfacet
+  facet normal 0.707106 0.707108 -0
+    outer loop
+      vertex 26.5267 223.152 -56.2
+      vertex 24.0887 225.59 -11.2
+      vertex 26.5267 223.152 -11.2
+    endloop
+  endfacet
+  facet normal 0.707106 0.707108 0
+    outer loop
+      vertex 24.0887 225.59 -11.2
+      vertex 26.5267 223.152 -56.2
+      vertex 24.0887 225.59 -56.2
+    endloop
+  endfacet
+  facet normal -0.156435 0.987688 0
+    outer loop
+      vertex -3.76302 234.639 -56.2
+      vertex -7.48482 234.05 -43.0438
+      vertex -3.76302 234.639 -43.0438
+    endloop
+  endfacet
+  facet normal -0.156435 0.987688 0
+    outer loop
+      vertex -7.48482 234.05 -43.0438
+      vertex -3.76302 234.639 -56.2
+      vertex -7.48482 234.05 -56.2
+    endloop
+  endfacet
+  facet normal -0.156433 0.987689 0
+    outer loop
+      vertex -7.17032 234.1 -23.9078
+      vertex -3.76302 234.639 -11.2
+      vertex -3.76302 234.639 -23.9078
+    endloop
+  endfacet
+  facet normal -0.156435 0.987688 5.83764e-07
+    outer loop
+      vertex -3.76302 234.639 -11.2
+      vertex -7.17032 234.1 -23.9078
+      vertex -7.48482 234.05 -11.2
+    endloop
+  endfacet
+  facet normal -0.156458 0.987685 0
+    outer loop
+      vertex -7.17032 234.1 -25.7938
+      vertex -7.48482 234.05 -11.2
+      vertex -7.17032 234.1 -23.9078
+    endloop
+  endfacet
+  facet normal -0.156435 0.987688 0
+    outer loop
+      vertex -7.48482 234.05 -40.9277
+      vertex -3.76302 234.639 -30.2272
+      vertex -3.76302 234.639 -40.9277
+    endloop
+  endfacet
+  facet normal -0.156458 0.987685 0
+    outer loop
+      vertex -7.17032 234.1 -25.7938
+      vertex -7.48482 234.05 -40.9277
+      vertex -7.48482 234.05 -11.2
+    endloop
+  endfacet
+  facet normal -0.156434 0.987688 -5.21325e-07
+    outer loop
+      vertex -3.76302 234.639 -30.2272
+      vertex -7.48482 234.05 -40.9277
+      vertex -7.17032 234.1 -25.7938
+    endloop
+  endfacet
+  facet normal -0.156422 0.98769 0
+    outer loop
+      vertex -3.76302 234.639 -26.6258
+      vertex -4.22733 234.566 -26.0238
+      vertex -3.76302 234.639 -26.0238
+    endloop
+  endfacet
+  facet normal -0.707106 0.707108 0
+    outer loop
+      vertex -24.0887 225.59 -56.2
+      vertex -26.5267 223.152 -11.2
+      vertex -24.0887 225.59 -11.2
+    endloop
+  endfacet
+  facet normal -0.707106 0.707108 0
+    outer loop
+      vertex -26.5267 223.152 -11.2
+      vertex -24.0887 225.59 -56.2
+      vertex -26.5267 223.152 -56.2
+    endloop
+  endfacet
+  facet normal -0.453991 0.891006 0
+    outer loop
+      vertex -14.6425 231.724 -56.2
+      vertex -18 230.013 -11.2
+      vertex -14.6425 231.724 -11.2
+    endloop
+  endfacet
+  facet normal -0.453991 0.891006 0
+    outer loop
+      vertex -18 230.013 -11.2
+      vertex -14.6425 231.724 -56.2
+      vertex -18 230.013 -56.2
+    endloop
+  endfacet
+  facet normal -0.54464 0.83867 0
+    outer loop
+      vertex -18 230.013 -56.2
+      vertex -21.1603 227.961 -11.2
+      vertex -18 230.013 -11.2
+    endloop
+  endfacet
+  facet normal -0.54464 0.83867 0
+    outer loop
+      vertex -21.1603 227.961 -11.2
+      vertex -18 230.013 -56.2
+      vertex -21.1603 227.961 -56.2
+    endloop
+  endfacet
+  facet normal -0.629321 0.777146 0
+    outer loop
+      vertex -21.1603 227.961 -56.2
+      vertex -24.0887 225.59 -11.2
+      vertex -21.1603 227.961 -11.2
+    endloop
+  endfacet
+  facet normal -0.629321 0.777146 0
+    outer loop
+      vertex -24.0887 225.59 -11.2
+      vertex -21.1603 227.961 -56.2
+      vertex -24.0887 225.59 -56.2
+    endloop
+  endfacet
+  facet normal 0.0523341 0.99863 -0
+    outer loop
+      vertex 3.76302 234.639 -23.9078
+      vertex -1.44666e-15 234.836 -11.2
+      vertex 3.76302 234.639 -11.2
+    endloop
+  endfacet
+  facet normal 0.0523341 0.99863 0
+    outer loop
+      vertex -1.44666e-15 234.836 -11.2
+      vertex 3.76302 234.639 -23.9078
+      vertex -1.44666e-15 234.836 -23.9078
+    endloop
+  endfacet
+  facet normal 0.0523341 0.99863 -0
+    outer loop
+      vertex 3.76302 234.639 -56.2
+      vertex -1.44666e-15 234.836 -43.0438
+      vertex 3.76302 234.639 -43.0438
+    endloop
+  endfacet
+  facet normal 0.0523341 0.99863 0
+    outer loop
+      vertex -1.44666e-15 234.836 -43.0438
+      vertex 3.76302 234.639 -56.2
+      vertex -1.44666e-15 234.836 -56.2
+    endloop
+  endfacet
+  facet normal 0.0523341 0.99863 0
+    outer loop
+      vertex 3.76302 234.639 -26.0238
+      vertex -1.44666e-15 234.836 -31.505
+      vertex -1.44666e-15 234.836 -26.0238
+    endloop
+  endfacet
+  facet normal 0.0523341 0.99863 0
+    outer loop
+      vertex -1.44666e-15 234.836 -31.505
+      vertex 3.76302 234.639 -26.0238
+      vertex 3.76302 234.639 -36.3842
+    endloop
+  endfacet
+  facet normal 0.0523343 0.99863 -9.43227e-07
+    outer loop
+      vertex -1.44666e-15 234.836 -40.9277
+      vertex 1.90253 234.737 -37.5991
+      vertex 3.76302 234.639 -40.02
+    endloop
+  endfacet
+  facet normal 0.0523341 0.99863 0
+    outer loop
+      vertex -1.44666e-15 234.836 -40.9277
+      vertex 3.76302 234.639 -40.02
+      vertex 3.76302 234.639 -40.9277
+    endloop
+  endfacet
+  facet normal 0.0523326 0.99863 0
+    outer loop
+      vertex 1.90253 234.737 -37.5991
+      vertex -1.44666e-15 234.836 -40.9277
+      vertex -1.44666e-15 234.836 -35.1236
+    endloop
+  endfacet
+  facet normal 0.453991 0.891006 -0
+    outer loop
+      vertex 18 230.013 -56.2
+      vertex 14.6425 231.724 -11.2
+      vertex 18 230.013 -11.2
+    endloop
+  endfacet
+  facet normal 0.453991 0.891006 0
+    outer loop
+      vertex 14.6425 231.724 -11.2
+      vertex 18 230.013 -56.2
+      vertex 14.6425 231.724 -56.2
+    endloop
+  endfacet
+  facet normal 0.54464 0.83867 -0
+    outer loop
+      vertex 21.1603 227.961 -56.2
+      vertex 18 230.013 -11.2
+      vertex 21.1603 227.961 -11.2
+    endloop
+  endfacet
+  facet normal 0.54464 0.83867 0
+    outer loop
+      vertex 18 230.013 -11.2
+      vertex 21.1603 227.961 -56.2
+      vertex 18 230.013 -56.2
+    endloop
+  endfacet
+  facet normal 0.629321 0.777146 -0
+    outer loop
+      vertex 24.0887 225.59 -56.2
+      vertex 21.1603 227.961 -11.2
+      vertex 24.0887 225.59 -11.2
+    endloop
+  endfacet
+  facet normal 0.629321 0.777146 0
+    outer loop
+      vertex 21.1603 227.961 -11.2
+      vertex 24.0887 225.59 -56.2
+      vertex 21.1603 227.961 -56.2
+    endloop
+  endfacet
+  facet normal -0.258805 0.96593 0
+    outer loop
+      vertex -7.48482 234.05 -43.0438
+      vertex -7.48482 234.05 -56.2
+      vertex -7.80733 233.963 -43.0438
+    endloop
+  endfacet
+  facet normal -0.258805 0.96593 0
+    outer loop
+      vertex -7.80733 233.963 -40.9277
+      vertex -7.48482 234.05 -11.2
+      vertex -7.48482 234.05 -40.9277
+    endloop
+  endfacet
+  facet normal -0.258819 0.965926 1.65844e-07
+    outer loop
+      vertex -7.48482 234.05 -11.2
+      vertex -7.80733 233.963 -40.9277
+      vertex -11.1246 233.075 -11.2
+    endloop
+  endfacet
+  facet normal -0.258821 0.965925 0
+    outer loop
+      vertex -11.1246 233.075 -56.2
+      vertex -7.80733 233.963 -40.9277
+      vertex -7.80733 233.963 -43.0438
+    endloop
+  endfacet
+  facet normal -0.258819 0.965926 -3.7474e-07
+    outer loop
+      vertex -11.1246 233.075 -56.2
+      vertex -7.80733 233.963 -43.0438
+      vertex -7.48482 234.05 -56.2
+    endloop
+  endfacet
+  facet normal -0.258821 0.965925 0
+    outer loop
+      vertex -7.80733 233.963 -40.9277
+      vertex -11.1246 233.075 -56.2
+      vertex -11.1246 233.075 -11.2
+    endloop
+  endfacet
+  facet normal 0.258819 0.965926 -0
+    outer loop
+      vertex 11.1246 233.075 -56.2
+      vertex 7.48482 234.05 -11.2
+      vertex 11.1246 233.075 -11.2
+    endloop
+  endfacet
+  facet normal 0.258819 0.965926 0
+    outer loop
+      vertex 7.48482 234.05 -11.2
+      vertex 11.1246 233.075 -56.2
+      vertex 7.48482 234.05 -56.2
+    endloop
+  endfacet
+  facet normal 0.156435 0.987688 5.75433e-07
+    outer loop
+      vertex 7.48482 234.05 -11.2
+      vertex 6.41367 234.219 -23.9078
+      vertex 3.76302 234.639 -11.2
+    endloop
+  endfacet
+  facet normal 0.156442 0.987687 0
+    outer loop
+      vertex 7.48482 234.05 -11.2
+      vertex 6.41367 234.219 -26.0238
+      vertex 6.41367 234.219 -23.9078
+    endloop
+  endfacet
+  facet normal 0.156433 0.987689 0
+    outer loop
+      vertex 6.41367 234.219 -26.0238
+      vertex 3.76302 234.639 -36.3842
+      vertex 3.76302 234.639 -26.0238
+    endloop
+  endfacet
+  facet normal 0.156433 0.987689 -1.17052e-07
+    outer loop
+      vertex 6.41367 234.219 -26.0238
+      vertex 7.40366 234.063 -41.1047
+      vertex 3.76302 234.639 -36.3842
+    endloop
+  endfacet
+  facet normal 0.156438 0.987688 2.52639e-07
+    outer loop
+      vertex 7.48482 234.05 -11.2
+      vertex 7.40366 234.063 -41.1047
+      vertex 6.41367 234.219 -26.0238
+    endloop
+  endfacet
+  facet normal 0.156529 0.987673 0
+    outer loop
+      vertex 7.48482 234.05 -11.2
+      vertex 7.40366 234.063 -43.0438
+      vertex 7.40366 234.063 -41.1047
+    endloop
+  endfacet
+  facet normal 0.156529 0.987673 -0
+    outer loop
+      vertex 7.48482 234.05 -56.2
+      vertex 7.40366 234.063 -43.0438
+      vertex 7.48482 234.05 -11.2
+    endloop
+  endfacet
+  facet normal 0.156433 0.987689 -6.08066e-07
+    outer loop
+      vertex 7.48482 234.05 -56.2
+      vertex 3.76302 234.639 -43.0438
+      vertex 7.40366 234.063 -43.0438
+    endloop
+  endfacet
+  facet normal 0.156435 0.987688 0
+    outer loop
+      vertex 3.76302 234.639 -43.0438
+      vertex 7.48482 234.05 -56.2
+      vertex 3.76302 234.639 -56.2
+    endloop
+  endfacet
+  facet normal 0.156433 0.987689 0
+    outer loop
+      vertex 3.76302 234.639 -11.2
+      vertex 6.41367 234.219 -23.9078
+      vertex 3.76302 234.639 -23.9078
+    endloop
+  endfacet
+  facet normal 0.156426 0.98769 0
+    outer loop
+      vertex 4.46066 234.529 -40.9277
+      vertex 3.76302 234.639 -40.9277
+      vertex 3.76302 234.639 -40.02
+    endloop
+  endfacet
+  facet normal 0.358365 0.933581 -0
+    outer loop
+      vertex 14.6425 231.724 -56.2
+      vertex 11.1246 233.075 -11.2
+      vertex 14.6425 231.724 -11.2
+    endloop
+  endfacet
+  facet normal 0.358365 0.933581 0
+    outer loop
+      vertex 11.1246 233.075 -11.2
+      vertex 14.6425 231.724 -56.2
+      vertex 11.1246 233.075 -56.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 0
+    outer loop
+      vertex -26.5267 223.152 -56.2
+      vertex -12.9904 215.336 -11.2
+      vertex -26.5267 223.152 -11.2
+    endloop
+  endfacet
+  facet normal -0.500001 -0.866025 -0
+    outer loop
+      vertex -12.9904 215.336 -11.2
+      vertex -26.5267 223.152 -56.2
+      vertex -12.9904 215.336 -56.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex 26.5267 223.152 -11.2
+      vertex 12.9904 215.336 -11.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 26.5267 223.152 -11.2
+      vertex 12.9904 215.336 -56.2
+      vertex 26.5267 223.152 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -43.3013 162.836 -56.2
+      vertex -12.9904 215.336 -11.2
+      vertex -12.9904 215.336 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -12.9904 215.336 -11.2
+      vertex -43.3013 162.836 -56.2
+      vertex -43.3013 162.836 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 43.3013 162.836 -11.2
+      vertex 12.9904 215.336 -56.2
+      vertex 12.9904 215.336 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 12.9904 215.336 -56.2
+      vertex 43.3013 162.836 -11.2
+      vertex 43.3013 162.836 -56.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex -43.3013 162.836 -56.2
+      vertex -39.836 160.836 -11.2
+      vertex -43.3013 162.836 -11.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 -0
+    outer loop
+      vertex -39.836 160.836 -11.2
+      vertex -43.3013 162.836 -56.2
+      vertex -39.836 160.836 -56.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 0
+    outer loop
+      vertex 39.8087 160.82 -56.2
+      vertex 43.3013 162.836 -11.2
+      vertex 39.8087 160.82 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 0
+    outer loop
+      vertex 43.3013 162.836 -11.2
+      vertex 39.8087 160.82 -56.2
+      vertex 43.3013 162.836 -56.2
+    endloop
+  endfacet
+  facet normal 0.809015 0.587788 0
+    outer loop
+      vertex -22.2717 182.729 -11.2
+      vertex -23.1557 183.946 -56.2
+      vertex -23.1557 183.946 -11.2
+    endloop
+  endfacet
+  facet normal 0.809015 0.587788 0
+    outer loop
+      vertex -23.1557 183.946 -56.2
+      vertex -22.2717 182.729 -11.2
+      vertex -22.2717 182.729 -56.2
+    endloop
+  endfacet
+  facet normal -0.968584 -0.248688 0
+    outer loop
+      vertex 23.8505 187.588 -56.2
+      vertex 23.4765 189.045 -11.2
+      vertex 23.4765 189.045 -56.2
+    endloop
+  endfacet
+  facet normal -0.968584 -0.248688 0
+    outer loop
+      vertex 23.4765 189.045 -11.2
+      vertex 23.8505 187.588 -56.2
+      vertex 23.8505 187.588 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 23.8505 186.084 -56.2
+      vertex 23.8505 187.588 -11.2
+      vertex 23.8505 187.588 -56.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 23.8505 187.588 -11.2
+      vertex 23.8505 186.084 -56.2
+      vertex 23.8505 186.084 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 22.752 190.363 -56.2
+      vertex 13.5144 206.363 -11.2
+      vertex 13.5144 206.363 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 13.5144 206.363 -11.2
+      vertex 22.752 190.363 -56.2
+      vertex 22.752 190.363 -11.2
+    endloop
+  endfacet
+  facet normal -0.0627904 0.998027 0
+    outer loop
+      vertex 19.0221 180.943 -56.2
+      vertex 17.5211 180.848 -11.2
+      vertex 19.0221 180.943 -11.2
+    endloop
+  endfacet
+  facet normal -0.0627904 0.998027 0
+    outer loop
+      vertex 17.5211 180.848 -11.2
+      vertex 19.0221 180.943 -56.2
+      vertex 17.5211 180.848 -56.2
+    endloop
+  endfacet
+  facet normal -0.968583 0.248691 0
+    outer loop
+      vertex 23.4765 184.628 -56.2
+      vertex 23.8505 186.084 -11.2
+      vertex 23.8505 186.084 -56.2
+    endloop
+  endfacet
+  facet normal -0.968583 0.248691 0
+    outer loop
+      vertex 23.8505 186.084 -11.2
+      vertex 23.4765 184.628 -56.2
+      vertex 23.4765 184.628 -11.2
+    endloop
+  endfacet
+  facet normal -0.876306 -0.481755 0
+    outer loop
+      vertex 23.4765 189.045 -56.2
+      vertex 22.752 190.363 -11.2
+      vertex 22.752 190.363 -56.2
+    endloop
+  endfacet
+  facet normal -0.876306 -0.481755 0
+    outer loop
+      vertex 22.752 190.363 -11.2
+      vertex 23.4765 189.045 -56.2
+      vertex 23.4765 189.045 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -23.1557 189.727 -11.2
+      vertex -13.9181 205.727 -56.2
+      vertex -13.9181 205.727 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -13.9181 205.727 -56.2
+      vertex -23.1557 189.727 -11.2
+      vertex -23.1557 189.727 -56.2
+    endloop
+  endfacet
+  facet normal -0.309021 0.951055 0
+    outer loop
+      vertex 20.4525 181.408 -56.2
+      vertex 19.0221 180.943 -11.2
+      vertex 20.4525 181.408 -11.2
+    endloop
+  endfacet
+  facet normal -0.309021 0.951055 0
+    outer loop
+      vertex 19.0221 180.943 -11.2
+      vertex 20.4525 181.408 -56.2
+      vertex 19.0221 180.943 -56.2
+    endloop
+  endfacet
+  facet normal -0.535824 -0.844329 0
+    outer loop
+      vertex 11.2149 208.265 -56.2
+      vertex 12.4848 207.46 -11.2
+      vertex 11.2149 208.265 -11.2
+    endloop
+  endfacet
+  facet normal -0.535824 -0.844329 -0
+    outer loop
+      vertex 12.4848 207.46 -11.2
+      vertex 11.2149 208.265 -56.2
+      vertex 12.4848 207.46 -56.2
+    endloop
+  endfacet
+  facet normal -0.728971 -0.684545 0
+    outer loop
+      vertex 13.5144 206.363 -56.2
+      vertex 12.4848 207.46 -11.2
+      vertex 12.4848 207.46 -56.2
+    endloop
+  endfacet
+  facet normal -0.728971 -0.684545 0
+    outer loop
+      vertex 12.4848 207.46 -11.2
+      vertex 13.5144 206.363 -56.2
+      vertex 13.5144 206.363 -11.2
+    endloop
+  endfacet
+  facet normal 0.992115 0.125335 0
+    outer loop
+      vertex -23.7094 185.344 -11.2
+      vertex -23.8979 186.836 -56.2
+      vertex -23.8979 186.836 -11.2
+    endloop
+  endfacet
+  facet normal 0.992115 0.125335 0
+    outer loop
+      vertex -23.8979 186.836 -56.2
+      vertex -23.7094 185.344 -11.2
+      vertex -23.7094 185.344 -56.2
+    endloop
+  endfacet
+  facet normal -0.535825 0.844329 0
+    outer loop
+      vertex 21.7224 182.213 -56.2
+      vertex 20.4525 181.408 -11.2
+      vertex 21.7224 182.213 -11.2
+    endloop
+  endfacet
+  facet normal -0.535825 0.844329 0
+    outer loop
+      vertex 20.4525 181.408 -11.2
+      vertex 21.7224 182.213 -56.2
+      vertex 20.4525 181.408 -56.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 17.5211 180.848 -56.2
+      vertex -18.2746 180.848 -11.2
+      vertex 17.5211 180.848 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.2746 180.848 -11.2
+      vertex 17.5211 180.848 -56.2
+      vertex -18.2746 180.848 -56.2
+    endloop
+  endfacet
+  facet normal 0.425776 0.904829 -0
+    outer loop
+      vertex -19.752 181.13 -56.2
+      vertex -21.1128 181.771 -11.2
+      vertex -19.752 181.13 -11.2
+    endloop
+  endfacet
+  facet normal 0.425776 0.904829 0
+    outer loop
+      vertex -21.1128 181.771 -11.2
+      vertex -19.752 181.13 -56.2
+      vertex -21.1128 181.771 -56.2
+    endloop
+  endfacet
+  facet normal 0.187377 -0.982288 0
+    outer loop
+      vertex -10.5144 208.543 -56.2
+      vertex -9.037 208.825 -11.2
+      vertex -10.5144 208.543 -11.2
+    endloop
+  endfacet
+  facet normal 0.187377 -0.982288 0
+    outer loop
+      vertex -9.037 208.825 -11.2
+      vertex -10.5144 208.543 -56.2
+      vertex -9.037 208.825 -56.2
+    endloop
+  endfacet
+  facet normal 0.929777 -0.368123 0
+    outer loop
+      vertex -23.7094 188.329 -11.2
+      vertex -23.1557 189.727 -56.2
+      vertex -23.1557 189.727 -11.2
+    endloop
+  endfacet
+  facet normal 0.929777 -0.368123 0
+    outer loop
+      vertex -23.1557 189.727 -56.2
+      vertex -23.7094 188.329 -11.2
+      vertex -23.7094 188.329 -56.2
+    endloop
+  endfacet
+  facet normal 0.929777 0.368123 0
+    outer loop
+      vertex -23.1557 183.946 -11.2
+      vertex -23.7094 185.344 -56.2
+      vertex -23.7094 185.344 -11.2
+    endloop
+  endfacet
+  facet normal 0.929777 0.368123 0
+    outer loop
+      vertex -23.7094 185.344 -56.2
+      vertex -23.1557 183.946 -11.2
+      vertex -23.1557 183.946 -56.2
+    endloop
+  endfacet
+  facet normal -0.876306 0.481755 0
+    outer loop
+      vertex 22.752 183.31 -56.2
+      vertex 23.4765 184.628 -11.2
+      vertex 23.4765 184.628 -56.2
+    endloop
+  endfacet
+  facet normal -0.876306 0.481755 0
+    outer loop
+      vertex 23.4765 184.628 -11.2
+      vertex 22.752 183.31 -56.2
+      vertex 22.752 183.31 -11.2
+    endloop
+  endfacet
+  facet normal -0.728971 0.684545 0
+    outer loop
+      vertex 21.7224 182.213 -56.2
+      vertex 22.752 183.31 -11.2
+      vertex 22.752 183.31 -56.2
+    endloop
+  endfacet
+  facet normal -0.728971 0.684545 0
+    outer loop
+      vertex 22.752 183.31 -11.2
+      vertex 21.7224 182.213 -56.2
+      vertex 21.7224 182.213 -11.2
+    endloop
+  endfacet
+  facet normal 0.187387 0.982286 -0
+    outer loop
+      vertex -18.2746 180.848 -56.2
+      vertex -19.752 181.13 -11.2
+      vertex -18.2746 180.848 -11.2
+    endloop
+  endfacet
+  facet normal 0.187387 0.982286 0
+    outer loop
+      vertex -19.752 181.13 -11.2
+      vertex -18.2746 180.848 -56.2
+      vertex -19.752 181.13 -56.2
+    endloop
+  endfacet
+  facet normal -0.309012 -0.951058 0
+    outer loop
+      vertex 9.78454 208.73 -56.2
+      vertex 11.2149 208.265 -11.2
+      vertex 9.78454 208.73 -11.2
+    endloop
+  endfacet
+  facet normal -0.309012 -0.951058 -0
+    outer loop
+      vertex 11.2149 208.265 -11.2
+      vertex 9.78454 208.73 -56.2
+      vertex 11.2149 208.265 -56.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -9.037 208.825 -56.2
+      vertex 8.28351 208.825 -11.2
+      vertex -9.037 208.825 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 8.28351 208.825 -11.2
+      vertex -9.037 208.825 -56.2
+      vertex 8.28351 208.825 -56.2
+    endloop
+  endfacet
+  facet normal 0.637428 -0.77051 0
+    outer loop
+      vertex -13.0341 206.944 -56.2
+      vertex -11.8752 207.902 -11.2
+      vertex -13.0341 206.944 -11.2
+    endloop
+  endfacet
+  facet normal 0.637428 -0.77051 0
+    outer loop
+      vertex -11.8752 207.902 -11.2
+      vertex -13.0341 206.944 -56.2
+      vertex -11.8752 207.902 -56.2
+    endloop
+  endfacet
+  facet normal 0.809015 -0.587788 0
+    outer loop
+      vertex -13.9181 205.727 -11.2
+      vertex -13.0341 206.944 -56.2
+      vertex -13.0341 206.944 -11.2
+    endloop
+  endfacet
+  facet normal 0.809015 -0.587788 0
+    outer loop
+      vertex -13.0341 206.944 -56.2
+      vertex -13.9181 205.727 -11.2
+      vertex -13.9181 205.727 -56.2
+    endloop
+  endfacet
+  facet normal 0.637428 0.77051 -0
+    outer loop
+      vertex -21.1128 181.771 -56.2
+      vertex -22.2717 182.729 -11.2
+      vertex -21.1128 181.771 -11.2
+    endloop
+  endfacet
+  facet normal 0.637428 0.77051 0
+    outer loop
+      vertex -22.2717 182.729 -11.2
+      vertex -21.1128 181.771 -56.2
+      vertex -22.2717 182.729 -56.2
+    endloop
+  endfacet
+  facet normal -0.0627904 -0.998027 0
+    outer loop
+      vertex 8.28351 208.825 -56.2
+      vertex 9.78454 208.73 -11.2
+      vertex 8.28351 208.825 -11.2
+    endloop
+  endfacet
+  facet normal -0.0627904 -0.998027 -0
+    outer loop
+      vertex 9.78454 208.73 -11.2
+      vertex 8.28351 208.825 -56.2
+      vertex 9.78454 208.73 -56.2
+    endloop
+  endfacet
+  facet normal 0.425776 -0.904829 0
+    outer loop
+      vertex -11.8752 207.902 -56.2
+      vertex -10.5144 208.543 -11.2
+      vertex -11.8752 207.902 -11.2
+    endloop
+  endfacet
+  facet normal 0.425776 -0.904829 0
+    outer loop
+      vertex -10.5144 208.543 -11.2
+      vertex -11.8752 207.902 -56.2
+      vertex -10.5144 208.543 -56.2
+    endloop
+  endfacet
+  facet normal 0.992115 -0.125333 0
+    outer loop
+      vertex -23.8979 186.836 -11.2
+      vertex -23.7094 188.329 -56.2
+      vertex -23.7094 188.329 -11.2
+    endloop
+  endfacet
+  facet normal 0.992115 -0.125333 0
+    outer loop
+      vertex -23.7094 188.329 -56.2
+      vertex -23.8979 186.836 -11.2
+      vertex -23.8979 186.836 -56.2
+    endloop
+  endfacet
+  facet normal -0.535825 -0.844329 0
+    outer loop
+      vertex 29.6901 176.265 -56.2
+      vertex 30.96 175.46 -11.2
+      vertex 29.6901 176.265 -11.2
+    endloop
+  endfacet
+  facet normal -0.535825 -0.844329 -0
+    outer loop
+      vertex 30.96 175.46 -11.2
+      vertex 29.6901 176.265 -56.2
+      vertex 30.96 175.46 -56.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex 39.8087 160.82 -56.2
+      vertex 31.9896 174.363 -11.2
+      vertex 31.9896 174.363 -56.2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.5 0
+    outer loop
+      vertex 31.9896 174.363 -11.2
+      vertex 39.8087 160.82 -56.2
+      vertex 39.8087 160.82 -11.2
+    endloop
+  endfacet
+  facet normal -0.728971 -0.684545 0
+    outer loop
+      vertex 31.9896 174.363 -56.2
+      vertex 30.96 175.46 -11.2
+      vertex 30.96 175.46 -56.2
+    endloop
+  endfacet
+  facet normal -0.728971 -0.684545 0
+    outer loop
+      vertex 30.96 175.46 -11.2
+      vertex 31.9896 174.363 -56.2
+      vertex 31.9896 174.363 -11.2
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex -39.836 160.836 -11.2
+      vertex -32.3933 173.727 -56.2
+      vertex -32.3933 173.727 -11.2
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex -32.3933 173.727 -56.2
+      vertex -39.836 160.836 -11.2
+      vertex -39.836 160.836 -56.2
+    endloop
+  endfacet
+  facet normal 0.187377 -0.982288 0
+    outer loop
+      vertex -28.9896 176.543 -56.2
+      vertex -27.5122 176.825 -11.2
+      vertex -28.9896 176.543 -11.2
+    endloop
+  endfacet
+  facet normal 0.187377 -0.982288 0
+    outer loop
+      vertex -27.5122 176.825 -11.2
+      vertex -28.9896 176.543 -56.2
+      vertex -27.5122 176.825 -56.2
+    endloop
+  endfacet
+  facet normal -0.0627904 -0.998027 0
+    outer loop
+      vertex 26.7587 176.825 -56.2
+      vertex 28.2598 176.73 -11.2
+      vertex 26.7587 176.825 -11.2
+    endloop
+  endfacet
+  facet normal -0.0627904 -0.998027 -0
+    outer loop
+      vertex 28.2598 176.73 -11.2
+      vertex 26.7587 176.825 -56.2
+      vertex 28.2598 176.73 -56.2
+    endloop
+  endfacet
+  facet normal -0.309012 -0.951058 0
+    outer loop
+      vertex 28.2598 176.73 -56.2
+      vertex 29.6901 176.265 -11.2
+      vertex 28.2598 176.73 -11.2
+    endloop
+  endfacet
+  facet normal -0.309012 -0.951058 -0
+    outer loop
+      vertex 29.6901 176.265 -11.2
+      vertex 28.2598 176.73 -56.2
+      vertex 29.6901 176.265 -56.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -27.5122 176.825 -56.2
+      vertex 26.7587 176.825 -11.2
+      vertex -27.5122 176.825 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 26.7587 176.825 -11.2
+      vertex -27.5122 176.825 -56.2
+      vertex 26.7587 176.825 -56.2
+    endloop
+  endfacet
+  facet normal 0.637428 -0.77051 0
+    outer loop
+      vertex -31.5093 174.944 -56.2
+      vertex -30.3504 175.902 -11.2
+      vertex -31.5093 174.944 -11.2
+    endloop
+  endfacet
+  facet normal 0.637428 -0.77051 0
+    outer loop
+      vertex -30.3504 175.902 -11.2
+      vertex -31.5093 174.944 -56.2
+      vertex -30.3504 175.902 -56.2
+    endloop
+  endfacet
+  facet normal 0.809016 -0.587787 0
+    outer loop
+      vertex -32.3933 173.727 -11.2
+      vertex -31.5093 174.944 -56.2
+      vertex -31.5093 174.944 -11.2
+    endloop
+  endfacet
+  facet normal 0.809016 -0.587787 0
+    outer loop
+      vertex -31.5093 174.944 -56.2
+      vertex -32.3933 173.727 -11.2
+      vertex -32.3933 173.727 -56.2
+    endloop
+  endfacet
+  facet normal 0.425776 -0.904829 0
+    outer loop
+      vertex -30.3504 175.902 -56.2
+      vertex -28.9896 176.543 -11.2
+      vertex -30.3504 175.902 -11.2
+    endloop
+  endfacet
+  facet normal 0.425776 -0.904829 0
+    outer loop
+      vertex -28.9896 176.543 -11.2
+      vertex -30.3504 175.902 -56.2
+      vertex -28.9896 176.543 -56.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.40366 230.836 -43.0438
+      vertex 4.46066 230.836 -40.9277
+      vertex 7.40366 230.836 -41.1047
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex 7.40366 230.836 -43.0438
+      vertex -7.80733 230.836 -43.0438
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex -7.80733 230.836 -43.0438
+      vertex -7.80733 230.836 -40.9277
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -4.22733 230.836 -26.0238
+      vertex -7.17032 230.836 -23.9078
+      vertex 6.41367 230.836 -23.9078
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -4.22733 230.836 -26.0238
+      vertex 6.41367 230.836 -23.9078
+      vertex 6.41367 230.836 -26.0238
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.17032 230.836 -23.9078
+      vertex -4.22733 230.836 -26.0238
+      vertex -7.17032 230.836 -25.7938
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex -7.17032 230.836 -25.7938
+      vertex -4.22733 230.836 -26.0238
+    endloop
+  endfacet
+  facet normal -0 1 -0
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex -4.22733 230.836 -26.0238
+      vertex 7.40366 230.836 -41.1047
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex 3.76302 234.639 -40.9277
+      vertex 4.46066 234.529 -40.9277
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex -1.44666e-15 234.836 -40.9277
+      vertex 3.76302 234.639 -40.9277
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex -3.76302 234.639 -40.9277
+      vertex -1.44666e-15 234.836 -40.9277
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.80733 230.836 -40.9277
+      vertex -3.76302 234.639 -40.9277
+      vertex 4.46066 230.836 -40.9277
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.76302 234.639 -40.9277
+      vertex -7.80733 230.836 -40.9277
+      vertex -7.48482 234.05 -40.9277
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.48482 234.05 -40.9277
+      vertex -7.80733 230.836 -40.9277
+      vertex -7.80733 233.963 -40.9277
+    endloop
+  endfacet
+  facet normal 0.792891 6.80453e-08 0.609363
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex 3.76302 234.639 -40.02
+      vertex 1.90253 234.737 -37.5991
+    endloop
+  endfacet
+  facet normal 0.792891 -4.57373e-07 0.609364
+    outer loop
+      vertex 4.46066 230.836 -40.9277
+      vertex 1.90253 234.737 -37.5991
+      vertex -7.17032 230.836 -25.7938
+    endloop
+  endfacet
+  facet normal 0.792891 0 0.609363
+    outer loop
+      vertex 3.76302 234.639 -40.02
+      vertex 4.46066 230.836 -40.9277
+      vertex 4.46066 234.529 -40.9277
+    endloop
+  endfacet
+  facet normal 0.792891 9.12523e-08 0.609364
+    outer loop
+      vertex -7.17032 230.836 -25.7938
+      vertex -1.44666e-15 234.836 -35.1236
+      vertex -3.76302 234.639 -30.2272
+    endloop
+  endfacet
+  facet normal 0.792891 -0 0.609364
+    outer loop
+      vertex -7.17032 230.836 -25.7938
+      vertex -3.76302 234.639 -30.2272
+      vertex -7.17032 234.1 -25.7938
+    endloop
+  endfacet
+  facet normal 0.792891 -2.15406e-07 0.609364
+    outer loop
+      vertex -1.44666e-15 234.836 -35.1236
+      vertex -7.17032 230.836 -25.7938
+      vertex 1.90253 234.737 -37.5991
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -7.17032 230.836 -23.9078
+      vertex -7.17032 234.1 -25.7938
+      vertex -7.17032 234.1 -23.9078
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -7.17032 234.1 -25.7938
+      vertex -7.17032 230.836 -23.9078
+      vertex -7.17032 230.836 -25.7938
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.41367 230.836 -23.9078
+      vertex 3.76302 234.639 -23.9078
+      vertex 6.41367 234.219 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.41367 230.836 -23.9078
+      vertex -1.44666e-15 234.836 -23.9078
+      vertex 3.76302 234.639 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.17032 230.836 -23.9078
+      vertex -1.44666e-15 234.836 -23.9078
+      vertex 6.41367 230.836 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.44666e-15 234.836 -23.9078
+      vertex -7.17032 230.836 -23.9078
+      vertex -3.76302 234.639 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.76302 234.639 -23.9078
+      vertex -7.17032 230.836 -23.9078
+      vertex -7.17032 234.1 -23.9078
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 6.41367 230.836 -26.0238
+      vertex 6.41367 234.219 -23.9078
+      vertex 6.41367 234.219 -26.0238
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 6.41367 234.219 -23.9078
+      vertex 6.41367 230.836 -26.0238
+      vertex 6.41367 230.836 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.76302 234.639 -26.0238
+      vertex 6.41367 230.836 -26.0238
+      vertex 6.41367 234.219 -26.0238
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44666e-15 234.836 -26.0238
+      vertex 6.41367 230.836 -26.0238
+      vertex 3.76302 234.639 -26.0238
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.22733 230.836 -26.0238
+      vertex -1.44666e-15 234.836 -26.0238
+      vertex -3.76302 234.639 -26.0238
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.22733 230.836 -26.0238
+      vertex -3.76302 234.639 -26.0238
+      vertex -4.22733 234.566 -26.0238
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44666e-15 234.836 -26.0238
+      vertex -4.22733 230.836 -26.0238
+      vertex 6.41367 230.836 -26.0238
+    endloop
+  endfacet
+  facet normal -0.791856 7.3418e-08 -0.610708
+    outer loop
+      vertex -4.22733 230.836 -26.0238
+      vertex -3.76302 234.639 -26.6258
+      vertex -1.69455 234.748 -29.3078
+    endloop
+  endfacet
+  facet normal -0.791856 1.45156e-07 -0.610707
+    outer loop
+      vertex -4.22733 230.836 -26.0238
+      vertex -1.69455 234.748 -29.3078
+      vertex 7.40366 230.836 -41.1047
+    endloop
+  endfacet
+  facet normal -0.791856 0 -0.610708
+    outer loop
+      vertex -3.76302 234.639 -26.6258
+      vertex -4.22733 230.836 -26.0238
+      vertex -4.22733 234.566 -26.0238
+    endloop
+  endfacet
+  facet normal -0.791856 -3.48695e-07 -0.610707
+    outer loop
+      vertex 7.40366 230.836 -41.1047
+      vertex -1.44666e-15 234.836 -31.505
+      vertex 3.76302 234.639 -36.3842
+    endloop
+  endfacet
+  facet normal -0.791856 0 -0.610708
+    outer loop
+      vertex 7.40366 230.836 -41.1047
+      vertex 3.76302 234.639 -36.3842
+      vertex 7.40366 234.063 -41.1047
+    endloop
+  endfacet
+  facet normal -0.791856 1.28582e-07 -0.610707
+    outer loop
+      vertex -1.44666e-15 234.836 -31.505
+      vertex 7.40366 230.836 -41.1047
+      vertex -1.69455 234.748 -29.3078
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 7.40366 230.836 -43.0438
+      vertex 7.40366 234.063 -41.1047
+      vertex 7.40366 234.063 -43.0438
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 7.40366 234.063 -41.1047
+      vertex 7.40366 230.836 -43.0438
+      vertex 7.40366 230.836 -41.1047
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.76302 234.639 -43.0438
+      vertex 7.40366 230.836 -43.0438
+      vertex 7.40366 234.063 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44666e-15 234.836 -43.0438
+      vertex 7.40366 230.836 -43.0438
+      vertex 3.76302 234.639 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.80733 230.836 -43.0438
+      vertex -1.44666e-15 234.836 -43.0438
+      vertex -3.76302 234.639 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.80733 230.836 -43.0438
+      vertex -3.76302 234.639 -43.0438
+      vertex -7.48482 234.05 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.80733 230.836 -43.0438
+      vertex -7.48482 234.05 -43.0438
+      vertex -7.80733 233.963 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44666e-15 234.836 -43.0438
+      vertex -7.80733 230.836 -43.0438
+      vertex 7.40366 230.836 -43.0438
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -7.80733 230.836 -40.9277
+      vertex -7.80733 233.963 -43.0438
+      vertex -7.80733 233.963 -40.9277
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -7.80733 233.963 -43.0438
+      vertex -7.80733 230.836 -40.9277
+      vertex -7.80733 230.836 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 228.336 249.8
+      vertex 3.5 222.836 249.8
+      vertex 7.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 228.336 249.8
+      vertex 2 224.336 249.8
+      vertex 3.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 224.336 249.8
+      vertex 7.5 228.336 249.8
+      vertex 2 228.336 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.5 218.836 249.8
+      vertex 7.5 213.336 249.8
+      vertex 7.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 222.836 249.8
+      vertex 2 224.336 249.8
+      vertex 3.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 217.336 249.8
+      vertex 3.5 218.836 249.8
+      vertex 2 224.336 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2 217.336 249.8
+      vertex 7.5 213.336 249.8
+      vertex 3.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 213.336 249.8
+      vertex 2 217.336 249.8
+      vertex 2 213.336 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -7.5 228.336 249.8
+      vertex -2 224.336 249.8
+      vertex -2 228.336 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 224.336 249.8
+      vertex -3.5 222.836 249.8
+      vertex -2 217.336 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.5 218.836 249.8
+      vertex -2 217.336 249.8
+      vertex -3.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 224.336 249.8
+      vertex -7.5 228.336 249.8
+      vertex -3.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.5 222.836 249.8
+      vertex -7.5 228.336 249.8
+      vertex -7.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2 224.336 249.8
+      vertex 2 217.336 249.8
+      vertex 2 224.336 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2 217.336 249.8
+      vertex -2 224.336 249.8
+      vertex -2 217.336 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.5 213.336 249.8
+      vertex -2 217.336 249.8
+      vertex -3.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.5 213.336 249.8
+      vertex -3.5 218.836 249.8
+      vertex -7.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2 217.336 249.8
+      vertex -7.5 213.336 249.8
+      vertex -2 213.336 249.8
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 222.836 -11.2
+      vertex -3.5 222.836 249.8
+      vertex -7.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -3.5 222.836 249.8
+      vertex -7.5 222.836 -11.2
+      vertex -3.5 222.836 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -3.5 218.836 -11.2
+      vertex -3.5 222.836 249.8
+      vertex -3.5 222.836 -11.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -3.5 222.836 249.8
+      vertex -3.5 218.836 -11.2
+      vertex -3.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.5 218.836 -11.2
+      vertex -7.5 218.836 249.8
+      vertex -3.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 218.836 249.8
+      vertex -3.5 218.836 -11.2
+      vertex -7.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 213.336 -11.2
+      vertex -7.5 218.836 249.8
+      vertex -7.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -7.5 218.836 249.8
+      vertex -7.5 213.336 -11.2
+      vertex -7.5 213.336 249.8
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.5 213.336 -11.2
+      vertex -2 213.336 249.8
+      vertex -7.5 213.336 249.8
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2 213.336 249.8
+      vertex -7.5 213.336 -11.2
+      vertex -2 213.336 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -2 213.336 249.8
+      vertex -2 217.336 -11.2
+      vertex -2 217.336 249.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -2 217.336 -11.2
+      vertex -2 213.336 249.8
+      vertex -2 213.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2 217.336 -11.2
+      vertex 2 217.336 249.8
+      vertex -2 217.336 249.8
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 2 217.336 249.8
+      vertex -2 217.336 -11.2
+      vertex 2 217.336 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 2 213.336 -11.2
+      vertex 2 217.336 249.8
+      vertex 2 217.336 -11.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 2 217.336 249.8
+      vertex 2 213.336 -11.2
+      vertex 2 213.336 249.8
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 2 213.336 -11.2
+      vertex 7.5 213.336 249.8
+      vertex 2 213.336 249.8
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 213.336 249.8
+      vertex 2 213.336 -11.2
+      vertex 7.5 213.336 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 7.5 213.336 249.8
+      vertex 7.5 218.836 -11.2
+      vertex 7.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 218.836 -11.2
+      vertex 7.5 213.336 249.8
+      vertex 7.5 213.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 218.836 -11.2
+      vertex 3.5 218.836 249.8
+      vertex 7.5 218.836 249.8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.5 218.836 249.8
+      vertex 7.5 218.836 -11.2
+      vertex 3.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 3.5 218.836 249.8
+      vertex 3.5 222.836 -11.2
+      vertex 3.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3.5 222.836 -11.2
+      vertex 3.5 218.836 249.8
+      vertex 3.5 218.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 3.5 222.836 -11.2
+      vertex 7.5 222.836 249.8
+      vertex 3.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 7.5 222.836 249.8
+      vertex 3.5 222.836 -11.2
+      vertex 7.5 222.836 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 7.5 222.836 249.8
+      vertex 7.5 228.336 -11.2
+      vertex 7.5 228.336 249.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 7.5 228.336 -11.2
+      vertex 7.5 222.836 249.8
+      vertex 7.5 222.836 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 7.5 228.336 -11.2
+      vertex 2 228.336 249.8
+      vertex 7.5 228.336 249.8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2 228.336 249.8
+      vertex 7.5 228.336 -11.2
+      vertex 2 228.336 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 2 224.336 -11.2
+      vertex 2 228.336 249.8
+      vertex 2 228.336 -11.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 2 228.336 249.8
+      vertex 2 224.336 -11.2
+      vertex 2 224.336 249.8
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2 224.336 -11.2
+      vertex -2 224.336 249.8
+      vertex 2 224.336 249.8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2 224.336 249.8
+      vertex 2 224.336 -11.2
+      vertex -2 224.336 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -2 224.336 249.8
+      vertex -2 228.336 -11.2
+      vertex -2 228.336 249.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -2 228.336 -11.2
+      vertex -2 224.336 249.8
+      vertex -2 224.336 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2 228.336 -11.2
+      vertex -7.5 228.336 249.8
+      vertex -2 228.336 249.8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.5 228.336 249.8
+      vertex -2 228.336 -11.2
+      vertex -7.5 228.336 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -7.5 222.836 -11.2
+      vertex -7.5 228.336 249.8
+      vertex -7.5 228.336 -11.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -7.5 228.336 249.8
+      vertex -7.5 222.836 -11.2
+      vertex -7.5 222.836 249.8
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 1.67311e-08
+    outer loop
+      vertex 18.6824 217.478 -45.2
+      vertex 17.3833 216.728 -46.7
+      vertex 13.9192 214.728 -41.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 13.9192 214.728 -41.2
+      vertex 17.3833 216.728 -46.7
+      vertex 13.9192 214.728 -46.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 26.9096 222.228 -41.2
+      vertex 22.1465 219.478 -45.2
+      vertex 22.1465 219.478 -41.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 18.6824 217.478 -41.2
+      vertex 18.6824 217.478 -45.2
+      vertex 13.9192 214.728 -41.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 -1.36239e-07
+    outer loop
+      vertex 22.1465 219.478 -52.2
+      vertex 18.6824 217.478 -52.2
+      vertex 18.6824 217.478 -45.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 -1.36239e-07
+    outer loop
+      vertex 18.6824 217.478 -45.2
+      vertex 18.6824 217.478 -52.2
+      vertex 17.3833 216.728 -46.7
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex 18.6824 217.478 -52.2
+      vertex 17.3833 216.728 -50.7
+      vertex 17.3833 216.728 -46.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 -2.84429e-07
+    outer loop
+      vertex 13.9192 214.728 -56.2
+      vertex 17.3833 216.728 -50.7
+      vertex 18.6824 217.478 -52.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 13.9192 214.728 -56.2
+      vertex 18.6824 217.478 -52.2
+      vertex 18.6824 217.478 -56.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 17.3833 216.728 -50.7
+      vertex 13.9192 214.728 -56.2
+      vertex 13.9192 214.728 -50.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 22.1465 219.478 -45.2
+      vertex 22.1465 219.478 -52.2
+      vertex 18.6824 217.478 -45.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 26.9096 222.228 -56.2
+      vertex 23.4455 220.228 -50.7
+      vertex 26.9096 222.228 -50.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 3.34622e-07
+    outer loop
+      vertex 23.4455 220.228 -50.7
+      vertex 26.9096 222.228 -56.2
+      vertex 22.1465 219.478 -52.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 22.1465 219.478 -52.2
+      vertex 26.9096 222.228 -56.2
+      vertex 22.1465 219.478 -56.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 23.4455 220.228 -46.7
+      vertex 26.9096 222.228 -41.2
+      vertex 26.9096 222.228 -46.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 -3.34622e-07
+    outer loop
+      vertex 26.9096 222.228 -41.2
+      vertex 23.4455 220.228 -46.7
+      vertex 22.1465 219.478 -45.2
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex 23.4455 220.228 -50.7
+      vertex 22.1465 219.478 -45.2
+      vertex 23.4455 220.228 -46.7
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex 22.1465 219.478 -45.2
+      vertex 23.4455 220.228 -50.7
+      vertex 22.1465 219.478 -52.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 192.919 -95.3094 -41.2
+      vertex 197.682 -92.5594 -45.2
+      vertex 197.682 -92.5594 -41.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 -8.03094e-07
+    outer loop
+      vertex 192.919 -95.3094 -41.2
+      vertex 196.383 -93.3094 -46.7
+      vertex 197.682 -92.5594 -45.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 196.383 -93.3094 -46.7
+      vertex 192.919 -95.3094 -41.2
+      vertex 192.919 -95.3094 -46.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 201.146 -90.5594 -45.2
+      vertex 205.91 -87.8094 -41.2
+      vertex 201.146 -90.5594 -41.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 -1.90735e-06
+    outer loop
+      vertex 197.682 -92.5594 -45.2
+      vertex 196.383 -93.3094 -46.7
+      vertex 201.146 -90.5594 -45.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 1.08991e-06
+    outer loop
+      vertex 202.446 -89.8094 -46.7
+      vertex 201.146 -90.5594 -45.2
+      vertex 196.383 -93.3094 -46.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 8.03094e-07
+    outer loop
+      vertex 202.446 -89.8094 -46.7
+      vertex 205.91 -87.8094 -41.2
+      vertex 201.146 -90.5594 -45.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 205.91 -87.8094 -41.2
+      vertex 202.446 -89.8094 -46.7
+      vertex 205.91 -87.8094 -46.7
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 192.919 -95.3094 -56.2
+      vertex 196.383 -93.3094 -50.7
+      vertex 192.919 -95.3094 -50.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 1.08991e-06
+    outer loop
+      vertex 196.383 -93.3094 -50.7
+      vertex 197.682 -92.5594 -52.2
+      vertex 202.446 -89.8094 -50.7
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 -1.90735e-06
+    outer loop
+      vertex 201.146 -90.5594 -52.2
+      vertex 202.446 -89.8094 -50.7
+      vertex 197.682 -92.5594 -52.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 8.03094e-07
+    outer loop
+      vertex 196.383 -93.3094 -50.7
+      vertex 192.919 -95.3094 -56.2
+      vertex 197.682 -92.5594 -52.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 197.682 -92.5594 -52.2
+      vertex 192.919 -95.3094 -56.2
+      vertex 197.682 -92.5594 -56.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 196.383 -93.3094 -50.7
+      vertex 202.446 -89.8094 -46.7
+      vertex 196.383 -93.3094 -46.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 202.446 -89.8094 -46.7
+      vertex 196.383 -93.3094 -50.7
+      vertex 202.446 -89.8094 -50.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 -8.03094e-07
+    outer loop
+      vertex 205.91 -87.8094 -56.2
+      vertex 202.446 -89.8094 -50.7
+      vertex 201.146 -90.5594 -52.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 205.91 -87.8094 -56.2
+      vertex 201.146 -90.5594 -52.2
+      vertex 201.146 -90.5594 -56.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 202.446 -89.8094 -50.7
+      vertex 205.91 -87.8094 -56.2
+      vertex 205.91 -87.8094 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -50.7
+      vertex 202.446 -89.8094 -50.7
+      vertex 205.91 -87.8094 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 202.446 -89.8094 -50.7
+      vertex 26.9096 222.228 -50.7
+      vertex 23.4455 220.228 -50.7
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 202.446 -89.8094 -46.7
+      vertex 23.4455 220.228 -50.7
+      vertex 23.4455 220.228 -46.7
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 23.4455 220.228 -50.7
+      vertex 202.446 -89.8094 -46.7
+      vertex 202.446 -89.8094 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 202.446 -89.8094 -46.7
+      vertex 26.9096 222.228 -46.7
+      vertex 205.91 -87.8094 -46.7
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 26.9096 222.228 -46.7
+      vertex 202.446 -89.8094 -46.7
+      vertex 23.4455 220.228 -46.7
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 205.91 -87.8094 -41.2
+      vertex 26.9096 222.228 -46.7
+      vertex 26.9096 222.228 -41.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 26.9096 222.228 -46.7
+      vertex 205.91 -87.8094 -41.2
+      vertex 205.91 -87.8094 -46.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -41.2
+      vertex 201.146 -90.5594 -41.2
+      vertex 205.91 -87.8094 -41.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 201.146 -90.5594 -41.2
+      vertex 26.9096 222.228 -41.2
+      vertex 22.1465 219.478 -41.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 22.1465 219.478 -45.2
+      vertex 201.146 -90.5594 -41.2
+      vertex 22.1465 219.478 -41.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 201.146 -90.5594 -45.2
+      vertex 201.146 -90.5594 -41.2
+      vertex 22.1465 219.478 -45.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.1465 219.478 -45.2
+      vertex 197.682 -92.5594 -45.2
+      vertex 201.146 -90.5594 -45.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 197.682 -92.5594 -45.2
+      vertex 22.1465 219.478 -45.2
+      vertex 18.6824 217.478 -45.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 197.682 -92.5594 -41.2
+      vertex 18.6824 217.478 -45.2
+      vertex 18.6824 217.478 -41.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 18.6824 217.478 -45.2
+      vertex 197.682 -92.5594 -41.2
+      vertex 197.682 -92.5594 -45.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6824 217.478 -41.2
+      vertex 192.919 -95.3094 -41.2
+      vertex 197.682 -92.5594 -41.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.919 -95.3094 -41.2
+      vertex 18.6824 217.478 -41.2
+      vertex 13.9192 214.728 -41.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 192.919 -95.3094 -46.7
+      vertex 13.9192 214.728 -41.2
+      vertex 13.9192 214.728 -46.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 13.9192 214.728 -41.2
+      vertex 192.919 -95.3094 -46.7
+      vertex 192.919 -95.3094 -41.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.919 -95.3094 -46.7
+      vertex 17.3833 216.728 -46.7
+      vertex 196.383 -93.3094 -46.7
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 17.3833 216.728 -46.7
+      vertex 192.919 -95.3094 -46.7
+      vertex 13.9192 214.728 -46.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 196.383 -93.3094 -50.7
+      vertex 17.3833 216.728 -46.7
+      vertex 17.3833 216.728 -50.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 17.3833 216.728 -46.7
+      vertex 196.383 -93.3094 -50.7
+      vertex 196.383 -93.3094 -46.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.3833 216.728 -50.7
+      vertex 192.919 -95.3094 -50.7
+      vertex 196.383 -93.3094 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.919 -95.3094 -50.7
+      vertex 17.3833 216.728 -50.7
+      vertex 13.9192 214.728 -50.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 192.919 -95.3094 -56.2
+      vertex 13.9192 214.728 -50.7
+      vertex 13.9192 214.728 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 13.9192 214.728 -50.7
+      vertex 192.919 -95.3094 -56.2
+      vertex 192.919 -95.3094 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.919 -95.3094 -56.2
+      vertex 18.6824 217.478 -56.2
+      vertex 197.682 -92.5594 -56.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 18.6824 217.478 -56.2
+      vertex 192.919 -95.3094 -56.2
+      vertex 13.9192 214.728 -56.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 197.682 -92.5594 -52.2
+      vertex 18.6824 217.478 -56.2
+      vertex 18.6824 217.478 -52.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 18.6824 217.478 -56.2
+      vertex 197.682 -92.5594 -52.2
+      vertex 197.682 -92.5594 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 197.682 -92.5594 -52.2
+      vertex 22.1465 219.478 -52.2
+      vertex 201.146 -90.5594 -52.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 22.1465 219.478 -52.2
+      vertex 197.682 -92.5594 -52.2
+      vertex 18.6824 217.478 -52.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 201.146 -90.5594 -56.2
+      vertex 22.1465 219.478 -52.2
+      vertex 22.1465 219.478 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 22.1465 219.478 -52.2
+      vertex 201.146 -90.5594 -56.2
+      vertex 201.146 -90.5594 -52.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 201.146 -90.5594 -56.2
+      vertex 26.9096 222.228 -56.2
+      vertex 205.91 -87.8094 -56.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 26.9096 222.228 -56.2
+      vertex 201.146 -90.5594 -56.2
+      vertex 22.1465 219.478 -56.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 205.91 -87.8094 -50.7
+      vertex 26.9096 222.228 -56.2
+      vertex 26.9096 222.228 -50.7
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 26.9096 222.228 -56.2
+      vertex 205.91 -87.8094 -50.7
+      vertex 205.91 -87.8094 -56.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 1.67311e-08
+    outer loop
+      vertex 18.6824 217.478 -15.2
+      vertex 17.3833 216.728 -16.7
+      vertex 13.9192 214.728 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 13.9192 214.728 -11.2
+      vertex 17.3833 216.728 -16.7
+      vertex 13.9192 214.728 -16.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 22.1465 219.478 -15.2
+      vertex 22.1465 219.478 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 18.6824 217.478 -11.2
+      vertex 18.6824 217.478 -15.2
+      vertex 13.9192 214.728 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 -1.36239e-07
+    outer loop
+      vertex 22.1465 219.478 -22.2
+      vertex 18.6824 217.478 -22.2
+      vertex 18.6824 217.478 -15.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 -1.36239e-07
+    outer loop
+      vertex 18.6824 217.478 -15.2
+      vertex 18.6824 217.478 -22.2
+      vertex 17.3833 216.728 -16.7
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex 18.6824 217.478 -22.2
+      vertex 17.3833 216.728 -20.7
+      vertex 17.3833 216.728 -16.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 -2.84429e-07
+    outer loop
+      vertex 13.9192 214.728 -26.2
+      vertex 17.3833 216.728 -20.7
+      vertex 18.6824 217.478 -22.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 13.9192 214.728 -26.2
+      vertex 18.6824 217.478 -22.2
+      vertex 18.6824 217.478 -26.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 17.3833 216.728 -20.7
+      vertex 13.9192 214.728 -26.2
+      vertex 13.9192 214.728 -20.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 22.1465 219.478 -15.2
+      vertex 22.1465 219.478 -22.2
+      vertex 18.6824 217.478 -15.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 26.9096 222.228 -26.2
+      vertex 23.4455 220.228 -20.7
+      vertex 26.9096 222.228 -20.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 3.34622e-07
+    outer loop
+      vertex 23.4455 220.228 -20.7
+      vertex 26.9096 222.228 -26.2
+      vertex 22.1465 219.478 -22.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 22.1465 219.478 -22.2
+      vertex 26.9096 222.228 -26.2
+      vertex 22.1465 219.478 -26.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 23.4455 220.228 -16.7
+      vertex 26.9096 222.228 -11.2
+      vertex 26.9096 222.228 -16.7
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 -3.34622e-07
+    outer loop
+      vertex 26.9096 222.228 -11.2
+      vertex 23.4455 220.228 -16.7
+      vertex 22.1465 219.478 -15.2
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex 23.4455 220.228 -20.7
+      vertex 22.1465 219.478 -15.2
+      vertex 23.4455 220.228 -16.7
+    endloop
+  endfacet
+  facet normal -0.499999 0.866026 0
+    outer loop
+      vertex 22.1465 219.478 -15.2
+      vertex 23.4455 220.228 -20.7
+      vertex 22.1465 219.478 -22.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 192.919 -95.3094 -11.2
+      vertex 197.682 -92.5594 -15.2
+      vertex 197.682 -92.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 -8.03093e-07
+    outer loop
+      vertex 192.919 -95.3094 -11.2
+      vertex 196.383 -93.3094 -16.7
+      vertex 197.682 -92.5594 -15.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 196.383 -93.3094 -16.7
+      vertex 192.919 -95.3094 -11.2
+      vertex 192.919 -95.3094 -16.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 201.146 -90.5594 -15.2
+      vertex 205.91 -87.8094 -11.2
+      vertex 201.146 -90.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 -1.90735e-06
+    outer loop
+      vertex 197.682 -92.5594 -15.2
+      vertex 196.383 -93.3094 -16.7
+      vertex 201.146 -90.5594 -15.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 1.08991e-06
+    outer loop
+      vertex 202.446 -89.8094 -16.7
+      vertex 201.146 -90.5594 -15.2
+      vertex 196.383 -93.3094 -16.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 8.03093e-07
+    outer loop
+      vertex 202.446 -89.8094 -16.7
+      vertex 205.91 -87.8094 -11.2
+      vertex 201.146 -90.5594 -15.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 205.91 -87.8094 -11.2
+      vertex 202.446 -89.8094 -16.7
+      vertex 205.91 -87.8094 -16.7
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 192.919 -95.3094 -26.2
+      vertex 196.383 -93.3094 -20.7
+      vertex 192.919 -95.3094 -20.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 1.08991e-06
+    outer loop
+      vertex 196.383 -93.3094 -20.7
+      vertex 197.682 -92.5594 -22.2
+      vertex 202.446 -89.8094 -20.7
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 -1.90735e-06
+    outer loop
+      vertex 201.146 -90.5594 -22.2
+      vertex 202.446 -89.8094 -20.7
+      vertex 197.682 -92.5594 -22.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 8.03094e-07
+    outer loop
+      vertex 196.383 -93.3094 -20.7
+      vertex 192.919 -95.3094 -26.2
+      vertex 197.682 -92.5594 -22.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 197.682 -92.5594 -22.2
+      vertex 192.919 -95.3094 -26.2
+      vertex 197.682 -92.5594 -26.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 196.383 -93.3094 -20.7
+      vertex 202.446 -89.8094 -16.7
+      vertex 196.383 -93.3094 -16.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 202.446 -89.8094 -16.7
+      vertex 196.383 -93.3094 -20.7
+      vertex 202.446 -89.8094 -20.7
+    endloop
+  endfacet
+  facet normal 0.5 -0.866026 -8.03094e-07
+    outer loop
+      vertex 205.91 -87.8094 -26.2
+      vertex 202.446 -89.8094 -20.7
+      vertex 201.146 -90.5594 -22.2
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex 205.91 -87.8094 -26.2
+      vertex 201.146 -90.5594 -22.2
+      vertex 201.146 -90.5594 -26.2
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex 202.446 -89.8094 -20.7
+      vertex 205.91 -87.8094 -26.2
+      vertex 205.91 -87.8094 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9096 222.228 -20.7
+      vertex 202.446 -89.8094 -20.7
+      vertex 205.91 -87.8094 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 202.446 -89.8094 -20.7
+      vertex 26.9096 222.228 -20.7
+      vertex 23.4455 220.228 -20.7
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 202.446 -89.8094 -16.7
+      vertex 23.4455 220.228 -20.7
+      vertex 23.4455 220.228 -16.7
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 23.4455 220.228 -20.7
+      vertex 202.446 -89.8094 -16.7
+      vertex 202.446 -89.8094 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 202.446 -89.8094 -16.7
+      vertex 26.9096 222.228 -16.7
+      vertex 205.91 -87.8094 -16.7
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 26.9096 222.228 -16.7
+      vertex 202.446 -89.8094 -16.7
+      vertex 23.4455 220.228 -16.7
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 87.9096 116.573 -11.2
+      vertex 26.9096 222.228 -16.7
+      vertex 26.9096 222.228 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 -9.07354e-07
+    outer loop
+      vertex 144.91 17.8457 -11.2
+      vertex 26.9096 222.228 -16.7
+      vertex 87.9096 116.573 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 -0
+    outer loop
+      vertex 205.91 -87.8094 -16.7
+      vertex 144.91 17.8457 -11.2
+      vertex 205.91 -87.8094 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 1.44001e-07
+    outer loop
+      vertex 144.91 17.8457 -11.2
+      vertex 205.91 -87.8094 -16.7
+      vertex 26.9096 222.228 -16.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 22.1465 219.478 -15.2
+      vertex 81.6465 116.421 -11.2
+      vertex 22.1465 219.478 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 1.4921e-06
+    outer loop
+      vertex 22.1465 219.478 -15.2
+      vertex 141.646 12.4976 -11.2
+      vertex 81.6465 116.421 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 -6.81196e-08
+    outer loop
+      vertex 141.646 12.4976 -11.2
+      vertex 22.1465 219.478 -15.2
+      vertex 201.146 -90.5594 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 201.146 -90.5594 -15.2
+      vertex 201.146 -90.5594 -11.2
+      vertex 22.1465 219.478 -15.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.1465 219.478 -15.2
+      vertex 197.682 -92.5594 -15.2
+      vertex 201.146 -90.5594 -15.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 197.682 -92.5594 -15.2
+      vertex 22.1465 219.478 -15.2
+      vertex 18.6824 217.478 -15.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 78.1824 114.421 -11.2
+      vertex 18.6824 217.478 -15.2
+      vertex 18.6824 217.478 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 5.58897e-07
+    outer loop
+      vertex 138.182 10.4976 -11.2
+      vertex 18.6824 217.478 -15.2
+      vertex 78.1824 114.421 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 -0
+    outer loop
+      vertex 197.682 -92.5594 -15.2
+      vertex 138.182 10.4976 -11.2
+      vertex 197.682 -92.5594 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 -3.89156e-07
+    outer loop
+      vertex 138.182 10.4976 -11.2
+      vertex 197.682 -92.5594 -15.2
+      vertex 18.6824 217.478 -15.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 13.9192 214.728 -16.7
+      vertex 73.4192 111.671 -11.2
+      vertex 13.9192 214.728 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 -2.56306e-07
+    outer loop
+      vertex 13.9192 214.728 -16.7
+      vertex 133.419 7.74759 -11.2
+      vertex 73.4192 111.671 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 3.32938e-07
+    outer loop
+      vertex 192.919 -95.3094 -16.7
+      vertex 133.419 7.74759 -11.2
+      vertex 13.9192 214.728 -16.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 133.419 7.74759 -11.2
+      vertex 192.919 -95.3094 -16.7
+      vertex 192.919 -95.3094 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.919 -95.3094 -16.7
+      vertex 17.3833 216.728 -16.7
+      vertex 196.383 -93.3094 -16.7
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 17.3833 216.728 -16.7
+      vertex 192.919 -95.3094 -16.7
+      vertex 13.9192 214.728 -16.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 196.383 -93.3094 -20.7
+      vertex 17.3833 216.728 -16.7
+      vertex 17.3833 216.728 -20.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 17.3833 216.728 -16.7
+      vertex 196.383 -93.3094 -20.7
+      vertex 196.383 -93.3094 -16.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.3833 216.728 -20.7
+      vertex 192.919 -95.3094 -20.7
+      vertex 196.383 -93.3094 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.919 -95.3094 -20.7
+      vertex 17.3833 216.728 -20.7
+      vertex 13.9192 214.728 -20.7
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 192.919 -95.3094 -26.2
+      vertex 13.9192 214.728 -20.7
+      vertex 13.9192 214.728 -26.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 13.9192 214.728 -20.7
+      vertex 192.919 -95.3094 -26.2
+      vertex 192.919 -95.3094 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.919 -95.3094 -26.2
+      vertex 18.6824 217.478 -26.2
+      vertex 197.682 -92.5594 -26.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 18.6824 217.478 -26.2
+      vertex 192.919 -95.3094 -26.2
+      vertex 13.9192 214.728 -26.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 197.682 -92.5594 -22.2
+      vertex 18.6824 217.478 -26.2
+      vertex 18.6824 217.478 -22.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 18.6824 217.478 -26.2
+      vertex 197.682 -92.5594 -22.2
+      vertex 197.682 -92.5594 -26.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 197.682 -92.5594 -22.2
+      vertex 22.1465 219.478 -22.2
+      vertex 201.146 -90.5594 -22.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 22.1465 219.478 -22.2
+      vertex 197.682 -92.5594 -22.2
+      vertex 18.6824 217.478 -22.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 201.146 -90.5594 -26.2
+      vertex 22.1465 219.478 -22.2
+      vertex 22.1465 219.478 -26.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 22.1465 219.478 -22.2
+      vertex 201.146 -90.5594 -26.2
+      vertex 201.146 -90.5594 -22.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 201.146 -90.5594 -26.2
+      vertex 26.9096 222.228 -26.2
+      vertex 205.91 -87.8094 -26.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 26.9096 222.228 -26.2
+      vertex 201.146 -90.5594 -26.2
+      vertex 22.1465 219.478 -26.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 205.91 -87.8094 -20.7
+      vertex 26.9096 222.228 -26.2
+      vertex 26.9096 222.228 -20.7
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 26.9096 222.228 -26.2
+      vertex 205.91 -87.8094 -20.7
+      vertex 205.91 -87.8094 -26.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 57 -134.395 -11.2
+      vertex 57.376 -134.395 -5.2
+      vertex 57 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 57.376 -134.395 -5.2
+      vertex 57 -134.395 -11.2
+      vertex 57.376 -134.395 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 -119.418 -11.2
+      vertex 59.9822 -107.418 -11.2
+      vertex 60 -107.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57 -104.418 -11.2
+      vertex 59.9822 -107.418 -11.2
+      vertex 60 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 59.533 -105.811 -11.2
+      vertex 59.9822 -107.418 -11.2
+      vertex 57 -104.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.9822 -107.418 -11.2
+      vertex 59.533 -105.811 -11.2
+      vertex 59.8532 -106.491 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.533 -105.811 -11.2
+      vertex 57 -104.418 -11.2
+      vertex 59.0536 -105.231 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.0536 -105.231 -11.2
+      vertex 57 -104.418 -11.2
+      vertex 58.4453 -104.789 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.4453 -104.789 -11.2
+      vertex 57 -104.418 -11.2
+      vertex 57.7461 -104.512 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60 -119.418 -11.2
+      vertex -57 -104.418 -11.2
+      vertex 57 -104.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -60 -119.418 -11.2
+      vertex -57 -104.418 -11.2
+      vertex 60 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -59.9822 -107.418 -11.2
+      vertex -57 -104.418 -11.2
+      vertex -60 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -57 -104.418 -11.2
+      vertex -59.9822 -107.418 -11.2
+      vertex -57.7461 -104.512 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -57.7461 -104.512 -11.2
+      vertex -59.9822 -107.418 -11.2
+      vertex -58.4453 -104.789 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -58.4453 -104.789 -11.2
+      vertex -59.9822 -107.418 -11.2
+      vertex -59.0536 -105.231 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.0536 -105.231 -11.2
+      vertex -59.9822 -107.418 -11.2
+      vertex -59.533 -105.811 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.533 -105.811 -11.2
+      vertex -59.9822 -107.418 -11.2
+      vertex -59.8532 -106.491 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -59.9822 -107.418 -11.2
+      vertex -60 -119.418 -11.2
+      vertex -60 -107.418 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.9941 -107.23 -11.2
+      vertex 59.9822 -107.418 -11.2
+      vertex 59.8532 -106.491 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -59.8532 -106.491 -11.2
+      vertex -59.9822 -107.418 -11.2
+      vertex -59.9941 -107.23 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60 -128.918 -11.2
+      vertex -179 -128.918 -11.2
+      vertex -60 -131.418 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.376 -134.395 -11.2
+      vertex -57 -134.418 -11.2
+      vertex -57 -134.395 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -60 -131.418 -11.2
+      vertex -59.9469 -131.98 -11.2
+      vertex -59.9822 -131.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -179 -134.418 -11.2
+      vertex -60 -131.418 -11.2
+      vertex -179 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60 -131.418 -11.2
+      vertex -179 -134.418 -11.2
+      vertex -59.9469 -131.98 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.9469 -131.98 -11.2
+      vertex -179 -134.418 -11.2
+      vertex -59.7145 -132.696 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.7145 -132.696 -11.2
+      vertex -179 -134.418 -11.2
+      vertex -59.3115 -133.331 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3115 -133.331 -11.2
+      vertex -179 -134.418 -11.2
+      vertex -58.7634 -133.845 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.7634 -133.845 -11.2
+      vertex -179 -134.418 -11.2
+      vertex -58.1044 -134.208 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.1044 -134.208 -11.2
+      vertex -179 -134.418 -11.2
+      vertex -57.376 -134.395 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57.376 -134.395 -11.2
+      vertex -179 -134.418 -11.2
+      vertex -57 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -131.418 -11.2
+      vertex 179 -128.918 -11.2
+      vertex 60 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -128.918 -11.2
+      vertex 60 -131.418 -11.2
+      vertex 179 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.9469 -131.98 -11.2
+      vertex 60 -131.418 -11.2
+      vertex 59.9822 -131.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -131.418 -11.2
+      vertex 59.9469 -131.98 -11.2
+      vertex 179 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.7145 -132.696 -11.2
+      vertex 179 -134.418 -11.2
+      vertex 59.9469 -131.98 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.3115 -133.331 -11.2
+      vertex 179 -134.418 -11.2
+      vertex 59.7145 -132.696 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.7634 -133.845 -11.2
+      vertex 179 -134.418 -11.2
+      vertex 59.3115 -133.331 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.1044 -134.208 -11.2
+      vertex 179 -134.418 -11.2
+      vertex 58.7634 -133.845 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 57.376 -134.395 -11.2
+      vertex 179 -134.418 -11.2
+      vertex 58.1044 -134.208 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57 -134.418 -11.2
+      vertex 57.376 -134.395 -11.2
+      vertex 57 -134.395 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.376 -134.395 -11.2
+      vertex 57 -134.418 -11.2
+      vertex 179 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60 -119.418 -11.2
+      vertex 179 -124.918 -11.2
+      vertex 179 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -124.918 -11.2
+      vertex 60 -119.418 -11.2
+      vertex 60 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -119.418 -11.2
+      vertex -60 -124.918 -11.2
+      vertex -60 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60 -124.918 -11.2
+      vertex -179 -119.418 -11.2
+      vertex -179 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -60 -128.918 -11.2
+      vertex 60 -124.918 -11.2
+      vertex 60 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60 -124.918 -11.2
+      vertex -60 -128.918 -11.2
+      vertex -60 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal 0.844327 -0.535828 0
+    outer loop
+      vertex 59.3115 -133.331 -5.2
+      vertex 59.7145 -132.696 -11.2
+      vertex 59.7145 -132.696 -5.2
+    endloop
+  endfacet
+  facet normal 0.844327 -0.535828 0
+    outer loop
+      vertex 59.7145 -132.696 -11.2
+      vertex 59.3115 -133.331 -5.2
+      vertex 59.3115 -133.331 -11.2
+    endloop
+  endfacet
+  facet normal 0.684552 -0.728964 0
+    outer loop
+      vertex 58.7634 -133.845 -11.2
+      vertex 59.3115 -133.331 -5.2
+      vertex 58.7634 -133.845 -5.2
+    endloop
+  endfacet
+  facet normal 0.684552 -0.728964 0
+    outer loop
+      vertex 59.3115 -133.331 -5.2
+      vertex 58.7634 -133.845 -11.2
+      vertex 59.3115 -133.331 -11.2
+    endloop
+  endfacet
+  facet normal 0.998027 -0.0627898 0
+    outer loop
+      vertex 59.9469 -131.98 -5.2
+      vertex 59.9822 -131.418 -11.2
+      vertex 59.9822 -131.418 -5.2
+    endloop
+  endfacet
+  facet normal 0.998027 -0.0627898 0
+    outer loop
+      vertex 59.9822 -131.418 -11.2
+      vertex 59.9469 -131.98 -5.2
+      vertex 59.9469 -131.98 -11.2
+    endloop
+  endfacet
+  facet normal 0.48175 -0.876309 0
+    outer loop
+      vertex 58.1044 -134.208 -11.2
+      vertex 58.7634 -133.845 -5.2
+      vertex 58.1044 -134.208 -5.2
+    endloop
+  endfacet
+  facet normal 0.48175 -0.876309 0
+    outer loop
+      vertex 58.7634 -133.845 -5.2
+      vertex 58.1044 -134.208 -11.2
+      vertex 58.7634 -133.845 -11.2
+    endloop
+  endfacet
+  facet normal 0.248686 -0.968584 0
+    outer loop
+      vertex 57.376 -134.395 -11.2
+      vertex 58.1044 -134.208 -5.2
+      vertex 57.376 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal 0.248686 -0.968584 0
+    outer loop
+      vertex 58.1044 -134.208 -5.2
+      vertex 57.376 -134.395 -11.2
+      vertex 58.1044 -134.208 -11.2
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309016 0
+    outer loop
+      vertex 59.7145 -132.696 -5.2
+      vertex 59.9469 -131.98 -11.2
+      vertex 59.9469 -131.98 -5.2
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309016 0
+    outer loop
+      vertex 59.9469 -131.98 -11.2
+      vertex 59.7145 -132.696 -5.2
+      vertex 59.7145 -132.696 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -57.376 -134.395 -11.2
+      vertex -57 -134.395 -5.2
+      vertex -57.376 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -57 -134.395 -5.2
+      vertex -57.376 -134.395 -11.2
+      vertex -57 -134.395 -11.2
+    endloop
+  endfacet
+  facet normal -0.998027 -0.0627898 0
+    outer loop
+      vertex -59.9469 -131.98 -11.2
+      vertex -59.9822 -131.418 -5.2
+      vertex -59.9822 -131.418 -11.2
+    endloop
+  endfacet
+  facet normal -0.998027 -0.0627898 0
+    outer loop
+      vertex -59.9822 -131.418 -5.2
+      vertex -59.9469 -131.98 -11.2
+      vertex -59.9469 -131.98 -5.2
+    endloop
+  endfacet
+  facet normal -0.684552 -0.728964 0
+    outer loop
+      vertex -59.3115 -133.331 -11.2
+      vertex -58.7634 -133.845 -5.2
+      vertex -59.3115 -133.331 -5.2
+    endloop
+  endfacet
+  facet normal -0.684552 -0.728964 -0
+    outer loop
+      vertex -58.7634 -133.845 -5.2
+      vertex -59.3115 -133.331 -11.2
+      vertex -58.7634 -133.845 -11.2
+    endloop
+  endfacet
+  facet normal -0.844327 -0.535828 0
+    outer loop
+      vertex -59.3115 -133.331 -11.2
+      vertex -59.7145 -132.696 -5.2
+      vertex -59.7145 -132.696 -11.2
+    endloop
+  endfacet
+  facet normal -0.844327 -0.535828 0
+    outer loop
+      vertex -59.7145 -132.696 -5.2
+      vertex -59.3115 -133.331 -11.2
+      vertex -59.3115 -133.331 -5.2
+    endloop
+  endfacet
+  facet normal -0.48175 -0.876309 0
+    outer loop
+      vertex -58.7634 -133.845 -11.2
+      vertex -58.1044 -134.208 -5.2
+      vertex -58.7634 -133.845 -5.2
+    endloop
+  endfacet
+  facet normal -0.48175 -0.876309 -0
+    outer loop
+      vertex -58.1044 -134.208 -5.2
+      vertex -58.7634 -133.845 -11.2
+      vertex -58.1044 -134.208 -11.2
+    endloop
+  endfacet
+  facet normal -0.248686 -0.968584 0
+    outer loop
+      vertex -58.1044 -134.208 -11.2
+      vertex -57.376 -134.395 -5.2
+      vertex -58.1044 -134.208 -5.2
+    endloop
+  endfacet
+  facet normal -0.248686 -0.968584 -0
+    outer loop
+      vertex -57.376 -134.395 -5.2
+      vertex -58.1044 -134.208 -11.2
+      vertex -57.376 -134.395 -11.2
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309016 0
+    outer loop
+      vertex -59.7145 -132.696 -11.2
+      vertex -59.9469 -131.98 -5.2
+      vertex -59.9469 -131.98 -11.2
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309016 0
+    outer loop
+      vertex -59.9469 -131.98 -5.2
+      vertex -59.7145 -132.696 -11.2
+      vertex -59.7145 -132.696 -5.2
+    endloop
+  endfacet
+  facet normal 0.982287 0.187382 0
+    outer loop
+      vertex 59.9941 -107.23 -5.2
+      vertex 59.8532 -106.491 -11.2
+      vertex 59.8532 -106.491 -5.2
+    endloop
+  endfacet
+  facet normal 0.982287 0.187382 0
+    outer loop
+      vertex 59.8532 -106.491 -11.2
+      vertex 59.9941 -107.23 -5.2
+      vertex 59.9941 -107.23 -11.2
+    endloop
+  endfacet
+  facet normal 0.587781 0.80902 -0
+    outer loop
+      vertex 59.0536 -105.231 -11.2
+      vertex 58.4453 -104.789 -5.2
+      vertex 59.0536 -105.231 -5.2
+    endloop
+  endfacet
+  facet normal 0.587781 0.80902 0
+    outer loop
+      vertex 58.4453 -104.789 -5.2
+      vertex 59.0536 -105.231 -11.2
+      vertex 58.4453 -104.789 -11.2
+    endloop
+  endfacet
+  facet normal 0.368128 0.929775 -0
+    outer loop
+      vertex 58.4453 -104.789 -11.2
+      vertex 57.7461 -104.512 -5.2
+      vertex 58.4453 -104.789 -5.2
+    endloop
+  endfacet
+  facet normal 0.368128 0.929775 0
+    outer loop
+      vertex 57.7461 -104.512 -5.2
+      vertex 58.4453 -104.789 -11.2
+      vertex 57.7461 -104.512 -11.2
+    endloop
+  endfacet
+  facet normal 0.904826 0.425781 0
+    outer loop
+      vertex 59.8532 -106.491 -5.2
+      vertex 59.533 -105.811 -11.2
+      vertex 59.533 -105.811 -5.2
+    endloop
+  endfacet
+  facet normal 0.904826 0.425781 0
+    outer loop
+      vertex 59.533 -105.811 -11.2
+      vertex 59.8532 -106.491 -5.2
+      vertex 59.8532 -106.491 -11.2
+    endloop
+  endfacet
+  facet normal 0.125337 0.992114 -0
+    outer loop
+      vertex 57.7461 -104.512 -11.2
+      vertex 57 -104.418 -5.2
+      vertex 57.7461 -104.512 -5.2
+    endloop
+  endfacet
+  facet normal 0.125337 0.992114 0
+    outer loop
+      vertex 57 -104.418 -5.2
+      vertex 57.7461 -104.512 -11.2
+      vertex 57 -104.418 -11.2
+    endloop
+  endfacet
+  facet normal 0.998026 -0.062796 0
+    outer loop
+      vertex 59.9822 -107.418 -5.2
+      vertex 59.9941 -107.23 -11.2
+      vertex 59.9941 -107.23 -5.2
+    endloop
+  endfacet
+  facet normal 0.998026 -0.062796 0
+    outer loop
+      vertex 59.9941 -107.23 -11.2
+      vertex 59.9822 -107.418 -5.2
+      vertex 59.9822 -107.418 -11.2
+    endloop
+  endfacet
+  facet normal 0.770517 0.637419 0
+    outer loop
+      vertex 59.533 -105.811 -5.2
+      vertex 59.0536 -105.231 -11.2
+      vertex 59.0536 -105.231 -5.2
+    endloop
+  endfacet
+  facet normal 0.770517 0.637419 0
+    outer loop
+      vertex 59.0536 -105.231 -11.2
+      vertex 59.533 -105.811 -5.2
+      vertex 59.533 -105.811 -11.2
+    endloop
+  endfacet
+  facet normal -0.125338 0.992114 0
+    outer loop
+      vertex -57 -104.418 -11.2
+      vertex -57.7461 -104.512 -5.2
+      vertex -57 -104.418 -5.2
+    endloop
+  endfacet
+  facet normal -0.125338 0.992114 0
+    outer loop
+      vertex -57.7461 -104.512 -5.2
+      vertex -57 -104.418 -11.2
+      vertex -57.7461 -104.512 -11.2
+    endloop
+  endfacet
+  facet normal -0.998026 -0.062796 0
+    outer loop
+      vertex -59.9822 -107.418 -11.2
+      vertex -59.9941 -107.23 -5.2
+      vertex -59.9941 -107.23 -11.2
+    endloop
+  endfacet
+  facet normal -0.998026 -0.062796 0
+    outer loop
+      vertex -59.9941 -107.23 -5.2
+      vertex -59.9822 -107.418 -11.2
+      vertex -59.9822 -107.418 -5.2
+    endloop
+  endfacet
+  facet normal -0.770515 0.637422 0
+    outer loop
+      vertex -59.533 -105.811 -11.2
+      vertex -59.0536 -105.231 -5.2
+      vertex -59.0536 -105.231 -11.2
+    endloop
+  endfacet
+  facet normal -0.770515 0.637422 0
+    outer loop
+      vertex -59.0536 -105.231 -5.2
+      vertex -59.533 -105.811 -11.2
+      vertex -59.533 -105.811 -5.2
+    endloop
+  endfacet
+  facet normal -0.368128 0.929775 0
+    outer loop
+      vertex -57.7461 -104.512 -11.2
+      vertex -58.4453 -104.789 -5.2
+      vertex -57.7461 -104.512 -5.2
+    endloop
+  endfacet
+  facet normal -0.368128 0.929775 0
+    outer loop
+      vertex -58.4453 -104.789 -5.2
+      vertex -57.7461 -104.512 -11.2
+      vertex -58.4453 -104.789 -11.2
+    endloop
+  endfacet
+  facet normal -0.904826 0.425781 0
+    outer loop
+      vertex -59.8532 -106.491 -11.2
+      vertex -59.533 -105.811 -5.2
+      vertex -59.533 -105.811 -11.2
+    endloop
+  endfacet
+  facet normal -0.904826 0.425781 0
+    outer loop
+      vertex -59.533 -105.811 -5.2
+      vertex -59.8532 -106.491 -11.2
+      vertex -59.8532 -106.491 -5.2
+    endloop
+  endfacet
+  facet normal -0.587781 0.80902 0
+    outer loop
+      vertex -58.4453 -104.789 -11.2
+      vertex -59.0536 -105.231 -5.2
+      vertex -58.4453 -104.789 -5.2
+    endloop
+  endfacet
+  facet normal -0.587781 0.80902 0
+    outer loop
+      vertex -59.0536 -105.231 -5.2
+      vertex -58.4453 -104.789 -11.2
+      vertex -59.0536 -105.231 -11.2
+    endloop
+  endfacet
+  facet normal -0.982287 0.187382 0
+    outer loop
+      vertex -59.9941 -107.23 -11.2
+      vertex -59.8532 -106.491 -5.2
+      vertex -59.8532 -106.491 -11.2
+    endloop
+  endfacet
+  facet normal -0.982287 0.187382 0
+    outer loop
+      vertex -59.8532 -106.491 -5.2
+      vertex -59.9941 -107.23 -11.2
+      vertex -59.9941 -107.23 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 59.9822 -131.418 -11.2
+      vertex 60 -131.418 -5.2
+      vertex 59.9822 -131.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 60 -131.418 -5.2
+      vertex 59.9822 -131.418 -11.2
+      vertex 60 -131.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -60 -131.418 -11.2
+      vertex -59.9822 -131.418 -5.2
+      vertex -60 -131.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -59.9822 -131.418 -5.2
+      vertex -60 -131.418 -11.2
+      vertex -59.9822 -131.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 60 -107.418 -11.2
+      vertex 59.9822 -107.418 -5.2
+      vertex 60 -107.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 59.9822 -107.418 -5.2
+      vertex 60 -107.418 -11.2
+      vertex 59.9822 -107.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -59.9822 -107.418 -11.2
+      vertex -60 -107.418 -5.2
+      vertex -59.9822 -107.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -60 -107.418 -5.2
+      vertex -59.9822 -107.418 -11.2
+      vertex -60 -107.418 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -60 -107.418 -11.2
+      vertex -60 -109.594 -5.2
+      vertex -60 -107.418 -5.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -60 -119.418 -11.2
+      vertex -60 -109.594 -5.2
+      vertex -60 -107.418 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -60 -131.418 -5.2
+      vertex -60 -119.418 -11.2
+      vertex -60 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -60 -131.418 -5.2
+      vertex -60 -124.918 -11.2
+      vertex -60 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -60 -131.418 -5.2
+      vertex -60 -128.918 -11.2
+      vertex -60 -131.418 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -60 -119.418 -11.2
+      vertex -60 -131.418 -5.2
+      vertex -60 -109.594 -5.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 60 -109.599 -5.2
+      vertex 60 -107.418 -11.2
+      vertex 60 -107.418 -5.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 -109.599 -5.2
+      vertex 60 -119.418 -11.2
+      vertex 60 -107.418 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 60 -131.418 -5.2
+      vertex 60 -119.418 -11.2
+      vertex 60 -109.599 -5.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 -119.418 -11.2
+      vertex 60 -131.418 -5.2
+      vertex 60 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 -124.918 -11.2
+      vertex 60 -131.418 -5.2
+      vertex 60 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 -128.918 -11.2
+      vertex 60 -131.418 -5.2
+      vertex 60 -131.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -57 -134.418 -11.2
+      vertex -33 -134.418 -5.2
+      vertex -57 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -33 -134.418 -5.2
+      vertex -57 -134.418 -11.2
+      vertex 33 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 57 -134.418 -11.2
+      vertex 33 -134.418 -5.2
+      vertex -57 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 33 -134.418 -5.2
+      vertex 57 -134.418 -11.2
+      vertex 57 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -33 -134.418 -5.2
+      vertex 33 -134.418 -0.2
+      vertex -33 -134.418 -0.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 33 -134.418 -0.2
+      vertex -33 -134.418 -5.2
+      vertex 33 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 57 -104.418 -11.2
+      vertex -57 -104.418 -5.2
+      vertex 57 -104.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -57 -104.418 -5.2
+      vertex 57 -104.418 -11.2
+      vertex -57 -104.418 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -57 -134.418 -11.2
+      vertex -57 -134.395 -5.2
+      vertex -57 -134.395 -11.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -57 -134.395 -5.2
+      vertex -57 -134.418 -11.2
+      vertex -57 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 57 -134.418 -5.2
+      vertex 57 -134.395 -11.2
+      vertex 57 -134.395 -5.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 57 -134.395 -11.2
+      vertex 57 -134.418 -5.2
+      vertex 57 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 33 -134.402 -5.2
+      vertex 33.2507 -134.402 -0.2
+      vertex 33 -134.402 -0.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 33.2507 -134.402 -0.2
+      vertex 33 -134.402 -5.2
+      vertex 33.2507 -134.402 -5.2
+    endloop
+  endfacet
+  facet normal 0.684547 -0.728969 0
+    outer loop
+      vertex 34.1756 -134.036 -5.2
+      vertex 34.541 -133.693 -0.2
+      vertex 34.1756 -134.036 -0.2
+    endloop
+  endfacet
+  facet normal 0.684547 -0.728969 0
+    outer loop
+      vertex 34.541 -133.693 -0.2
+      vertex 34.1756 -134.036 -5.2
+      vertex 34.541 -133.693 -5.2
+    endloop
+  endfacet
+  facet normal 0.998027 -0.0627932 0
+    outer loop
+      vertex 34.9646 -132.793 -0.2
+      vertex 34.9882 -132.418 -5.2
+      vertex 34.9882 -132.418 -0.2
+    endloop
+  endfacet
+  facet normal 0.998027 -0.0627932 0
+    outer loop
+      vertex 34.9882 -132.418 -5.2
+      vertex 34.9646 -132.793 -0.2
+      vertex 34.9646 -132.793 -5.2
+    endloop
+  endfacet
+  facet normal 0.844331 -0.535822 0
+    outer loop
+      vertex 34.541 -133.693 -0.2
+      vertex 34.8097 -133.27 -5.2
+      vertex 34.8097 -133.27 -0.2
+    endloop
+  endfacet
+  facet normal 0.844331 -0.535822 0
+    outer loop
+      vertex 34.8097 -133.27 -5.2
+      vertex 34.541 -133.693 -0.2
+      vertex 34.541 -133.693 -5.2
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309017 0
+    outer loop
+      vertex 34.8097 -133.27 -0.2
+      vertex 34.9646 -132.793 -5.2
+      vertex 34.9646 -132.793 -0.2
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309017 0
+    outer loop
+      vertex 34.9646 -132.793 -5.2
+      vertex 34.8097 -133.27 -0.2
+      vertex 34.8097 -133.27 -5.2
+    endloop
+  endfacet
+  facet normal 0.481748 -0.87631 0
+    outer loop
+      vertex 33.7362 -134.278 -5.2
+      vertex 34.1756 -134.036 -0.2
+      vertex 33.7362 -134.278 -0.2
+    endloop
+  endfacet
+  facet normal 0.481748 -0.87631 0
+    outer loop
+      vertex 34.1756 -134.036 -0.2
+      vertex 33.7362 -134.278 -5.2
+      vertex 34.1756 -134.036 -5.2
+    endloop
+  endfacet
+  facet normal 0.248697 -0.968581 0
+    outer loop
+      vertex 33.2507 -134.402 -5.2
+      vertex 33.7362 -134.278 -0.2
+      vertex 33.2507 -134.402 -0.2
+    endloop
+  endfacet
+  facet normal 0.248697 -0.968581 0
+    outer loop
+      vertex 33.7362 -134.278 -0.2
+      vertex 33.2507 -134.402 -5.2
+      vertex 33.7362 -134.278 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -33.2507 -134.402 -5.2
+      vertex -33 -134.402 -0.2
+      vertex -33.2507 -134.402 -0.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -33 -134.402 -0.2
+      vertex -33.2507 -134.402 -5.2
+      vertex -33 -134.402 -5.2
+    endloop
+  endfacet
+  facet normal -0.998027 -0.0627932 0
+    outer loop
+      vertex -34.9646 -132.793 -5.2
+      vertex -34.9882 -132.418 -0.2
+      vertex -34.9882 -132.418 -5.2
+    endloop
+  endfacet
+  facet normal -0.998027 -0.0627932 0
+    outer loop
+      vertex -34.9882 -132.418 -0.2
+      vertex -34.9646 -132.793 -5.2
+      vertex -34.9646 -132.793 -0.2
+    endloop
+  endfacet
+  facet normal -0.684547 -0.728969 0
+    outer loop
+      vertex -34.541 -133.693 -5.2
+      vertex -34.1756 -134.036 -0.2
+      vertex -34.541 -133.693 -0.2
+    endloop
+  endfacet
+  facet normal -0.684547 -0.728969 -0
+    outer loop
+      vertex -34.1756 -134.036 -0.2
+      vertex -34.541 -133.693 -5.2
+      vertex -34.1756 -134.036 -5.2
+    endloop
+  endfacet
+  facet normal -0.844331 -0.535822 0
+    outer loop
+      vertex -34.541 -133.693 -5.2
+      vertex -34.8097 -133.27 -0.2
+      vertex -34.8097 -133.27 -5.2
+    endloop
+  endfacet
+  facet normal -0.844331 -0.535822 0
+    outer loop
+      vertex -34.8097 -133.27 -0.2
+      vertex -34.541 -133.693 -5.2
+      vertex -34.541 -133.693 -0.2
+    endloop
+  endfacet
+  facet normal -0.481748 -0.87631 0
+    outer loop
+      vertex -34.1756 -134.036 -5.2
+      vertex -33.7362 -134.278 -0.2
+      vertex -34.1756 -134.036 -0.2
+    endloop
+  endfacet
+  facet normal -0.481748 -0.87631 -0
+    outer loop
+      vertex -33.7362 -134.278 -0.2
+      vertex -34.1756 -134.036 -5.2
+      vertex -33.7362 -134.278 -5.2
+    endloop
+  endfacet
+  facet normal -0.248695 -0.968582 0
+    outer loop
+      vertex -33.7362 -134.278 -5.2
+      vertex -33.2507 -134.402 -0.2
+      vertex -33.7362 -134.278 -0.2
+    endloop
+  endfacet
+  facet normal -0.248695 -0.968582 -0
+    outer loop
+      vertex -33.2507 -134.402 -0.2
+      vertex -33.7362 -134.278 -5.2
+      vertex -33.2507 -134.402 -5.2
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309017 0
+    outer loop
+      vertex -34.8097 -133.27 -5.2
+      vertex -34.9646 -132.793 -0.2
+      vertex -34.9646 -132.793 -5.2
+    endloop
+  endfacet
+  facet normal -0.951057 -0.309017 0
+    outer loop
+      vertex -34.9646 -132.793 -0.2
+      vertex -34.8097 -133.27 -5.2
+      vertex -34.8097 -133.27 -0.2
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 34.9961 -126.793 -0.2
+      vertex 34.9021 -126.3 -5.2
+      vertex 34.9021 -126.3 -0.2
+    endloop
+  endfacet
+  facet normal 0.982288 0.187377 0
+    outer loop
+      vertex 34.9021 -126.3 -5.2
+      vertex 34.9961 -126.793 -0.2
+      vertex 34.9961 -126.793 -5.2
+    endloop
+  endfacet
+  facet normal 0.368127 0.929776 -0
+    outer loop
+      vertex 33.9635 -125.166 -5.2
+      vertex 33.4974 -124.981 -0.2
+      vertex 33.9635 -125.166 -0.2
+    endloop
+  endfacet
+  facet normal 0.368127 0.929776 0
+    outer loop
+      vertex 33.4974 -124.981 -0.2
+      vertex 33.9635 -125.166 -5.2
+      vertex 33.4974 -124.981 -5.2
+    endloop
+  endfacet
+  facet normal 0.125337 0.992114 -0
+    outer loop
+      vertex 33.4974 -124.981 -5.2
+      vertex 33 -124.918 -0.2
+      vertex 33.4974 -124.981 -0.2
+    endloop
+  endfacet
+  facet normal 0.125337 0.992114 0
+    outer loop
+      vertex 33 -124.918 -0.2
+      vertex 33.4974 -124.981 -5.2
+      vertex 33 -124.918 -5.2
+    endloop
+  endfacet
+  facet normal 0.587788 0.809015 -0
+    outer loop
+      vertex 34.3691 -125.46 -5.2
+      vertex 33.9635 -125.166 -0.2
+      vertex 34.3691 -125.46 -0.2
+    endloop
+  endfacet
+  facet normal 0.587788 0.809015 0
+    outer loop
+      vertex 33.9635 -125.166 -0.2
+      vertex 34.3691 -125.46 -5.2
+      vertex 33.9635 -125.166 -5.2
+    endloop
+  endfacet
+  facet normal 0.998027 -0.062786 0
+    outer loop
+      vertex 34.9882 -126.918 -0.2
+      vertex 34.9961 -126.793 -5.2
+      vertex 34.9961 -126.793 -0.2
+    endloop
+  endfacet
+  facet normal 0.998027 -0.062786 0
+    outer loop
+      vertex 34.9961 -126.793 -5.2
+      vertex 34.9882 -126.918 -0.2
+      vertex 34.9882 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal 0.770514 0.637423 0
+    outer loop
+      vertex 34.6887 -125.847 -0.2
+      vertex 34.3691 -125.46 -5.2
+      vertex 34.3691 -125.46 -0.2
+    endloop
+  endfacet
+  facet normal 0.770514 0.637423 0
+    outer loop
+      vertex 34.3691 -125.46 -5.2
+      vertex 34.6887 -125.847 -0.2
+      vertex 34.6887 -125.847 -5.2
+    endloop
+  endfacet
+  facet normal 0.904826 0.425781 0
+    outer loop
+      vertex 34.9021 -126.3 -0.2
+      vertex 34.6887 -125.847 -5.2
+      vertex 34.6887 -125.847 -0.2
+    endloop
+  endfacet
+  facet normal 0.904826 0.425781 0
+    outer loop
+      vertex 34.6887 -125.847 -5.2
+      vertex 34.9021 -126.3 -0.2
+      vertex 34.9021 -126.3 -5.2
+    endloop
+  endfacet
+  facet normal -0.125337 0.992114 0
+    outer loop
+      vertex -33 -124.918 -5.2
+      vertex -33.4974 -124.981 -0.2
+      vertex -33 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal -0.125337 0.992114 0
+    outer loop
+      vertex -33.4974 -124.981 -0.2
+      vertex -33 -124.918 -5.2
+      vertex -33.4974 -124.981 -5.2
+    endloop
+  endfacet
+  facet normal -0.998027 -0.062786 0
+    outer loop
+      vertex -34.9882 -126.918 -5.2
+      vertex -34.9961 -126.793 -0.2
+      vertex -34.9961 -126.793 -5.2
+    endloop
+  endfacet
+  facet normal -0.998027 -0.062786 0
+    outer loop
+      vertex -34.9961 -126.793 -0.2
+      vertex -34.9882 -126.918 -5.2
+      vertex -34.9882 -126.918 -0.2
+    endloop
+  endfacet
+  facet normal -0.770514 0.637423 0
+    outer loop
+      vertex -34.6887 -125.847 -5.2
+      vertex -34.3691 -125.46 -0.2
+      vertex -34.3691 -125.46 -5.2
+    endloop
+  endfacet
+  facet normal -0.770514 0.637423 0
+    outer loop
+      vertex -34.3691 -125.46 -0.2
+      vertex -34.6887 -125.847 -5.2
+      vertex -34.6887 -125.847 -0.2
+    endloop
+  endfacet
+  facet normal -0.904829 0.425775 0
+    outer loop
+      vertex -34.9021 -126.3 -5.2
+      vertex -34.6887 -125.847 -0.2
+      vertex -34.6887 -125.847 -5.2
+    endloop
+  endfacet
+  facet normal -0.904829 0.425775 0
+    outer loop
+      vertex -34.6887 -125.847 -0.2
+      vertex -34.9021 -126.3 -5.2
+      vertex -34.9021 -126.3 -0.2
+    endloop
+  endfacet
+  facet normal -0.587784 0.809018 0
+    outer loop
+      vertex -33.9635 -125.166 -5.2
+      vertex -34.3691 -125.46 -0.2
+      vertex -33.9635 -125.166 -0.2
+    endloop
+  endfacet
+  facet normal -0.587784 0.809018 0
+    outer loop
+      vertex -34.3691 -125.46 -0.2
+      vertex -33.9635 -125.166 -5.2
+      vertex -34.3691 -125.46 -5.2
+    endloop
+  endfacet
+  facet normal -0.36813 0.929774 0
+    outer loop
+      vertex -33.4974 -124.981 -5.2
+      vertex -33.9635 -125.166 -0.2
+      vertex -33.4974 -124.981 -0.2
+    endloop
+  endfacet
+  facet normal -0.36813 0.929774 0
+    outer loop
+      vertex -33.9635 -125.166 -0.2
+      vertex -33.4974 -124.981 -5.2
+      vertex -33.9635 -125.166 -5.2
+    endloop
+  endfacet
+  facet normal -0.982287 0.187384 0
+    outer loop
+      vertex -34.9961 -126.793 -5.2
+      vertex -34.9021 -126.3 -0.2
+      vertex -34.9021 -126.3 -5.2
+    endloop
+  endfacet
+  facet normal -0.982287 0.187384 0
+    outer loop
+      vertex -34.9021 -126.3 -0.2
+      vertex -34.9961 -126.793 -5.2
+      vertex -34.9961 -126.793 -0.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 34.9882 -132.418 -5.2
+      vertex 35 -132.418 -0.2
+      vertex 34.9882 -132.418 -0.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 35 -132.418 -0.2
+      vertex 34.9882 -132.418 -5.2
+      vertex 35 -132.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -35 -132.418 -5.2
+      vertex -34.9882 -132.418 -0.2
+      vertex -35 -132.418 -0.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -34.9882 -132.418 -0.2
+      vertex -35 -132.418 -5.2
+      vertex -34.9882 -132.418 -5.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 35 -126.918 -5.2
+      vertex 34.9882 -126.918 -0.2
+      vertex 35 -126.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.9882 -126.918 -0.2
+      vertex 35 -126.918 -5.2
+      vertex 34.9882 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -34.9882 -126.918 -5.2
+      vertex -35 -126.918 -0.2
+      vertex -34.9882 -126.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -35 -126.918 -0.2
+      vertex -34.9882 -126.918 -5.2
+      vertex -35 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 35 -132.418 -0.2
+      vertex 35 -126.918 -5.2
+      vertex 35 -126.918 -0.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 35 -126.918 -5.2
+      vertex 35 -132.418 -0.2
+      vertex 35 -132.418 -5.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -35 -132.418 -5.2
+      vertex -35 -126.918 -0.2
+      vertex -35 -126.918 -5.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -35 -126.918 -0.2
+      vertex -35 -132.418 -5.2
+      vertex -35 -132.418 -0.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -3.65479 -124.918 -5.2
+      vertex -33 -124.918 -0.2
+      vertex -3.65479 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -33 -124.918 -0.2
+      vertex -3.65479 -124.918 -5.2
+      vertex -33 -124.918 -5.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 33 -124.918 -5.2
+      vertex 2.57163 -124.918 -0.2
+      vertex 33 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.57163 -124.918 -0.2
+      vertex 33 -124.918 -5.2
+      vertex 2.57163 -124.918 -5.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 33 -134.418 -0.2
+      vertex 33 -134.402 -5.2
+      vertex 33 -134.402 -0.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 33 -134.402 -5.2
+      vertex 33 -134.418 -0.2
+      vertex 33 -134.418 -5.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -33 -134.418 -5.2
+      vertex -33 -134.402 -0.2
+      vertex -33 -134.402 -5.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -33 -134.402 -0.2
+      vertex -33 -134.418 -5.2
+      vertex -33 -134.418 -0.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 128.25 -134.518 -16.2237
+      vertex 128.626 -146.518 -16.2237
+      vertex 128.626 -134.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 128.626 -146.518 -16.2237
+      vertex 128.25 -134.518 -16.2237
+      vertex 128.25 -146.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.103 -134.518 -49.1271
+      vertex 131.232 -134.518 -48.2
+      vertex 131.244 -134.518 -48.3884
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.232 -134.518 -48.2
+      vertex 128.25 -134.518 -51.2
+      vertex 61.2678 -134.518 -48.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 130.783 -134.518 -49.8075
+      vertex 131.232 -134.518 -48.2
+      vertex 131.103 -134.518 -49.1271
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 64.25 -134.518 -51.2
+      vertex 61.2678 -134.518 -48.2
+      vertex 128.25 -134.518 -51.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.232 -134.518 -48.2
+      vertex 130.783 -134.518 -49.8075
+      vertex 128.25 -134.518 -51.2
+    endloop
+  endfacet
+  facet normal -0 1 -0
+    outer loop
+      vertex 61.717 -134.518 -49.8075
+      vertex 61.2678 -134.518 -48.2
+      vertex 64.25 -134.518 -51.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 128.25 -134.518 -51.2
+      vertex 130.783 -134.518 -49.8075
+      vertex 130.304 -134.518 -50.3869
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.3968 -134.518 -49.1271
+      vertex 61.2559 -134.518 -48.3884
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 128.25 -134.518 -51.2
+      vertex 130.304 -134.518 -50.3869
+      vertex 129.695 -134.518 -50.8289
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.717 -134.518 -49.8075
+      vertex 61.3968 -134.518 -49.1271
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 128.25 -134.518 -51.2
+      vertex 129.695 -134.518 -50.8289
+      vertex 128.996 -134.518 -51.1058
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.717 -134.518 -49.8075
+      vertex 64.25 -134.518 -51.2
+      vertex 62.1964 -134.518 -50.3869
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 62.1964 -134.518 -50.3869
+      vertex 64.25 -134.518 -51.2
+      vertex 62.8047 -134.518 -50.8289
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 62.8047 -134.518 -50.8289
+      vertex 64.25 -134.518 -51.2
+      vertex 63.5039 -134.518 -51.1058
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.232 -134.518 -48.2
+      vertex 131.232 -134.518 -19.2
+      vertex 131.25 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.232 -134.518 -19.2
+      vertex 131.232 -134.518 -48.2
+      vertex 61.2678 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.232 -134.518 -48.2
+      vertex 131.25 -134.518 -19.2
+      vertex 131.25 -134.518 -48.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.2678 -134.518 -19.2
+      vertex 131.232 -134.518 -48.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.2678 -134.518 -19.2
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.25 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.25 -134.518 -19.2
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.25 -134.518 -48.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 129.354 -134.518 -16.4107
+      vertex 128.25 -134.518 -16.2237
+      vertex 128.626 -134.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 128.25 -134.518 -16.2237
+      vertex 131.232 -134.518 -19.2
+      vertex 64.25 -134.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 130.013 -134.518 -16.7729
+      vertex 128.25 -134.518 -16.2237
+      vertex 129.354 -134.518 -16.4107
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.2678 -134.518 -19.2
+      vertex 64.25 -134.518 -16.2237
+      vertex 131.232 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 128.25 -134.518 -16.2237
+      vertex 130.013 -134.518 -16.7729
+      vertex 131.232 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal -0 1 0
+    outer loop
+      vertex 62.4866 -134.518 -16.7729
+      vertex 64.25 -134.518 -16.2237
+      vertex 61.2678 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.232 -134.518 -19.2
+      vertex 130.013 -134.518 -16.7729
+      vertex 130.562 -134.518 -17.2877
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 64.25 -134.518 -16.2237
+      vertex 63.1456 -134.518 -16.4107
+      vertex 63.874 -134.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.232 -134.518 -19.2
+      vertex 130.562 -134.518 -17.2877
+      vertex 130.964 -134.518 -17.9227
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 64.25 -134.518 -16.2237
+      vertex 62.4866 -134.518 -16.7729
+      vertex 63.1456 -134.518 -16.4107
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 131.232 -134.518 -19.2
+      vertex 130.964 -134.518 -17.9227
+      vertex 131.197 -134.518 -18.6379
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 62.4866 -134.518 -16.7729
+      vertex 61.2678 -134.518 -19.2
+      vertex 61.9385 -134.518 -17.2877
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.9385 -134.518 -17.2877
+      vertex 61.2678 -134.518 -19.2
+      vertex 61.5355 -134.518 -17.9227
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 61.5355 -134.518 -17.9227
+      vertex 61.2678 -134.518 -19.2
+      vertex 61.3031 -134.518 -18.6379
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 128.25 -134.518 -16.2237
+      vertex 64.25 -134.518 -16.2
+      vertex 128.25 -134.518 -16.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 64.25 -134.518 -16.2
+      vertex 128.25 -134.518 -16.2237
+      vertex 64.25 -134.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0.844329 -0 0.535825
+    outer loop
+      vertex 130.562 -146.518 -17.2877
+      vertex 130.964 -134.518 -17.9227
+      vertex 130.562 -134.518 -17.2877
+    endloop
+  endfacet
+  facet normal 0.844329 0 0.535825
+    outer loop
+      vertex 130.964 -134.518 -17.9227
+      vertex 130.562 -146.518 -17.2877
+      vertex 130.964 -146.518 -17.9227
+    endloop
+  endfacet
+  facet normal 0.684546 0 0.72897
+    outer loop
+      vertex 130.013 -134.518 -16.7729
+      vertex 130.562 -146.518 -17.2877
+      vertex 130.562 -134.518 -17.2877
+    endloop
+  endfacet
+  facet normal 0.684546 0 0.72897
+    outer loop
+      vertex 130.562 -146.518 -17.2877
+      vertex 130.013 -134.518 -16.7729
+      vertex 130.013 -146.518 -16.7729
+    endloop
+  endfacet
+  facet normal 0.248692 0 0.968583
+    outer loop
+      vertex 128.626 -134.518 -16.2237
+      vertex 129.354 -146.518 -16.4107
+      vertex 129.354 -134.518 -16.4107
+    endloop
+  endfacet
+  facet normal 0.248692 0 0.968583
+    outer loop
+      vertex 129.354 -146.518 -16.4107
+      vertex 128.626 -134.518 -16.2237
+      vertex 128.626 -146.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0.998028 -0 0.0627685
+    outer loop
+      vertex 131.197 -146.518 -18.6379
+      vertex 131.232 -134.518 -19.2
+      vertex 131.197 -134.518 -18.6379
+    endloop
+  endfacet
+  facet normal 0.998028 0 0.0627685
+    outer loop
+      vertex 131.232 -134.518 -19.2
+      vertex 131.197 -146.518 -18.6379
+      vertex 131.232 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 88.525 -146.518 -43.2
+      vertex 64.25 -146.518 -51.2
+      vertex 103.554 -146.518 -43.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 128.25 -146.518 -51.2
+      vertex 103.554 -146.518 -43.2
+      vertex 64.25 -146.518 -51.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 64.25 -146.518 -51.2
+      vertex 61.2559 -146.518 -48.3884
+      vertex 61.3968 -146.518 -49.1271
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 103.554 -146.518 -43.2
+      vertex 128.25 -146.518 -51.2
+      vertex 131.232 -146.518 -48.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 64.25 -146.518 -51.2
+      vertex 61.3968 -146.518 -49.1271
+      vertex 61.717 -146.518 -49.8075
+    endloop
+  endfacet
+  facet normal -0 -1 0
+    outer loop
+      vertex 130.783 -146.518 -49.8075
+      vertex 131.232 -146.518 -48.2
+      vertex 128.25 -146.518 -51.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 64.25 -146.518 -51.2
+      vertex 61.717 -146.518 -49.8075
+      vertex 62.1964 -146.518 -50.3869
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 131.232 -146.518 -48.2
+      vertex 131.103 -146.518 -49.1271
+      vertex 131.244 -146.518 -48.3884
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 64.25 -146.518 -51.2
+      vertex 62.1964 -146.518 -50.3869
+      vertex 62.8047 -146.518 -50.8289
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 131.232 -146.518 -48.2
+      vertex 130.783 -146.518 -49.8075
+      vertex 131.103 -146.518 -49.1271
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 64.25 -146.518 -51.2
+      vertex 62.8047 -146.518 -50.8289
+      vertex 63.5039 -146.518 -51.1058
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 130.783 -146.518 -49.8075
+      vertex 128.25 -146.518 -51.2
+      vertex 130.304 -146.518 -50.3869
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 130.304 -146.518 -50.3869
+      vertex 128.25 -146.518 -51.2
+      vertex 129.695 -146.518 -50.8289
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 129.695 -146.518 -50.8289
+      vertex 128.25 -146.518 -51.2
+      vertex 128.996 -146.518 -51.1058
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 91.115 -146.518 -34.409
+      vertex 91.115 -146.518 -41.084
+      vertex 102.187 -146.518 -34.409
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 102.187 -146.518 -32.32
+      vertex 91.115 -146.518 -26.18
+      vertex 91.115 -146.518 -32.32
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -48.2
+      vertex 61.2678 -146.518 -19.2
+      vertex 61.25 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -19.2
+      vertex 88.525 -146.518 -24.064
+      vertex 131.232 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 102.999 -146.518 -24.064
+      vertex 131.232 -146.518 -19.2
+      vertex 88.525 -146.518 -24.064
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -19.2
+      vertex 88.525 -146.518 -43.2
+      vertex 88.525 -146.518 -24.064
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -19.2
+      vertex 61.2678 -146.518 -48.2
+      vertex 88.525 -146.518 -43.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -48.2
+      vertex 61.25 -146.518 -19.2
+      vertex 61.25 -146.518 -48.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 63.1456 -146.518 -16.4107
+      vertex 64.25 -146.518 -16.2237
+      vertex 63.874 -146.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 64.25 -146.518 -16.2237
+      vertex 61.2678 -146.518 -19.2
+      vertex 128.25 -146.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 62.4866 -146.518 -16.7729
+      vertex 64.25 -146.518 -16.2237
+      vertex 63.1456 -146.518 -16.4107
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 131.232 -146.518 -19.2
+      vertex 128.25 -146.518 -16.2237
+      vertex 61.2678 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 64.25 -146.518 -16.2237
+      vertex 62.4866 -146.518 -16.7729
+      vertex 61.2678 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal -0 -1 -0
+    outer loop
+      vertex 130.013 -146.518 -16.7729
+      vertex 128.25 -146.518 -16.2237
+      vertex 131.232 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -19.2
+      vertex 62.4866 -146.518 -16.7729
+      vertex 61.9385 -146.518 -17.2877
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 128.25 -146.518 -16.2237
+      vertex 129.354 -146.518 -16.4107
+      vertex 128.626 -146.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -19.2
+      vertex 61.9385 -146.518 -17.2877
+      vertex 61.5355 -146.518 -17.9227
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 128.25 -146.518 -16.2237
+      vertex 130.013 -146.518 -16.7729
+      vertex 129.354 -146.518 -16.4107
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -19.2
+      vertex 61.5355 -146.518 -17.9227
+      vertex 61.3031 -146.518 -18.6379
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 130.013 -146.518 -16.7729
+      vertex 131.232 -146.518 -19.2
+      vertex 130.562 -146.518 -17.2877
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 130.562 -146.518 -17.2877
+      vertex 131.232 -146.518 -19.2
+      vertex 130.964 -146.518 -17.9227
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 130.964 -146.518 -17.9227
+      vertex 131.232 -146.518 -19.2
+      vertex 131.197 -146.518 -18.6379
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 64.25 -146.518 -16.2237
+      vertex 128.25 -146.518 -16.2
+      vertex 64.25 -146.518 -16.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 128.25 -146.518 -16.2
+      vertex 64.25 -146.518 -16.2237
+      vertex 128.25 -146.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 102.999 -146.518 -26.18
+      vertex 131.232 -146.518 -19.2
+      vertex 102.999 -146.518 -24.064
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 102.187 -146.518 -32.32
+      vertex 131.232 -146.518 -19.2
+      vertex 102.999 -146.518 -26.18
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 91.115 -146.518 -26.18
+      vertex 102.187 -146.518 -32.32
+      vertex 102.999 -146.518 -26.18
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 102.187 -146.518 -34.409
+      vertex 131.232 -146.518 -19.2
+      vertex 102.187 -146.518 -32.32
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 131.232 -146.518 -48.2
+      vertex 131.232 -146.518 -19.2
+      vertex 102.187 -146.518 -34.409
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 103.554 -146.518 -41.084
+      vertex 102.187 -146.518 -34.409
+      vertex 91.115 -146.518 -41.084
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 131.232 -146.518 -48.2
+      vertex 102.187 -146.518 -34.409
+      vertex 103.554 -146.518 -41.084
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 131.232 -146.518 -48.2
+      vertex 103.554 -146.518 -41.084
+      vertex 103.554 -146.518 -43.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 64.25 -146.518 -51.2
+      vertex 61.2678 -146.518 -48.2
+      vertex 61.2559 -146.518 -48.3884
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.2678 -146.518 -48.2
+      vertex 64.25 -146.518 -51.2
+      vertex 88.525 -146.518 -43.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 131.232 -146.518 -19.2
+      vertex 131.232 -146.518 -48.2
+      vertex 131.25 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 131.25 -146.518 -19.2
+      vertex 131.232 -146.518 -48.2
+      vertex 131.25 -146.518 -48.2
+    endloop
+  endfacet
+  facet normal 0.481754 0 0.876307
+    outer loop
+      vertex 129.354 -134.518 -16.4107
+      vertex 130.013 -146.518 -16.7729
+      vertex 130.013 -134.518 -16.7729
+    endloop
+  endfacet
+  facet normal 0.481754 0 0.876307
+    outer loop
+      vertex 130.013 -146.518 -16.7729
+      vertex 129.354 -134.518 -16.4107
+      vertex 129.354 -146.518 -16.4107
+    endloop
+  endfacet
+  facet normal 0.951052 -0 0.30903
+    outer loop
+      vertex 130.964 -146.518 -17.9227
+      vertex 131.197 -134.518 -18.6379
+      vertex 130.964 -134.518 -17.9227
+    endloop
+  endfacet
+  facet normal 0.951052 0 0.30903
+    outer loop
+      vertex 131.197 -134.518 -18.6379
+      vertex 130.964 -146.518 -17.9227
+      vertex 131.197 -146.518 -18.6379
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.874 -134.518 -16.2237
+      vertex 64.25 -146.518 -16.2237
+      vertex 64.25 -134.518 -16.2237
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.25 -146.518 -16.2237
+      vertex 63.874 -134.518 -16.2237
+      vertex 63.874 -146.518 -16.2237
+    endloop
+  endfacet
+  facet normal -0.998027 0 0.0627887
+    outer loop
+      vertex 61.2678 -146.518 -19.2
+      vertex 61.3031 -134.518 -18.6379
+      vertex 61.2678 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal -0.998027 0 0.0627887
+    outer loop
+      vertex 61.3031 -134.518 -18.6379
+      vertex 61.2678 -146.518 -19.2
+      vertex 61.3031 -146.518 -18.6379
+    endloop
+  endfacet
+  facet normal -0.684548 0 0.728968
+    outer loop
+      vertex 61.9385 -134.518 -17.2877
+      vertex 62.4866 -146.518 -16.7729
+      vertex 62.4866 -134.518 -16.7729
+    endloop
+  endfacet
+  facet normal -0.684548 0 0.728968
+    outer loop
+      vertex 62.4866 -146.518 -16.7729
+      vertex 61.9385 -134.518 -17.2877
+      vertex 61.9385 -146.518 -17.2877
+    endloop
+  endfacet
+  facet normal -0.844327 0 0.535828
+    outer loop
+      vertex 61.5355 -146.518 -17.9227
+      vertex 61.9385 -134.518 -17.2877
+      vertex 61.5355 -134.518 -17.9227
+    endloop
+  endfacet
+  facet normal -0.844327 0 0.535828
+    outer loop
+      vertex 61.9385 -134.518 -17.2877
+      vertex 61.5355 -146.518 -17.9227
+      vertex 61.9385 -146.518 -17.2877
+    endloop
+  endfacet
+  facet normal -0.481754 0 0.876307
+    outer loop
+      vertex 62.4866 -134.518 -16.7729
+      vertex 63.1456 -146.518 -16.4107
+      vertex 63.1456 -134.518 -16.4107
+    endloop
+  endfacet
+  facet normal -0.481754 0 0.876307
+    outer loop
+      vertex 63.1456 -146.518 -16.4107
+      vertex 62.4866 -134.518 -16.7729
+      vertex 62.4866 -146.518 -16.7729
+    endloop
+  endfacet
+  facet normal -0.248688 0 0.968584
+    outer loop
+      vertex 63.1456 -134.518 -16.4107
+      vertex 63.874 -146.518 -16.2237
+      vertex 63.874 -134.518 -16.2237
+    endloop
+  endfacet
+  facet normal -0.248688 0 0.968584
+    outer loop
+      vertex 63.874 -146.518 -16.2237
+      vertex 63.1456 -134.518 -16.4107
+      vertex 63.1456 -146.518 -16.4107
+    endloop
+  endfacet
+  facet normal -0.951057 0 0.309016
+    outer loop
+      vertex 61.3031 -146.518 -18.6379
+      vertex 61.5355 -134.518 -17.9227
+      vertex 61.3031 -134.518 -18.6379
+    endloop
+  endfacet
+  facet normal -0.951057 0 0.309016
+    outer loop
+      vertex 61.5355 -134.518 -17.9227
+      vertex 61.3031 -146.518 -18.6379
+      vertex 61.5355 -146.518 -17.9227
+    endloop
+  endfacet
+  facet normal 0.904832 0 -0.425769
+    outer loop
+      vertex 131.103 -146.518 -49.1271
+      vertex 130.783 -134.518 -49.8075
+      vertex 131.103 -134.518 -49.1271
+    endloop
+  endfacet
+  facet normal 0.904832 0 -0.425769
+    outer loop
+      vertex 130.783 -134.518 -49.8075
+      vertex 131.103 -146.518 -49.1271
+      vertex 130.783 -146.518 -49.8075
+    endloop
+  endfacet
+  facet normal 0.368123 0 -0.929777
+    outer loop
+      vertex 128.996 -146.518 -51.1058
+      vertex 129.695 -134.518 -50.8289
+      vertex 129.695 -146.518 -50.8289
+    endloop
+  endfacet
+  facet normal 0.368123 0 -0.929777
+    outer loop
+      vertex 129.695 -134.518 -50.8289
+      vertex 128.996 -146.518 -51.1058
+      vertex 128.996 -134.518 -51.1058
+    endloop
+  endfacet
+  facet normal 0.587792 0 -0.809012
+    outer loop
+      vertex 129.695 -146.518 -50.8289
+      vertex 130.304 -134.518 -50.3869
+      vertex 130.304 -146.518 -50.3869
+    endloop
+  endfacet
+  facet normal 0.587792 0 -0.809012
+    outer loop
+      vertex 130.304 -134.518 -50.3869
+      vertex 129.695 -146.518 -50.8289
+      vertex 129.695 -134.518 -50.8289
+    endloop
+  endfacet
+  facet normal 0.125333 0 -0.992115
+    outer loop
+      vertex 128.25 -146.518 -51.2
+      vertex 128.996 -134.518 -51.1058
+      vertex 128.996 -146.518 -51.1058
+    endloop
+  endfacet
+  facet normal 0.125333 0 -0.992115
+    outer loop
+      vertex 128.996 -134.518 -51.1058
+      vertex 128.25 -146.518 -51.2
+      vertex 128.25 -134.518 -51.2
+    endloop
+  endfacet
+  facet normal 0.770505 0 -0.637434
+    outer loop
+      vertex 130.783 -146.518 -49.8075
+      vertex 130.304 -134.518 -50.3869
+      vertex 130.783 -134.518 -49.8075
+    endloop
+  endfacet
+  facet normal 0.770505 0 -0.637434
+    outer loop
+      vertex 130.304 -134.518 -50.3869
+      vertex 130.783 -146.518 -49.8075
+      vertex 130.304 -146.518 -50.3869
+    endloop
+  endfacet
+  facet normal 0.982286 0 -0.187386
+    outer loop
+      vertex 131.244 -146.518 -48.3884
+      vertex 131.103 -134.518 -49.1271
+      vertex 131.244 -134.518 -48.3884
+    endloop
+  endfacet
+  facet normal 0.982286 0 -0.187386
+    outer loop
+      vertex 131.103 -134.518 -49.1271
+      vertex 131.244 -146.518 -48.3884
+      vertex 131.103 -146.518 -49.1271
+    endloop
+  endfacet
+  facet normal 0.998025 -0 0.0628162
+    outer loop
+      vertex 131.232 -146.518 -48.2
+      vertex 131.244 -134.518 -48.3884
+      vertex 131.232 -134.518 -48.2
+    endloop
+  endfacet
+  facet normal 0.998025 0 0.0628162
+    outer loop
+      vertex 131.244 -134.518 -48.3884
+      vertex 131.232 -146.518 -48.2
+      vertex 131.244 -146.518 -48.3884
+    endloop
+  endfacet
+  facet normal -0.125333 0 -0.992115
+    outer loop
+      vertex 63.5039 -146.518 -51.1058
+      vertex 64.25 -134.518 -51.2
+      vertex 64.25 -146.518 -51.2
+    endloop
+  endfacet
+  facet normal -0.125333 0 -0.992115
+    outer loop
+      vertex 64.25 -134.518 -51.2
+      vertex 63.5039 -146.518 -51.1058
+      vertex 63.5039 -134.518 -51.1058
+    endloop
+  endfacet
+  facet normal -0.587785 0 -0.809017
+    outer loop
+      vertex 62.1964 -146.518 -50.3869
+      vertex 62.8047 -134.518 -50.8289
+      vertex 62.8047 -146.518 -50.8289
+    endloop
+  endfacet
+  facet normal -0.587785 0 -0.809017
+    outer loop
+      vertex 62.8047 -134.518 -50.8289
+      vertex 62.1964 -146.518 -50.3869
+      vertex 62.1964 -134.518 -50.3869
+    endloop
+  endfacet
+  facet normal -0.368128 0 -0.929775
+    outer loop
+      vertex 62.8047 -146.518 -50.8289
+      vertex 63.5039 -134.518 -51.1058
+      vertex 63.5039 -146.518 -51.1058
+    endloop
+  endfacet
+  facet normal -0.368128 0 -0.929775
+    outer loop
+      vertex 63.5039 -134.518 -51.1058
+      vertex 62.8047 -146.518 -50.8289
+      vertex 62.8047 -134.518 -50.8289
+    endloop
+  endfacet
+  facet normal -0.770513 0 -0.637425
+    outer loop
+      vertex 62.1964 -146.518 -50.3869
+      vertex 61.717 -134.518 -49.8075
+      vertex 62.1964 -134.518 -50.3869
+    endloop
+  endfacet
+  facet normal -0.770513 -0 -0.637425
+    outer loop
+      vertex 61.717 -134.518 -49.8075
+      vertex 62.1964 -146.518 -50.3869
+      vertex 61.717 -146.518 -49.8075
+    endloop
+  endfacet
+  facet normal -0.998026 0 0.062796
+    outer loop
+      vertex 61.2559 -146.518 -48.3884
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.2559 -134.518 -48.3884
+    endloop
+  endfacet
+  facet normal -0.998026 0 0.062796
+    outer loop
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.2559 -146.518 -48.3884
+      vertex 61.2678 -146.518 -48.2
+    endloop
+  endfacet
+  facet normal -0.904826 0 -0.425781
+    outer loop
+      vertex 61.717 -146.518 -49.8075
+      vertex 61.3968 -134.518 -49.1271
+      vertex 61.717 -134.518 -49.8075
+    endloop
+  endfacet
+  facet normal -0.904826 -0 -0.425781
+    outer loop
+      vertex 61.3968 -134.518 -49.1271
+      vertex 61.717 -146.518 -49.8075
+      vertex 61.3968 -146.518 -49.1271
+    endloop
+  endfacet
+  facet normal -0.982287 0 -0.187381
+    outer loop
+      vertex 61.3968 -146.518 -49.1271
+      vertex 61.2559 -134.518 -48.3884
+      vertex 61.3968 -134.518 -49.1271
+    endloop
+  endfacet
+  facet normal -0.982287 -0 -0.187381
+    outer loop
+      vertex 61.2559 -134.518 -48.3884
+      vertex 61.3968 -146.518 -49.1271
+      vertex 61.2559 -146.518 -48.3884
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 131.232 -134.518 -19.2
+      vertex 131.25 -146.518 -19.2
+      vertex 131.25 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 131.25 -146.518 -19.2
+      vertex 131.232 -134.518 -19.2
+      vertex 131.232 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.25 -134.518 -19.2
+      vertex 61.2678 -146.518 -19.2
+      vertex 61.2678 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2678 -146.518 -19.2
+      vertex 61.25 -134.518 -19.2
+      vertex 61.25 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 131.232 -146.518 -48.2
+      vertex 131.25 -134.518 -48.2
+      vertex 131.25 -146.518 -48.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 131.25 -134.518 -48.2
+      vertex 131.232 -146.518 -48.2
+      vertex 131.232 -134.518 -48.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.25 -146.518 -48.2
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.2678 -146.518 -48.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.2678 -134.518 -48.2
+      vertex 61.25 -146.518 -48.2
+      vertex 61.25 -134.518 -48.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 61.25 -146.518 -48.2
+      vertex 61.25 -134.518 -19.2
+      vertex 61.25 -134.518 -48.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 61.25 -134.518 -19.2
+      vertex 61.25 -146.518 -48.2
+      vertex 61.25 -146.518 -19.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 131.25 -146.518 -19.2
+      vertex 131.25 -134.518 -48.2
+      vertex 131.25 -134.518 -19.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 131.25 -134.518 -48.2
+      vertex 131.25 -146.518 -19.2
+      vertex 131.25 -146.518 -48.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.25 -134.518 -16.2
+      vertex 128.25 -146.518 -16.2
+      vertex 128.25 -134.518 -16.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 128.25 -146.518 -16.2
+      vertex 64.25 -134.518 -16.2
+      vertex 64.25 -146.518 -16.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.25 -146.518 -51.2
+      vertex 128.25 -134.518 -51.2
+      vertex 128.25 -146.518 -51.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 128.25 -134.518 -51.2
+      vertex 64.25 -146.518 -51.2
+      vertex 64.25 -134.518 -51.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 128.25 -146.518 -16.2
+      vertex 128.25 -134.518 -16.2237
+      vertex 128.25 -134.518 -16.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 128.25 -134.518 -16.2237
+      vertex 128.25 -146.518 -16.2
+      vertex 128.25 -146.518 -16.2237
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 64.25 -146.518 -16.2237
+      vertex 64.25 -134.518 -16.2
+      vertex 64.25 -134.518 -16.2237
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 64.25 -134.518 -16.2
+      vertex 64.25 -146.518 -16.2237
+      vertex 64.25 -146.518 -16.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 88.525 -143.518 -24.064
+      vertex 91.115 -143.518 -26.18
+      vertex 102.999 -143.518 -24.064
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 88.525 -143.518 -24.064
+      vertex 91.115 -143.518 -32.32
+      vertex 91.115 -143.518 -26.18
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 91.115 -143.518 -32.32
+      vertex 91.115 -143.518 -34.409
+      vertex 102.187 -143.518 -32.32
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 88.525 -143.518 -24.064
+      vertex 91.115 -143.518 -34.409
+      vertex 91.115 -143.518 -32.32
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 88.525 -143.518 -43.2
+      vertex 91.115 -143.518 -34.409
+      vertex 88.525 -143.518 -24.064
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 91.115 -143.518 -34.409
+      vertex 88.525 -143.518 -43.2
+      vertex 91.115 -143.518 -41.084
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 103.554 -143.518 -43.2
+      vertex 91.115 -143.518 -41.084
+      vertex 88.525 -143.518 -43.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 91.115 -143.518 -41.084
+      vertex 103.554 -143.518 -43.2
+      vertex 103.554 -143.518 -41.084
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 102.999 -143.518 -24.064
+      vertex 91.115 -143.518 -26.18
+      vertex 102.999 -143.518 -26.18
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 102.187 -143.518 -32.32
+      vertex 91.115 -143.518 -34.409
+      vertex 102.187 -143.518 -34.409
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.115 -146.518 -41.084
+      vertex 103.554 -143.518 -41.084
+      vertex 103.554 -146.518 -41.084
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 103.554 -143.518 -41.084
+      vertex 91.115 -146.518 -41.084
+      vertex 91.115 -143.518 -41.084
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 91.115 -146.518 -41.084
+      vertex 91.115 -143.518 -34.409
+      vertex 91.115 -143.518 -41.084
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 91.115 -143.518 -34.409
+      vertex 91.115 -146.518 -41.084
+      vertex 91.115 -146.518 -34.409
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 91.115 -143.518 -34.409
+      vertex 102.187 -146.518 -34.409
+      vertex 102.187 -143.518 -34.409
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 102.187 -146.518 -34.409
+      vertex 91.115 -143.518 -34.409
+      vertex 91.115 -146.518 -34.409
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 102.187 -146.518 -34.409
+      vertex 102.187 -143.518 -32.32
+      vertex 102.187 -143.518 -34.409
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 102.187 -143.518 -32.32
+      vertex 102.187 -146.518 -34.409
+      vertex 102.187 -146.518 -32.32
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 91.115 -146.518 -32.32
+      vertex 102.187 -143.518 -32.32
+      vertex 102.187 -146.518 -32.32
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 102.187 -143.518 -32.32
+      vertex 91.115 -146.518 -32.32
+      vertex 91.115 -143.518 -32.32
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 91.115 -146.518 -32.32
+      vertex 91.115 -143.518 -26.18
+      vertex 91.115 -143.518 -32.32
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 91.115 -143.518 -26.18
+      vertex 91.115 -146.518 -32.32
+      vertex 91.115 -146.518 -26.18
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 91.115 -143.518 -26.18
+      vertex 102.999 -146.518 -26.18
+      vertex 102.999 -143.518 -26.18
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 102.999 -146.518 -26.18
+      vertex 91.115 -143.518 -26.18
+      vertex 91.115 -146.518 -26.18
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 102.999 -146.518 -26.18
+      vertex 102.999 -143.518 -24.064
+      vertex 102.999 -143.518 -26.18
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 102.999 -143.518 -24.064
+      vertex 102.999 -146.518 -26.18
+      vertex 102.999 -146.518 -24.064
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 88.525 -146.518 -24.064
+      vertex 102.999 -143.518 -24.064
+      vertex 102.999 -146.518 -24.064
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 102.999 -143.518 -24.064
+      vertex 88.525 -146.518 -24.064
+      vertex 88.525 -143.518 -24.064
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 88.525 -146.518 -24.064
+      vertex 88.525 -143.518 -43.2
+      vertex 88.525 -143.518 -24.064
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 88.525 -143.518 -43.2
+      vertex 88.525 -146.518 -24.064
+      vertex 88.525 -146.518 -43.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 88.525 -143.518 -43.2
+      vertex 103.554 -146.518 -43.2
+      vertex 103.554 -143.518 -43.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 103.554 -146.518 -43.2
+      vertex 88.525 -143.518 -43.2
+      vertex 88.525 -146.518 -43.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 103.554 -146.518 -43.2
+      vertex 103.554 -143.518 -41.084
+      vertex 103.554 -143.518 -43.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 103.554 -143.518 -41.084
+      vertex 103.554 -146.518 -43.2
+      vertex 103.554 -146.518 -41.084
+    endloop
+  endfacet
+  facet normal 0.891006 -0.453992 0
+    outer loop
+      vertex 203.374 -117.418 -11.2
+      vertex 205.085 -114.061 -27.4284
+      vertex 205.085 -114.061 -11.2
+    endloop
+  endfacet
+  facet normal 0.891006 -0.453992 0
+    outer loop
+      vertex 205.085 -114.061 -27.4284
+      vertex 203.374 -117.418 -11.2
+      vertex 203.374 -117.418 -32.6823
+    endloop
+  endfacet
+  facet normal 0.891003 -0.453998 5.43412e-06
+    outer loop
+      vertex 205.085 -114.061 -27.4284
+      vertex 203.374 -117.418 -32.6823
+      vertex 203.474 -117.224 -33.0248
+    endloop
+  endfacet
+  facet normal 0.890996 -0.454011 3.79222e-06
+    outer loop
+      vertex 204.047 -116.099 -43.0438
+      vertex 205.085 -114.061 -31.6366
+      vertex 204.828 -114.565 -32.4961
+    endloop
+  endfacet
+  facet normal 0.891007 -0.45399 0
+    outer loop
+      vertex 204.047 -116.099 -43.0438
+      vertex 204.828 -114.565 -32.4961
+      vertex 204.047 -116.099 -35.1127
+    endloop
+  endfacet
+  facet normal 0.891005 -0.453994 0
+    outer loop
+      vertex 205.085 -114.061 -31.6366
+      vertex 204.047 -116.099 -43.0438
+      vertex 205.085 -114.061 -56.2
+    endloop
+  endfacet
+  facet normal 0.891008 -0.453988 0
+    outer loop
+      vertex 203.374 -117.418 -56.2
+      vertex 204.047 -116.099 -43.0438
+      vertex 203.374 -117.418 -43.0438
+    endloop
+  endfacet
+  facet normal 0.891006 -0.453992 4.6561e-07
+    outer loop
+      vertex 204.047 -116.099 -43.0438
+      vertex 203.374 -117.418 -56.2
+      vertex 205.085 -114.061 -56.2
+    endloop
+  endfacet
+  facet normal 0.987688 -0.156435 0
+    outer loop
+      vertex 207.411 -106.903 -11.2
+      vertex 208 -103.181 -56.2
+      vertex 208 -103.181 -11.2
+    endloop
+  endfacet
+  facet normal 0.987688 -0.156435 0
+    outer loop
+      vertex 208 -103.181 -56.2
+      vertex 207.411 -106.903 -11.2
+      vertex 207.411 -106.903 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 173.754 -72.7221 -56.2
+      vertex 167.385 -63.1657 -56.2
+      vertex 167.511 -61.667 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 169.384 -72.0768 -56.2
+      vertex 166.891 -64.5861 -56.2
+      vertex 167.385 -63.1657 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 166.739 -73.4594 -56.2
+      vertex 166.891 -64.5861 -56.2
+      vertex 167.974 -72.601 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 165.757 -74.5979 -56.2
+      vertex 166.891 -64.5861 -56.2
+      vertex 166.739 -73.4594 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 147.859 -105.598 -56.2
+      vertex 166.891 -64.5861 -56.2
+      vertex 165.757 -74.5979 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 139.755 -111.586 -56.2
+      vertex 147.859 -105.598 -56.2
+      vertex 147.19 -106.945 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 147.859 -105.598 -56.2
+      vertex 139.755 -111.586 -56.2
+      vertex 166.891 -64.5861 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 139.755 -111.586 -56.2
+      vertex 147.19 -106.945 -56.2
+      vertex 146.877 -108.416 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.982 -96.4182 -56.2
+      vertex 185.861 -95.1657 -56.2
+      vertex 185.986 -93.667 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 190.197 -130.595 -56.2
+      vertex 185.366 -96.5861 -56.2
+      vertex 185.861 -95.1657 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 186.84 -132.306 -56.2
+      vertex 183.322 -133.656 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 183.322 -133.656 -56.2
+      vertex 179.992 -134.549 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 190.197 -130.595 -56.2
+      vertex 179.992 -118.918 -56.2
+      vertex 185.366 -96.5861 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 176.706 -111.586 -56.2
+      vertex 185.366 -96.5861 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 175.873 -112.839 -56.2
+      vertex 176.706 -111.586 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 174.756 -113.845 -56.2
+      vertex 175.873 -112.839 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 173.423 -114.542 -56.2
+      vertex 174.756 -113.845 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 171.959 -114.885 -56.2
+      vertex 173.423 -114.542 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 153.483 -114.885 -56.2
+      vertex 171.959 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 151.98 -114.854 -56.2
+      vertex 153.483 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 146.94 -109.919 -56.2
+      vertex 139.755 -111.586 -56.2
+      vertex 146.877 -108.416 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 147.375 -111.359 -56.2
+      vertex 139.755 -111.586 -56.2
+      vertex 146.94 -109.919 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 148.154 -112.645 -56.2
+      vertex 139.755 -111.586 -56.2
+      vertex 147.375 -111.359 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 138.923 -112.839 -56.2
+      vertex 148.154 -112.645 -56.2
+      vertex 149.229 -113.697 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 137.805 -113.845 -56.2
+      vertex 149.229 -113.697 -56.2
+      vertex 150.531 -114.449 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 136.472 -114.542 -56.2
+      vertex 150.531 -114.449 -56.2
+      vertex 151.98 -114.854 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 148.154 -112.645 -56.2
+      vertex 138.923 -112.839 -56.2
+      vertex 139.755 -111.586 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 149.229 -113.697 -56.2
+      vertex 137.805 -113.845 -56.2
+      vertex 138.923 -112.839 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 119.37 -118.918 -56.2
+      vertex 151.98 -114.854 -56.2
+      vertex 179.992 -118.918 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 150.531 -114.449 -56.2
+      vertex 136.472 -114.542 -56.2
+      vertex 137.805 -113.845 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 151.98 -114.854 -56.2
+      vertex 135.008 -114.885 -56.2
+      vertex 136.472 -114.542 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 151.98 -114.854 -56.2
+      vertex 119.37 -118.918 -56.2
+      vertex 135.008 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 135.008 -114.885 -56.2
+      vertex 119.37 -118.918 -56.2
+      vertex 119.37 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.982 -96.4182 -56.2
+      vertex 208.197 -99.4182 -56.2
+      vertex 208 -103.181 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.982 -96.4182 -56.2
+      vertex 208 -103.181 -56.2
+      vertex 207.411 -106.903 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 208.197 -99.4182 -56.2
+      vertex 192.982 -96.4182 -56.2
+      vertex 208 -95.6552 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 208 -95.6552 -56.2
+      vertex 192.982 -96.4182 -56.2
+      vertex 207.411 -91.9334 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.982 -96.4182 -56.2
+      vertex 207.411 -106.903 -56.2
+      vertex 206.435 -110.543 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.982 -96.4182 -56.2
+      vertex 206.435 -110.543 -56.2
+      vertex 205.085 -114.061 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.982 -96.4182 -56.2
+      vertex 205.085 -114.061 -56.2
+      vertex 203.374 -117.418 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.982 -96.4182 -56.2
+      vertex 203.374 -117.418 -56.2
+      vertex 201.322 -120.579 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 192.982 -96.4182 -56.2
+      vertex 201.322 -120.579 -56.2
+      vertex 198.951 -123.507 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 185.861 -95.1657 -56.2
+      vertex 198.951 -123.507 -56.2
+      vertex 196.286 -126.171 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 185.861 -95.1657 -56.2
+      vertex 196.286 -126.171 -56.2
+      vertex 193.358 -128.543 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 207.411 -91.9334 -56.2
+      vertex 192.982 -96.4182 -56.2
+      vertex 206.518 -88.603 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 185.861 -95.1657 -56.2
+      vertex 193.358 -128.543 -56.2
+      vertex 190.197 -130.595 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 179.992 -118.918 -56.2
+      vertex 190.197 -130.595 -56.2
+      vertex 186.84 -132.306 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 198.951 -123.507 -56.2
+      vertex 185.861 -95.1657 -56.2
+      vertex 192.982 -96.4182 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 185.736 -92.1841 -56.2
+      vertex 192.982 -96.4182 -56.2
+      vertex 185.986 -93.667 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 185.124 -90.8101 -56.2
+      vertex 192.982 -96.4182 -56.2
+      vertex 185.736 -92.1841 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 175.886 -74.8101 -56.2
+      vertex 192.982 -96.4182 -56.2
+      vertex 185.124 -90.8101 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 166.891 -64.5861 -56.2
+      vertex 169.384 -72.0768 -56.2
+      vertex 167.974 -72.601 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 167.385 -63.1657 -56.2
+      vertex 170.88 -71.9196 -56.2
+      vertex 169.384 -72.0768 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 167.385 -63.1657 -56.2
+      vertex 172.368 -72.1393 -56.2
+      vertex 170.88 -71.9196 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 167.385 -63.1657 -56.2
+      vertex 173.754 -72.7221 -56.2
+      vertex 172.368 -72.1393 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 167.511 -61.667 -56.2
+      vertex 174.952 -73.6314 -56.2
+      vertex 173.754 -72.7221 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 167.26 -60.184 -56.2
+      vertex 174.952 -73.6314 -56.2
+      vertex 167.511 -61.667 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 174.952 -73.6314 -56.2
+      vertex 167.26 -60.184 -56.2
+      vertex 175.886 -74.8101 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 162.671 -43.9182 -56.2
+      vertex 175.886 -74.8101 -56.2
+      vertex 167.26 -60.184 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 162.671 -43.9182 -56.2
+      vertex 167.26 -60.184 -56.2
+      vertex 166.649 -58.8101 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 175.886 -74.8101 -56.2
+      vertex 162.671 -43.9182 -56.2
+      vertex 192.982 -96.4182 -56.2
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 162.671 -43.9182 -56.2
+      vertex 166.649 -58.8101 -56.2
+      vertex 159.206 -45.9189 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 185.861 -95.1657 -11.2
+      vertex 188.505 -100.173 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 185.366 -96.5861 -11.2
+      vertex 188.505 -100.173 -11.2
+      vertex 185.861 -95.1657 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 188.505 -100.173 -11.2
+      vertex 185.366 -96.5861 -11.2
+      vertex 185.755 -104.936 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 191.232 -114.449 -11.2
+      vertex 187.768 -112.449 -11.2
+      vertex 189.232 -117.913 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 195.281 -110.436 -11.2
+      vertex 196.745 -115.9 -11.2
+      vertex 198.745 -112.436 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 196.745 -115.9 -11.2
+      vertex 195.281 -110.436 -11.2
+      vertex 193.281 -113.9 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 208.197 -99.4182 -11.2
+      vertex 208 -95.6552 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 208 -95.6552 -11.2
+      vertex 207.411 -91.9334 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 208.197 -99.4182 -11.2
+      vertex 196.732 -104.923 -11.2
+      vertex 208 -103.181 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 207.411 -91.9334 -11.2
+      vertex 206.518 -88.603 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 208 -103.181 -11.2
+      vertex 196.732 -104.923 -11.2
+      vertex 201.495 -107.673 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 207.411 -106.903 -11.2
+      vertex 201.495 -107.673 -11.2
+      vertex 206.435 -110.543 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 206.435 -110.543 -11.2
+      vertex 201.495 -107.673 -11.2
+      vertex 205.085 -114.061 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 198.745 -112.436 -11.2
+      vertex 205.085 -114.061 -11.2
+      vertex 201.495 -107.673 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 208 -103.181 -11.2
+      vertex 201.495 -107.673 -11.2
+      vertex 207.411 -106.903 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 196.732 -104.923 -11.2
+      vertex 193.268 -102.923 -11.2
+      vertex 194.732 -108.387 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 208.197 -99.4182 -11.2
+      vertex 192.982 -96.4182 -11.2
+      vertex 196.732 -104.923 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 196.732 -104.923 -11.2
+      vertex 192.982 -96.4182 -11.2
+      vertex 193.268 -102.923 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 188.505 -100.173 -11.2
+      vertex 193.268 -102.923 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 185.861 -95.1657 -11.2
+      vertex 192.982 -96.4182 -11.2
+      vertex 185.986 -93.667 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 185.736 -92.1841 -11.2
+      vertex 185.986 -93.667 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 185.124 -90.8101 -11.2
+      vertex 185.736 -92.1841 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 175.886 -74.8101 -11.2
+      vertex 185.124 -90.8101 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 172.368 -72.1393 -11.2
+      vertex 166.891 -64.5861 -11.2
+      vertex 170.88 -71.9196 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 166.891 -64.5861 -11.2
+      vertex 172.368 -72.1393 -11.2
+      vertex 167.385 -63.1657 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 173.754 -72.7221 -11.2
+      vertex 167.385 -63.1657 -11.2
+      vertex 172.368 -72.1393 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 167.385 -63.1657 -11.2
+      vertex 173.754 -72.7221 -11.2
+      vertex 167.511 -61.667 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 174.952 -73.6314 -11.2
+      vertex 167.511 -61.667 -11.2
+      vertex 173.754 -72.7221 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 167.26 -60.184 -11.2
+      vertex 174.952 -73.6314 -11.2
+      vertex 175.886 -74.8101 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 162.671 -43.9182 -11.2
+      vertex 175.886 -74.8101 -11.2
+      vertex 192.982 -96.4182 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 174.952 -73.6314 -11.2
+      vertex 167.26 -60.184 -11.2
+      vertex 167.511 -61.667 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 175.886 -74.8101 -11.2
+      vertex 162.671 -43.9182 -11.2
+      vertex 167.26 -60.184 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 167.26 -60.184 -11.2
+      vertex 162.671 -43.9182 -11.2
+      vertex 166.649 -58.8101 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 166.649 -58.8101 -11.2
+      vertex 162.671 -43.9182 -11.2
+      vertex 159.206 -45.9189 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 205.085 -114.061 -11.2
+      vertex 198.745 -112.436 -11.2
+      vertex 203.374 -117.418 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 196.745 -115.9 -11.2
+      vertex 203.374 -117.418 -11.2
+      vertex 198.745 -112.436 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 203.374 -117.418 -11.2
+      vertex 196.745 -115.9 -11.2
+      vertex 201.322 -120.579 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 193.995 -120.663 -11.2
+      vertex 201.322 -120.579 -11.2
+      vertex 196.745 -115.9 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 201.322 -120.579 -11.2
+      vertex 193.995 -120.663 -11.2
+      vertex 198.951 -123.507 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 198.951 -123.507 -11.2
+      vertex 193.995 -120.663 -11.2
+      vertex 196.286 -126.171 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 193.995 -120.663 -11.2
+      vertex 193.358 -128.543 -11.2
+      vertex 196.286 -126.171 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 189.232 -117.913 -11.2
+      vertex 193.358 -128.543 -11.2
+      vertex 193.995 -120.663 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 193.358 -128.543 -11.2
+      vertex 189.232 -117.913 -11.2
+      vertex 190.197 -130.595 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 185.768 -115.913 -11.2
+      vertex 189.232 -117.913 -11.2
+      vertex 187.768 -112.449 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179.992 -118.918 -11.2
+      vertex 189.232 -117.913 -11.2
+      vertex 185.768 -115.913 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 189.232 -117.913 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 190.197 -130.595 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 190.197 -130.595 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 186.84 -132.306 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179.992 -118.918 -11.2
+      vertex 185.768 -115.913 -11.2
+      vertex 181.005 -113.163 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 186.84 -132.306 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 183.322 -133.656 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 183.322 -133.656 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 179.992 -134.549 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 194.732 -108.387 -11.2
+      vertex 193.268 -102.923 -11.2
+      vertex 191.268 -106.387 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 185.755 -104.936 -11.2
+      vertex 187.219 -110.4 -11.2
+      vertex 189.219 -106.936 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 185.755 -104.936 -11.2
+      vertex 183.755 -108.4 -11.2
+      vertex 187.219 -110.4 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 176.706 -111.586 -11.2
+      vertex 185.755 -104.936 -11.2
+      vertex 185.366 -96.5861 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 185.755 -104.936 -11.2
+      vertex 176.706 -111.586 -11.2
+      vertex 183.755 -108.4 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 183.755 -108.4 -11.2
+      vertex 176.706 -111.586 -11.2
+      vertex 181.005 -113.163 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 175.873 -112.839 -11.2
+      vertex 181.005 -113.163 -11.2
+      vertex 176.706 -111.586 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 181.005 -113.163 -11.2
+      vertex 175.873 -112.839 -11.2
+      vertex 179.992 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 174.756 -113.845 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 175.873 -112.839 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 173.423 -114.542 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 174.756 -113.845 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 171.959 -114.885 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 173.423 -114.542 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 153.483 -114.885 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 171.959 -114.885 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 151.98 -114.854 -11.2
+      vertex 179.992 -118.918 -11.2
+      vertex 153.483 -114.885 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 139.755 -111.586 -11.2
+      vertex 146.94 -109.919 -11.2
+      vertex 146.877 -108.416 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 139.755 -111.586 -11.2
+      vertex 147.375 -111.359 -11.2
+      vertex 146.94 -109.919 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 139.755 -111.586 -11.2
+      vertex 148.154 -112.645 -11.2
+      vertex 147.375 -111.359 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 138.923 -112.839 -11.2
+      vertex 148.154 -112.645 -11.2
+      vertex 139.755 -111.586 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 148.154 -112.645 -11.2
+      vertex 138.923 -112.839 -11.2
+      vertex 149.229 -113.697 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 137.805 -113.845 -11.2
+      vertex 149.229 -113.697 -11.2
+      vertex 138.923 -112.839 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 149.229 -113.697 -11.2
+      vertex 137.805 -113.845 -11.2
+      vertex 150.531 -114.449 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 136.472 -114.542 -11.2
+      vertex 150.531 -114.449 -11.2
+      vertex 137.805 -113.845 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 150.531 -114.449 -11.2
+      vertex 136.472 -114.542 -11.2
+      vertex 151.98 -114.854 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 135.008 -114.885 -11.2
+      vertex 151.98 -114.854 -11.2
+      vertex 136.472 -114.542 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.37 -118.918 -11.2
+      vertex 151.98 -114.854 -11.2
+      vertex 135.008 -114.885 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 119.37 -118.918 -11.2
+      vertex 135.008 -114.885 -11.2
+      vertex 119.37 -114.885 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 151.98 -114.854 -11.2
+      vertex 119.37 -118.918 -11.2
+      vertex 179.992 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 170.88 -71.9196 -11.2
+      vertex 166.891 -64.5861 -11.2
+      vertex 169.384 -72.0768 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 169.384 -72.0768 -11.2
+      vertex 166.891 -64.5861 -11.2
+      vertex 167.974 -72.601 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 166.891 -64.5861 -11.2
+      vertex 166.739 -73.4594 -11.2
+      vertex 167.974 -72.601 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 166.891 -64.5861 -11.2
+      vertex 165.757 -74.5979 -11.2
+      vertex 166.739 -73.4594 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 166.891 -64.5861 -11.2
+      vertex 147.859 -105.598 -11.2
+      vertex 165.757 -74.5979 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 139.755 -111.586 -11.2
+      vertex 147.859 -105.598 -11.2
+      vertex 166.891 -64.5861 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.19 -106.945 -11.2
+      vertex 139.755 -111.586 -11.2
+      vertex 146.877 -108.416 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 147.859 -105.598 -11.2
+      vertex 139.755 -111.586 -11.2
+      vertex 147.19 -106.945 -11.2
+    endloop
+  endfacet
+  facet normal 0.258821 -0.965925 0
+    outer loop
+      vertex 179.992 -134.549 -56.2
+      vertex 183.322 -133.656 -11.2
+      vertex 179.992 -134.549 -11.2
+    endloop
+  endfacet
+  facet normal 0.258821 -0.965925 0
+    outer loop
+      vertex 183.322 -133.656 -11.2
+      vertex 179.992 -134.549 -56.2
+      vertex 183.322 -133.656 -56.2
+    endloop
+  endfacet
+  facet normal 0.933581 -0.358366 0
+    outer loop
+      vertex 205.085 -114.061 -31.6366
+      vertex 206.435 -110.543 -56.2
+      vertex 206.435 -110.543 -25.972
+    endloop
+  endfacet
+  facet normal 0.933581 -0.358366 0
+    outer loop
+      vertex 206.435 -110.543 -56.2
+      vertex 205.085 -114.061 -31.6366
+      vertex 205.085 -114.061 -56.2
+    endloop
+  endfacet
+  facet normal 0.933582 -0.358363 0
+    outer loop
+      vertex 206.435 -110.543 -11.2
+      vertex 205.894 -111.953 -23.9078
+      vertex 206.435 -110.543 -23.9078
+    endloop
+  endfacet
+  facet normal 0.933581 -0.358366 2.9917e-07
+    outer loop
+      vertex 205.085 -114.061 -11.2
+      vertex 205.894 -111.953 -23.9078
+      vertex 206.435 -110.543 -11.2
+    endloop
+  endfacet
+  facet normal 0.933581 -0.358367 0
+    outer loop
+      vertex 205.894 -111.953 -23.9078
+      vertex 205.085 -114.061 -11.2
+      vertex 205.085 -114.061 -27.4284
+    endloop
+  endfacet
+  facet normal 0.965926 0.258817 0
+    outer loop
+      vertex 207.411 -91.9334 -11.2
+      vertex 206.518 -88.603 -56.2
+      vertex 206.518 -88.603 -11.2
+    endloop
+  endfacet
+  facet normal 0.965926 0.258817 0
+    outer loop
+      vertex 206.518 -88.603 -56.2
+      vertex 207.411 -91.9334 -11.2
+      vertex 207.411 -91.9334 -56.2
+    endloop
+  endfacet
+  facet normal 0.99863 -0.052334 0
+    outer loop
+      vertex 208 -103.181 -11.2
+      vertex 208.197 -99.4182 -56.2
+      vertex 208.197 -99.4182 -11.2
+    endloop
+  endfacet
+  facet normal 0.99863 -0.052334 0
+    outer loop
+      vertex 208.197 -99.4182 -56.2
+      vertex 208 -103.181 -11.2
+      vertex 208 -103.181 -56.2
+    endloop
+  endfacet
+  facet normal 0.99863 0.0523341 0
+    outer loop
+      vertex 208.197 -99.4182 -11.2
+      vertex 208 -95.6552 -56.2
+      vertex 208 -95.6552 -11.2
+    endloop
+  endfacet
+  facet normal 0.99863 0.0523341 0
+    outer loop
+      vertex 208 -95.6552 -56.2
+      vertex 208.197 -99.4182 -11.2
+      vertex 208.197 -99.4182 -56.2
+    endloop
+  endfacet
+  facet normal 0.987688 0.156435 0
+    outer loop
+      vertex 208 -95.6552 -11.2
+      vertex 207.411 -91.9334 -56.2
+      vertex 207.411 -91.9334 -11.2
+    endloop
+  endfacet
+  facet normal 0.987688 0.156435 0
+    outer loop
+      vertex 207.411 -91.9334 -56.2
+      vertex 208 -95.6552 -11.2
+      vertex 208 -95.6552 -56.2
+    endloop
+  endfacet
+  facet normal 0.83867 -0.54464 0
+    outer loop
+      vertex 201.322 -120.579 -26.7744
+      vertex 203.374 -117.418 -11.2
+      vertex 201.322 -120.579 -11.2
+    endloop
+  endfacet
+  facet normal 0.83867 -0.54464 0
+    outer loop
+      vertex 203.374 -117.418 -11.2
+      vertex 201.322 -120.579 -26.7744
+      vertex 203.374 -117.418 -32.6823
+    endloop
+  endfacet
+  facet normal 0.83867 -0.54464 0
+    outer loop
+      vertex 202.776 -118.34 -35.1127
+      vertex 201.322 -120.579 -31.0437
+      vertex 202.776 -118.34 -43.0438
+    endloop
+  endfacet
+  facet normal 0.838671 -0.544638 0
+    outer loop
+      vertex 202.776 -118.34 -43.0438
+      vertex 203.374 -117.418 -56.2
+      vertex 203.374 -117.418 -43.0438
+    endloop
+  endfacet
+  facet normal 0.83867 -0.54464 0
+    outer loop
+      vertex 201.322 -120.579 -56.2
+      vertex 202.776 -118.34 -43.0438
+      vertex 201.322 -120.579 -31.0437
+    endloop
+  endfacet
+  facet normal 0.83867 -0.54464 -1.62633e-07
+    outer loop
+      vertex 202.776 -118.34 -43.0438
+      vertex 201.322 -120.579 -56.2
+      vertex 203.374 -117.418 -56.2
+    endloop
+  endfacet
+  facet normal 0.544639 -0.838671 0
+    outer loop
+      vertex 190.197 -130.595 -56.2
+      vertex 193.358 -128.543 -11.2
+      vertex 190.197 -130.595 -11.2
+    endloop
+  endfacet
+  facet normal 0.544639 -0.838671 0
+    outer loop
+      vertex 193.358 -128.543 -11.2
+      vertex 190.197 -130.595 -56.2
+      vertex 193.358 -128.543 -56.2
+    endloop
+  endfacet
+  facet normal 0.453992 -0.891006 0
+    outer loop
+      vertex 186.84 -132.306 -56.2
+      vertex 190.197 -130.595 -11.2
+      vertex 186.84 -132.306 -11.2
+    endloop
+  endfacet
+  facet normal 0.453992 -0.891006 0
+    outer loop
+      vertex 190.197 -130.595 -11.2
+      vertex 186.84 -132.306 -56.2
+      vertex 190.197 -130.595 -56.2
+    endloop
+  endfacet
+  facet normal 0.358365 -0.933582 0
+    outer loop
+      vertex 183.322 -133.656 -56.2
+      vertex 186.84 -132.306 -11.2
+      vertex 183.322 -133.656 -11.2
+    endloop
+  endfacet
+  facet normal 0.358365 -0.933582 0
+    outer loop
+      vertex 186.84 -132.306 -11.2
+      vertex 183.322 -133.656 -56.2
+      vertex 186.84 -132.306 -56.2
+    endloop
+  endfacet
+  facet normal 0.965926 -0.258817 0
+    outer loop
+      vertex 207.411 -106.903 -11.2
+      vertex 206.799 -109.187 -23.9078
+      vertex 207.411 -106.903 -56.2
+    endloop
+  endfacet
+  facet normal 0.965926 -0.258819 3.59698e-07
+    outer loop
+      vertex 206.435 -110.543 -11.2
+      vertex 206.799 -109.187 -23.9078
+      vertex 207.411 -106.903 -11.2
+    endloop
+  endfacet
+  facet normal 0.965925 -0.258822 0
+    outer loop
+      vertex 206.799 -109.187 -23.9078
+      vertex 206.435 -110.543 -11.2
+      vertex 206.435 -110.543 -23.9078
+    endloop
+  endfacet
+  facet normal 0.965925 -0.258822 -3.4296e-07
+    outer loop
+      vertex 206.435 -110.543 -25.972
+      vertex 207.411 -106.903 -56.2
+      vertex 206.799 -109.187 -23.9078
+    endloop
+  endfacet
+  facet normal 0.965926 -0.258819 0
+    outer loop
+      vertex 207.411 -106.903 -56.2
+      vertex 206.435 -110.543 -25.972
+      vertex 206.435 -110.543 -56.2
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 198.951 -123.507 -11.2
+      vertex 198.254 -124.204 -23.9078
+      vertex 198.951 -123.507 -23.9078
+    endloop
+  endfacet
+  facet normal 0.707108 -0.707106 -1.11044e-07
+    outer loop
+      vertex 198.254 -124.204 -23.9078
+      vertex 198.951 -123.507 -11.2
+      vertex 196.286 -126.171 -11.2
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 1.48226e-07
+    outer loop
+      vertex 196.286 -126.171 -56.2
+      vertex 198.951 -123.507 -25.3614
+      vertex 198.254 -124.204 -23.9078
+    endloop
+  endfacet
+  facet normal 0.707108 -0.707105 0
+    outer loop
+      vertex 196.286 -126.171 -56.2
+      vertex 198.254 -124.204 -23.9078
+      vertex 196.286 -126.171 -11.2
+    endloop
+  endfacet
+  facet normal 0.707108 -0.707106 0
+    outer loop
+      vertex 198.951 -123.507 -25.3614
+      vertex 196.286 -126.171 -56.2
+      vertex 198.951 -123.507 -56.2
+    endloop
+  endfacet
+  facet normal 0.777148 -0.629317 0
+    outer loop
+      vertex 201.322 -120.579 -11.2
+      vertex 200.159 -122.015 -23.9078
+      vertex 201.322 -120.579 -26.7744
+    endloop
+  endfacet
+  facet normal 0.777146 -0.62932 4.95765e-07
+    outer loop
+      vertex 198.951 -123.507 -11.2
+      vertex 200.159 -122.015 -23.9078
+      vertex 201.322 -120.579 -11.2
+    endloop
+  endfacet
+  facet normal 0.777144 -0.629323 0
+    outer loop
+      vertex 200.159 -122.015 -23.9078
+      vertex 198.951 -123.507 -11.2
+      vertex 198.951 -123.507 -23.9078
+    endloop
+  endfacet
+  facet normal 0.777148 -0.629318 -3.91226e-07
+    outer loop
+      vertex 198.951 -123.507 -56.2
+      vertex 201.322 -120.579 -31.0437
+      vertex 199.814 -122.441 -27.4307
+    endloop
+  endfacet
+  facet normal 0.777143 -0.629324 0
+    outer loop
+      vertex 198.951 -123.507 -56.2
+      vertex 199.814 -122.441 -27.4307
+      vertex 198.951 -123.507 -25.3614
+    endloop
+  endfacet
+  facet normal 0.777146 -0.62932 0
+    outer loop
+      vertex 201.322 -120.579 -31.0437
+      vertex 198.951 -123.507 -56.2
+      vertex 201.322 -120.579 -56.2
+    endloop
+  endfacet
+  facet normal 0.629319 -0.777147 0
+    outer loop
+      vertex 193.358 -128.543 -56.2
+      vertex 196.286 -126.171 -11.2
+      vertex 193.358 -128.543 -11.2
+    endloop
+  endfacet
+  facet normal 0.629319 -0.777147 0
+    outer loop
+      vertex 196.286 -126.171 -11.2
+      vertex 193.358 -128.543 -56.2
+      vertex 196.286 -126.171 -56.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 0
+    outer loop
+      vertex 206.518 -88.603 -56.2
+      vertex 192.982 -96.4182 -11.2
+      vertex 206.518 -88.603 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866026 0
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 206.518 -88.603 -56.2
+      vertex 192.982 -96.4182 -56.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 179.992 -134.549 -56.2
+      vertex 179.992 -118.918 -11.2
+      vertex 179.992 -118.918 -56.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 179.992 -118.918 -11.2
+      vertex 179.992 -134.549 -56.2
+      vertex 179.992 -134.549 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 192.982 -96.4182 -11.2
+      vertex 162.671 -43.9182 -56.2
+      vertex 162.671 -43.9182 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 162.671 -43.9182 -56.2
+      vertex 192.982 -96.4182 -11.2
+      vertex 192.982 -96.4182 -56.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 119.37 -118.918 -56.2
+      vertex 179.992 -118.918 -11.2
+      vertex 119.37 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179.992 -118.918 -11.2
+      vertex 119.37 -118.918 -56.2
+      vertex 179.992 -118.918 -56.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 162.671 -43.9182 -56.2
+      vertex 159.206 -45.9189 -11.2
+      vertex 162.671 -43.9182 -11.2
+    endloop
+  endfacet
+  facet normal -0.5 0.866025 0
+    outer loop
+      vertex 159.206 -45.9189 -11.2
+      vertex 162.671 -43.9182 -56.2
+      vertex 159.206 -45.9189 -56.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 119.37 -118.918 -56.2
+      vertex 119.37 -114.885 -11.2
+      vertex 119.37 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 119.37 -114.885 -11.2
+      vertex 119.37 -118.918 -56.2
+      vertex 119.37 -118.918 -11.2
+    endloop
+  endfacet
+  facet normal 0.104529 -0.994522 0
+    outer loop
+      vertex 169.384 -72.0768 -56.2
+      vertex 170.88 -71.9196 -11.2
+      vertex 169.384 -72.0768 -11.2
+    endloop
+  endfacet
+  facet normal 0.104529 -0.994522 0
+    outer loop
+      vertex 170.88 -71.9196 -11.2
+      vertex 169.384 -72.0768 -56.2
+      vertex 170.88 -71.9196 -56.2
+    endloop
+  endfacet
+  facet normal 0.268921 0.963162 -0
+    outer loop
+      vertex 151.98 -114.854 -56.2
+      vertex 150.531 -114.449 -11.2
+      vertex 151.98 -114.854 -11.2
+    endloop
+  endfacet
+  facet normal 0.268921 0.963162 0
+    outer loop
+      vertex 150.531 -114.449 -11.2
+      vertex 151.98 -114.854 -56.2
+      vertex 150.531 -114.449 -56.2
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 -0
+    outer loop
+      vertex 150.531 -114.449 -56.2
+      vertex 149.229 -113.697 -11.2
+      vertex 150.531 -114.449 -11.2
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 0
+    outer loop
+      vertex 149.229 -113.697 -11.2
+      vertex 150.531 -114.449 -56.2
+      vertex 149.229 -113.697 -56.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 171.959 -114.885 -56.2
+      vertex 153.483 -114.885 -11.2
+      vertex 171.959 -114.885 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 153.483 -114.885 -11.2
+      vertex 171.959 -114.885 -56.2
+      vertex 153.483 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal 0.895715 -0.444629 0
+    outer loop
+      vertex 147.19 -106.945 -11.2
+      vertex 147.859 -105.598 -56.2
+      vertex 147.859 -105.598 -11.2
+    endloop
+  endfacet
+  facet normal 0.895715 -0.444629 0
+    outer loop
+      vertex 147.859 -105.598 -56.2
+      vertex 147.19 -106.945 -11.2
+      vertex 147.19 -106.945 -56.2
+    endloop
+  endfacet
+  facet normal 0.699667 0.714469 -0
+    outer loop
+      vertex 149.229 -113.697 -56.2
+      vertex 148.154 -112.645 -11.2
+      vertex 149.229 -113.697 -11.2
+    endloop
+  endfacet
+  facet normal 0.699667 0.714469 0
+    outer loop
+      vertex 148.154 -112.645 -11.2
+      vertex 149.229 -113.697 -56.2
+      vertex 148.154 -112.645 -56.2
+    endloop
+  endfacet
+  facet normal 0.0209402 0.999781 -0
+    outer loop
+      vertex 153.483 -114.885 -56.2
+      vertex 151.98 -114.854 -11.2
+      vertex 153.483 -114.885 -11.2
+    endloop
+  endfacet
+  facet normal 0.0209402 0.999781 0
+    outer loop
+      vertex 151.98 -114.854 -11.2
+      vertex 153.483 -114.885 -56.2
+      vertex 151.98 -114.854 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 185.124 -90.8101 -56.2
+      vertex 175.886 -74.8101 -11.2
+      vertex 175.886 -74.8101 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 175.886 -74.8101 -11.2
+      vertex 185.124 -90.8101 -56.2
+      vertex 185.124 -90.8101 -11.2
+    endloop
+  endfacet
+  facet normal 0.978148 -0.207912 0
+    outer loop
+      vertex 146.877 -108.416 -11.2
+      vertex 147.19 -106.945 -56.2
+      vertex 147.19 -106.945 -11.2
+    endloop
+  endfacet
+  facet normal 0.978148 -0.207912 0
+    outer loop
+      vertex 147.19 -106.945 -56.2
+      vertex 146.877 -108.416 -11.2
+      vertex 146.877 -108.416 -56.2
+    endloop
+  endfacet
+  facet normal -0.4633 0.886201 0
+    outer loop
+      vertex 174.756 -113.845 -56.2
+      vertex 173.423 -114.542 -11.2
+      vertex 174.756 -113.845 -11.2
+    endloop
+  endfacet
+  facet normal -0.4633 0.886201 0
+    outer loop
+      vertex 173.423 -114.542 -11.2
+      vertex 174.756 -113.845 -56.2
+      vertex 173.423 -114.542 -56.2
+    endloop
+  endfacet
+  facet normal -0.228349 0.973579 0
+    outer loop
+      vertex 173.423 -114.542 -56.2
+      vertex 171.959 -114.885 -11.2
+      vertex 173.423 -114.542 -11.2
+    endloop
+  endfacet
+  facet normal -0.228349 0.973579 0
+    outer loop
+      vertex 171.959 -114.885 -11.2
+      vertex 173.423 -114.542 -56.2
+      vertex 171.959 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal -0.387514 -0.921864 0
+    outer loop
+      vertex 172.368 -72.1393 -56.2
+      vertex 173.754 -72.7221 -11.2
+      vertex 172.368 -72.1393 -11.2
+    endloop
+  endfacet
+  facet normal -0.387514 -0.921864 -0
+    outer loop
+      vertex 173.754 -72.7221 -11.2
+      vertex 172.368 -72.1393 -56.2
+      vertex 173.754 -72.7221 -56.2
+    endloop
+  endfacet
+  facet normal 0.999123 0.0418702 0
+    outer loop
+      vertex 146.94 -109.919 -11.2
+      vertex 146.877 -108.416 -56.2
+      vertex 146.877 -108.416 -11.2
+    endloop
+  endfacet
+  facet normal 0.999123 0.0418702 0
+    outer loop
+      vertex 146.877 -108.416 -56.2
+      vertex 146.94 -109.919 -11.2
+      vertex 146.94 -109.919 -56.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 147.859 -105.598 -11.2
+      vertex 165.757 -74.5979 -56.2
+      vertex 165.757 -74.5979 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 165.757 -74.5979 -56.2
+      vertex 147.859 -105.598 -11.2
+      vertex 147.859 -105.598 -56.2
+    endloop
+  endfacet
+  facet normal 0.570716 -0.821148 0
+    outer loop
+      vertex 166.739 -73.4594 -56.2
+      vertex 167.974 -72.601 -11.2
+      vertex 166.739 -73.4594 -11.2
+    endloop
+  endfacet
+  facet normal 0.570716 -0.821148 0
+    outer loop
+      vertex 167.974 -72.601 -11.2
+      vertex 166.739 -73.4594 -56.2
+      vertex 167.974 -72.601 -56.2
+    endloop
+  endfacet
+  facet normal -0.944377 0.328866 0
+    outer loop
+      vertex 185.366 -96.5861 -56.2
+      vertex 185.861 -95.1657 -11.2
+      vertex 185.861 -95.1657 -56.2
+    endloop
+  endfacet
+  facet normal -0.944377 0.328866 0
+    outer loop
+      vertex 185.861 -95.1657 -11.2
+      vertex 185.366 -96.5861 -56.2
+      vertex 185.366 -96.5861 -11.2
+    endloop
+  endfacet
+  facet normal -0.783696 -0.621145 0
+    outer loop
+      vertex 175.886 -74.8101 -56.2
+      vertex 174.952 -73.6314 -11.2
+      vertex 174.952 -73.6314 -56.2
+    endloop
+  endfacet
+  facet normal -0.783696 -0.621145 0
+    outer loop
+      vertex 174.952 -73.6314 -11.2
+      vertex 175.886 -74.8101 -56.2
+      vertex 175.886 -74.8101 -11.2
+    endloop
+  endfacet
+  facet normal -0.146084 -0.989272 0
+    outer loop
+      vertex 170.88 -71.9196 -56.2
+      vertex 172.368 -72.1393 -11.2
+      vertex 170.88 -71.9196 -11.2
+    endloop
+  endfacet
+  facet normal -0.146084 -0.989272 -0
+    outer loop
+      vertex 172.368 -72.1393 -11.2
+      vertex 170.88 -71.9196 -56.2
+      vertex 172.368 -72.1393 -56.2
+    endloop
+  endfacet
+  facet normal 0.855364 0.518027 0
+    outer loop
+      vertex 148.154 -112.645 -11.2
+      vertex 147.375 -111.359 -56.2
+      vertex 147.375 -111.359 -11.2
+    endloop
+  endfacet
+  facet normal 0.855364 0.518027 0
+    outer loop
+      vertex 147.375 -111.359 -56.2
+      vertex 148.154 -112.645 -11.2
+      vertex 148.154 -112.645 -56.2
+    endloop
+  endfacet
+  facet normal 0.957319 0.289035 0
+    outer loop
+      vertex 147.375 -111.359 -11.2
+      vertex 146.94 -109.919 -56.2
+      vertex 146.94 -109.919 -11.2
+    endloop
+  endfacet
+  facet normal 0.957319 0.289035 0
+    outer loop
+      vertex 146.94 -109.919 -56.2
+      vertex 147.375 -111.359 -11.2
+      vertex 147.375 -111.359 -56.2
+    endloop
+  endfacet
+  facet normal 0.75699 -0.653426 0
+    outer loop
+      vertex 165.757 -74.5979 -11.2
+      vertex 166.739 -73.4594 -56.2
+      vertex 166.739 -73.4594 -11.2
+    endloop
+  endfacet
+  facet normal 0.75699 -0.653426 0
+    outer loop
+      vertex 166.739 -73.4594 -56.2
+      vertex 165.757 -74.5979 -11.2
+      vertex 165.757 -74.5979 -56.2
+    endloop
+  endfacet
+  facet normal -0.66913 0.743146 0
+    outer loop
+      vertex 175.873 -112.839 -56.2
+      vertex 174.756 -113.845 -11.2
+      vertex 175.873 -112.839 -11.2
+    endloop
+  endfacet
+  facet normal -0.66913 0.743146 0
+    outer loop
+      vertex 174.756 -113.845 -11.2
+      vertex 175.873 -112.839 -56.2
+      vertex 174.756 -113.845 -56.2
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 176.706 -111.586 -56.2
+      vertex 185.366 -96.5861 -11.2
+      vertex 185.366 -96.5861 -56.2
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 185.366 -96.5861 -11.2
+      vertex 176.706 -111.586 -56.2
+      vertex 176.706 -111.586 -11.2
+    endloop
+  endfacet
+  facet normal -0.985996 -0.166772 0
+    outer loop
+      vertex 185.986 -93.667 -56.2
+      vertex 185.736 -92.1841 -11.2
+      vertex 185.736 -92.1841 -56.2
+    endloop
+  endfacet
+  facet normal -0.985996 -0.166772 0
+    outer loop
+      vertex 185.736 -92.1841 -11.2
+      vertex 185.986 -93.667 -56.2
+      vertex 185.986 -93.667 -11.2
+    endloop
+  endfacet
+  facet normal -0.913547 -0.406733 0
+    outer loop
+      vertex 185.736 -92.1841 -56.2
+      vertex 185.124 -90.8101 -11.2
+      vertex 185.124 -90.8101 -56.2
+    endloop
+  endfacet
+  facet normal -0.913547 -0.406733 0
+    outer loop
+      vertex 185.124 -90.8101 -11.2
+      vertex 185.736 -92.1841 -56.2
+      vertex 185.736 -92.1841 -11.2
+    endloop
+  endfacet
+  facet normal 0.348574 -0.937281 0
+    outer loop
+      vertex 167.974 -72.601 -56.2
+      vertex 169.384 -72.0768 -11.2
+      vertex 167.974 -72.601 -11.2
+    endloop
+  endfacet
+  facet normal 0.348574 -0.937281 0
+    outer loop
+      vertex 169.384 -72.0768 -11.2
+      vertex 167.974 -72.601 -56.2
+      vertex 169.384 -72.0768 -56.2
+    endloop
+  endfacet
+  facet normal -0.832919 0.553395 0
+    outer loop
+      vertex 175.873 -112.839 -56.2
+      vertex 176.706 -111.586 -11.2
+      vertex 176.706 -111.586 -56.2
+    endloop
+  endfacet
+  facet normal -0.832919 0.553395 0
+    outer loop
+      vertex 176.706 -111.586 -11.2
+      vertex 175.873 -112.839 -56.2
+      vertex 175.873 -112.839 -11.2
+    endloop
+  endfacet
+  facet normal -0.996493 0.0836798 0
+    outer loop
+      vertex 185.861 -95.1657 -56.2
+      vertex 185.986 -93.667 -11.2
+      vertex 185.986 -93.667 -56.2
+    endloop
+  endfacet
+  facet normal -0.996493 0.0836798 0
+    outer loop
+      vertex 185.986 -93.667 -11.2
+      vertex 185.861 -95.1657 -56.2
+      vertex 185.861 -95.1657 -11.2
+    endloop
+  endfacet
+  facet normal -0.604599 -0.79653 0
+    outer loop
+      vertex 173.754 -72.7221 -56.2
+      vertex 174.952 -73.6314 -11.2
+      vertex 173.754 -72.7221 -11.2
+    endloop
+  endfacet
+  facet normal -0.604599 -0.79653 -0
+    outer loop
+      vertex 174.952 -73.6314 -11.2
+      vertex 173.754 -72.7221 -56.2
+      vertex 174.952 -73.6314 -56.2
+    endloop
+  endfacet
+  facet normal -0.463296 0.886203 0
+    outer loop
+      vertex 137.805 -113.845 -56.2
+      vertex 136.472 -114.542 -11.2
+      vertex 137.805 -113.845 -11.2
+    endloop
+  endfacet
+  facet normal -0.463296 0.886203 0
+    outer loop
+      vertex 136.472 -114.542 -11.2
+      vertex 137.805 -113.845 -56.2
+      vertex 136.472 -114.542 -56.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 135.008 -114.885 -56.2
+      vertex 119.37 -114.885 -11.2
+      vertex 135.008 -114.885 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 119.37 -114.885 -11.2
+      vertex 135.008 -114.885 -56.2
+      vertex 119.37 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal -0.228349 0.973579 0
+    outer loop
+      vertex 136.472 -114.542 -56.2
+      vertex 135.008 -114.885 -11.2
+      vertex 136.472 -114.542 -11.2
+    endloop
+  endfacet
+  facet normal -0.228349 0.973579 0
+    outer loop
+      vertex 135.008 -114.885 -11.2
+      vertex 136.472 -114.542 -56.2
+      vertex 135.008 -114.885 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 166.649 -58.8101 -56.2
+      vertex 159.206 -45.9189 -11.2
+      vertex 159.206 -45.9189 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 159.206 -45.9189 -11.2
+      vertex 166.649 -58.8101 -56.2
+      vertex 166.649 -58.8101 -11.2
+    endloop
+  endfacet
+  facet normal -0.944377 0.328866 0
+    outer loop
+      vertex 166.891 -64.5861 -56.2
+      vertex 167.385 -63.1657 -11.2
+      vertex 167.385 -63.1657 -56.2
+    endloop
+  endfacet
+  facet normal -0.944377 0.328866 0
+    outer loop
+      vertex 167.385 -63.1657 -11.2
+      vertex 166.891 -64.5861 -56.2
+      vertex 166.891 -64.5861 -11.2
+    endloop
+  endfacet
+  facet normal -0.832923 0.553388 0
+    outer loop
+      vertex 138.923 -112.839 -56.2
+      vertex 139.755 -111.586 -11.2
+      vertex 139.755 -111.586 -56.2
+    endloop
+  endfacet
+  facet normal -0.832923 0.553388 0
+    outer loop
+      vertex 139.755 -111.586 -11.2
+      vertex 138.923 -112.839 -56.2
+      vertex 138.923 -112.839 -11.2
+    endloop
+  endfacet
+  facet normal -0.66913 0.743146 0
+    outer loop
+      vertex 138.923 -112.839 -56.2
+      vertex 137.805 -113.845 -11.2
+      vertex 138.923 -112.839 -11.2
+    endloop
+  endfacet
+  facet normal -0.66913 0.743146 0
+    outer loop
+      vertex 137.805 -113.845 -11.2
+      vertex 138.923 -112.839 -56.2
+      vertex 137.805 -113.845 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 139.755 -111.586 -56.2
+      vertex 166.891 -64.5861 -11.2
+      vertex 166.891 -64.5861 -56.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 166.891 -64.5861 -11.2
+      vertex 139.755 -111.586 -56.2
+      vertex 139.755 -111.586 -11.2
+    endloop
+  endfacet
+  facet normal -0.985996 -0.166771 0
+    outer loop
+      vertex 167.511 -61.667 -56.2
+      vertex 167.26 -60.184 -11.2
+      vertex 167.26 -60.184 -56.2
+    endloop
+  endfacet
+  facet normal -0.985996 -0.166771 0
+    outer loop
+      vertex 167.26 -60.184 -11.2
+      vertex 167.511 -61.667 -56.2
+      vertex 167.511 -61.667 -11.2
+    endloop
+  endfacet
+  facet normal -0.913547 -0.406733 0
+    outer loop
+      vertex 167.26 -60.184 -56.2
+      vertex 166.649 -58.8101 -11.2
+      vertex 166.649 -58.8101 -56.2
+    endloop
+  endfacet
+  facet normal -0.913547 -0.406733 0
+    outer loop
+      vertex 166.649 -58.8101 -11.2
+      vertex 167.26 -60.184 -56.2
+      vertex 167.26 -60.184 -11.2
+    endloop
+  endfacet
+  facet normal -0.996493 0.0836798 0
+    outer loop
+      vertex 167.385 -63.1657 -56.2
+      vertex 167.511 -61.667 -11.2
+      vertex 167.511 -61.667 -56.2
+    endloop
+  endfacet
+  facet normal -0.996493 0.0836798 0
+    outer loop
+      vertex 167.511 -61.667 -11.2
+      vertex 167.385 -63.1657 -56.2
+      vertex 167.385 -63.1657 -11.2
+    endloop
+  endfacet
+  facet normal 0.866027 -0.499998 -1.42907e-06
+    outer loop
+      vertex 204.331 -107.762 -23.9078
+      vertex 202.907 -110.228 -23.9078
+      vertex 200.65 -114.137 -35.1127
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499998 -1.2907e-06
+    outer loop
+      vertex 200.65 -114.137 -35.1127
+      vertex 202.907 -110.228 -23.9078
+      vertex 200.019 -115.229 -33.0248
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 1.91344e-07
+    outer loop
+      vertex 197.116 -120.258 -23.9078
+      vertex 195.692 -122.725 -23.9078
+      vertex 199.361 -116.369 -35.1127
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499998 -1.22364e-06
+    outer loop
+      vertex 199.361 -116.369 -35.1127
+      vertex 200.65 -114.137 -35.1127
+      vertex 200.019 -115.229 -33.0248
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499998 0
+    outer loop
+      vertex 200.65 -114.137 -35.1127
+      vertex 199.361 -116.369 -35.1127
+      vertex 200.65 -114.137 -43.0438
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499998 0
+    outer loop
+      vertex 200.65 -114.137 -43.0438
+      vertex 199.361 -116.369 -35.1127
+      vertex 199.361 -116.369 -43.0438
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 2.40681e-07
+    outer loop
+      vertex 200.019 -115.229 -33.0248
+      vertex 197.116 -120.258 -23.9078
+      vertex 199.361 -116.369 -35.1127
+    endloop
+  endfacet
+  facet normal -0.417874 -0.72378 0.549112
+    outer loop
+      vertex 200.65 -114.137 -35.1127
+      vertex 204.828 -114.565 -32.4961
+      vertex 204.331 -107.762 -23.9078
+    endloop
+  endfacet
+  facet normal -0.417874 -0.72378 0.549112
+    outer loop
+      vertex 204.828 -114.565 -32.4961
+      vertex 200.65 -114.137 -35.1127
+      vertex 204.047 -116.099 -35.1127
+    endloop
+  endfacet
+  facet normal -0.417873 -0.723779 0.549114
+    outer loop
+      vertex 204.331 -107.762 -23.9078
+      vertex 206.435 -110.543 -25.972
+      vertex 206.799 -109.187 -23.9078
+    endloop
+  endfacet
+  facet normal -0.417876 -0.72378 0.549111
+    outer loop
+      vertex 204.331 -107.762 -23.9078
+      vertex 205.085 -114.061 -31.6366
+      vertex 206.435 -110.543 -25.972
+    endloop
+  endfacet
+  facet normal -0.417864 -0.723783 0.549115
+    outer loop
+      vertex 205.085 -114.061 -31.6366
+      vertex 204.331 -107.762 -23.9078
+      vertex 204.828 -114.565 -32.4961
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 202.907 -110.228 -23.9078
+      vertex 206.435 -110.543 -23.9078
+      vertex 205.894 -111.953 -23.9078
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 204.331 -107.762 -23.9078
+      vertex 206.435 -110.543 -23.9078
+      vertex 202.907 -110.228 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 206.435 -110.543 -23.9078
+      vertex 204.331 -107.762 -23.9078
+      vertex 206.799 -109.187 -23.9078
+    endloop
+  endfacet
+  facet normal 0.422391 0.731602 -0.535111
+    outer loop
+      vertex 205.085 -114.061 -27.4284
+      vertex 202.907 -110.228 -23.9078
+      vertex 205.894 -111.953 -23.9078
+    endloop
+  endfacet
+  facet normal 0.42239 0.731603 -0.535111
+    outer loop
+      vertex 200.019 -115.229 -33.0248
+      vertex 205.085 -114.061 -27.4284
+      vertex 203.474 -117.224 -33.0248
+    endloop
+  endfacet
+  facet normal 0.422391 0.731602 -0.535112
+    outer loop
+      vertex 205.085 -114.061 -27.4284
+      vertex 200.019 -115.229 -33.0248
+      vertex 202.907 -110.228 -23.9078
+    endloop
+  endfacet
+  facet normal -0.421719 -0.730442 -0.537222
+    outer loop
+      vertex 197.116 -120.258 -23.9078
+      vertex 201.322 -120.579 -26.7744
+      vertex 200.159 -122.015 -23.9078
+    endloop
+  endfacet
+  facet normal -0.421719 -0.730441 -0.537223
+    outer loop
+      vertex 200.019 -115.229 -33.0248
+      vertex 201.322 -120.579 -26.7744
+      vertex 197.116 -120.258 -23.9078
+    endloop
+  endfacet
+  facet normal -0.42172 -0.730441 -0.537223
+    outer loop
+      vertex 201.322 -120.579 -26.7744
+      vertex 200.019 -115.229 -33.0248
+      vertex 203.374 -117.418 -32.6823
+    endloop
+  endfacet
+  facet normal -0.42172 -0.730441 -0.537223
+    outer loop
+      vertex 203.374 -117.418 -32.6823
+      vertex 200.019 -115.229 -33.0248
+      vertex 203.474 -117.224 -33.0248
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 195.692 -122.725 -23.9078
+      vertex 198.951 -123.507 -23.9078
+      vertex 198.254 -124.204 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 198.951 -123.507 -23.9078
+      vertex 197.116 -120.258 -23.9078
+      vertex 200.159 -122.015 -23.9078
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 198.951 -123.507 -23.9078
+      vertex 195.692 -122.725 -23.9078
+      vertex 197.116 -120.258 -23.9078
+    endloop
+  endfacet
+  facet normal 0.418267 0.724463 0.547911
+    outer loop
+      vertex 198.951 -123.507 -25.3614
+      vertex 195.692 -122.725 -23.9078
+      vertex 198.254 -124.204 -23.9078
+    endloop
+  endfacet
+  facet normal 0.418268 0.72446 0.547913
+    outer loop
+      vertex 199.814 -122.441 -27.4307
+      vertex 195.692 -122.725 -23.9078
+      vertex 198.951 -123.507 -25.3614
+    endloop
+  endfacet
+  facet normal 0.418267 0.724462 0.547912
+    outer loop
+      vertex 195.692 -122.725 -23.9078
+      vertex 199.814 -122.441 -27.4307
+      vertex 199.361 -116.369 -35.1127
+    endloop
+  endfacet
+  facet normal 0.418267 0.724461 0.547913
+    outer loop
+      vertex 199.361 -116.369 -35.1127
+      vertex 201.322 -120.579 -31.0437
+      vertex 202.776 -118.34 -35.1127
+    endloop
+  endfacet
+  facet normal 0.418268 0.724461 0.547912
+    outer loop
+      vertex 201.322 -120.579 -31.0437
+      vertex 199.361 -116.369 -35.1127
+      vertex 199.814 -122.441 -27.4307
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 -0
+    outer loop
+      vertex 202.776 -118.34 -43.0438
+      vertex 199.361 -116.369 -35.1127
+      vertex 202.776 -118.34 -35.1127
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 0
+    outer loop
+      vertex 199.361 -116.369 -35.1127
+      vertex 202.776 -118.34 -43.0438
+      vertex 199.361 -116.369 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 200.65 -114.137 -43.0438
+      vertex 203.374 -117.418 -43.0438
+      vertex 204.047 -116.099 -43.0438
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 199.361 -116.369 -43.0438
+      vertex 203.374 -117.418 -43.0438
+      vertex 200.65 -114.137 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 203.374 -117.418 -43.0438
+      vertex 199.361 -116.369 -43.0438
+      vertex 202.776 -118.34 -43.0438
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex 200.65 -114.137 -43.0438
+      vertex 204.047 -116.099 -35.1127
+      vertex 200.65 -114.137 -35.1127
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 -0
+    outer loop
+      vertex 204.047 -116.099 -35.1127
+      vertex 200.65 -114.137 -43.0438
+      vertex 204.047 -116.099 -43.0438
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 194.732 -108.387 249.8
+      vertex 201.495 -107.673 249.8
+      vertex 196.732 -104.923 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 201.495 -107.673 249.8
+      vertex 195.281 -110.436 249.8
+      vertex 198.745 -112.436 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 201.495 -107.673 249.8
+      vertex 194.732 -108.387 249.8
+      vertex 195.281 -110.436 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 194.732 -108.387 249.8
+      vertex 193.281 -113.9 249.8
+      vertex 195.281 -110.436 249.8
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 193.281 -113.9 249.8
+      vertex 194.732 -108.387 249.8
+      vertex 191.268 -106.387 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 193.281 -113.9 249.8
+      vertex 193.995 -120.663 249.8
+      vertex 196.745 -115.9 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 191.232 -114.449 249.8
+      vertex 193.281 -113.9 249.8
+      vertex 191.268 -106.387 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 193.281 -113.9 249.8
+      vertex 191.232 -114.449 249.8
+      vertex 193.995 -120.663 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 193.995 -120.663 249.8
+      vertex 191.232 -114.449 249.8
+      vertex 189.232 -117.913 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 191.268 -106.387 249.8
+      vertex 189.219 -106.936 249.8
+      vertex 191.232 -114.449 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 188.505 -100.173 249.8
+      vertex 191.268 -106.387 249.8
+      vertex 193.268 -102.923 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 191.268 -106.387 249.8
+      vertex 188.505 -100.173 249.8
+      vertex 189.219 -106.936 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 189.219 -106.936 249.8
+      vertex 188.505 -100.173 249.8
+      vertex 185.755 -104.936 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 189.219 -106.936 249.8
+      vertex 187.768 -112.449 249.8
+      vertex 191.232 -114.449 249.8
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 187.219 -110.4 249.8
+      vertex 187.768 -112.449 249.8
+      vertex 189.219 -106.936 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 181.005 -113.163 249.8
+      vertex 187.768 -112.449 249.8
+      vertex 187.219 -110.4 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 181.005 -113.163 249.8
+      vertex 187.219 -110.4 249.8
+      vertex 183.755 -108.4 249.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 187.768 -112.449 249.8
+      vertex 181.005 -113.163 249.8
+      vertex 185.768 -115.913 249.8
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 194.732 -108.387 -11.2
+      vertex 196.732 -104.923 249.8
+      vertex 196.732 -104.923 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 196.732 -104.923 249.8
+      vertex 194.732 -108.387 -11.2
+      vertex 194.732 -108.387 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 -0
+    outer loop
+      vertex 194.732 -108.387 -11.2
+      vertex 191.268 -106.387 249.8
+      vertex 194.732 -108.387 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 0
+    outer loop
+      vertex 191.268 -106.387 249.8
+      vertex 194.732 -108.387 -11.2
+      vertex 191.268 -106.387 -11.2
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex 191.268 -106.387 249.8
+      vertex 193.268 -102.923 -11.2
+      vertex 193.268 -102.923 249.8
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex 193.268 -102.923 -11.2
+      vertex 191.268 -106.387 249.8
+      vertex 191.268 -106.387 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex 193.268 -102.923 -11.2
+      vertex 188.505 -100.173 249.8
+      vertex 193.268 -102.923 249.8
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex 188.505 -100.173 249.8
+      vertex 193.268 -102.923 -11.2
+      vertex 188.505 -100.173 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 185.755 -104.936 -11.2
+      vertex 188.505 -100.173 249.8
+      vertex 188.505 -100.173 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 188.505 -100.173 249.8
+      vertex 185.755 -104.936 -11.2
+      vertex 185.755 -104.936 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex 185.755 -104.936 -11.2
+      vertex 189.219 -106.936 249.8
+      vertex 185.755 -104.936 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 -0
+    outer loop
+      vertex 189.219 -106.936 249.8
+      vertex 185.755 -104.936 -11.2
+      vertex 189.219 -106.936 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 187.219 -110.4 -11.2
+      vertex 189.219 -106.936 249.8
+      vertex 189.219 -106.936 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 189.219 -106.936 249.8
+      vertex 187.219 -110.4 -11.2
+      vertex 187.219 -110.4 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 -0
+    outer loop
+      vertex 187.219 -110.4 -11.2
+      vertex 183.755 -108.4 249.8
+      vertex 187.219 -110.4 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 0
+    outer loop
+      vertex 183.755 -108.4 249.8
+      vertex 187.219 -110.4 -11.2
+      vertex 183.755 -108.4 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 181.005 -113.163 -11.2
+      vertex 183.755 -108.4 249.8
+      vertex 183.755 -108.4 -11.2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 183.755 -108.4 249.8
+      vertex 181.005 -113.163 -11.2
+      vertex 181.005 -113.163 249.8
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex 181.005 -113.163 -11.2
+      vertex 185.768 -115.913 249.8
+      vertex 181.005 -113.163 249.8
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 -0
+    outer loop
+      vertex 185.768 -115.913 249.8
+      vertex 181.005 -113.163 -11.2
+      vertex 185.768 -115.913 -11.2
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex 185.768 -115.913 249.8
+      vertex 187.768 -112.449 -11.2
+      vertex 187.768 -112.449 249.8
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex 187.768 -112.449 -11.2
+      vertex 185.768 -115.913 249.8
+      vertex 185.768 -115.913 -11.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex 187.768 -112.449 -11.2
+      vertex 191.232 -114.449 249.8
+      vertex 187.768 -112.449 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 -0
+    outer loop
+      vertex 191.232 -114.449 249.8
+      vertex 187.768 -112.449 -11.2
+      vertex 191.232 -114.449 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 189.232 -117.913 -11.2
+      vertex 191.232 -114.449 249.8
+      vertex 191.232 -114.449 -11.2
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex 191.232 -114.449 249.8
+      vertex 189.232 -117.913 -11.2
+      vertex 189.232 -117.913 249.8
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 0
+    outer loop
+      vertex 189.232 -117.913 -11.2
+      vertex 193.995 -120.663 249.8
+      vertex 189.232 -117.913 249.8
+    endloop
+  endfacet
+  facet normal -0.5 -0.866025 -0
+    outer loop
+      vertex 193.995 -120.663 249.8
+      vertex 189.232 -117.913 -11.2
+      vertex 193.995 -120.663 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 193.995 -120.663 249.8
+      vertex 196.745 -115.9 -11.2
+      vertex 196.745 -115.9 249.8
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 196.745 -115.9 -11.2
+      vertex 193.995 -120.663 249.8
+      vertex 193.995 -120.663 -11.2
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 -0
+    outer loop
+      vertex 196.745 -115.9 -11.2
+      vertex 193.281 -113.9 249.8
+      vertex 196.745 -115.9 249.8
+    endloop
+  endfacet
+  facet normal 0.499999 0.866026 0
+    outer loop
+      vertex 193.281 -113.9 249.8
+      vertex 196.745 -115.9 -11.2
+      vertex 193.281 -113.9 -11.2
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex 193.281 -113.9 249.8
+      vertex 195.281 -110.436 -11.2
+      vertex 195.281 -110.436 249.8
+    endloop
+  endfacet
+  facet normal 0.866026 -0.5 0
+    outer loop
+      vertex 195.281 -110.436 -11.2
+      vertex 193.281 -113.9 249.8
+      vertex 193.281 -113.9 -11.2
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 0
+    outer loop
+      vertex 195.281 -110.436 -11.2
+      vertex 198.745 -112.436 249.8
+      vertex 195.281 -110.436 249.8
+    endloop
+  endfacet
+  facet normal -0.499999 -0.866026 -0
+    outer loop
+      vertex 198.745 -112.436 249.8
+      vertex 195.281 -110.436 -11.2
+      vertex 198.745 -112.436 -11.2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 198.745 -112.436 249.8
+      vertex 201.495 -107.673 -11.2
+      vertex 201.495 -107.673 249.8
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 201.495 -107.673 -11.2
+      vertex 198.745 -112.436 249.8
+      vertex 198.745 -112.436 -11.2
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex 201.495 -107.673 -11.2
+      vertex 196.732 -104.923 249.8
+      vertex 201.495 -107.673 249.8
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex 196.732 -104.923 249.8
+      vertex 201.495 -107.673 -11.2
+      vertex 196.732 -104.923 -11.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -124.918 -45.2
+      vertex 179 -123.418 -46.7
+      vertex 179 -119.418 -41.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -119.418 -41.2
+      vertex 179 -123.418 -46.7
+      vertex 179 -119.418 -46.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -128.918 -41.2
+      vertex 179 -134.418 -41.2
+      vertex 179 -128.918 -45.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -124.918 -41.2
+      vertex 179 -124.918 -45.2
+      vertex 179 -119.418 -41.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -124.918 -45.2
+      vertex 179 -128.918 -52.2
+      vertex 179 -124.918 -52.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -124.918 -45.2
+      vertex 179 -124.918 -52.2
+      vertex 179 -123.418 -46.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -123.418 -46.7
+      vertex 179 -124.918 -52.2
+      vertex 179 -123.418 -50.7
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -123.418 -50.7
+      vertex 179 -119.418 -56.2
+      vertex 179 -119.418 -50.7
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -124.918 -52.2
+      vertex 179 -119.418 -56.2
+      vertex 179 -123.418 -50.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -119.418 -56.2
+      vertex 179 -124.918 -52.2
+      vertex 179 -124.918 -56.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -128.918 -45.2
+      vertex 179 -128.918 -52.2
+      vertex 179 -124.918 -45.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -130.418 -50.7
+      vertex 179 -128.918 -52.2
+      vertex 179 -128.918 -45.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -130.418 -50.7
+      vertex 179 -128.918 -45.2
+      vertex 179 -130.418 -46.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -134.418 -41.2
+      vertex 179 -130.418 -46.7
+      vertex 179 -128.918 -45.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -130.418 -46.7
+      vertex 179 -134.418 -41.2
+      vertex 179 -134.418 -46.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -134.418 -56.2
+      vertex 179 -128.918 -52.2
+      vertex 179 -130.418 -50.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -134.418 -56.2
+      vertex 179 -130.418 -50.7
+      vertex 179 -134.418 -50.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -128.918 -52.2
+      vertex 179 -134.418 -56.2
+      vertex 179 -128.918 -56.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -119.418 -56.2
+      vertex -179 -123.418 -50.7
+      vertex -179 -119.418 -50.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -119.418 -56.2
+      vertex -179 -124.918 -52.2
+      vertex -179 -123.418 -50.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -124.918 -52.2
+      vertex -179 -119.418 -56.2
+      vertex -179 -124.918 -56.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -123.418 -46.7
+      vertex -179 -119.418 -41.2
+      vertex -179 -119.418 -46.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -123.418 -50.7
+      vertex -179 -124.918 -52.2
+      vertex -179 -123.418 -46.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -124.918 -45.2
+      vertex -179 -123.418 -46.7
+      vertex -179 -124.918 -52.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -124.918 -45.2
+      vertex -179 -119.418 -41.2
+      vertex -179 -123.418 -46.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -119.418 -41.2
+      vertex -179 -124.918 -45.2
+      vertex -179 -124.918 -41.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -134.418 -56.2
+      vertex -179 -128.918 -52.2
+      vertex -179 -128.918 -56.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -128.918 -52.2
+      vertex -179 -130.418 -50.7
+      vertex -179 -128.918 -45.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -130.418 -46.7
+      vertex -179 -128.918 -45.2
+      vertex -179 -130.418 -50.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -128.918 -52.2
+      vertex -179 -134.418 -56.2
+      vertex -179 -130.418 -50.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -130.418 -50.7
+      vertex -179 -134.418 -56.2
+      vertex -179 -134.418 -50.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -128.918 -52.2
+      vertex -179 -124.918 -45.2
+      vertex -179 -124.918 -52.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -124.918 -45.2
+      vertex -179 -128.918 -52.2
+      vertex -179 -128.918 -45.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -134.418 -41.2
+      vertex -179 -128.918 -45.2
+      vertex -179 -130.418 -46.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -134.418 -41.2
+      vertex -179 -130.418 -46.7
+      vertex -179 -134.418 -46.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -128.918 -45.2
+      vertex -179 -134.418 -41.2
+      vertex -179 -128.918 -41.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -130.418 -50.7
+      vertex 179 -134.418 -50.7
+      vertex 179 -130.418 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -134.418 -50.7
+      vertex -179 -130.418 -50.7
+      vertex -179 -134.418 -50.7
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -130.418 -50.7
+      vertex 179 -130.418 -46.7
+      vertex -179 -130.418 -46.7
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179 -130.418 -46.7
+      vertex -179 -130.418 -50.7
+      vertex 179 -130.418 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -134.418 -46.7
+      vertex 179 -130.418 -46.7
+      vertex 179 -134.418 -46.7
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -130.418 -46.7
+      vertex -179 -134.418 -46.7
+      vertex -179 -130.418 -46.7
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -134.418 -46.7
+      vertex 179 -134.418 -41.2
+      vertex -179 -134.418 -41.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179 -134.418 -41.2
+      vertex -179 -134.418 -46.7
+      vertex 179 -134.418 -46.7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -128.918 -41.2
+      vertex 179 -134.418 -41.2
+      vertex 179 -128.918 -41.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -134.418 -41.2
+      vertex -179 -128.918 -41.2
+      vertex -179 -134.418 -41.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 179 -128.918 -41.2
+      vertex 179 -128.918 -45.2
+      vertex -179 -128.918 -41.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -128.918 -41.2
+      vertex 179 -128.918 -45.2
+      vertex -179 -128.918 -45.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -124.918 -45.2
+      vertex 179 -128.918 -45.2
+      vertex 179 -124.918 -45.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -128.918 -45.2
+      vertex -179 -124.918 -45.2
+      vertex -179 -128.918 -45.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -124.918 -45.2
+      vertex 179 -124.918 -41.2
+      vertex -179 -124.918 -41.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179 -124.918 -41.2
+      vertex -179 -124.918 -45.2
+      vertex 179 -124.918 -45.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -119.418 -41.2
+      vertex 179 -124.918 -41.2
+      vertex 179 -119.418 -41.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -124.918 -41.2
+      vertex -179 -119.418 -41.2
+      vertex -179 -124.918 -41.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -119.418 -46.7
+      vertex -179 -119.418 -41.2
+      vertex 179 -119.418 -41.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -119.418 -41.2
+      vertex 179 -119.418 -46.7
+      vertex -179 -119.418 -46.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -123.418 -46.7
+      vertex 179 -119.418 -46.7
+      vertex 179 -123.418 -46.7
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -119.418 -46.7
+      vertex -179 -123.418 -46.7
+      vertex -179 -119.418 -46.7
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -123.418 -50.7
+      vertex -179 -123.418 -46.7
+      vertex 179 -123.418 -46.7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -123.418 -46.7
+      vertex 179 -123.418 -50.7
+      vertex -179 -123.418 -50.7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -119.418 -50.7
+      vertex 179 -123.418 -50.7
+      vertex 179 -119.418 -50.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -123.418 -50.7
+      vertex -179 -119.418 -50.7
+      vertex -179 -123.418 -50.7
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -119.418 -56.2
+      vertex -179 -119.418 -50.7
+      vertex 179 -119.418 -50.7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -119.418 -50.7
+      vertex 179 -119.418 -56.2
+      vertex -179 -119.418 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -124.918 -56.2
+      vertex 179 -119.418 -56.2
+      vertex 179 -124.918 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -119.418 -56.2
+      vertex -179 -124.918 -56.2
+      vertex -179 -119.418 -56.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -124.918 -56.2
+      vertex 179 -124.918 -52.2
+      vertex -179 -124.918 -52.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179 -124.918 -52.2
+      vertex -179 -124.918 -56.2
+      vertex 179 -124.918 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -128.918 -52.2
+      vertex 179 -124.918 -52.2
+      vertex 179 -128.918 -52.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -124.918 -52.2
+      vertex -179 -128.918 -52.2
+      vertex -179 -124.918 -52.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -128.918 -56.2
+      vertex -179 -128.918 -52.2
+      vertex 179 -128.918 -52.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -128.918 -52.2
+      vertex 179 -128.918 -56.2
+      vertex -179 -128.918 -56.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -134.418 -56.2
+      vertex 179 -128.918 -56.2
+      vertex 179 -134.418 -56.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -128.918 -56.2
+      vertex -179 -134.418 -56.2
+      vertex -179 -128.918 -56.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -134.418 -56.2
+      vertex 179 -134.418 -50.7
+      vertex -179 -134.418 -50.7
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179 -134.418 -50.7
+      vertex -179 -134.418 -56.2
+      vertex 179 -134.418 -56.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -124.918 -15.2
+      vertex 179 -123.418 -16.7
+      vertex 179 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -119.418 -11.2
+      vertex 179 -123.418 -16.7
+      vertex 179 -119.418 -16.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -128.918 -11.2
+      vertex 179 -134.418 -11.2
+      vertex 179 -128.918 -15.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -124.918 -11.2
+      vertex 179 -124.918 -15.2
+      vertex 179 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -124.918 -15.2
+      vertex 179 -128.918 -22.2
+      vertex 179 -124.918 -22.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -124.918 -15.2
+      vertex 179 -124.918 -22.2
+      vertex 179 -123.418 -16.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -123.418 -16.7
+      vertex 179 -124.918 -22.2
+      vertex 179 -123.418 -20.7
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -123.418 -20.7
+      vertex 179 -119.418 -26.2
+      vertex 179 -119.418 -20.7
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -124.918 -22.2
+      vertex 179 -119.418 -26.2
+      vertex 179 -123.418 -20.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -119.418 -26.2
+      vertex 179 -124.918 -22.2
+      vertex 179 -124.918 -26.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -128.918 -15.2
+      vertex 179 -128.918 -22.2
+      vertex 179 -124.918 -15.2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 179 -130.418 -20.7
+      vertex 179 -128.918 -22.2
+      vertex 179 -128.918 -15.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -130.418 -20.7
+      vertex 179 -128.918 -15.2
+      vertex 179 -130.418 -16.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -134.418 -11.2
+      vertex 179 -130.418 -16.7
+      vertex 179 -128.918 -15.2
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -130.418 -16.7
+      vertex 179 -134.418 -11.2
+      vertex 179 -134.418 -16.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -134.418 -26.2
+      vertex 179 -128.918 -22.2
+      vertex 179 -130.418 -20.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -134.418 -26.2
+      vertex 179 -130.418 -20.7
+      vertex 179 -134.418 -20.7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 179 -128.918 -22.2
+      vertex 179 -134.418 -26.2
+      vertex 179 -128.918 -26.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -119.418 -26.2
+      vertex -179 -123.418 -20.7
+      vertex -179 -119.418 -20.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -119.418 -26.2
+      vertex -179 -124.918 -22.2
+      vertex -179 -123.418 -20.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -124.918 -22.2
+      vertex -179 -119.418 -26.2
+      vertex -179 -124.918 -26.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -123.418 -16.7
+      vertex -179 -119.418 -11.2
+      vertex -179 -119.418 -16.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -123.418 -20.7
+      vertex -179 -124.918 -22.2
+      vertex -179 -123.418 -16.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -124.918 -15.2
+      vertex -179 -123.418 -16.7
+      vertex -179 -124.918 -22.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -124.918 -15.2
+      vertex -179 -119.418 -11.2
+      vertex -179 -123.418 -16.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -119.418 -11.2
+      vertex -179 -124.918 -15.2
+      vertex -179 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -134.418 -26.2
+      vertex -179 -128.918 -22.2
+      vertex -179 -128.918 -26.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -128.918 -22.2
+      vertex -179 -130.418 -20.7
+      vertex -179 -128.918 -15.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -130.418 -16.7
+      vertex -179 -128.918 -15.2
+      vertex -179 -130.418 -20.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -128.918 -22.2
+      vertex -179 -134.418 -26.2
+      vertex -179 -130.418 -20.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -130.418 -20.7
+      vertex -179 -134.418 -26.2
+      vertex -179 -134.418 -20.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -128.918 -22.2
+      vertex -179 -124.918 -15.2
+      vertex -179 -124.918 -22.2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -179 -124.918 -15.2
+      vertex -179 -128.918 -22.2
+      vertex -179 -128.918 -15.2
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -134.418 -11.2
+      vertex -179 -128.918 -15.2
+      vertex -179 -130.418 -16.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -134.418 -11.2
+      vertex -179 -130.418 -16.7
+      vertex -179 -134.418 -16.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -179 -128.918 -15.2
+      vertex -179 -134.418 -11.2
+      vertex -179 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -130.418 -20.7
+      vertex 179 -134.418 -20.7
+      vertex 179 -130.418 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -134.418 -20.7
+      vertex -179 -130.418 -20.7
+      vertex -179 -134.418 -20.7
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -130.418 -20.7
+      vertex 179 -130.418 -16.7
+      vertex -179 -130.418 -16.7
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179 -130.418 -16.7
+      vertex -179 -130.418 -20.7
+      vertex 179 -130.418 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -134.418 -16.7
+      vertex 179 -130.418 -16.7
+      vertex 179 -134.418 -16.7
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -130.418 -16.7
+      vertex -179 -134.418 -16.7
+      vertex -179 -130.418 -16.7
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -134.418 -16.7
+      vertex -57 -134.418 -11.2
+      vertex -179 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -57 -134.418 -11.2
+      vertex -179 -134.418 -16.7
+      vertex 57 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 179 -134.418 -16.7
+      vertex 57 -134.418 -11.2
+      vertex -179 -134.418 -16.7
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 57 -134.418 -11.2
+      vertex 179 -134.418 -16.7
+      vertex 179 -134.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -128.918 -15.2
+      vertex 60 -128.918 -11.2
+      vertex 179 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 60 -128.918 -11.2
+      vertex 179 -128.918 -15.2
+      vertex -60 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -60 -128.918 -11.2
+      vertex 179 -128.918 -15.2
+      vertex -179 -128.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -128.918 -11.2
+      vertex 179 -128.918 -15.2
+      vertex -179 -128.918 -15.2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -124.918 -15.2
+      vertex 179 -128.918 -15.2
+      vertex 179 -124.918 -15.2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -128.918 -15.2
+      vertex -179 -124.918 -15.2
+      vertex -179 -128.918 -15.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -124.918 -15.2
+      vertex -60 -124.918 -11.2
+      vertex -179 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -60 -124.918 -11.2
+      vertex -179 -124.918 -15.2
+      vertex 60 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 179 -124.918 -15.2
+      vertex 60 -124.918 -11.2
+      vertex -179 -124.918 -15.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 60 -124.918 -11.2
+      vertex 179 -124.918 -15.2
+      vertex 179 -124.918 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -119.418 -16.7
+      vertex 60 -119.418 -11.2
+      vertex 179 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 60 -119.418 -11.2
+      vertex 179 -119.418 -16.7
+      vertex -60 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -119.418 -16.7
+      vertex -60 -119.418 -11.2
+      vertex 179 -119.418 -16.7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -60 -119.418 -11.2
+      vertex -179 -119.418 -16.7
+      vertex -179 -119.418 -11.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -123.418 -16.7
+      vertex 179 -119.418 -16.7
+      vertex 179 -123.418 -16.7
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -119.418 -16.7
+      vertex -179 -123.418 -16.7
+      vertex -179 -119.418 -16.7
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -123.418 -20.7
+      vertex -179 -123.418 -16.7
+      vertex 179 -123.418 -16.7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -123.418 -16.7
+      vertex 179 -123.418 -20.7
+      vertex -179 -123.418 -20.7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -179 -119.418 -20.7
+      vertex 179 -123.418 -20.7
+      vertex 179 -119.418 -20.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 179 -123.418 -20.7
+      vertex -179 -119.418 -20.7
+      vertex -179 -123.418 -20.7
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -119.418 -26.2
+      vertex -179 -119.418 -20.7
+      vertex 179 -119.418 -20.7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -119.418 -20.7
+      vertex 179 -119.418 -26.2
+      vertex -179 -119.418 -26.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -124.918 -26.2
+      vertex 179 -119.418 -26.2
+      vertex 179 -124.918 -26.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -119.418 -26.2
+      vertex -179 -124.918 -26.2
+      vertex -179 -119.418 -26.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -124.918 -26.2
+      vertex 179 -124.918 -22.2
+      vertex -179 -124.918 -22.2
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179 -124.918 -22.2
+      vertex -179 -124.918 -26.2
+      vertex 179 -124.918 -26.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -128.918 -22.2
+      vertex 179 -124.918 -22.2
+      vertex 179 -128.918 -22.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -124.918 -22.2
+      vertex -179 -128.918 -22.2
+      vertex -179 -124.918 -22.2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 179 -128.918 -26.2
+      vertex -179 -128.918 -22.2
+      vertex 179 -128.918 -22.2
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -179 -128.918 -22.2
+      vertex 179 -128.918 -26.2
+      vertex -179 -128.918 -26.2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -179 -134.418 -26.2
+      vertex 179 -128.918 -26.2
+      vertex 179 -134.418 -26.2
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 179 -128.918 -26.2
+      vertex -179 -134.418 -26.2
+      vertex -179 -128.918 -26.2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -179 -134.418 -26.2
+      vertex 179 -134.418 -20.7
+      vertex -179 -134.418 -20.7
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 179 -134.418 -20.7
+      vertex -179 -134.418 -26.2
+      vertex 179 -134.418 -26.2
+    endloop
+  endfacet
+  facet normal -0.802817 -0.596225 0
+    outer loop
+      vertex -97.9617 -77.6435 -5.2
+      vertex -102.644 -71.3392 -0.2
+      vertex -102.644 -71.3392 -5.2
+    endloop
+  endfacet
+  facet normal -0.802817 -0.596225 0
+    outer loop
+      vertex -102.644 -71.3392 -0.2
+      vertex -97.9617 -77.6435 -5.2
+      vertex -97.9617 -77.6435 -0.2
+    endloop
+  endfacet
+  facet normal 0.900319 0.435232 0
+    outer loop
+      vertex 114.193 50.8421 -0.2
+      vertex 110.775 57.912 -5.2
+      vertex 110.775 57.912 -0.2
+    endloop
+  endfacet
+  facet normal 0.900319 0.435232 0
+    outer loop
+      vertex 110.775 57.912 -5.2
+      vertex 114.193 50.8421 -0.2
+      vertex 114.193 50.8421 -5.2
+    endloop
+  endfacet
+  facet normal -0.544648 0.838665 0
+    outer loop
+      vertex -64.9597 106.787 -5.2
+      vertex -64.7534 106.921 -0.2
+      vertex -64.7534 106.921 -5.2
+    endloop
+  endfacet
+  facet normal -0.544639 0.838671 -5.39822e-07
+    outer loop
+      vertex -64.7534 106.921 -0.2
+      vertex -64.9597 106.787 -5.2
+      vertex -71.3392 102.644 -0.2
+    endloop
+  endfacet
+  facet normal -0.544639 0.838671 0
+    outer loop
+      vertex -71.3392 102.644 -0.2
+      vertex -64.9597 106.787 -5.2
+      vertex -71.3392 102.644 -5.2
+    endloop
+  endfacet
+  facet normal -0.993373 0.114937 0
+    outer loop
+      vertex -124.562 10.4597 -5.2
+      vertex -123.659 18.2604 -0.2
+      vertex -123.659 18.2604 -5.2
+    endloop
+  endfacet
+  facet normal -0.993373 0.114937 0
+    outer loop
+      vertex -123.659 18.2604 -0.2
+      vertex -124.562 10.4597 -5.2
+      vertex -124.562 10.4597 -0.2
+    endloop
+  endfacet
+  facet normal 0.971134 -0.238534 0
+    outer loop
+      vertex 120.395 -33.615 -0.2
+      vertex 122.268 -25.989 -5.2
+      vertex 122.268 -25.989 -0.2
+    endloop
+  endfacet
+  facet normal 0.971134 -0.238534 0
+    outer loop
+      vertex 122.268 -25.989 -5.2
+      vertex 120.395 -33.615 -0.2
+      vertex 120.395 -33.615 -5.2
+    endloop
+  endfacet
+  facet normal 0.990748 0.135716 0
+    outer loop
+      vertex 124.315 13.0661 -0.2
+      vertex 123.25 20.8461 -5.2
+      vertex 123.25 20.8461 -0.2
+    endloop
+  endfacet
+  facet normal 0.990748 0.135716 0
+    outer loop
+      vertex 123.25 20.8461 -5.2
+      vertex 124.315 13.0661 -0.2
+      vertex 124.315 13.0661 -5.2
+    endloop
+  endfacet
+  facet normal 0.871215 0.490902 0
+    outer loop
+      vertex 110.775 57.912 -0.2
+      vertex 109.468 60.232 -5.2
+      vertex 109.468 60.232 -0.2
+    endloop
+  endfacet
+  facet normal 0.871215 0.490902 0
+    outer loop
+      vertex 109.468 60.232 -5.2
+      vertex 110.775 57.912 -0.2
+      vertex 110.775 57.912 -5.2
+    endloop
+  endfacet
+  facet normal 0.579281 0.815128 -0
+    outer loop
+      vertex 75.5749 99.5662 -5.2
+      vertex 69.1739 104.115 -0.2
+      vertex 75.5749 99.5662 -0.2
+    endloop
+  endfacet
+  facet normal 0.579281 0.815128 0
+    outer loop
+      vertex 69.1739 104.115 -0.2
+      vertex 75.5749 99.5662 -5.2
+      vertex 69.1739 104.115 -5.2
+    endloop
+  endfacet
+  facet normal -0.815128 0.579281 0
+    outer loop
+      vertex -104.115 69.1739 -5.2
+      vertex -99.5662 75.5749 -0.2
+      vertex -99.5662 75.5749 -5.2
+    endloop
+  endfacet
+  facet normal -0.815128 0.579281 0
+    outer loop
+      vertex -99.5662 75.5749 -0.2
+      vertex -104.115 69.1739 -5.2
+      vertex -104.115 69.1739 -0.2
+    endloop
+  endfacet
+  facet normal 0.238534 0.971134 -0
+    outer loop
+      vertex 33.615 120.395 -5.2
+      vertex 25.989 122.268 -0.2
+      vertex 33.615 120.395 -0.2
+    endloop
+  endfacet
+  facet normal 0.238534 0.971134 0
+    outer loop
+      vertex 25.989 122.268 -0.2
+      vertex 33.615 120.395 -5.2
+      vertex 25.989 122.268 -5.2
+    endloop
+  endfacet
+  facet normal -0.0732375 0.997315 0
+    outer loop
+      vertex -5.23446 124.89 -5.2
+      vertex -13.0661 124.315 -0.2
+      vertex -5.23446 124.89 -0.2
+    endloop
+  endfacet
+  facet normal -0.0732375 0.997315 0
+    outer loop
+      vertex -13.0661 124.315 -0.2
+      vertex -5.23446 124.89 -5.2
+      vertex -13.0661 124.315 -5.2
+    endloop
+  endfacet
+  facet normal 0.544639 -0.838671 0
+    outer loop
+      vertex 64.7534 -106.921 -5.2
+      vertex 71.3392 -102.644 -0.2
+      vertex 64.7534 -106.921 -0.2
+    endloop
+  endfacet
+  facet normal 0.544639 -0.838671 0
+    outer loop
+      vertex 71.3392 -102.644 -0.2
+      vertex 64.7534 -106.921 -5.2
+      vertex 71.3392 -102.644 -5.2
+    endloop
+  endfacet
+  facet normal -0.238534 -0.971134 0
+    outer loop
+      vertex -33.615 -120.395 -5.2
+      vertex -25.989 -122.268 -0.2
+      vertex -33.615 -120.395 -0.2
+    endloop
+  endfacet
+  facet normal -0.238534 -0.971134 -0
+    outer loop
+      vertex -25.989 -122.268 -0.2
+      vertex -33.615 -120.395 -5.2
+      vertex -25.989 -122.268 -5.2
+    endloop
+  endfacet
+  facet normal 0.197657 -0.980271 0
+    outer loop
+      vertex 20.8461 -123.25 -5.2
+      vertex 28.5439 -121.697 -0.2
+      vertex 20.8461 -123.25 -0.2
+    endloop
+  endfacet
+  facet normal 0.197657 -0.980271 0
+    outer loop
+      vertex 28.5439 -121.697 -0.2
+      vertex 20.8461 -123.25 -5.2
+      vertex 28.5439 -121.697 -5.2
+    endloop
+  endfacet
+  facet normal 0.909236 -0.416281 0
+    outer loop
+      vertex 111.964 -55.5794 -0.2
+      vertex 115.233 -48.4394 -5.2
+      vertex 115.233 -48.4394 -0.2
+    endloop
+  endfacet
+  facet normal 0.909236 -0.416281 0
+    outer loop
+      vertex 115.233 -48.4394 -5.2
+      vertex 111.964 -55.5794 -0.2
+      vertex 111.964 -55.5794 -5.2
+    endloop
+  endfacet
+  facet normal 0.993373 -0.114937 0
+    outer loop
+      vertex 123.659 -18.2604 -0.2
+      vertex 124.562 -10.4597 -5.2
+      vertex 124.562 -10.4597 -0.2
+    endloop
+  endfacet
+  facet normal 0.993373 -0.114937 0
+    outer loop
+      vertex 124.562 -10.4597 -5.2
+      vertex 123.659 -18.2604 -0.2
+      vertex 123.659 -18.2604 -5.2
+    endloop
+  endfacet
+  facet normal 0.99863 -0.0523362 0
+    outer loop
+      vertex 124.562 -10.4597 -0.2
+      vertex 124.973 -2.6178 -5.2
+      vertex 124.973 -2.6178 -0.2
+    endloop
+  endfacet
+  facet normal 0.99863 -0.0523362 0
+    outer loop
+      vertex 124.973 -2.6178 -5.2
+      vertex 124.562 -10.4597 -0.2
+      vertex 124.562 -10.4597 -5.2
+    endloop
+  endfacet
+  facet normal 0.676876 0.736097 -0
+    outer loop
+      vertex 87.4579 89.3091 -5.2
+      vertex 81.6776 94.6244 -0.2
+      vertex 87.4579 89.3091 -0.2
+    endloop
+  endfacet
+  facet normal 0.676876 0.736097 0
+    outer loop
+      vertex 81.6776 94.6244 -0.2
+      vertex 87.4579 89.3091 -5.2
+      vertex 81.6776 94.6244 -5.2
+    endloop
+  endfacet
+  facet normal -0.692144 0.72176 0
+    outer loop
+      vertex -83.6413 92.8931 -5.2
+      vertex -89.3091 87.4579 -0.2
+      vertex -83.6413 92.8931 -0.2
+    endloop
+  endfacet
+  facet normal -0.692144 0.72176 0
+    outer loop
+      vertex -89.3091 87.4579 -0.2
+      vertex -83.6413 92.8931 -5.2
+      vertex -89.3091 87.4579 -5.2
+    endloop
+  endfacet
+  facet normal -0.596225 0.802817 0
+    outer loop
+      vertex -71.3392 102.644 -5.2
+      vertex -77.6435 97.9617 -0.2
+      vertex -71.3392 102.644 -0.2
+    endloop
+  endfacet
+  facet normal -0.596225 0.802817 0
+    outer loop
+      vertex -77.6435 97.9617 -0.2
+      vertex -71.3392 102.644 -5.2
+      vertex -77.6435 97.9617 -5.2
+    endloop
+  endfacet
+  facet normal -0.777146 0.62932 0
+    outer loop
+      vertex -99.5662 75.5749 -5.2
+      vertex -94.6244 81.6776 -0.2
+      vertex -94.6244 81.6776 -5.2
+    endloop
+  endfacet
+  facet normal -0.777146 0.62932 0
+    outer loop
+      vertex -94.6244 81.6776 -0.2
+      vertex -99.5662 75.5749 -5.2
+      vertex -99.5662 75.5749 -0.2
+    endloop
+  endfacet
+  facet normal -0.31896 0.947768 0
+    outer loop
+      vertex -36.129 119.665 -5.2
+      vertex -43.5715 117.16 -0.2
+      vertex -36.129 119.665 -0.2
+    endloop
+  endfacet
+  facet normal -0.31896 0.947768 0
+    outer loop
+      vertex -43.5715 117.16 -0.2
+      vertex -36.129 119.665 -5.2
+      vertex -43.5715 117.16 -5.2
+    endloop
+  endfacet
+  facet normal -0.490903 0.871214 0
+    outer loop
+      vertex -57.912 110.775 -5.2
+      vertex -64.7534 106.921 -0.2
+      vertex -57.912 110.775 -0.2
+    endloop
+  endfacet
+  facet normal -0.490903 0.871214 0
+    outer loop
+      vertex -64.7534 106.921 -0.2
+      vertex -57.912 110.775 -5.2
+      vertex -64.7534 106.921 -5.2
+    endloop
+  endfacet
+  facet normal -0.377841 0.925871 0
+    outer loop
+      vertex -43.5715 117.16 -5.2
+      vertex -50.8421 114.193 -0.2
+      vertex -43.5715 117.16 -0.2
+    endloop
+  endfacet
+  facet normal -0.377841 0.925871 0
+    outer loop
+      vertex -50.8421 114.193 -0.2
+      vertex -43.5715 117.16 -5.2
+      vertex -50.8421 114.193 -5.2
+    endloop
+  endfacet
+  facet normal 0.416281 0.909236 -0
+    outer loop
+      vertex 55.5794 111.964 -5.2
+      vertex 48.4394 115.233 -0.2
+      vertex 55.5794 111.964 -0.2
+    endloop
+  endfacet
+  facet normal 0.416281 0.909236 0
+    outer loop
+      vertex 48.4394 115.233 -0.2
+      vertex 55.5794 111.964 -5.2
+      vertex 48.4394 115.233 -5.2
+    endloop
+  endfacet
+  facet normal 0.299041 0.95424 -0
+    outer loop
+      vertex 41.1083 118.047 -5.2
+      vertex 33.615 120.395 -0.2
+      vertex 41.1083 118.047 -0.2
+    endloop
+  endfacet
+  facet normal 0.299041 0.95424 0
+    outer loop
+      vertex 33.615 120.395 -0.2
+      vertex 41.1083 118.047 -5.2
+      vertex 33.615 120.395 -5.2
+    endloop
+  endfacet
+  facet normal 0.358367 0.933581 -0
+    outer loop
+      vertex 48.4394 115.233 -5.2
+      vertex 41.1083 118.047 -0.2
+      vertex 48.4394 115.233 -0.2
+    endloop
+  endfacet
+  facet normal 0.358367 0.933581 0
+    outer loop
+      vertex 41.1083 118.047 -0.2
+      vertex 48.4394 115.233 -5.2
+      vertex 41.1083 118.047 -5.2
+    endloop
+  endfacet
+  facet normal 0.0523362 0.99863 -0
+    outer loop
+      vertex 10.4597 124.562 -5.2
+      vertex 2.6178 124.973 -0.2
+      vertex 10.4597 124.562 -0.2
+    endloop
+  endfacet
+  facet normal 0.0523362 0.99863 0
+    outer loop
+      vertex 2.6178 124.973 -0.2
+      vertex 10.4597 124.562 -5.2
+      vertex 2.6178 124.973 -5.2
+    endloop
+  endfacet
+  facet normal -0.0104725 0.999945 0
+    outer loop
+      vertex 2.6178 124.973 -5.2
+      vertex -5.23446 124.89 -0.2
+      vertex 2.6178 124.973 -0.2
+    endloop
+  endfacet
+  facet normal -0.0104725 0.999945 0
+    outer loop
+      vertex -5.23446 124.89 -0.2
+      vertex 2.6178 124.973 -5.2
+      vertex -5.23446 124.89 -5.2
+    endloop
+  endfacet
+  facet normal 0.881304 -0.472551 0
+    outer loop
+      vertex 108.253 -62.5 -0.2
+      vertex 111.964 -55.5794 -5.2
+      vertex 111.964 -55.5794 -0.2
+    endloop
+  endfacet
+  facet normal 0.881304 -0.472551 0
+    outer loop
+      vertex 111.964 -55.5794 -5.2
+      vertex 108.253 -62.5 -0.2
+      vertex 108.253 -62.5 -5.2
+    endloop
+  endfacet
+  facet normal -0.0523354 -0.99863 0
+    outer loop
+      vertex -10.4597 -124.562 -5.2
+      vertex -3.65479 -124.918 -0.2
+      vertex -10.4597 -124.562 -0.2
+    endloop
+  endfacet
+  facet normal -0.0523354 -0.99863 -0
+    outer loop
+      vertex -3.65479 -124.918 -0.2
+      vertex -10.4597 -124.562 -5.2
+      vertex -3.65479 -124.918 -5.2
+    endloop
+  endfacet
+  facet normal 0.135716 -0.990748 0
+    outer loop
+      vertex 13.0661 -124.315 -5.2
+      vertex 20.8461 -123.25 -0.2
+      vertex 13.0661 -124.315 -0.2
+    endloop
+  endfacet
+  facet normal 0.135716 -0.990748 0
+    outer loop
+      vertex 20.8461 -123.25 -0.2
+      vertex 13.0661 -124.315 -5.2
+      vertex 20.8461 -123.25 -5.2
+    endloop
+  endfacet
+  facet normal 0.490902 -0.871215 0
+    outer loop
+      vertex 60 -109.599 -5.2
+      vertex 57.912 -110.775 -0.2
+      vertex 57.912 -110.775 -5.2
+    endloop
+  endfacet
+  facet normal 0.490903 -0.871214 5.06598e-07
+    outer loop
+      vertex 57.912 -110.775 -0.2
+      vertex 60 -109.599 -5.2
+      vertex 64.7534 -106.921 -0.2
+    endloop
+  endfacet
+  facet normal 0.490904 -0.871214 0
+    outer loop
+      vertex 64.7534 -106.921 -0.2
+      vertex 60 -109.599 -5.2
+      vertex 64.7534 -106.921 -5.2
+    endloop
+  endfacet
+  facet normal -0.526955 -0.849893 0
+    outer loop
+      vertex -69.1739 -104.115 -5.2
+      vertex -62.5 -108.253 -0.2
+      vertex -69.1739 -104.115 -0.2
+    endloop
+  endfacet
+  facet normal -0.526955 -0.849893 -0
+    outer loop
+      vertex -62.5 -108.253 -0.2
+      vertex -69.1739 -104.115 -5.2
+      vertex -62.5 -108.253 -5.2
+    endloop
+  endfacet
+  facet normal -0.579281 -0.815128 0
+    outer loop
+      vertex -75.5749 -99.5662 -5.2
+      vertex -69.1739 -104.115 -0.2
+      vertex -75.5749 -99.5662 -0.2
+    endloop
+  endfacet
+  facet normal -0.579281 -0.815128 -0
+    outer loop
+      vertex -69.1739 -104.115 -0.2
+      vertex -75.5749 -99.5662 -5.2
+      vertex -69.1739 -104.115 -5.2
+    endloop
+  endfacet
+  facet normal -0.95424 0.299041 0
+    outer loop
+      vertex -120.395 33.615 -5.2
+      vertex -118.047 41.1083 -0.2
+      vertex -118.047 41.1083 -5.2
+    endloop
+  endfacet
+  facet normal -0.95424 0.299041 0
+    outer loop
+      vertex -118.047 41.1083 -0.2
+      vertex -120.395 33.615 -5.2
+      vertex -120.395 33.615 -0.2
+    endloop
+  endfacet
+  facet normal -0.971134 0.238534 0
+    outer loop
+      vertex -122.268 25.989 -5.2
+      vertex -120.395 33.615 -0.2
+      vertex -120.395 33.615 -5.2
+    endloop
+  endfacet
+  facet normal -0.971134 0.238534 0
+    outer loop
+      vertex -120.395 33.615 -0.2
+      vertex -122.268 25.989 -5.2
+      vertex -122.268 25.989 -0.2
+    endloop
+  endfacet
+  facet normal -0.997315 -0.0732375 0
+    outer loop
+      vertex -124.315 -13.0661 -5.2
+      vertex -124.89 -5.23446 -0.2
+      vertex -124.89 -5.23446 -5.2
+    endloop
+  endfacet
+  facet normal -0.997315 -0.0732375 0
+    outer loop
+      vertex -124.89 -5.23446 -0.2
+      vertex -124.315 -13.0661 -5.2
+      vertex -124.315 -13.0661 -0.2
+    endloop
+  endfacet
+  facet normal -0.980271 -0.197657 0
+    outer loop
+      vertex -121.697 -28.5439 -5.2
+      vertex -123.25 -20.8461 -0.2
+      vertex -123.25 -20.8461 -5.2
+    endloop
+  endfacet
+  facet normal -0.980271 -0.197657 0
+    outer loop
+      vertex -123.25 -20.8461 -0.2
+      vertex -121.697 -28.5439 -5.2
+      vertex -121.697 -28.5439 -0.2
+    endloop
+  endfacet
+  facet normal 0.984196 -0.177085 0
+    outer loop
+      vertex 122.268 -25.989 -0.2
+      vertex 123.659 -18.2604 -5.2
+      vertex 123.659 -18.2604 -0.2
+    endloop
+  endfacet
+  facet normal 0.984196 -0.177085 0
+    outer loop
+      vertex 123.659 -18.2604 -5.2
+      vertex 122.268 -25.989 -0.2
+      vertex 122.268 -25.989 -5.2
+    endloop
+  endfacet
+  facet normal 0.999945 0.0104732 0
+    outer loop
+      vertex 124.89 5.23446 -0.2
+      vertex 124.915 2.83794 -5.2
+      vertex 124.89 5.23446 -5.2
+    endloop
+  endfacet
+  facet normal 0.999945 0.0104725 3.5809e-07
+    outer loop
+      vertex 124.973 -2.6178 -0.2
+      vertex 124.915 2.83794 -5.2
+      vertex 124.89 5.23446 -0.2
+    endloop
+  endfacet
+  facet normal 0.999945 0.0104722 0
+    outer loop
+      vertex 124.915 2.83794 -5.2
+      vertex 124.973 -2.6178 -0.2
+      vertex 124.973 -2.6178 -5.2
+    endloop
+  endfacet
+  facet normal 0.997315 0.0732375 0
+    outer loop
+      vertex 124.89 5.23446 -0.2
+      vertex 124.315 13.0661 -5.2
+      vertex 124.315 13.0661 -0.2
+    endloop
+  endfacet
+  facet normal 0.997315 0.0732375 0
+    outer loop
+      vertex 124.315 13.0661 -5.2
+      vertex 124.89 5.23446 -0.2
+      vertex 124.89 5.23446 -5.2
+    endloop
+  endfacet
+  facet normal 0.965926 0.258819 0
+    outer loop
+      vertex 121.697 28.5439 -0.2
+      vertex 119.665 36.129 -5.2
+      vertex 119.665 36.129 -0.2
+    endloop
+  endfacet
+  facet normal 0.965926 0.258819 0
+    outer loop
+      vertex 119.665 36.129 -5.2
+      vertex 121.697 28.5439 -0.2
+      vertex 121.697 28.5439 -5.2
+    endloop
+  endfacet
+  facet normal 0.980271 0.197657 0
+    outer loop
+      vertex 123.25 20.8461 -0.2
+      vertex 121.697 28.5439 -5.2
+      vertex 121.697 28.5439 -0.2
+    endloop
+  endfacet
+  facet normal 0.980271 0.197657 0
+    outer loop
+      vertex 121.697 28.5439 -5.2
+      vertex 123.25 20.8461 -0.2
+      vertex 123.25 20.8461 -5.2
+    endloop
+  endfacet
+  facet normal 0.526955 0.849893 0
+    outer loop
+      vertex 64.9109 106.758 -5.2
+      vertex 69.1739 104.115 -0.2
+      vertex 69.1739 104.115 -5.2
+    endloop
+  endfacet
+  facet normal 0.526955 0.849893 -3.45665e-07
+    outer loop
+      vertex 69.1739 104.115 -0.2
+      vertex 64.9109 106.758 -5.2
+      vertex 62.5 108.253 -0.2
+    endloop
+  endfacet
+  facet normal 0.526956 0.849893 0
+    outer loop
+      vertex 62.5 108.253 -0.2
+      vertex 64.9109 106.758 -5.2
+      vertex 62.5 108.253 -5.2
+    endloop
+  endfacet
+  facet normal 0.925871 0.377841 0
+    outer loop
+      vertex 117.16 43.5715 -0.2
+      vertex 114.193 50.8421 -5.2
+      vertex 114.193 50.8421 -0.2
+    endloop
+  endfacet
+  facet normal 0.925871 0.377841 0
+    outer loop
+      vertex 114.193 50.8421 -5.2
+      vertex 117.16 43.5715 -0.2
+      vertex 117.16 43.5715 -5.2
+    endloop
+  endfacet
+  facet normal 0.802817 0.596225 0
+    outer loop
+      vertex 102.644 71.3392 -0.2
+      vertex 97.9617 77.6435 -5.2
+      vertex 97.9617 77.6435 -0.2
+    endloop
+  endfacet
+  facet normal 0.802817 0.596225 0
+    outer loop
+      vertex 97.9617 77.6435 -5.2
+      vertex 102.644 71.3392 -0.2
+      vertex 102.644 71.3392 -5.2
+    endloop
+  endfacet
+  facet normal 0.838671 0.544639 0
+    outer loop
+      vertex 106.355 65.6243 -0.2
+      vertex 102.644 71.3392 -5.2
+      vertex 102.644 71.3392 -0.2
+    endloop
+  endfacet
+  facet normal 0.838671 0.544639 0
+    outer loop
+      vertex 102.644 71.3392 -5.2
+      vertex 106.355 65.6243 -0.2
+      vertex 106.355 65.6243 -5.2
+    endloop
+  endfacet
+  facet normal 0.62932 0.777146 -0
+    outer loop
+      vertex 81.6776 94.6244 -5.2
+      vertex 75.5749 99.5662 -0.2
+      vertex 81.6776 94.6244 -0.2
+    endloop
+  endfacet
+  facet normal 0.62932 0.777146 0
+    outer loop
+      vertex 75.5749 99.5662 -0.2
+      vertex 81.6776 94.6244 -5.2
+      vertex 75.5749 99.5662 -5.2
+    endloop
+  endfacet
+  facet normal 0.72176 0.692144 0
+    outer loop
+      vertex 92.8931 83.6413 -0.2
+      vertex 87.4579 89.3091 -5.2
+      vertex 87.4579 89.3091 -0.2
+    endloop
+  endfacet
+  facet normal 0.72176 0.692144 0
+    outer loop
+      vertex 87.4579 89.3091 -5.2
+      vertex 92.8931 83.6413 -0.2
+      vertex 92.8931 83.6413 -5.2
+    endloop
+  endfacet
+  facet normal -0.849893 0.526955 0
+    outer loop
+      vertex -106.882 64.7122 -5.2
+      vertex -104.115 69.1739 -0.2
+      vertex -104.115 69.1739 -5.2
+    endloop
+  endfacet
+  facet normal -0.849893 0.526955 0
+    outer loop
+      vertex -104.115 69.1739 -0.2
+      vertex -106.882 64.7122 -5.2
+      vertex -106.882 64.7122 -0.2
+    endloop
+  endfacet
+  facet normal -0.645458 0.763796 0
+    outer loop
+      vertex -77.6435 97.9617 -5.2
+      vertex -83.6413 92.8931 -0.2
+      vertex -77.6435 97.9617 -0.2
+    endloop
+  endfacet
+  facet normal -0.645458 0.763796 0
+    outer loop
+      vertex -83.6413 92.8931 -0.2
+      vertex -77.6435 97.9617 -5.2
+      vertex -83.6413 92.8931 -5.2
+    endloop
+  endfacet
+  facet normal -0.736097 0.676876 0
+    outer loop
+      vertex -94.6244 81.6776 -5.2
+      vertex -89.3091 87.4579 -0.2
+      vertex -89.3091 87.4579 -5.2
+    endloop
+  endfacet
+  facet normal -0.736097 0.676876 0
+    outer loop
+      vertex -89.3091 87.4579 -0.2
+      vertex -94.6244 81.6776 -5.2
+      vertex -94.6244 81.6776 -0.2
+    endloop
+  endfacet
+  facet normal -0.435232 0.900319 0
+    outer loop
+      vertex -50.8421 114.193 -5.2
+      vertex -57.912 110.775 -0.2
+      vertex -50.8421 114.193 -0.2
+    endloop
+  endfacet
+  facet normal -0.435232 0.900319 0
+    outer loop
+      vertex -57.912 110.775 -0.2
+      vertex -50.8421 114.193 -5.2
+      vertex -57.912 110.775 -5.2
+    endloop
+  endfacet
+  facet normal -0.258819 0.965926 0
+    outer loop
+      vertex -28.5439 121.697 -5.2
+      vertex -36.129 119.665 -0.2
+      vertex -28.5439 121.697 -0.2
+    endloop
+  endfacet
+  facet normal -0.258819 0.965926 0
+    outer loop
+      vertex -36.129 119.665 -0.2
+      vertex -28.5439 121.697 -5.2
+      vertex -36.129 119.665 -5.2
+    endloop
+  endfacet
+  facet normal 0.177085 0.984196 -0
+    outer loop
+      vertex 25.989 122.268 -5.2
+      vertex 18.2604 123.659 -0.2
+      vertex 25.989 122.268 -0.2
+    endloop
+  endfacet
+  facet normal 0.177085 0.984196 0
+    outer loop
+      vertex 18.2604 123.659 -0.2
+      vertex 25.989 122.268 -5.2
+      vertex 18.2604 123.659 -5.2
+    endloop
+  endfacet
+  facet normal 0.472551 0.881304 -0
+    outer loop
+      vertex 62.5 108.253 -5.2
+      vertex 55.5794 111.964 -0.2
+      vertex 62.5 108.253 -0.2
+    endloop
+  endfacet
+  facet normal 0.472551 0.881304 0
+    outer loop
+      vertex 55.5794 111.964 -0.2
+      vertex 62.5 108.253 -5.2
+      vertex 55.5794 111.964 -5.2
+    endloop
+  endfacet
+  facet normal 0.114937 0.993373 -0
+    outer loop
+      vertex 18.2604 123.659 -5.2
+      vertex 10.4597 124.562 -0.2
+      vertex 18.2604 123.659 -0.2
+    endloop
+  endfacet
+  facet normal 0.114937 0.993373 0
+    outer loop
+      vertex 10.4597 124.562 -0.2
+      vertex 18.2604 123.659 -5.2
+      vertex 10.4597 124.562 -5.2
+    endloop
+  endfacet
+  facet normal -0.197657 0.980271 0
+    outer loop
+      vertex -20.8461 123.25 -5.2
+      vertex -28.5439 121.697 -0.2
+      vertex -20.8461 123.25 -0.2
+    endloop
+  endfacet
+  facet normal -0.197657 0.980271 0
+    outer loop
+      vertex -28.5439 121.697 -0.2
+      vertex -20.8461 123.25 -5.2
+      vertex -28.5439 121.697 -5.2
+    endloop
+  endfacet
+  facet normal -0.472552 -0.881303 0
+    outer loop
+      vertex -60 -109.594 -5.2
+      vertex -62.5 -108.253 -0.2
+      vertex -62.5 -108.253 -5.2
+    endloop
+  endfacet
+  facet normal -0.472551 -0.881304 7.76702e-07
+    outer loop
+      vertex -62.5 -108.253 -0.2
+      vertex -60 -109.594 -5.2
+      vertex -55.5794 -111.964 -0.2
+    endloop
+  endfacet
+  facet normal -0.47255 -0.881304 -0
+    outer loop
+      vertex -55.5794 -111.964 -0.2
+      vertex -60 -109.594 -5.2
+      vertex -55.5794 -111.964 -5.2
+    endloop
+  endfacet
+  facet normal 0.736097 -0.676876 0
+    outer loop
+      vertex 89.3091 -87.4579 -0.2
+      vertex 94.6244 -81.6776 -5.2
+      vertex 94.6244 -81.6776 -0.2
+    endloop
+  endfacet
+  facet normal 0.736097 -0.676876 0
+    outer loop
+      vertex 94.6244 -81.6776 -5.2
+      vertex 89.3091 -87.4579 -0.2
+      vertex 89.3091 -87.4579 -5.2
+    endloop
+  endfacet
+  facet normal 0.645458 -0.763796 0
+    outer loop
+      vertex 77.6435 -97.9617 -5.2
+      vertex 83.6413 -92.8931 -0.2
+      vertex 77.6435 -97.9617 -0.2
+    endloop
+  endfacet
+  facet normal 0.645458 -0.763796 0
+    outer loop
+      vertex 83.6413 -92.8931 -0.2
+      vertex 77.6435 -97.9617 -5.2
+      vertex 83.6413 -92.8931 -5.2
+    endloop
+  endfacet
+  facet normal -0.358367 -0.933581 0
+    outer loop
+      vertex -48.4394 -115.233 -5.2
+      vertex -41.1083 -118.047 -0.2
+      vertex -48.4394 -115.233 -0.2
+    endloop
+  endfacet
+  facet normal -0.358367 -0.933581 -0
+    outer loop
+      vertex -41.1083 -118.047 -0.2
+      vertex -48.4394 -115.233 -5.2
+      vertex -41.1083 -118.047 -5.2
+    endloop
+  endfacet
+  facet normal -0.114937 -0.993373 0
+    outer loop
+      vertex -18.2604 -123.659 -5.2
+      vertex -10.4597 -124.562 -0.2
+      vertex -18.2604 -123.659 -0.2
+    endloop
+  endfacet
+  facet normal -0.114937 -0.993373 -0
+    outer loop
+      vertex -10.4597 -124.562 -0.2
+      vertex -18.2604 -123.659 -5.2
+      vertex -10.4597 -124.562 -5.2
+    endloop
+  endfacet
+  facet normal 0.258819 -0.965926 0
+    outer loop
+      vertex 28.5439 -121.697 -5.2
+      vertex 36.129 -119.665 -0.2
+      vertex 28.5439 -121.697 -0.2
+    endloop
+  endfacet
+  facet normal 0.258819 -0.965926 0
+    outer loop
+      vertex 36.129 -119.665 -0.2
+      vertex 28.5439 -121.697 -5.2
+      vertex 36.129 -119.665 -5.2
+    endloop
+  endfacet
+  facet normal 0.0104716 -0.999945 0
+    outer loop
+      vertex 2.57163 -124.918 -5.2
+      vertex 5.23446 -124.89 -0.2
+      vertex 2.57163 -124.918 -0.2
+    endloop
+  endfacet
+  facet normal 0.0104716 -0.999945 0
+    outer loop
+      vertex 5.23446 -124.89 -0.2
+      vertex 2.57163 -124.918 -5.2
+      vertex 5.23446 -124.89 -5.2
+    endloop
+  endfacet
+  facet normal 0.596225 -0.802817 0
+    outer loop
+      vertex 71.3392 -102.644 -5.2
+      vertex 77.6435 -97.9617 -0.2
+      vertex 71.3392 -102.644 -0.2
+    endloop
+  endfacet
+  facet normal 0.596225 -0.802817 0
+    outer loop
+      vertex 77.6435 -97.9617 -0.2
+      vertex 71.3392 -102.644 -5.2
+      vertex 77.6435 -97.9617 -5.2
+    endloop
+  endfacet
+  facet normal 0.435232 -0.900319 0
+    outer loop
+      vertex 50.8421 -114.193 -5.2
+      vertex 57.912 -110.775 -0.2
+      vertex 50.8421 -114.193 -0.2
+    endloop
+  endfacet
+  facet normal 0.435232 -0.900319 0
+    outer loop
+      vertex 57.912 -110.775 -0.2
+      vertex 50.8421 -114.193 -5.2
+      vertex 57.912 -110.775 -5.2
+    endloop
+  endfacet
+  facet normal 0.31896 -0.947768 0
+    outer loop
+      vertex 36.129 -119.665 -5.2
+      vertex 43.5715 -117.16 -0.2
+      vertex 36.129 -119.665 -0.2
+    endloop
+  endfacet
+  facet normal 0.31896 -0.947768 0
+    outer loop
+      vertex 43.5715 -117.16 -0.2
+      vertex 36.129 -119.665 -5.2
+      vertex 43.5715 -117.16 -5.2
+    endloop
+  endfacet
+  facet normal -0.763796 -0.645458 0
+    outer loop
+      vertex -92.8931 -83.6413 -5.2
+      vertex -97.9617 -77.6435 -0.2
+      vertex -97.9617 -77.6435 -5.2
+    endloop
+  endfacet
+  facet normal -0.763796 -0.645458 0
+    outer loop
+      vertex -97.9617 -77.6435 -0.2
+      vertex -92.8931 -83.6413 -5.2
+      vertex -92.8931 -83.6413 -0.2
+    endloop
+  endfacet
+  facet normal -0.676876 -0.736097 0
+    outer loop
+      vertex -87.4579 -89.3091 -5.2
+      vertex -81.6776 -94.6244 -0.2
+      vertex -87.4579 -89.3091 -0.2
+    endloop
+  endfacet
+  facet normal -0.676876 -0.736097 -0
+    outer loop
+      vertex -81.6776 -94.6244 -0.2
+      vertex -87.4579 -89.3091 -5.2
+      vertex -81.6776 -94.6244 -5.2
+    endloop
+  endfacet
+  facet normal -0.925871 -0.377841 0
+    outer loop
+      vertex -114.193 -50.8421 -5.2
+      vertex -117.16 -43.5715 -0.2
+      vertex -117.16 -43.5715 -5.2
+    endloop
+  endfacet
+  facet normal -0.925871 -0.377841 0
+    outer loop
+      vertex -117.16 -43.5715 -0.2
+      vertex -114.193 -50.8421 -5.2
+      vertex -114.193 -50.8421 -0.2
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 0
+    outer loop
+      vertex -119.665 -36.129 -5.2
+      vertex -121.697 -28.5439 -0.2
+      vertex -121.697 -28.5439 -5.2
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258819 0
+    outer loop
+      vertex -121.697 -28.5439 -0.2
+      vertex -119.665 -36.129 -5.2
+      vertex -119.665 -36.129 -0.2
+    endloop
+  endfacet
+  facet normal -0.838671 -0.544639 0
+    outer loop
+      vertex -102.644 -71.3392 -5.2
+      vertex -106.921 -64.7534 -0.2
+      vertex -106.921 -64.7534 -5.2
+    endloop
+  endfacet
+  facet normal -0.838671 -0.544639 0
+    outer loop
+      vertex -106.921 -64.7534 -0.2
+      vertex -102.644 -71.3392 -5.2
+      vertex -102.644 -71.3392 -0.2
+    endloop
+  endfacet
+  facet normal -0.900319 -0.435232 0
+    outer loop
+      vertex -110.775 -57.912 -5.2
+      vertex -114.193 -50.8421 -0.2
+      vertex -114.193 -50.8421 -5.2
+    endloop
+  endfacet
+  facet normal -0.900319 -0.435232 0
+    outer loop
+      vertex -114.193 -50.8421 -0.2
+      vertex -110.775 -57.912 -5.2
+      vertex -110.775 -57.912 -0.2
+    endloop
+  endfacet
+  facet normal -0.881304 0.47255 0
+    outer loop
+      vertex -111.964 55.5794 -5.2
+      vertex -109.483 60.206 -0.2
+      vertex -109.483 60.206 -5.2
+    endloop
+  endfacet
+  facet normal -0.881304 0.47255 0
+    outer loop
+      vertex -109.483 60.206 -0.2
+      vertex -111.964 55.5794 -5.2
+      vertex -111.964 55.5794 -0.2
+    endloop
+  endfacet
+  facet normal -0.933581 0.358367 0
+    outer loop
+      vertex -118.047 41.1083 -5.2
+      vertex -115.233 48.4394 -0.2
+      vertex -115.233 48.4394 -5.2
+    endloop
+  endfacet
+  facet normal -0.933581 0.358367 0
+    outer loop
+      vertex -115.233 48.4394 -0.2
+      vertex -118.047 41.1083 -5.2
+      vertex -118.047 41.1083 -0.2
+    endloop
+  endfacet
+  facet normal -0.999945 -0.0104725 0
+    outer loop
+      vertex -124.89 -5.23446 -5.2
+      vertex -124.973 2.6178 -0.2
+      vertex -124.973 2.6178 -5.2
+    endloop
+  endfacet
+  facet normal -0.999945 -0.0104725 0
+    outer loop
+      vertex -124.973 2.6178 -0.2
+      vertex -124.89 -5.23446 -5.2
+      vertex -124.89 -5.23446 -0.2
+    endloop
+  endfacet
+  facet normal -0.99863 0.0523359 0
+    outer loop
+      vertex -124.96 2.86349 -5.2
+      vertex -124.562 10.4597 -0.2
+      vertex -124.562 10.4597 -5.2
+    endloop
+  endfacet
+  facet normal -0.998629 0.0523462 0
+    outer loop
+      vertex -124.973 2.6178 -0.2
+      vertex -124.96 2.86349 -5.2
+      vertex -124.973 2.6178 -5.2
+    endloop
+  endfacet
+  facet normal -0.99863 0.0523362 -4.91847e-07
+    outer loop
+      vertex -124.96 2.86349 -5.2
+      vertex -124.973 2.6178 -0.2
+      vertex -124.562 10.4597 -0.2
+    endloop
+  endfacet
+  facet normal -0.990748 -0.135716 0
+    outer loop
+      vertex -123.25 -20.8461 -5.2
+      vertex -124.315 -13.0661 -0.2
+      vertex -124.315 -13.0661 -5.2
+    endloop
+  endfacet
+  facet normal -0.990748 -0.135716 0
+    outer loop
+      vertex -124.315 -13.0661 -0.2
+      vertex -123.25 -20.8461 -5.2
+      vertex -123.25 -20.8461 -0.2
+    endloop
+  endfacet
+  facet normal 0.95424 -0.299041 0
+    outer loop
+      vertex 118.047 -41.1083 -0.2
+      vertex 120.395 -33.615 -5.2
+      vertex 120.395 -33.615 -0.2
+    endloop
+  endfacet
+  facet normal 0.95424 -0.299041 0
+    outer loop
+      vertex 120.395 -33.615 -5.2
+      vertex 118.047 -41.1083 -0.2
+      vertex 118.047 -41.1083 -5.2
+    endloop
+  endfacet
+  facet normal 0.933581 -0.358367 0
+    outer loop
+      vertex 115.233 -48.4394 -0.2
+      vertex 118.047 -41.1083 -5.2
+      vertex 118.047 -41.1083 -0.2
+    endloop
+  endfacet
+  facet normal 0.933581 -0.358367 0
+    outer loop
+      vertex 118.047 -41.1083 -5.2
+      vertex 115.233 -48.4394 -0.2
+      vertex 115.233 -48.4394 -5.2
+    endloop
+  endfacet
+  facet normal 0.947768 0.31896 0
+    outer loop
+      vertex 119.665 36.129 -0.2
+      vertex 117.16 43.5715 -5.2
+      vertex 117.16 43.5715 -0.2
+    endloop
+  endfacet
+  facet normal 0.947768 0.31896 0
+    outer loop
+      vertex 117.16 43.5715 -5.2
+      vertex 119.665 36.129 -0.2
+      vertex 119.665 36.129 -5.2
+    endloop
+  endfacet
+  facet normal 0.763796 0.645458 0
+    outer loop
+      vertex 97.9617 77.6435 -0.2
+      vertex 92.8931 83.6413 -5.2
+      vertex 92.8931 83.6413 -0.2
+    endloop
+  endfacet
+  facet normal 0.763796 0.645458 0
+    outer loop
+      vertex 92.8931 83.6413 -5.2
+      vertex 97.9617 77.6435 -0.2
+      vertex 97.9617 77.6435 -5.2
+    endloop
+  endfacet
+  facet normal -0.135716 0.990748 0
+    outer loop
+      vertex -13.0661 124.315 -5.2
+      vertex -20.8461 123.25 -0.2
+      vertex -13.0661 124.315 -0.2
+    endloop
+  endfacet
+  facet normal -0.135716 0.990748 0
+    outer loop
+      vertex -20.8461 123.25 -0.2
+      vertex -13.0661 124.315 -5.2
+      vertex -20.8461 123.25 -5.2
+    endloop
+  endfacet
+  facet normal 0.777146 -0.62932 0
+    outer loop
+      vertex 94.6244 -81.6776 -0.2
+      vertex 99.5662 -75.5749 -5.2
+      vertex 99.5662 -75.5749 -0.2
+    endloop
+  endfacet
+  facet normal 0.777146 -0.62932 0
+    outer loop
+      vertex 99.5662 -75.5749 -5.2
+      vertex 94.6244 -81.6776 -0.2
+      vertex 94.6244 -81.6776 -5.2
+    endloop
+  endfacet
+  facet normal 0.815128 -0.579281 0
+    outer loop
+      vertex 99.5662 -75.5749 -0.2
+      vertex 104.115 -69.1739 -5.2
+      vertex 104.115 -69.1739 -0.2
+    endloop
+  endfacet
+  facet normal 0.815128 -0.579281 0
+    outer loop
+      vertex 104.115 -69.1739 -5.2
+      vertex 99.5662 -75.5749 -0.2
+      vertex 99.5662 -75.5749 -5.2
+    endloop
+  endfacet
+  facet normal 0.692144 -0.72176 0
+    outer loop
+      vertex 83.6413 -92.8931 -5.2
+      vertex 89.3091 -87.4579 -0.2
+      vertex 83.6413 -92.8931 -0.2
+    endloop
+  endfacet
+  facet normal 0.692144 -0.72176 0
+    outer loop
+      vertex 89.3091 -87.4579 -0.2
+      vertex 83.6413 -92.8931 -5.2
+      vertex 89.3091 -87.4579 -5.2
+    endloop
+  endfacet
+  facet normal -0.299041 -0.95424 0
+    outer loop
+      vertex -41.1083 -118.047 -5.2
+      vertex -33.615 -120.395 -0.2
+      vertex -41.1083 -118.047 -0.2
+    endloop
+  endfacet
+  facet normal -0.299041 -0.95424 -0
+    outer loop
+      vertex -33.615 -120.395 -0.2
+      vertex -41.1083 -118.047 -5.2
+      vertex -33.615 -120.395 -5.2
+    endloop
+  endfacet
+  facet normal -0.416281 -0.909236 0
+    outer loop
+      vertex -55.5794 -111.964 -5.2
+      vertex -48.4394 -115.233 -0.2
+      vertex -55.5794 -111.964 -0.2
+    endloop
+  endfacet
+  facet normal -0.416281 -0.909236 -0
+    outer loop
+      vertex -48.4394 -115.233 -0.2
+      vertex -55.5794 -111.964 -5.2
+      vertex -48.4394 -115.233 -5.2
+    endloop
+  endfacet
+  facet normal -0.177085 -0.984196 0
+    outer loop
+      vertex -25.989 -122.268 -5.2
+      vertex -18.2604 -123.659 -0.2
+      vertex -25.989 -122.268 -0.2
+    endloop
+  endfacet
+  facet normal -0.177085 -0.984196 -0
+    outer loop
+      vertex -18.2604 -123.659 -0.2
+      vertex -25.989 -122.268 -5.2
+      vertex -18.2604 -123.659 -5.2
+    endloop
+  endfacet
+  facet normal 0.0732375 -0.997315 0
+    outer loop
+      vertex 5.23446 -124.89 -5.2
+      vertex 13.0661 -124.315 -0.2
+      vertex 5.23446 -124.89 -0.2
+    endloop
+  endfacet
+  facet normal 0.0732375 -0.997315 0
+    outer loop
+      vertex 13.0661 -124.315 -0.2
+      vertex 5.23446 -124.89 -5.2
+      vertex 13.0661 -124.315 -5.2
+    endloop
+  endfacet
+  facet normal 0.377841 -0.925871 0
+    outer loop
+      vertex 43.5715 -117.16 -5.2
+      vertex 50.8421 -114.193 -0.2
+      vertex 43.5715 -117.16 -0.2
+    endloop
+  endfacet
+  facet normal 0.377841 -0.925871 0
+    outer loop
+      vertex 50.8421 -114.193 -0.2
+      vertex 43.5715 -117.16 -5.2
+      vertex 50.8421 -114.193 -5.2
+    endloop
+  endfacet
+  facet normal -0.72176 -0.692144 0
+    outer loop
+      vertex -87.4579 -89.3091 -5.2
+      vertex -92.8931 -83.6413 -0.2
+      vertex -92.8931 -83.6413 -5.2
+    endloop
+  endfacet
+  facet normal -0.72176 -0.692144 0
+    outer loop
+      vertex -92.8931 -83.6413 -0.2
+      vertex -87.4579 -89.3091 -5.2
+      vertex -87.4579 -89.3091 -0.2
+    endloop
+  endfacet
+  facet normal -0.62932 -0.777146 0
+    outer loop
+      vertex -81.6776 -94.6244 -5.2
+      vertex -75.5749 -99.5662 -0.2
+      vertex -81.6776 -94.6244 -0.2
+    endloop
+  endfacet
+  facet normal -0.62932 -0.777146 -0
+    outer loop
+      vertex -75.5749 -99.5662 -0.2
+      vertex -81.6776 -94.6244 -5.2
+      vertex -75.5749 -99.5662 -5.2
+    endloop
+  endfacet
+  facet normal -0.947768 -0.31896 0
+    outer loop
+      vertex -117.16 -43.5715 -5.2
+      vertex -119.665 -36.129 -0.2
+      vertex -119.665 -36.129 -5.2
+    endloop
+  endfacet
+  facet normal -0.947768 -0.31896 0
+    outer loop
+      vertex -119.665 -36.129 -0.2
+      vertex -117.16 -43.5715 -5.2
+      vertex -117.16 -43.5715 -0.2
+    endloop
+  endfacet
+  facet normal -0.871214 -0.490903 0
+    outer loop
+      vertex -106.921 -64.7534 -5.2
+      vertex -110.775 -57.912 -0.2
+      vertex -110.775 -57.912 -5.2
+    endloop
+  endfacet
+  facet normal -0.871214 -0.490903 0
+    outer loop
+      vertex -110.775 -57.912 -0.2
+      vertex -106.921 -64.7534 -5.2
+      vertex -106.921 -64.7534 -0.2
+    endloop
+  endfacet
+  facet normal -0.909236 0.416281 0
+    outer loop
+      vertex -115.233 48.4394 -5.2
+      vertex -111.964 55.5794 -0.2
+      vertex -111.964 55.5794 -5.2
+    endloop
+  endfacet
+  facet normal -0.909236 0.416281 0
+    outer loop
+      vertex -111.964 55.5794 -0.2
+      vertex -115.233 48.4394 -5.2
+      vertex -115.233 48.4394 -0.2
+    endloop
+  endfacet
+  facet normal -0.984196 0.177085 0
+    outer loop
+      vertex -123.659 18.2604 -5.2
+      vertex -122.268 25.989 -0.2
+      vertex -122.268 25.989 -5.2
+    endloop
+  endfacet
+  facet normal -0.984196 0.177085 0
+    outer loop
+      vertex -122.268 25.989 -0.2
+      vertex -123.659 18.2604 -5.2
+      vertex -123.659 18.2604 -0.2
+    endloop
+  endfacet
+  facet normal 0.849893 -0.526955 0
+    outer loop
+      vertex 104.115 -69.1739 -0.2
+      vertex 108.253 -62.5 -5.2
+      vertex 108.253 -62.5 -0.2
+    endloop
+  endfacet
+  facet normal 0.849893 -0.526955 0
+    outer loop
+      vertex 108.253 -62.5 -5.2
+      vertex 104.115 -69.1739 -0.2
+      vertex 104.115 -69.1739 -5.2
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
Kossel Pro is a larger version of the Kossel Mini, which is already represented here.

Source for generating these files can be found here:

https://github.com/dotscad/openbeam/blob/master/kossel_pro_build_platform/