### PR TITLE
Add only_grow_skin setting

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1345,6 +1345,15 @@
                             "settable_per_mesh": true
                         }
                     }
+                },
+                "only_grow_skin":
+                {
+                    "label": "Only Grow Skin",
+                    "description": "When enabled, skin areas never become smaller than their original size. When disabled, skin areas may become smaller than their original size and may be removed completely.",
+                    "type": "bool",
+                    "default_value": true,
+                    "enabled": "expand_upper_skins or expand_lower_skins",
+                    "settable_per_mesh": true
                 }
             }
         },


### PR DESCRIPTION
This is an additional option to the expand/shrink skins code to control whether the shrunk+expanded skin is unioned with the original skin shape or not. Doing the union means that the skin never ends up smaller than it's original size. Not doing the union means that the skin can end up smaller and even get removed completely. Some people could find the ability to remove the skin useful.