### PR TITLE
Fixes to Add Machine dialog

### DIFF
--- a/resources/qml/AddMachineDialog.qml
+++ b/resources/qml/AddMachineDialog.qml
@@ -104,8 +104,8 @@ UM.Dialog
                     base.activeCategory = section;
                     if (machineList.model.getItem(machineList.currentIndex).section != section) {
                         // Find the first machine from this section
-                        for(var i = 0; i < sortedMachineDefinitionsModel.count; i++) {
-                            var item = sortedMachineDefinitionsModel.getItem(i);
+                        for(var i = 0; i < machineList.model.rowCount(); i++) {
+                            var item = machineList.model.getItem(i);
                             if (item.section == section) {
                                 machineList.currentIndex = i;
                                 break;

--- a/resources/qml/AddMachineDialog.qml
+++ b/resources/qml/AddMachineDialog.qml
@@ -46,7 +46,7 @@ UM.Dialog
             left: parent.left;
             top: parent.top;
             right: parent.right;
-            bottom: machineName.top;
+            bottom: machineNameRow.top;
             bottomMargin: UM.Theme.getSize("default_margin").height
         }
 
@@ -171,21 +171,33 @@ UM.Dialog
         }
     }
 
-    TextField
+    Row
     {
-        id: machineName;
-        text: getMachineName()
-        implicitWidth: UM.Theme.getSize("standard_list_input").width
-        maximumLength: 40
-        //validator: Cura.MachineNameValidator { } //TODO: Gives a segfault in PyQt5.6. For now, we must use a signal on text changed.
-        validator: RegExpValidator
-        {
-            regExp: {
-                machineName.machine_name_validator.machineNameRegex
-            }
-        }
-        property var machine_name_validator: Cura.MachineNameValidator { }
+        id: machineNameRow
         anchors.bottom:parent.bottom
+        spacing: UM.Theme.getSize("default_margin").width
+
+        Label
+        {
+            text: catalog.i18nc("@label", "Printer Name:")
+            anchors.verticalCenter: machineName.verticalCenter
+        }
+
+        TextField
+        {
+            id: machineName
+            text: getMachineName()
+            implicitWidth: UM.Theme.getSize("standard_list_input").width
+            maximumLength: 40
+            //validator: Cura.MachineNameValidator { } //TODO: Gives a segfault in PyQt5.6. For now, we must use a signal on text changed.
+            validator: RegExpValidator
+            {
+                regExp: {
+                    machineName.machine_name_validator.machineNameRegex
+                }
+            }
+            property var machine_name_validator: Cura.MachineNameValidator { }
+        }
     }
 
     Button

--- a/resources/qml/AddMachineDialog.qml
+++ b/resources/qml/AddMachineDialog.qml
@@ -46,7 +46,8 @@ UM.Dialog
             left: parent.left;
             top: parent.top;
             right: parent.right;
-            bottom: parent.bottom;
+            bottom: machineName.top;
+            bottomMargin: UM.Theme.getSize("default_margin").height
         }
 
         ListView

--- a/resources/qml/AddMachineDialog.qml
+++ b/resources/qml/AddMachineDialog.qml
@@ -66,6 +66,7 @@ UM.Dialog
             section.delegate: Button
             {
                 text: section
+                width: machineList.width
                 style: ButtonStyle
                 {
                     background: Rectangle


### PR DESCRIPTION
This PR fixes some minor issues with the Add Machine dialog:

* the last printer in the "other" list is cut off by the machine name field
* the right-end side of the sections can not be clicked
* when switching to another section, an invisible printer stays selected (and QML complains)
* the purpose of the textfield is unclear