### PR TITLE
Fix prime disallowed areas when center is zero 

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -538,8 +538,11 @@ class BuildVolume(SceneNode):
             prime_tower_size = self._global_container_stack.getProperty("prime_tower_size", "value")
             machine_width = self._global_container_stack.getProperty("machine_width", "value")
             machine_depth = self._global_container_stack.getProperty("machine_depth", "value")
-            prime_tower_x = self._global_container_stack.getProperty("prime_tower_position_x", "value") - machine_width / 2 #Offset by half machine_width and _depth to put the origin in the front-left.
-            prime_tower_y = - self._global_container_stack.getProperty("prime_tower_position_y", "value") + machine_depth / 2
+            prime_tower_x = self._global_container_stack.getProperty("prime_tower_position_x", "value")
+            prime_tower_y = - self._global_container_stack.getProperty("prime_tower_position_y", "value")
+            if not self._global_container_stack.getProperty("machine_center_is_zero", "value"):
+                prime_tower_x = prime_tower_x - machine_width / 2 #Offset by half machine_width and _depth to put the origin in the front-left.
+                prime_tower_y = prime_tower_y + machine_depth / 2
 
             prime_tower_area = Polygon([
                 [prime_tower_x - prime_tower_size, prime_tower_y - prime_tower_size],
@@ -570,8 +573,17 @@ class BuildVolume(SceneNode):
         machine_width = self._global_container_stack.getProperty("machine_width", "value")
         machine_depth = self._global_container_stack.getProperty("machine_depth", "value")
         for extruder in used_extruders:
-            prime_x = extruder.getProperty("extruder_prime_pos_x", "value") - machine_width / 2 #Offset by half machine_width and _depth to put the origin in the front-left.
-            prime_y = machine_depth / 2 - extruder.getProperty("extruder_prime_pos_y", "value")
+            prime_x = extruder.getProperty("extruder_prime_pos_x", "value")
+            prime_y = - extruder.getProperty("extruder_prime_pos_y", "value")
+
+            #Ignore extruder prime position if it is not set
+            if prime_x == 0 and prime_y == 0:
+                result[extruder.getId()] = []
+                continue
+
+            if not self._global_container_stack.getProperty("machine_center_is_zero", "value"):
+                prime_x = prime_x - machine_width / 2 #Offset by half machine_width and _depth to put the origin in the front-left.
+                prime_y = prime_x + machine_depth / 2
 
             prime_polygon = Polygon.approximatedCircle(PRIME_CLEARANCE)
             prime_polygon = prime_polygon.translate(prime_x, prime_y)

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -3128,8 +3128,8 @@
                     "type": "float",
                     "unit": "mm",
                     "default_value": 0,
-                    "minimum_value_warning": "0",
-                    "maximum_value_warning": "machine_width",
+                    "minimum_value_warning": "machine_width / -2 if machine_center_is_zero else 0",
+                    "maximum_value_warning": "machine_width / 2 if machine_center_is_zero else machine_width",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
                     "enabled": false
@@ -3141,8 +3141,8 @@
                     "type": "float",
                     "unit": "mm",
                     "default_value": 0,
-                    "minimum_value_warning": "0",
-                    "maximum_value_warning": "machine_depth",
+                    "minimum_value_warning": "machine_depth / -2 if machine_center_is_zero else 0",
+                    "maximum_value_warning": "machine_depth / 2 if machine_center_is_zero else machine_depth",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
                     "enabled": false
@@ -3791,8 +3791,8 @@
                     "default_value": 200,
                     "minimum_value_warning": "-1000",
                     "maximum_value_warning": "1000",
-                    "maximum_value": "machine_width",
-                    "minimum_value": "resolveOrValue('prime_tower_size')",
+                    "maximum_value": "machine_width / 2 if machine_center_is_zero else machine_width",
+                    "minimum_value": "resolveOrValue('prime_tower_size') - machine_width / 2 if machine_center_is_zero else resolveOrValue('prime_tower_size')",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },
@@ -3808,6 +3808,8 @@
                     "maximum_value_warning": "1000",
                     "maximum_value": "machine_depth - resolveOrValue('prime_tower_size')",
                     "minimum_value": "0",
+                    "maximum_value": "machine_depth / 2 - resolveOrValue('prime_tower_size') if machine_center_is_zero else machine_depth - resolveOrValue('prime_tower_size')",
+                    "minimum_value": "machine_depth / -2 if machine_center_is_zero else 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },


### PR DESCRIPTION
This PR fixes how Cura determines the disallowed areas when machine_center_is_zero is true. It fixes https://github.com/Ultimaker/Cura/issues/1232

The PR contains a minor hack to ignore the extruder prime position when it is not set in the printer definition. Without this hack, Cura plonks a fairly large disallowed area in the center of the buildplate, because the extruder_prime_position is not settable inside Cura and it defaults to (0,0).