### PR TITLE
Add preference to reduce the widths of lines shown in the layer view.

### DIFF
--- a/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py
+++ b/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py
@@ -4,6 +4,7 @@
 import gc
 
 from UM.Job import Job
+from UM.Preferences import Preferences
 from UM.Scene.Iterator.DepthFirstIterator import DepthFirstIterator
 from UM.Scene.SceneNode import SceneNode
 from UM.Application import Application
@@ -86,6 +87,8 @@ class ProcessSlicedLayersJob(Job):
 
         current_layer = 0
 
+        reduce_line_widths = bool(Preferences.getInstance().getValue("view/reduce_line_widths"))
+
         for layer in self._layers:
             abs_layer_number = layer.id + abs(min_layer_number)
 
@@ -110,7 +113,9 @@ class ProcessSlicedLayersJob(Job):
 
                 line_widths = numpy.fromstring(polygon.line_width, dtype="f4")  # Convert bytearray to numpy array
                 line_widths = line_widths.reshape((-1,1))  # We get a linear list of pairs that make up the points, so make numpy interpret them correctly.
-                
+                if reduce_line_widths:
+                    line_widths = line_widths * 0.9;
+
                 # Create a new 3D-array, copy the 2D points over and insert the right height.
                 # This uses manual array creation + copy rather than numpy.insert since this is
                 # faster.

--- a/plugins/LayerView/LayerView.py
+++ b/plugins/LayerView/LayerView.py
@@ -64,6 +64,7 @@ class LayerView(View):
 
         Preferences.getInstance().addPreference("view/top_layer_count", 5)
         Preferences.getInstance().addPreference("view/only_show_top_layers", False)
+        Preferences.getInstance().addPreference("view/reduce_line_widths", False)
         Preferences.getInstance().preferenceChanged.connect(self._onPreferencesChanged)
 
         self._solid_layers = int(Preferences.getInstance().getValue("view/top_layer_count"))

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -168,114 +168,124 @@ UM.PreferencesPage
             text: catalog.i18nc("@label","Viewport behavior")
         }
 
-        UM.TooltipArea
+        Row
         {
-            width: childrenRect.width;
-            height: childrenRect.height;
-
-            text: catalog.i18nc("@info:tooltip","Highlight unsupported areas of the model in red. Without support these areas will not print properly.")
-
-            CheckBox
+            Column
             {
-                id: showOverhangCheckbox
-
-                checked: boolCheck(UM.Preferences.getValue("view/show_overhang"))
-                onClicked: UM.Preferences.setValue("view/show_overhang",  checked)
-
-                text: catalog.i18nc("@option:check","Display overhang");
-            }
-        }
-
-        UM.TooltipArea {
-            width: childrenRect.width;
-            height: childrenRect.height;
-            text: catalog.i18nc("@info:tooltip","Moves the camera so the model is in the center of the view when an model is selected")
-
-            CheckBox
-            {
-                id: centerOnSelectCheckbox
-                text: catalog.i18nc("@action:button","Center camera when item is selected");
-                checked: boolCheck(UM.Preferences.getValue("view/center_on_select"))
-                onClicked: UM.Preferences.setValue("view/center_on_select",  checked)
-            }
-        }
-
-        UM.TooltipArea {
-            width: childrenRect.width
-            height: childrenRect.height
-            text: catalog.i18nc("@info:tooltip", "Should models on the platform be moved so that they no longer intersect?")
-
-            CheckBox
-            {
-                id: pushFreeCheckbox
-                text: catalog.i18nc("@option:check", "Ensure models are kept apart")
-                checked: boolCheck(UM.Preferences.getValue("physics/automatic_push_free"))
-                onCheckedChanged: UM.Preferences.setValue("physics/automatic_push_free", checked)
-            }
-        }
-        UM.TooltipArea {
-            width: childrenRect.width
-            height: childrenRect.height
-            text: catalog.i18nc("@info:tooltip", "Should models on the platform be moved down to touch the build plate?")
-
-            CheckBox
-            {
-                id: dropDownCheckbox
-                text: catalog.i18nc("@option:check", "Automatically drop models to the build plate")
-                checked: boolCheck(UM.Preferences.getValue("physics/automatic_drop_down"))
-                onCheckedChanged: UM.Preferences.setValue("physics/automatic_drop_down", checked)
-            }
-        }
-
-        UM.TooltipArea {
-            width: childrenRect.width;
-            height: childrenRect.height;
-            text: catalog.i18nc("@info:tooltip","Display 5 top layers in layer view or only the top-most layer. Rendering 5 layers takes longer, but may show more information.")
-
-            CheckBox
-            {
-                id: topLayerCountCheckbox
-                text: catalog.i18nc("@action:button","Display five top layers in layer view");
-                checked: UM.Preferences.getValue("view/top_layer_count") == 5
-                onClicked:
+                UM.TooltipArea
                 {
-                    if(UM.Preferences.getValue("view/top_layer_count") == 5)
+                    width: childrenRect.width;
+                    height: childrenRect.height;
+
+                    text: catalog.i18nc("@info:tooltip","Highlight unsupported areas of the model in red. Without support these areas will not print properly.")
+
+                    CheckBox
                     {
-                        UM.Preferences.setValue("view/top_layer_count", 1)
+                        id: showOverhangCheckbox
+
+                        checked: boolCheck(UM.Preferences.getValue("view/show_overhang"))
+                        onClicked: UM.Preferences.setValue("view/show_overhang",  checked)
+
+                        text: catalog.i18nc("@option:check","Display overhang");
                     }
-                    else
+                }
+
+                UM.TooltipArea {
+                    width: childrenRect.width;
+                    height: childrenRect.height;
+                    text: catalog.i18nc("@info:tooltip","Moves the camera so the model is in the center of the view when an model is selected")
+
+                    CheckBox
                     {
-                        UM.Preferences.setValue("view/top_layer_count", 5)
+                        id: centerOnSelectCheckbox
+                        text: catalog.i18nc("@action:button","Center camera when item is selected");
+                        checked: boolCheck(UM.Preferences.getValue("view/center_on_select"))
+                        onClicked: UM.Preferences.setValue("view/center_on_select",  checked)
+                    }
+                }
+
+                UM.TooltipArea {
+                    width: childrenRect.width
+                    height: childrenRect.height
+                    text: catalog.i18nc("@info:tooltip", "Should models on the platform be moved so that they no longer intersect?")
+
+                    CheckBox
+                    {
+                        id: pushFreeCheckbox
+                        text: catalog.i18nc("@option:check", "Ensure models are kept apart")
+                        checked: boolCheck(UM.Preferences.getValue("physics/automatic_push_free"))
+                        onCheckedChanged: UM.Preferences.setValue("physics/automatic_push_free", checked)
+                    }
+                }
+                UM.TooltipArea {
+                    width: childrenRect.width
+                    height: childrenRect.height
+                    text: catalog.i18nc("@info:tooltip", "Should models on the platform be moved down to touch the build plate?")
+
+                    CheckBox
+                    {
+                        id: dropDownCheckbox
+                        text: catalog.i18nc("@option:check", "Automatically drop models to the build plate")
+                        checked: boolCheck(UM.Preferences.getValue("physics/automatic_drop_down"))
+                        onCheckedChanged: UM.Preferences.setValue("physics/automatic_drop_down", checked)
+                    }
+                }
+            }
+            Column
+            {
+                UM.TooltipArea {
+                    width: childrenRect.width;
+                    height: childrenRect.height;
+                    text: catalog.i18nc("@info:tooltip","Display 5 top layers in layer view or only the top-most layer. Rendering 5 layers takes longer, but may show more information.")
+
+                    CheckBox
+                    {
+                        id: topLayerCountCheckbox
+                        text: catalog.i18nc("@action:button","Display five top layers in layer view");
+                        checked: UM.Preferences.getValue("view/top_layer_count") == 5
+                        onClicked:
+                        {
+                            if(UM.Preferences.getValue("view/top_layer_count") == 5)
+                            {
+                                UM.Preferences.setValue("view/top_layer_count", 1)
+                            }
+                            else
+                            {
+                                UM.Preferences.setValue("view/top_layer_count", 5)
+                            }
+                        }
+                    }
+                }
+                UM.TooltipArea {
+                    width: childrenRect.width
+                    height: childrenRect.height
+                    text: catalog.i18nc("@info:tooltip", "Should only the top layers be displayed in layerview?")
+
+                    CheckBox
+                    {
+                        id: topLayersOnlyCheckbox
+                        text: catalog.i18nc("@option:check", "Only display top layer(s) in layer view")
+                        checked: boolCheck(UM.Preferences.getValue("view/only_show_top_layers"))
+                        onCheckedChanged: UM.Preferences.setValue("view/only_show_top_layers", checked)
+                    }
+                }
+                UM.TooltipArea
+                {
+                    width: childrenRect.width
+                    height: childrenRect.height
+                    text: catalog.i18nc("@info:tooltip", "Reduce width of displayed lines by 10% so that all line edges are visible (reslice required after changing).")
+
+                    CheckBox
+                    {
+                        id: reduceLineWidthsCheckbox
+                        text: catalog.i18nc("@option:check", "Reduce line widths in layer view")
+                        checked: boolCheck(UM.Preferences.getValue("view/reduce_line_widths"))
+                        onCheckedChanged: UM.Preferences.setValue("view/reduce_line_widths", checked)
                     }
                 }
             }
         }
-        UM.TooltipArea {
-            width: childrenRect.width
-            height: childrenRect.height
-            text: catalog.i18nc("@info:tooltip", "Should only the top layers be displayed in layerview?")
 
-            CheckBox
-            {
-                id: topLayersOnlyCheckbox
-                text: catalog.i18nc("@option:check", "Only display top layer(s) in layer view")
-                checked: boolCheck(UM.Preferences.getValue("view/only_show_top_layers"))
-                onCheckedChanged: UM.Preferences.setValue("view/only_show_top_layers", checked)
-            }
-        }
-        UM.TooltipArea {
-            width: childrenRect.width
-            height: childrenRect.height
-            text: catalog.i18nc("@info:tooltip", "Slightly reduce width of displayed lines so that the inter-line gaps are always visible (reslice required after changing).")
-
-            CheckBox
-            {
-                id: reduceLineWidthsCheckbox
-                text: catalog.i18nc("@option:check", "Slightly reduce line widths in layer view")
-                checked: boolCheck(UM.Preferences.getValue("view/reduce_line_widths"))
-                onCheckedChanged: UM.Preferences.setValue("view/reduce_line_widths", checked)
-            }
-        }
         Item
         {
             //: Spacer

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -263,7 +263,19 @@ UM.PreferencesPage
                 onCheckedChanged: UM.Preferences.setValue("view/only_show_top_layers", checked)
             }
         }
+        UM.TooltipArea {
+            width: childrenRect.width
+            height: childrenRect.height
+            text: catalog.i18nc("@info:tooltip", "Slightly reduce width of displayed lines so that the inter-line gaps are always visible (reslice required after changing).")
 
+            CheckBox
+            {
+                id: reduceLineWidthsCheckbox
+                text: catalog.i18nc("@option:check", "Slightly reduce line widths in layer view")
+                checked: boolCheck(UM.Preferences.getValue("view/reduce_line_widths"))
+                onCheckedChanged: UM.Preferences.setValue("view/reduce_line_widths", checked)
+            }
+        }
         Item
         {
             //: Spacer


### PR DESCRIPTION
All lines are reduced in width by 10%. Doing this makes it possible to
discern the edges of the skin lines which, otherwise, merge together.

Without this preference enabled it's not at all easy when looking at the layer view to discern the directions of the skin lines because they butt up to each other with no gaps. This preference simply scales the widths of all lines in the layer view to 90% of their original width and so the individual skin lines become visible.

One thing I noticed is that adding this preference requires me to resize the preferences dialog otherwise the lower down preferences start to disappear. Can the dialog be made to auto-size?