### PR TITLE
Add open source projects to the About dialog

### DIFF
--- a/resources/qml/AboutDialog.qml
+++ b/resources/qml/AboutDialog.qml
@@ -15,7 +15,7 @@ UM.Dialog
     title: catalog.i18nc("@title:window","About Cura")
 
     minimumWidth: 450 * Screen.devicePixelRatio
-    minimumHeight: 500 * Screen.devicePixelRatio
+    minimumHeight: 550 * Screen.devicePixelRatio
     width: minimumWidth
     height: minimumHeight
 
@@ -112,13 +112,14 @@ UM.Dialog
         Component.onCompleted:
         {
             projectsModel.append({ name:"Cura", description: catalog.i18nc("@label", "Graphical user interface"), license: "AGPLv3", url: "https://github.com/Ultimaker/Cura" });
-            projectsModel.append({ name:"Uranium", description: catalog.i18nc("@label", "Application Framework"), license: "AGPLv3", url: "https://github.com/Ultimaker/Uranium" });
-            projectsModel.append({ name:"CuraEngine", description: catalog.i18nc("@label", "GCode Generator"), license: "AGPLv3", url: "https://github.com/Ultimaker/CuraEngine" });
-            projectsModel.append({ name:"libArcus", description: catalog.i18nc("@label", "Interprocess Communication library"), license: "AGPLv3", url: "https://github.com/Ultimaker/libArcus" });
+            projectsModel.append({ name:"Uranium", description: catalog.i18nc("@label", "Application framework"), license: "AGPLv3", url: "https://github.com/Ultimaker/Uranium" });
+            projectsModel.append({ name:"CuraEngine", description: catalog.i18nc("@label", "GCode generator"), license: "AGPLv3", url: "https://github.com/Ultimaker/CuraEngine" });
+            projectsModel.append({ name:"libArcus", description: catalog.i18nc("@label", "Interprocess communication library"), license: "AGPLv3", url: "https://github.com/Ultimaker/libArcus" });
 
-            projectsModel.append({ name:"Python", description: catalog.i18nc("@label", "Programming Language"), license: "Python", url: "http://python.org/" });
-            projectsModel.append({ name:"Qt5", description: catalog.i18nc("@label", "GUI Framework"), license: "LGPLv3", url: "https://www.qt.io/" });
-            projectsModel.append({ name:"PyQt", description: catalog.i18nc("@label", "GUI Framework bindings"), license: "GPL", url: "https://riverbankcomputing.com/software/pyqt" });
+            projectsModel.append({ name:"Python", description: catalog.i18nc("@label", "Programming language"), license: "Python", url: "http://python.org/" });
+            projectsModel.append({ name:"Qt5", description: catalog.i18nc("@label", "GUI framework"), license: "LGPLv3", url: "https://www.qt.io/" });
+            projectsModel.append({ name:"PyQt", description: catalog.i18nc("@label", "GUI framework bindings"), license: "GPL", url: "https://riverbankcomputing.com/software/pyqt" });
+            projectsModel.append({ name:"SIP", description: catalog.i18nc("@label", "C/C++ Binding library"), license: "GPL", url: "https://riverbankcomputing.com/software/sip" });
             projectsModel.append({ name:"Protobuf", description: catalog.i18nc("@label", "Data interchange format"), license: "BSD", url: "https://developers.google.com/protocol-buffers" });
             projectsModel.append({ name:"SciPy", description: catalog.i18nc("@label", "Support library for scientific computing "), license: "BSD-new", url: "https://www.scipy.org/" });
             projectsModel.append({ name:"NumPy", description: catalog.i18nc("@label", "Support library for faster math"), license: "BSD", url: "http://www.numpy.org/" });
@@ -127,7 +128,7 @@ UM.Dialog
             projectsModel.append({ name:"python-zeroconf", description: catalog.i18nc("@label", "ZeroConf discovery library"), license: "LGPL", url: "https://github.com/jstasiak/python-zeroconf" });
             projectsModel.append({ name:"Clipper", description: catalog.i18nc("@label", "Polygon clipping library"), license: "Boost", url: "http://www.angusj.com/delphi/clipper.php" });
             projectsModel.append({ name:"Open Sans", description: catalog.i18nc("@label", "Font"), license: "Apache 2.0", url: "https://fonts.google.com/specimen/Open+Sans" });
-            projectsModel.append({ name:"Font-Awesome-SVG-PNG", description: catalog.i18nc("@label", "Selected SVG Icons"), license: "SIL OFL 1.1", url: "https://github.com/encharm/Font-Awesome-SVG-PNG" });
+            projectsModel.append({ name:"Font-Awesome-SVG-PNG", description: catalog.i18nc("@label", "SVG icons"), license: "SIL OFL 1.1", url: "https://github.com/encharm/Font-Awesome-SVG-PNG" });
         }
     }
 

--- a/resources/qml/AboutDialog.qml
+++ b/resources/qml/AboutDialog.qml
@@ -14,25 +14,25 @@ UM.Dialog
     //: About dialog title
     title: catalog.i18nc("@title:window","About Cura")
 
-    minimumWidth: 400 * Screen.devicePixelRatio
-    minimumHeight: 300 * Screen.devicePixelRatio
+    minimumWidth: 450 * Screen.devicePixelRatio
+    minimumHeight: 500 * Screen.devicePixelRatio
     width: minimumWidth
     height: minimumHeight
-    //UM.I18nCatalog { id: catalog; }
-
 
     Image
     {
         id: logo
-        width: parent.width * 0.75
+        width: base.minimumWidth * 0.85
         height: width * (1/4.25)
 
         source: UM.Theme.getImage("logo")
 
         sourceSize.width: width
         sourceSize.height: height
-        anchors.centerIn: parent
-        anchors.verticalCenterOffset : -(height * 0.5)
+        anchors.top: parent.top
+        anchors.topMargin: (base.minimumWidth - width) / 2
+        anchors.horizontalCenter: parent.horizontalCenter
+
         UM.I18nCatalog{id: catalog; name:"cura"}
     }
 
@@ -42,10 +42,9 @@ UM.Dialog
 
         text: "Cura %1".arg(UM.Application.version)
         font: UM.Theme.getFont("large")
-        anchors.horizontalCenter : logo.horizontalCenter
-        anchors.horizontalCenterOffset : (logo.width * 0.25)
+        anchors.right : logo.right
         anchors.top: logo.bottom
-        anchors.topMargin : 5
+        anchors.topMargin: UM.Theme.getSize("default_margin").height / 2
     }
 
     Label
@@ -55,20 +54,80 @@ UM.Dialog
 
         //: About dialog application description
         text: catalog.i18nc("@label","End-to-end solution for fused filament 3D printing.")
+        font: UM.Theme.getFont("system")
         wrapMode: Text.WordWrap
         anchors.top: version.bottom
-        anchors.topMargin : 10
+        anchors.topMargin: UM.Theme.getSize("default_margin").height
     }
 
     Label
     {
-        id: author_note
+        id: creditsNotes
         width: parent.width
 
         //: About dialog application author note
-        text: catalog.i18nc("@info:credit","Cura has been developed by Ultimaker B.V. in cooperation with the community.")
+        text: catalog.i18nc("@info:credit","Cura is developed by Ultimaker B.V. in cooperation with the community.\nCura proudly uses the following open source projects:")
+        font: UM.Theme.getFont("system")
         wrapMode: Text.WordWrap
         anchors.top: description.bottom
+        anchors.topMargin: UM.Theme.getSize("default_margin").height
+    }
+
+    ListView
+    {
+        id: projectsList
+
+        anchors.top: creditsNotes.bottom
+        anchors.topMargin: 10
+
+        width: parent.width
+        height: childrenRect.height
+
+        delegate: Row
+        {
+            Label
+            {
+                text: "<a href='%1' title='%2'>%2</a>".arg(model.url).arg(model.name)
+                width: projectsList.width * 0.25
+                elide: Text.ElideRight
+                onLinkActivated: Qt.openUrlExternally(link)
+            }
+            Label
+            {
+                text: model.description
+                elide: Text.ElideRight
+                width: projectsList.width * 0.6
+            }
+            Label
+            {
+                text: model.license
+                elide: Text.ElideRight
+                width: projectsList.width * 0.15
+            }
+        }
+        model: ListModel
+        {
+            id: projectsModel
+        }
+        Component.onCompleted:
+        {
+            projectsModel.append({ name:"Cura", description: catalog.i18nc("@label", "Graphical user interface"), license: "AGPLv3", url: "https://github.com/Ultimaker/Cura" });
+            projectsModel.append({ name:"Uranium", description: catalog.i18nc("@label", "Application Framework"), license: "AGPLv3", url: "https://github.com/Ultimaker/Uranium" });
+            projectsModel.append({ name:"CuraEngine", description: catalog.i18nc("@label", "GCode Generator"), license: "AGPLv3", url: "https://github.com/Ultimaker/CuraEngine" });
+            projectsModel.append({ name:"libArcus", description: catalog.i18nc("@label", "Interprocess Communication library"), license: "AGPLv3", url: "https://github.com/Ultimaker/libArcus" });
+
+            projectsModel.append({ name:"Python", description: catalog.i18nc("@label", "Programming Language"), license: "Python", url: "http://python.org/" });
+            projectsModel.append({ name:"Qt5", description: catalog.i18nc("@label", "GUI Framework"), license: "LGPLv3", url: "https://www.qt.io/" });
+            projectsModel.append({ name:"PyQt", description: catalog.i18nc("@label", "GUI Framework bindings"), license: "GPL", url: "https://riverbankcomputing.com/software/pyqt" });
+            projectsModel.append({ name:"Protobuf", description: catalog.i18nc("@label", "Data interchange format"), license: "BSD", url: "https://developers.google.com/protocol-buffers" });
+            projectsModel.append({ name:"SciPy", description: catalog.i18nc("@label", "Support library for scientific computing "), license: "BSD-new", url: "https://www.scipy.org/" });
+            projectsModel.append({ name:"NumPy", description: catalog.i18nc("@label", "Support library for faster math"), license: "BSD", url: "http://www.numpy.org/" });
+            projectsModel.append({ name:"NumPy-STL", description: catalog.i18nc("@label", "Support library for handling STL files"), license: "BSD", url: "https://github.com/WoLpH/numpy-stl" });
+            projectsModel.append({ name:"PySerial", description: catalog.i18nc("@label", "Serial communication library"), license: "Python", url: "http://pyserial.sourceforge.net/" });
+            projectsModel.append({ name:"python-zeroconf", description: catalog.i18nc("@label", "ZeroConf discovery library"), license: "LGPL", url: "https://github.com/jstasiak/python-zeroconf" });
+            projectsModel.append({ name:"Clipper", description: catalog.i18nc("@label", "Polygon clipping library"), license: "Boost", url: "http://www.angusj.com/delphi/clipper.php" });
+            projectsModel.append({ name:"Font-Awesome-SVG-PNG", description: catalog.i18nc("@label", "Selected SVG Icons"), license: "SIL OFL 1.1", url: "https://github.com/encharm/Font-Awesome-SVG-PNG" });
+        }
     }
 
     rightButtons: Button

--- a/resources/qml/AboutDialog.qml
+++ b/resources/qml/AboutDialog.qml
@@ -126,6 +126,7 @@ UM.Dialog
             projectsModel.append({ name:"PySerial", description: catalog.i18nc("@label", "Serial communication library"), license: "Python", url: "http://pyserial.sourceforge.net/" });
             projectsModel.append({ name:"python-zeroconf", description: catalog.i18nc("@label", "ZeroConf discovery library"), license: "LGPL", url: "https://github.com/jstasiak/python-zeroconf" });
             projectsModel.append({ name:"Clipper", description: catalog.i18nc("@label", "Polygon clipping library"), license: "Boost", url: "http://www.angusj.com/delphi/clipper.php" });
+            projectsModel.append({ name:"Open Sans", description: catalog.i18nc("@label", "Font"), license: "Apache 2.0", url: "https://fonts.google.com/specimen/Open+Sans" });
             projectsModel.append({ name:"Font-Awesome-SVG-PNG", description: catalog.i18nc("@label", "Selected SVG Icons"), license: "SIL OFL 1.1", url: "https://github.com/encharm/Font-Awesome-SVG-PNG" });
         }
     }


### PR DESCRIPTION
This PR adds a list of projects, their description and licenses to the About dialog, similar to how legacy had it (except this PR adds an actual hyperlink).

The list of projects may have to be expanded, it could very well be that I missed some project(s).