### PR TITLE
Add missing label color

### DIFF
--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -97,6 +97,7 @@ Column
                     Label //Temperature indication.
                     {
                         text: (connectedPrinter != null && connectedPrinter.hotendTemperatures[index] != null) ? Math.round(connectedPrinter.hotendTemperatures[index]) + "°C" : ""
+                        color: UM.Theme.getColor("text")
                         font: UM.Theme.getFont("large")
                         anchors.right: parent.right
                         anchors.top: parent.top


### PR DESCRIPTION
One of the labels in the newly redesigned printmonitor is lacking a color, thus making the hotend temperature unstylable. This PR fixes that.

TL;DR: "Oops, you missed a spot"