### PR TITLE
Added min_infill_area setting.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1230,6 +1230,16 @@
                     "default_value": true,
                     "enabled": "infill_sparse_density > 0",
                     "settable_per_mesh": true
+                },
+                "min_infill_area":
+                {
+                    "label": "Min Infill Area",
+                    "description": "Don't generate areas of infill smaller than this (use skin instead).",
+                    "unit": "mm²",
+                    "type": "float",
+                    "minimum_value": "0",
+                    "default_value": 0,
+                    "settable_per_mesh": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1233,7 +1233,7 @@
                 },
                 "min_infill_area":
                 {
-                    "label": "Min Infill Area",
+                    "label": "Minimum Infill Area",
                     "description": "Don't generate areas of infill smaller than this (use skin instead).",
                     "unit": "mm²",
                     "type": "float",


### PR DESCRIPTION
This allows the user to specify in mm^2 the minimum area of infill regions.
Areas smaller than this will be merged into the surrounding skin rather
than being filled with infill.