### PR TITLE
Make sure definition_changes containers are not upgraded to stacks

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
+++ b/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
@@ -19,6 +19,10 @@ class VersionUpgrade22to24(VersionUpgrade):
 
         config = configparser.ConfigParser(interpolation = None)
         config.read_string(serialised) # Read the input string as config file.
+        if config.get("metadata", "type") == "definition_changes":
+            # This is not a container stack, don't upgrade it here
+            return
+
         config.set("general", "version", "3")
 
         container_list = []


### PR DESCRIPTION
This PR fixes an issue introduced by the version upgrade from 2.3 to 2.4.

Since definition_changes containers are stored in the same folder as their machine_instances, the version upgrade system tried to upgrade them as containerstacks. This PR ignores definition_changes containers when looking at container stacks.