### PR TITLE
Fix connections to devices not based on arduino

### DIFF
--- a/plugins/USBPrinting/avr_isp/stk500v2.py
+++ b/plugins/USBPrinting/avr_isp/stk500v2.py
@@ -43,17 +43,20 @@ class Stk500v2(ispBase.IspBase):
 
         self.serial.flushInput()
         self.serial.flushOutput()
-        if self.sendMessage([0x10, 0xc8, 0x64, 0x19, 0x20, 0x00, 0x53, 0x03, 0xac, 0x53, 0x00, 0x00]) != [0x10, 0x00]:
+        try:
+            if self.sendMessage([0x10, 0xc8, 0x64, 0x19, 0x20, 0x00, 0x53, 0x03, 0xac, 0x53, 0x00, 0x00]) != [0x10, 0x00]:
+                raise ispBase.IspError("Failed to enter programming mode")
+
+            self.sendMessage([0x06, 0x80, 0x00, 0x00, 0x00])
+            if self.sendMessage([0xEE])[1] == 0x00:
+                self._has_checksum = True
+            else:
+                self._has_checksum = False
+        except ispBase.IspError:
             self.close()
-            raise ispBase.IspError("Failed to enter programming mode")
-
-        self.sendMessage([0x06, 0x80, 0x00, 0x00, 0x00])
-        if self.sendMessage([0xEE])[1] == 0x00:
-            self._has_checksum = True
-        else:
-            self._has_checksum = False
+            raise
         self.serial.timeout = 5
-
+ 
     def close(self):
         if self.serial is not None:
             self.serial.close()


### PR DESCRIPTION
stk500v2 failed to release the serial port on timeout. Fixes Cura unable to connect to not arduino based printers on Windows. Bug did not occur on Linux due to different serial port behavior. 