### PR TITLE
Refactor properties that start with 'get' to avoid confusion

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -705,7 +705,7 @@ class CuraApplication(QtApplication):
     sceneBoundingBoxChanged = pyqtSignal()
 
     @pyqtProperty(bool, notify = activityChanged)
-    def getPlatformActivity(self):
+    def platformActivity(self):
         return self._platform_activity
 
     @pyqtProperty(str, notify = sceneBoundingBoxChanged)

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -182,7 +182,7 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
         self._dialog.setMachineType(machine_type)
         self._dialog.setExtruders(extruders)
         self._dialog.setVariantType(variant_type_name)
-        self._dialog.setHasObjectsOnPlate(Application.getInstance().getPlatformActivity)
+        self._dialog.setHasObjectsOnPlate(Application.getInstance().platformActivity)
         self._dialog.show()
 
         # Block until the dialog is closed.

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -247,7 +247,7 @@ class CuraEngineBackend(Backend):
             return
 
         if job.getResult() == StartSliceJob.StartJobResult.MaterialIncompatible:
-            if Application.getInstance().getPlatformActivity:
+            if Application.getInstance().platformActivity:
                 self._error_message = Message(catalog.i18nc("@info:status",
                                             "The selected material is incompatible with the selected machine or configuration."))
                 self._error_message.show()
@@ -257,7 +257,7 @@ class CuraEngineBackend(Backend):
             return
 
         if job.getResult() == StartSliceJob.StartJobResult.SettingError:
-            if Application.getInstance().getPlatformActivity:
+            if Application.getInstance().platformActivity:
                 extruders = list(ExtruderManager.getInstance().getMachineExtruders(self._global_container_stack.getId()))
                 error_keys = []
                 for extruder in extruders:
@@ -278,7 +278,7 @@ class CuraEngineBackend(Backend):
             return
 
         if job.getResult() == StartSliceJob.StartJobResult.BuildPlateError:
-            if Application.getInstance().getPlatformActivity:
+            if Application.getInstance().platformActivity:
                 self._error_message = Message(catalog.i18nc("@info:status", "Unable to slice because the prime tower or prime position(s) are invalid."))
                 self._error_message.show()
                 self.backendStateChange.emit(BackendState.Error)
@@ -286,7 +286,7 @@ class CuraEngineBackend(Backend):
                 self.backendStateChange.emit(BackendState.NotStarted)
 
         if job.getResult() == StartSliceJob.StartJobResult.NothingToSlice:
-            if Application.getInstance().getPlatformActivity:
+            if Application.getInstance().platformActivity:
                 self._error_message = Message(catalog.i18nc("@info:status", "Nothing to slice because none of the models fit the build volume. Please scale or rotate models to fit."))
                 self._error_message.show()
                 self.backendStateChange.emit(BackendState.Error)

--- a/plugins/LayerView/LayerView.qml
+++ b/plugins/LayerView/LayerView.qml
@@ -75,7 +75,7 @@ Item
             border.color: UM.Theme.getColor("slider_groove_border")
             color: UM.Theme.getColor("tool_panel_background")
 
-            visible: UM.LayerView.getLayerActivity && Printer.getPlatformActivity ? true : false
+            visible: UM.LayerView.layerActivity && Printer.platformActivity ? true : false
 
             TextField
             {
@@ -214,7 +214,7 @@ Item
                     UM.LayerView.setExtruderOpacity(0, checked ? 1.0 : 0.0);
                 }
                 text: "Extruder 1"
-                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.getExtruderCount >= 1)
+                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.extruderCount >= 1)
             }
             CheckBox {
                 checked: true
@@ -222,7 +222,7 @@ Item
                     UM.LayerView.setExtruderOpacity(1, checked ? 1.0 : 0.0);
                 }
                 text: "Extruder 2"
-                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.getExtruderCount >= 2)
+                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.extruderCount >= 2)
             }
             CheckBox {
                 checked: true
@@ -230,7 +230,7 @@ Item
                     UM.LayerView.setExtruderOpacity(2, checked ? 1.0 : 0.0);
                 }
                 text: "Extruder 3"
-                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.getExtruderCount >= 3)
+                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.etruderCount >= 3)
             }
             CheckBox {
                 checked: true
@@ -238,11 +238,11 @@ Item
                     UM.LayerView.setExtruderOpacity(3, checked ? 1.0 : 0.0);
                 }
                 text: "Extruder 4"
-                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.getExtruderCount >= 4)
+                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.extruderCount >= 4)
             }
             Label {
                 text: "Other extruders always visible"
-                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.getExtruderCount >= 5)
+                visible: !UM.LayerView.compatibilityMode && (UM.LayerView.extruderCount >= 5)
             }
             CheckBox {
                 onClicked: {

--- a/plugins/LayerView/LayerViewProxy.py
+++ b/plugins/LayerView/LayerViewProxy.py
@@ -20,7 +20,7 @@ class LayerViewProxy(QObject):
     preferencesChanged = pyqtSignal()
 
     @pyqtProperty(bool, notify = activityChanged)
-    def getLayerActivity(self):
+    def layerActivity(self):
         active_view = self._controller.getActiveView()
         if type(active_view) == LayerView.LayerView.LayerView:
             return active_view.getActivity()
@@ -79,7 +79,7 @@ class LayerViewProxy(QObject):
         if type(active_view) == LayerView.LayerView.LayerView:
             active_view.setLayerViewType(layer_view_type)
 
-    @pyqtProperty(bool)
+    @pyqtSlot(result = int)
     def getLayerViewType(self):
         active_view = self._controller.getActiveView()
         if type(active_view) == LayerView.LayerView.LayerView:
@@ -124,7 +124,7 @@ class LayerViewProxy(QObject):
             active_view.setShowInfill(show)
 
     @pyqtProperty(int, notify = globalStackChanged)
-    def getExtruderCount(self):
+    def extruderCount(self):
         active_view = self._controller.getActiveView()
         if type(active_view) == LayerView.LayerView.LayerView:
             return active_view.getExtruderCount()

--- a/resources/qml/JobSpecs.qml
+++ b/resources/qml/JobSpecs.qml
@@ -12,7 +12,7 @@ import Cura 1.0 as Cura
 Item {
     id: base
 
-    property bool activity: Printer.getPlatformActivity
+    property bool activity: Printer.platformActivity
     property string fileBaseName
     property variant activeMachineName: Cura.MachineManager.activeMachineName
 

--- a/resources/qml/MonitorButton.qml
+++ b/resources/qml/MonitorButton.qml
@@ -80,7 +80,7 @@ Item
         }
     }
 
-    property bool activity: Printer.getPlatformActivity;
+    property bool activity: Printer.platformActivity;
     property int totalHeight: childrenRect.height + UM.Theme.getSize("default_margin").height
     property string fileBaseName
     property string statusText:

--- a/resources/qml/SaveButton.qml
+++ b/resources/qml/SaveButton.qml
@@ -14,7 +14,7 @@ Item {
 
     property real progress: UM.Backend.progress;
     property int backendState: UM.Backend.state;
-    property bool activity: Printer.getPlatformActivity;
+    property bool activity: Printer.platformActivity;
     property int totalHeight: childrenRect.height + UM.Theme.getSize("default_margin").height
     property string fileBaseName
     property string statusText:


### PR DESCRIPTION
…between slots & properties

Case in point: LayerViewProxy.getLayerViewType was decorated as a property but was used/intended as a slot. This PR refactors property names to not start with the verb "get".