### PR TITLE
Version Upgrade 2.4 to 2.5

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade24to25/VersionUpgrade24to25.py
+++ b/plugins/VersionUpgrade/VersionUpgrade24to25/VersionUpgrade24to25.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2017 Ultimaker B.V.
+# Cura is released under the terms of the AGPLv3 or higher.
+
+import configparser #To parse the files we need to upgrade and write the new files.
+import io #To serialise configparser output to a string.
+
+from UM.VersionUpgrade import VersionUpgrade
+
+_removed_settings = { #Settings that were removed in 2.5.
+    "start_layers_at_same_position"
+}
+
+##  A collection of functions that convert the configuration of the user in Cura
+#   2.4 to a configuration for Cura 2.5.
+#
+#   All of these methods are essentially stateless.
+class VersionUpgrade24to25(VersionUpgrade):
+    ##  Gets the version number from a CFG file in Uranium's 2.4 format.
+    #
+    #   Since the format may change, this is implemented for the 2.4 format only
+    #   and needs to be included in the version upgrade system rather than
+    #   globally in Uranium.
+    #
+    #   \param serialised The serialised form of a CFG file.
+    #   \return The version number stored in the CFG file.
+    #   \raises ValueError The format of the version number in the file is
+    #   incorrect.
+    #   \raises KeyError The format of the file is incorrect.
+    def getCfgVersion(self, serialised):
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialised)
+        return int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
+
+    ##  Upgrades the preferences file from version 2.4 to 2.5.
+    #
+    #   \param serialised The serialised form of a preferences file.
+    #   \param filename The name of the file to upgrade.
+    def upgradePreferences(self, serialised, filename):
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialised)
+
+        #Remove settings from the visible_settings.
+        if parser.has_section("general") and "visible_settings" in parser["general"]:
+            visible_settings = parser["general"]["visible_settings"].split(";")
+            visible_settings = filter(lambda setting: setting not in _removed_settings, visible_settings)
+            parser["general"]["visible_settings"] = ";".join(visible_settings)
+
+        #Change the version number in the file.
+        if parser.has_section("general"): #It better have!
+            parser["general"]["version"] = "5"
+
+        #Re-serialise the file.
+        output = io.StringIO()
+        parser.write(output)
+        return [filename], [output.getvalue()]
+
+    ##  Upgrades an instance container from version 2.4 to 2.5.
+    #
+    #   \param serialised The serialised form of a quality profile.
+    #   \param filename The name of the file to upgrade.
+    def upgradeInstanceContainer(self, serialised, filename):
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialised)
+
+        #Remove settings from the [values] section.
+        if parser.has_section("values"):
+            for removed_setting in (_removed_settings & parser["values"].keys()): #Both in keys that need to be removed and in keys present in the file.
+                del parser["values"][removed_setting]
+
+        #Change the version number in the file.
+        if parser.has_section("general"):
+            parser["general"]["version"] = "3"
+
+        #Re-serialise the file.
+        output = io.StringIO()
+        parser.write(output)
+        return [filename], [output.getvalue()]

--- a/plugins/VersionUpgrade/VersionUpgrade24to25/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade24to25/__init__.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2017 Ultimaker B.V.
+# Cura is released under the terms of the AGPLv3 or higher.
+
+from . import VersionUpgrade24to25
+
+from UM.i18n import i18nCatalog
+catalog = i18nCatalog("cura")
+
+upgrade = VersionUpgrade24to25.VersionUpgrade24to25()
+
+def getMetaData():
+    return {
+        "plugin": {
+            "name": catalog.i18nc("@label", "Version Upgrade 2.4 to 2.5"),
+            "author": "Ultimaker",
+            "version": "1.0",
+            "description": catalog.i18nc("@info:whatsthis", "Upgrades configurations from Cura 2.4 to Cura 2.5."),
+            "api": 3
+        },
+        "version_upgrade": {
+            # From              To                 Upgrade function
+            ("preferences", 4): ("preferences", 5, upgrade.upgradePreferences),
+            ("quality", 2):     ("quality", 3,     upgrade.upgradeInstanceContainer),
+            ("variant", 2):     ("variant", 3,     upgrade.upgradeInstanceContainer), #We can re-use upgradeContainerStack since there is nothing specific to quality, variant or user profiles being changed.
+            ("user", 2):        ("user", 3,        upgrade.upgradeInstanceContainer)
+        },
+        "sources": {
+            "quality": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./quality"}
+            },
+            "preferences": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"."}
+            },
+            "user": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./user"}
+            }
+        }
+    }
+
+def register(app):
+    return { "version_upgrade": upgrade }

--- a/resources/quality/abax_pri3/apri3_pla_fast.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_fast.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_pri3
 

--- a/resources/quality/abax_pri3/apri3_pla_high.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_high.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = abax_pri3
 

--- a/resources/quality/abax_pri3/apri3_pla_normal.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_normal.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_pri3
 

--- a/resources/quality/abax_pri5/apri5_pla_fast.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_fast.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_pri5
 

--- a/resources/quality/abax_pri5/apri5_pla_high.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_high.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = abax_pri5
 

--- a/resources/quality/abax_pri5/apri5_pla_normal.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_normal.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_pri5
 

--- a/resources/quality/abax_titan/atitan_pla_fast.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_fast.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_titan
 

--- a/resources/quality/abax_titan/atitan_pla_high.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_high.inst.cfg
@@ -1,8 +1,8 @@
-
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = abax_titan
+
 [metadata]
 type = quality
 material = generic_pla

--- a/resources/quality/abax_titan/atitan_pla_normal.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_normal.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_titan
 

--- a/resources/quality/high.inst.cfg
+++ b/resources/quality/high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = fdmprinter
 

--- a/resources/quality/low.inst.cfg
+++ b/resources/quality/low.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Low Quality
 definition = fdmprinter
 

--- a/resources/quality/normal.inst.cfg
+++ b/resources/quality/normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = fdmprinter
 

--- a/resources/quality/ultimaker2_plus/pla_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.4_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.4_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.6_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.6_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.8_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.25_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.6_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.8_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.25_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.6_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.8_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.25_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.6_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PVA_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PVA_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Superdraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Superdraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Verydraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Verydraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Superdraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Verydraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_ABS_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_ABS_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_CPE_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_CPE_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_Nylon_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_Nylon_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PLA_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PLA_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Superdraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Superdraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Verydraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Verydraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_Draft_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Draft_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Fast_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_Superdraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Superdraft_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Superdraft Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_Verydraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Verydraft_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Verydraft Quality
 definition = ultimaker3
 

--- a/resources/variants/cartesio_0.25.inst.cfg
+++ b/resources/variants/cartesio_0.25.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.25 mm
-version = 2
+version = 3
 definition = cartesio
 
 [metadata]

--- a/resources/variants/cartesio_0.4.inst.cfg
+++ b/resources/variants/cartesio_0.4.inst.cfg
@@ -1,7 +1,6 @@
-
 [general]
 name = 0.4 mm
-version = 2
+version = 3
 definition = cartesio
 
 [metadata]

--- a/resources/variants/cartesio_0.8.inst.cfg
+++ b/resources/variants/cartesio_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.8 mm
-version = 2
+version = 3
 definition = cartesio
 
 [metadata]

--- a/resources/variants/ultimaker2_extended_plus_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.25.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.25 mm
-version = 2
+version = 3
 definition = ultimaker2_extended_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_extended_plus_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.4.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.4 mm
-version = 2
+version = 3
 definition = ultimaker2_extended_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_extended_plus_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.6.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.6 mm
-version = 2
+version = 3
 definition = ultimaker2_extended_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_extended_plus_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.8 mm
-version = 2
+version = 3
 definition = ultimaker2_extended_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_plus_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.25.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.25 mm
-version = 2
+version = 3
 definition = ultimaker2_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_plus_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.4.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.4 mm
-version = 2
+version = 3
 definition = ultimaker2_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_plus_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.6.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.6 mm
-version = 2
+version = 3
 definition = ultimaker2_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_plus_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.8 mm
-version = 2
+version = 3
 definition = ultimaker2_plus
 
 [metadata]

--- a/resources/variants/ultimaker3_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker3_aa0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = AA 0.8
-version = 2
+version = 3
 definition = ultimaker3
 
 [metadata]

--- a/resources/variants/ultimaker3_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_aa04.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = AA 0.4
-version = 2
+version = 3
 definition = ultimaker3
 
 [metadata]

--- a/resources/variants/ultimaker3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_bb0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = BB 0.8
-version = 2
+version = 3
 definition = ultimaker3
 
 [metadata]

--- a/resources/variants/ultimaker3_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_bb04.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = BB 0.4
-version = 2
+version = 3
 definition = ultimaker3
 
 [metadata]

--- a/resources/variants/ultimaker3_extended_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = AA 0.8
-version = 2
+version = 3
 definition = ultimaker3_extended
 
 [metadata]

--- a/resources/variants/ultimaker3_extended_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa04.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = AA 0.4
-version = 2
+version = 3
 definition = ultimaker3_extended
 
 [metadata]

--- a/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = BB 0.8
-version = 2
+version = 3
 definition = ultimaker3_extended
 
 [metadata]

--- a/resources/variants/ultimaker3_extended_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb04.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = BB 0.4
-version = 2
+version = 3
 definition = ultimaker3_extended
 
 [metadata]


### PR DESCRIPTION
This implements the version upgrade plug-in for upgrading from version 2.4 to version 2.5. The upgrade removes the `start_layers_at_same_position` setting.