### PR TITLE
Implement material cost

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -217,6 +217,10 @@ class CuraApplication(QtApplication):
         Preferences.getInstance().addPreference("mesh/scale_tiny_meshes", True)
         Preferences.getInstance().addPreference("cura/dialog_on_project_save", True)
         Preferences.getInstance().addPreference("cura/asked_dialog_on_project_save", False)
+
+        Preferences.getInstance().addPreference("cura/currency", "€")
+        Preferences.getInstance().addPreference("cura/material_settings", "{}")
+
         for key in [
             "dialog_load_path",  # dialog_save_path is in LocalFileOutputDevicePlugin
             "dialog_profile_path",

--- a/resources/qml/JobSpecs.qml
+++ b/resources/qml/JobSpecs.qml
@@ -26,6 +26,7 @@ Rectangle {
     property variant printDuration: PrintInformation.currentPrintTime
     property variant printMaterialLengths: PrintInformation.materialLengths
     property variant printMaterialWeights: PrintInformation.materialWeights
+    property variant printMaterialCosts: PrintInformation.materialCosts
 
     height: childrenRect.height
     color: "transparent"
@@ -133,7 +134,8 @@ Rectangle {
         }
     }
 
-    Label{
+    Label
+    {
         id: boundingSpec
         anchors.top: jobNameRow.bottom
         anchors.right: parent.right
@@ -144,17 +146,20 @@ Rectangle {
         text: Printer.getSceneBoundingBoxString
     }
 
-    Rectangle {
+    Rectangle
+    {
         id: specsRow
         anchors.top: boundingSpec.bottom
         anchors.right: parent.right
         height: UM.Theme.getSize("jobspecs_line").height
 
-        Item{
+        Item
+        {
             width: parent.width
             height: parent.height
 
-            UM.RecolorImage {
+            UM.RecolorImage
+            {
                 id: timeIcon
                 anchors.right: timeSpec.left
                 anchors.rightMargin: UM.Theme.getSize("default_margin").width/2
@@ -166,7 +171,8 @@ Rectangle {
                 color: UM.Theme.getColor("text_subtext")
                 source: UM.Theme.getIcon("print_time")
             }
-            Label{
+            Label
+            {
                 id: timeSpec
                 anchors.right: lengthIcon.left
                 anchors.rightMargin: UM.Theme.getSize("default_margin").width
@@ -175,7 +181,8 @@ Rectangle {
                 color: UM.Theme.getColor("text_subtext")
                 text: (!base.printDuration || !base.printDuration.valid) ? catalog.i18nc("@label", "00h 00min") : base.printDuration.getDisplayString(UM.DurationFormat.Short)
             }
-            UM.RecolorImage {
+            UM.RecolorImage
+            {
                 id: lengthIcon
                 anchors.right: lengthSpec.left
                 anchors.rightMargin: UM.Theme.getSize("default_margin").width/2
@@ -187,7 +194,8 @@ Rectangle {
                 color: UM.Theme.getColor("text_subtext")
                 source: UM.Theme.getIcon("category_material")
             }
-            Label{
+            Label
+            {
                 id: lengthSpec
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
@@ -197,19 +205,38 @@ Rectangle {
                 {
                     var lengths = [];
                     var weights = [];
+                    var costs = [];
+                    var someCostsKnown = false;
                     if(base.printMaterialLengths) {
-                        for(var index = 0; index < base.printMaterialLengths.length; index++) {
-                            if(base.printMaterialLengths[index] > 0) {
+                        for(var index = 0; index < base.printMaterialLengths.length; index++)
+                        {
+                            if(base.printMaterialLengths[index] > 0)
+                            {
                                 lengths.push(base.printMaterialLengths[index].toFixed(2));
                                 weights.push(String(Math.floor(base.printMaterialWeights[index])));
+                                costs.push(base.printMaterialCosts[index].toFixed(2));
+                                if(base.printMaterialCosts[index] > 0)
+                                {
+                                    someCostsKnown = true;
+                                }
                             }
                         }
                     }
-                    if(lengths.length == 0) {
+                    if(lengths.length == 0)
+                    {
                         lengths = ["0.00"];
                         weights = ["0"];
+                        costs = ["0.00"];
                     }
-                    return catalog.i18nc("@label", "%1 m / ~ %2 g").arg(lengths.join(" + ")).arg(weights.join(" + "));
+                    if(someCostsKnown)
+                    {
+                        return catalog.i18nc("@label", "%1 m / ~ %2 g / ~ %4 %3").arg(lengths.join(" + "))
+                                .arg(weights.join(" + ")).arg(costs.join(" + ")).arg(UM.Preferences.getValue("cura/currency"));
+                    }
+                    else
+                    {
+                        return catalog.i18nc("@label", "%1 m / ~ %2 g").arg(lengths.join(" + ")).arg(weights.join(" + "));
+                    }
                 }
             }
         }

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -128,6 +128,19 @@ UM.PreferencesPage
                     currentIndex -= 1;
                 }
             }
+
+            Label
+            {
+                id: currencyLabel
+                text: catalog.i18nc("@label","Currency:")
+                anchors.verticalCenter: languageComboBox.verticalCenter
+            }
+            TextField
+            {
+                id: currencyField
+                text: UM.Preferences.getValue("cura/currency")
+                onTextChanged: UM.Preferences.setValue("cura/currency", text)
+            }
         }
 
         Label

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -189,7 +189,7 @@ TabView
                     height: parent.rowHeight
                 }
 
-                Label { width: base.firstColumnWidth; height: parent.rowHeight; verticalAlignment: Qt.AlignVCenter; text: catalog.i18nc("@label", "Cost per Meter (Approx.)") }
+                Label { width: base.firstColumnWidth; height: parent.rowHeight; verticalAlignment: Qt.AlignVCenter; text: catalog.i18nc("@label", "Cost per Meter") }
                 Label
                 {
                     width: base.secondColumnWidth

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -40,6 +40,7 @@ TabView
         {
             anchors.fill: parent
             horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
+            flickableItem.flickableDirection: Flickable.VerticalFlick
 
             Flow
             {
@@ -219,12 +220,12 @@ TabView
                     onEditingFinished: base.setMetaDataEntry("adhesion_info", properties.adhesion_info, text)
                 }
             }
+
             function updateCostPerMeter()
             {
                 base.spoolLength = calculateSpoolLength(diameterSpinBox.value, densitySpinBox.value, spoolWeightSpinBox.value);
                 base.costPerMeter = calculateCostPerMeter(spoolCostSpinBox.value);
             }
-
         }
     }
 

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -21,6 +21,28 @@ TabView
     property string containerId: ""
     property var materialPreferenceValues: UM.Preferences.getValue("cura/material_settings") ? JSON.parse(UM.Preferences.getValue("cura/material_settings")) : {}
 
+    property double spoolLength:
+    {
+        if (properties.diameter == 0 || properties.density == 0 || getMaterialPreferenceValue(properties.guid, "spool_weight") == 0)
+        {
+            return 0;
+        }
+        print(properties.diameter / 2);
+        var area = Math.PI * Math.pow(properties.diameter / 2, 2); // in mm2
+        var volume = (getMaterialPreferenceValue(properties.guid, "spool_weight") / properties.density); // in cm3
+        return volume / area; // in m
+    }
+
+    property real costPerMeter:
+    {
+        if (spoolLength == 0)
+        {
+            return 0;
+        }
+        return getMaterialPreferenceValue(properties.guid, "spool_cost") / spoolLength;
+    }
+
+
     Tab
     {
         title: catalog.i18nc("@title","Information")
@@ -163,7 +185,7 @@ TabView
                 Label
                 {
                     width: base.secondColumnWidth
-                    text: "%1 m".arg(properties.spool_length)
+                    text: "%1 m".arg(Math.round(base.spoolLength))
                     verticalAlignment: Qt.AlignVCenter
                     height: parent.rowHeight
                 }
@@ -172,7 +194,7 @@ TabView
                 Label
                 {
                     width: base.secondColumnWidth
-                    text: "%1 %2/m".arg(parseFloat(properties.cost_per_meter).toFixed(2)).arg(base.currency)
+                    text: "%1 %2/m".arg(base.costPerMeter.toFixed(2)).arg(base.currency)
                     verticalAlignment: Qt.AlignVCenter
                     height: parent.rowHeight
                 }

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -185,7 +185,7 @@ TabView
                 Label
                 {
                     width: base.secondColumnWidth
-                    text: "%1 m".arg(Math.round(base.spoolLength))
+                    text: "~ %1 m".arg(Math.round(base.spoolLength))
                     verticalAlignment: Qt.AlignVCenter
                     height: parent.rowHeight
                 }
@@ -194,7 +194,7 @@ TabView
                 Label
                 {
                     width: base.secondColumnWidth
-                    text: "%1 %2/m".arg(base.costPerMeter.toFixed(2)).arg(base.currency)
+                    text: "~ %1 %2/m".arg(base.costPerMeter.toFixed(2)).arg(base.currency)
                     verticalAlignment: Qt.AlignVCenter
                     height: parent.rowHeight
                 }

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -27,7 +27,6 @@ TabView
         {
             return 0;
         }
-        print(properties.diameter / 2);
         var area = Math.PI * Math.pow(properties.diameter / 2, 2); // in mm2
         var volume = (getMaterialPreferenceValue(properties.guid, "spool_weight") / properties.density); // in cm3
         return volume / area; // in m

--- a/resources/qml/Preferences/MaterialsPage.qml
+++ b/resources/qml/Preferences/MaterialsPage.qml
@@ -185,17 +185,6 @@ UM.ManagementPage
             height: childrenRect.height
 
             Label { text: materialProperties.name; font: UM.Theme.getFont("large"); }
-            Button
-            {
-                id: editButton
-                anchors.right: parent.right;
-                text: catalog.i18nc("@action:button", "Edit");
-                iconName: "document-edit";
-
-                enabled: base.currentItem != null && !base.currentItem.readOnly
-
-                checkable: enabled
-            }
         }
 
         MaterialView
@@ -209,7 +198,7 @@ UM.ManagementPage
                 bottom: parent.bottom
             }
 
-            editingEnabled: editButton.checkable && editButton.checked;
+            editingEnabled: base.currentItem != null && !base.currentItem.readOnly
 
             properties: materialProperties
             containerId: base.currentItem != null ? base.currentItem.id : ""

--- a/resources/qml/Preferences/MaterialsPage.qml
+++ b/resources/qml/Preferences/MaterialsPage.qml
@@ -219,6 +219,7 @@ UM.ManagementPage
         {
             id: materialProperties
 
+            property string guid: "00000000-0000-0000-0000-000000000000"
             property string name: "Unknown";
             property string profile_type: "Unknown";
             property string supplier: "Unknown";
@@ -344,6 +345,7 @@ UM.ManagementPage
             return
         }
         materialProperties.name = currentItem.name;
+        materialProperties.guid = Cura.ContainerManager.getContainerMetaDataEntry(base.currentItem.id, "GUID");
 
         if(currentItem.metadata != undefined && currentItem.metadata != null)
         {


### PR DESCRIPTION
This PR implements the forgotten material cost feature.

In this PR, filament weight per spool and cost per spool are stored per material guid in the preferences (instead of in the material profile). It can be argues that the price (and to a lesser extend the spool size) is not a material property but something that is set eg by the reseller. Furthermore this enables editing these values for readonly materials without affecting the xml profile.

Filament length on the spool as well as cost per meter are calculated on the material view tab.

TODO:
* ~~use cost per meter to calculate print cost on the print stats area~~
* ~~make currency a settable preference~~ fixed