### PR TITLE
Add a margin to the highlight rect, making it more symmetrical

### DIFF
--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -131,6 +131,7 @@ Rectangle
                             anchors.left: parent.left
                             anchors.right: parent.right
                             anchors.bottom: parent.bottom
+                            anchors.leftMargin: UM.Theme.getSize("default_margin").width
                             height: UM.Theme.getSize("sidebar_header_highlight").height
                             color: UM.Theme.getColor("sidebar_header_highlight_hover")
                             visible: control.hovered || control.pressed


### PR DESCRIPTION
This is a purely cosmetic tweak which makes the hover effect slightly more distinct, and balance more evenly; the right-most mode-button also has a margin to the right as opposed to hugging the side of the window.

Sorry I did not catch this in one go with this PR: https://github.com/Ultimaker/Cura/pull/1260