### PR TITLE
Hide profiles selection when hiding settings

### DIFF
--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -271,7 +271,7 @@ Rectangle
     Rectangle {
         id: headerSeparator
         width: parent.width
-        visible: !monitoringPrint
+        visible: !monitoringPrint && !hideSettings
         height: visible ? UM.Theme.getSize("sidebar_lining").height : 0
         color: UM.Theme.getColor("sidebar_lining")
         anchors.top: header.bottom

--- a/resources/qml/SidebarHeader.qml
+++ b/resources/qml/SidebarHeader.qml
@@ -164,7 +164,7 @@ Column
         id: variantRow
 
         height: UM.Theme.getSize("sidebar_setup").height
-        visible: (Cura.MachineManager.hasVariants || Cura.MachineManager.hasMaterials) && !sidebar.monitoringPrint
+        visible: (Cura.MachineManager.hasVariants || Cura.MachineManager.hasMaterials) && !sidebar.monitoringPrint && !sidebar.hideSettings
 
         anchors
         {
@@ -261,7 +261,7 @@ Column
     {
         id: globalProfileRow
         height: UM.Theme.getSize("sidebar_setup").height
-        visible: !sidebar.monitoringPrint
+        visible: !sidebar.monitoringPrint && !sidebar.hideSettings
 
         anchors
         {


### PR DESCRIPTION
This PR ensures the selection of profiles (variant/material/quality) is not shown when hiding the settings (eg when showing a gcode file). Showing the dropdown boxes for profile selection enables the user to change settings, and this should not be possible.