### PR TITLE
CURA-3480 Fix boolean values for Cartesio config files

### DIFF
--- a/resources/variants/cartesio_0.25.inst.cfg
+++ b/resources/variants/cartesio_0.25.inst.cfg
@@ -45,19 +45,19 @@ speed_travel_layer_0 = =round(speed_travel)
 speed_support_interface = =round(speed_topbottom)
 
 retraction_combing = off
-retraction_hop_enabled = true
+retraction_hop_enabled = True
 retraction_hop = 1
 
 support_z_distance = 0
 support_xy_distance = 0.5
 support_join_distance = 10
-support_interface_enable = true
+support_interface_enable = True
 
 adhesion_type = skirt
 skirt_gap = 0.5
 skirt_brim_minimal_length = 50
 
-coasting_enable = true
+coasting_enable = True
 coasting_volume = 0.1
 coasting_min_volume = 0.17
 coasting_speed = 90

--- a/resources/variants/cartesio_0.4.inst.cfg
+++ b/resources/variants/cartesio_0.4.inst.cfg
@@ -45,19 +45,19 @@ speed_travel_layer_0 = =round(speed_travel)
 speed_support_interface = =round(speed_topbottom)
 
 retraction_combing = off
-retraction_hop_enabled = true
+retraction_hop_enabled = True
 retraction_hop = 1
 
 support_z_distance = 0
 support_xy_distance = 0.5
 support_join_distance = 10
-support_interface_enable = true
+support_interface_enable = True
 
 adhesion_type = skirt
 skirt_gap = 0.5
 skirt_brim_minimal_length = 50
 
-coasting_enable = true
+coasting_enable = True
 coasting_volume = 0.1
 coasting_min_volume = 0.17
 coasting_speed = 90

--- a/resources/variants/cartesio_0.8.inst.cfg
+++ b/resources/variants/cartesio_0.8.inst.cfg
@@ -46,19 +46,19 @@ speed_travel_layer_0 = =round(speed_travel)
 speed_support_interface = =round(speed_topbottom)
 
 retraction_combing = off
-retraction_hop_enabled = true
+retraction_hop_enabled = True
 retraction_hop = 1
 
 support_z_distance = 0
 support_xy_distance = 0.5
 support_join_distance = 10
-support_interface_enable = true
+support_interface_enable = True
 
 adhesion_type = skirt
 skirt_gap = 0.5
 skirt_brim_minimal_length = 50
 
-coasting_enable = true
+coasting_enable = True
 coasting_volume = 0.1
 coasting_min_volume = 0.17
 coasting_speed = 90


### PR DESCRIPTION
Fixes this issue:
```
Version: 2.4.99-master.20170308115948
Platform: Windows-10-10.0.14393
Qt: 5.7.1
PyQt: 5.7.1

Exception:
Traceback (most recent call last):
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Qt\Bindings\ActiveToolProxy.py", line 67, in setProperty
  File "C:\Program Files\Cura 2.4.99 2017-03-08 v2\plugins\PerObjectSettingsTool\PerObjectSettingsTool.py", line 70, in setSelectedActiveExtruder
    selected_object.addDecorator(SettingOverrideDecorator())
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Scene\SceneNode.py", line 183, in addDecorator
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Signal.py", line 201, in emit
  File "D:/master/build/inst/lib/python3.5/site-packages/UM\Signal.py", line 305, in __performEmit
  File "D:/master/build/inst/lib/python3.5/site-packages/cura\BuildVolume.py", line 139, in _onNodeDecoratorChanged
  File "D:/master/build/inst/lib/python3.5/site-packages/cura\BuildVolume.py", line 489, in _updateDisallowedAreasAndRebuild
  File "D:/master/build/inst/lib/python3.5/site-packages/cura\BuildVolume.py", line 499, in _updateDisallowedAreas
  File "D:/master/build/inst/lib/python3.5/site-packages/cura\Settings\ExtruderManager.py", line 355, in getUsedExtruderStacks
TypeError: unsupported operand type(s) for |=: 'bool' and 'str'
```