### PR TITLE
Added combing_retract_before_outer_wall setting.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2423,10 +2423,10 @@
                 "combing_retract_before_outer_wall":
                 {
                     "label": "Retract Before Outer Wall",
-                    "description": "When combing is enabled, always retract when moving to start an outer wall.",
+                    "description": "Always retract when moving to start an outer wall.",
                     "type": "bool",
                     "default_value": false,
-                    "enabled": "resolveOrValue('retraction_combing') != 'off'",
+                    "enabled": "retraction_enable",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2520,7 +2520,7 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },
-                "combing_retract_before_outer_wall":
+                "travel_retract_before_outer_wall":
                 {
                     "label": "Retract Before Outer Wall",
                     "description": "Always retract when moving to start an outer wall.",

--- a/resources/definitions/renkforce_rf100.def.json
+++ b/resources/definitions/renkforce_rf100.def.json
@@ -18,8 +18,8 @@
         "bottom_thickness": {
             "value": "0.5"
         },
-        "brim_line_count": {
-            "value": "20.0"
+        "brim_width": {
+            "value": "2.0"
         },
         "cool_fan_enabled": {
             "value": "True"
@@ -80,6 +80,9 @@
         },
         "material_diameter": {
             "value": "1.75"
+        },
+        "material_flow": {
+            "value": "110"
         },
         "material_print_temperature": {
             "value": "210.0"
@@ -151,13 +154,13 @@
             "value": "3.0"
         },
         "skirt_line_count": {
-            "value": "1.0"
+            "value": "3"
         },
         "speed_infill": {
             "value": "50.0"
         },
         "speed_layer_0": {
-            "value": "30.0"
+            "value": "15.0"
         },
         "speed_print": {
             "value": "50.0"


### PR DESCRIPTION
This boolean setting controls whether travel moves to the first point in an
outer wall will always involve a retraction. IMHO, forcing a retraction has
two benefits:

1 - avoids taking the ooze that would occur during the travel to the outer
surface.

2 - the slight pause when un-retracting could help reduce any ripples
introduced by the rapid movement hot-end movement.