### PR TITLE
Add a setting to select skin pattern for first layer

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -890,6 +890,20 @@
                     "default_value": "lines",
                     "settable_per_mesh": true
                 },
+                "top_bottom_pattern_0":
+                {
+                    "label": "Bottom Pattern Initial Layer",
+                    "description": "The pattern on the bottom of the print on the first layer.",
+                    "type": "enum",
+                    "options":
+                    {
+                        "lines": "Lines",
+                        "concentric": "Concentric",
+                        "zigzag": "Zig Zag"
+                    },
+                    "default_value": "lines",
+                    "settable_per_mesh": true
+                },
                 "wall_0_inset":
                 {
                     "label": "Outer Wall Inset",


### PR DESCRIPTION
This pull req creates a setting to change the skin pattern for just the first layer. I like concentric skin for bed adhesion but not for anything else so this allows to set just the layer that does the bed adhesion to concentric.
I've used this for a while but now I decided to make a PR for it, it was tested on the Ultimaker 2 printer.