### PR TITLE
Fix the location of the configuration folder on Windows

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -50,7 +50,7 @@ import cura.CuraApplication
 import cura.Settings.CuraContainerRegistry
 
 if Platform.isWindows() and hasattr(sys, "frozen"):
-    dirpath = os.path.expanduser("~/AppData/Local/cura/")
+    dirpath = os.path.expandvars("%LOCALAPPDATA%\cura")
     os.makedirs(dirpath, exist_ok = True)
     sys.stdout = open(os.path.join(dirpath, "stdout.log"), "w")
     sys.stderr = open(os.path.join(dirpath, "stderr.log"), "w")


### PR DESCRIPTION
~/AppData/Local may not be correctly expanded to the AppData folder on systems with itinerant profiles (eg corporate/educational networks where the user profile is stored on the network)

See https://github.com/Ultimaker/Cura/issues/1369 for discussion
Also see the Uranium PR: https://github.com/Ultimaker/Uranium/pull/216