### PR TITLE
Fix version upgrade with user variants

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
+++ b/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
@@ -62,7 +62,7 @@ class VersionUpgrade22to24(VersionUpgrade):
             config.remove_option("general", "containers")
 
             for index in range(len(container_list)):
-                config.set("containers", index, container_list[index])
+                config.set("containers", str(index), container_list[index])
 
         output = io.StringIO()
         config.write(output)

--- a/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
+++ b/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
@@ -51,8 +51,8 @@ class VersionUpgrade22to24(VersionUpgrade):
                     if not item: # the last item may be an empty string
                         continue
                     if item == variant_name:
-                        new_container_list.append(config_name)
                         new_container_list.append("empty_variant")
+                        new_container_list.append(config_name)
                     else:
                         new_container_list.append(item)
 

--- a/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
+++ b/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
@@ -48,6 +48,8 @@ class VersionUpgrade22to24(VersionUpgrade):
                 # Change the name of variant and insert empty_variant into the stack.
                 new_container_list = []
                 for item in container_list:
+                    if not item: # the last item may be an empty string
+                        continue
                     if item == variant_name:
                         new_container_list.append(config_name)
                         new_container_list.append("empty_variant")


### PR DESCRIPTION
This PR fixes three related issues with the 2.3 to 2.4 version upgrade when there are Machine Settings.

Steps to reproduce the issues:
* Launch Cura 2.3.1 with an empty config
* Add a UM2
* Open machinesettings
* Close Cura 2.3.1 and launch Cura 2.4

Result: the UM2 cannot be loaded, because the versionupgrade screws up. 