### PR TITLE
CURA-3507 Make quality lookup more robust

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -731,8 +731,11 @@ class MachineManager(QObject):
             else:
                 self._material_incompatible_message.hide()
 
-            new_quality_id = old_quality.getId()
-            quality_type = old_quality.getMetaDataEntry("quality_type")
+            quality_type = None
+            new_quality_id = None
+            if old_quality:
+                new_quality_id = old_quality.getId()
+                quality_type = old_quality.getMetaDataEntry("quality_type")
             if old_quality_changes:
                 quality_type = old_quality_changes.getMetaDataEntry("quality_type")
                 new_quality_id = old_quality_changes.getId()
@@ -740,9 +743,11 @@ class MachineManager(QObject):
             # See if the requested quality type is available in the new situation.
             machine_definition = self._active_container_stack.getBottom()
             quality_manager = QualityManager.getInstance()
-            candidate_quality = quality_manager.findQualityByQualityType(quality_type,
-                                    quality_manager.getWholeMachineDefinition(machine_definition),
-                                    [material_container])
+            candidate_quality = None
+            if quality_type:
+                candidate_quality = quality_manager.findQualityByQualityType(quality_type,
+                                        quality_manager.getWholeMachineDefinition(machine_definition),
+                                        [material_container])
             if not candidate_quality or candidate_quality.getId() == "empty_quality":
                 # Fall back to a quality
                 new_quality = quality_manager.findQualityByQualityType(None,


### PR DESCRIPTION
Fixes this issue:
```
DEBUG - cura.Settings.MachineManager.setActiveMaterial [708]: Attempting to change the active material to generic_pla_ultimaker3_AA_0.4
DEBUG - cura.Settings.MachineManager.setActiveMaterial [725]: Active material changed
CRITICAL - cura.CrashHandler.show [36]: An uncaught exception has occurred!
CRITICAL - cura.CrashHandler.show [39]: Traceback (most recent call last):
CRITICAL - cura.CrashHandler.show [39]:   File "/Users/ultimaker/build/2.5/build/inst/lib/python3.5/site-packages/cura/Settings/MachineManager.py", line 734, in setActiveMaterial
CRITICAL - cura.CrashHandler.show [39]: AttributeError: 'NoneType' object has no attribute 'getId'
```