### PR TITLE
Fix scale of Add Machine and Select (Per Object) Settings dialogs...

### DIFF
--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -322,7 +322,7 @@ Item {
         id: settingPickDialog
 
         title: catalog.i18nc("@title:window", "Select Settings to Customize for this model")
-        width: screenScaleFactor * 360;
+        width: Screen.devicePixelRatio * 360;
 
         property string labelFilter: ""
 

--- a/resources/qml/AddMachineDialog.qml
+++ b/resources/qml/AddMachineDialog.qml
@@ -20,6 +20,11 @@ UM.Dialog
     property string preferredCategory: "Ultimaker"
     property string activeCategory: preferredCategory
 
+    minimumWidth: UM.Theme.getSize("modal_window_minimum").width
+    minimumHeight: UM.Theme.getSize("modal_window_minimum").height
+    width: minimumWidth
+    height: minimumHeight
+
     onVisibilityChanged:
     {
         // Reset selection and machine name


### PR DESCRIPTION
... on fairly high, but non-"retina" screens.

I have a new laptop with a 13" 1080p display, which I use at its native resolution. This works fine for most dialogs, except the mentioned two which are shown comically large.