### PR TITLE
CURA-3397 Set override profile preference option upon visibility change

### DIFF
--- a/resources/qml/DiscardOrKeepProfileChangesDialog.qml
+++ b/resources/qml/DiscardOrKeepProfileChangesDialog.qml
@@ -22,6 +22,8 @@ UM.Dialog
         {
             changesModel.forceUpdate()
         }
+
+        discardOrKeepProfileChangesDropDownButton.currentIndex = UM.Preferences.getValue("cura/choice_on_profile_override")
     }
 
     Column


### PR DESCRIPTION
Fix the problem that the option shown in the override profile dialog is not in sync when the option in the Preferences settings has been changed.