### PR TITLE
Fix unslicable model rendering and add overhang color theming

### DIFF
--- a/plugins/SolidView/SolidView.py
+++ b/plugins/SolidView/SolidView.py
@@ -9,7 +9,7 @@ from UM.Application import Application
 from UM.Preferences import Preferences
 from UM.View.Renderer import Renderer
 from UM.Settings.Validator import ValidatorState
-
+from UM.Math.Color import Color
 from UM.View.GL.OpenGL import OpenGL
 
 import cura.Settings
@@ -35,12 +35,14 @@ class SolidView(View):
 
         if not self._enabled_shader:
             self._enabled_shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "overhang.shader"))
+            theme = Application.getInstance().getTheme()
+            self._enabled_shader.setUniformValue("u_overhangColor", Color(*theme.getColor("model_overhang").getRgb()))
 
         if not self._disabled_shader:
             self._disabled_shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "striped.shader"))
             theme = Application.getInstance().getTheme()
-            self._disabled_shader.setUniformValue("u_diffuseColor1", theme.getColor("model_unslicable").getRgbF())
-            self._disabled_shader.setUniformValue("u_diffuseColor2", theme.getColor("model_unslicable_alt").getRgbF())
+            self._disabled_shader.setUniformValue("u_diffuseColor1", Color(*theme.getColor("model_unslicable").getRgb()))
+            self._disabled_shader.setUniformValue("u_diffuseColor2", Color(*theme.getColor("model_unslicable_alt").getRgb()))
             self._disabled_shader.setUniformValue("u_width", 50.0)
 
         multi_extrusion = False
@@ -89,7 +91,7 @@ class SolidView(View):
                             extruder_index = max(0, self._extruders_model.find("id", extruder_id))
                         try:
                             material_color = self._extruders_model.getItem(extruder_index)["color"]
-                        except KeyError: 
+                        except KeyError:
                             material_color = self._extruders_model.defaultColors[0]
 
                         if extruder_index != ExtruderManager.getInstance().activeExtruderIndex:


### PR DESCRIPTION
This PR fixes an error rendering unsliceable (striped) meshes, and adds theming for the color of overhang. It is a follow-up to https://github.com/Ultimaker/Cura/pull/1370; sorry I missed these two issues.