### PR TITLE
CURA-3482 _onMaterialMetaDataChanged() should take an argument

### DIFF
--- a/cura/PrintInformation.py
+++ b/cura/PrintInformation.py
@@ -177,7 +177,7 @@ class PrintInformation(QObject):
             self._active_material_container = active_material_containers[0]
             self._active_material_container.metaDataChanged.connect(self._onMaterialMetaDataChanged)
 
-    def _onMaterialMetaDataChanged(self):
+    def _onMaterialMetaDataChanged(self, *args, **kwargs):
         self._calculateInformation()
 
     @pyqtSlot(str)


### PR DESCRIPTION
Fixes this issue:
```
Version: 2.4.99-master.20170309034509
Platform: Windows-10-10.0.14393
Qt: 5.7.1
PyQt: 5.7.1

Exception:
Traceback (most recent call last):
  File "D:/master/build/inst/lib/python3.5/site-packages/cura\Settings\ContainerManager.py", line 232, in setContainerMetaDataEntry
  File "C:\Users\qa_tester\Desktop\Cura 2.4 master\Cura 2.4\plugins\XmlMaterialProfile\XmlMaterialProfile.py", line 43, in setMetaDataEntry
    super().setMetaDataEntry(key, value)
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Settings\InstanceContainer.py", line 196, in setMetaDataEntry
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Signal.py", line 201, in emit
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Signal.py", line 305, in __performEmit
TypeError: _onMaterialMetaDataChanged() takes 1 positional argument but 2 were given
```