### PR TITLE
CURA-3470 Return list instead of set for QVariantList

### DIFF
--- a/cura/MachineActionManager.py
+++ b/cura/MachineActionManager.py
@@ -105,7 +105,7 @@ class MachineActionManager(QObject):
         if definition_id in self._supported_actions:
             return list(self._supported_actions[definition_id])
         else:
-            return set()
+            return list()
 
     ##  Get all actions required by given machine
     #   \param definition_id The ID of the definition you want the required actions of


### PR DESCRIPTION
Fix this crash:
```
Version: 2.4.99-master.20170307132702
Platform: Windows-10-10.0.14393
Qt: 5.7.1
PyQt: 5.7.1

Exception:
TypeError: unable to convert a Python 'set' object to a C++ 'QVariantList' instance
```