### PR TITLE
Version Upgrade 2.4 to 2.5 tests

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade24to25/VersionUpgrade24to25.py
+++ b/plugins/VersionUpgrade/VersionUpgrade24to25/VersionUpgrade24to25.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2017 Ultimaker B.V.
+# Cura is released under the terms of the AGPLv3 or higher.
+
+import configparser #To parse the files we need to upgrade and write the new files.
+import io #To serialise configparser output to a string.
+
+from UM.VersionUpgrade import VersionUpgrade
+
+_removed_settings = { #Settings that were removed in 2.5.
+    "start_layers_at_same_position"
+}
+
+##  A collection of functions that convert the configuration of the user in Cura
+#   2.4 to a configuration for Cura 2.5.
+#
+#   All of these methods are essentially stateless.
+class VersionUpgrade24to25(VersionUpgrade):
+    ##  Gets the version number from a CFG file in Uranium's 2.4 format.
+    #
+    #   Since the format may change, this is implemented for the 2.4 format only
+    #   and needs to be included in the version upgrade system rather than
+    #   globally in Uranium.
+    #
+    #   \param serialised The serialised form of a CFG file.
+    #   \return The version number stored in the CFG file.
+    #   \raises ValueError The format of the version number in the file is
+    #   incorrect.
+    #   \raises KeyError The format of the file is incorrect.
+    def getCfgVersion(self, serialised):
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialised)
+        return int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
+
+    ##  Upgrades the preferences file from version 2.4 to 2.5.
+    #
+    #   \param serialised The serialised form of a preferences file.
+    #   \param filename The name of the file to upgrade.
+    def upgradePreferences(self, serialised, filename):
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialised)
+
+        #Remove settings from the visible_settings.
+        if parser.has_section("general") and "visible_settings" in parser["general"]:
+            visible_settings = parser["general"]["visible_settings"].split(";")
+            visible_settings = filter(lambda setting: setting not in _removed_settings, visible_settings)
+            parser["general"]["visible_settings"] = ";".join(visible_settings)
+
+        #Change the version number in the file.
+        if parser.has_section("general"): #It better have!
+            parser["general"]["version"] = "5"
+
+        #Re-serialise the file.
+        output = io.StringIO()
+        parser.write(output)
+        return [filename], [output.getvalue()]
+
+    ##  Upgrades an instance container from version 2.4 to 2.5.
+    #
+    #   \param serialised The serialised form of a quality profile.
+    #   \param filename The name of the file to upgrade.
+    def upgradeInstanceContainer(self, serialised, filename):
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialised)
+
+        #Remove settings from the [values] section.
+        if parser.has_section("values"):
+            for removed_setting in (_removed_settings & parser["values"].keys()): #Both in keys that need to be removed and in keys present in the file.
+                del parser["values"][removed_setting]
+
+        #Change the version number in the file.
+        if parser.has_section("general"):
+            parser["general"]["version"] = "3"
+
+        #Re-serialise the file.
+        output = io.StringIO()
+        parser.write(output)
+        return [filename], [output.getvalue()]

--- a/plugins/VersionUpgrade/VersionUpgrade24to25/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade24to25/__init__.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2017 Ultimaker B.V.
+# Cura is released under the terms of the AGPLv3 or higher.
+
+from . import VersionUpgrade24to25
+
+from UM.i18n import i18nCatalog
+catalog = i18nCatalog("cura")
+
+upgrade = VersionUpgrade24to25.VersionUpgrade24to25()
+
+def getMetaData():
+    return {
+        "plugin": {
+            "name": catalog.i18nc("@label", "Version Upgrade 2.4 to 2.5"),
+            "author": "Ultimaker",
+            "version": "1.0",
+            "description": catalog.i18nc("@info:whatsthis", "Upgrades configurations from Cura 2.4 to Cura 2.5."),
+            "api": 3
+        },
+        "version_upgrade": {
+            # From              To                 Upgrade function
+            ("preferences", 4): ("preferences", 5, upgrade.upgradePreferences),
+            ("quality", 2):     ("quality", 3,     upgrade.upgradeInstanceContainer),
+            ("variant", 2):     ("variant", 3,     upgrade.upgradeInstanceContainer), #We can re-use upgradeContainerStack since there is nothing specific to quality, variant or user profiles being changed.
+            ("user", 2):        ("user", 3,        upgrade.upgradeInstanceContainer)
+        },
+        "sources": {
+            "quality": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./quality"}
+            },
+            "preferences": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"."}
+            },
+            "user": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./user"}
+            }
+        }
+    }
+
+def register(app):
+    return { "version_upgrade": upgrade }

--- a/plugins/VersionUpgrade/VersionUpgrade24to25/tests/TestVersionUpgrade24to25.py
+++ b/plugins/VersionUpgrade/VersionUpgrade24to25/tests/TestVersionUpgrade24to25.py
@@ -49,7 +49,7 @@ version = -20
 #   version number in that CFG file.
 #   \param upgrader The instance of the upgrade class to test.
 @pytest.mark.parametrize("data", test_cfg_version_good_data)
-def test_cfg_version_good(data, upgrader):
+def test_cfgVersionGood(data, upgrader):
     version = upgrader.getCfgVersion(data["file_data"])
     assert version == data["version"]
 
@@ -90,6 +90,6 @@ version = not-a-text-version-number
 #   exception it needs to throw.
 #   \param upgrader The instance of the upgrader to test.
 @pytest.mark.parametrize("data", test_cfg_version_bad_data)
-def test_cfg_version_bad(data, upgrader):
+def test_cfgVersionBad(data, upgrader):
     with pytest.raises(data["exception"]):
         upgrader.getCfgVersion(data["file_data"])

--- a/plugins/VersionUpgrade/VersionUpgrade24to25/tests/TestVersionUpgrade24to25.py
+++ b/plugins/VersionUpgrade/VersionUpgrade24to25/tests/TestVersionUpgrade24to25.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2017 Ultimaker B.V.
+# Cura is released under the terms of the AGPLv3 or higher.
+
+import configparser #To check whether the appropriate exceptions are raised.
+import pytest #To register tests with.
+
+import VersionUpgrade24to25 #The module we're testing.
+
+##  Creates an instance of the upgrader to test with.
+@pytest.fixture
+def upgrader():
+    return VersionUpgrade24to25.VersionUpgrade24to25()
+
+test_cfg_version_good_data = [
+    {
+        "test_name": "Simple",
+        "file_data": """[general]
+version = 1
+""",
+        "version": 1
+    },
+    {
+        "test_name": "Other Data Around",
+        "file_data": """[nonsense]
+life = good
+
+[general]
+version = 3
+
+[values]
+layer_height = 0.12
+infill_sparse_density = 42
+""",
+        "version": 3
+    },
+    {
+        "test_name": "Negative Version", #Why not?
+        "file_data": """[general]
+version = -20
+""",
+        "version": -20
+    }
+]
+
+##  Tests the technique that gets the version number from CFG files.
+#
+#   \param data The parametrised data to test with. It contains a test name
+#   to debug with, the serialised contents of a CFG file and the correct
+#   version number in that CFG file.
+#   \param upgrader The instance of the upgrade class to test.
+@pytest.mark.parametrize("data", test_cfg_version_good_data)
+def test_cfg_version_good(data, upgrader):
+    version = upgrader.getCfgVersion(data["file_data"])
+    assert version == data["version"]
+
+test_cfg_version_bad_data = [
+    {
+        "test_name": "Empty",
+        "file_data": "",
+        "exception": configparser.Error #Explicitly not specified further which specific error we're getting, because that depends on the implementation of configparser.
+    },
+    {
+        "test_name": "No General",
+        "file_data": """[values]
+layer_height = 0.1337
+""",
+        "exception": configparser.Error
+    },
+    {
+        "test_name": "No Version",
+        "file_data": """[general]
+true = false
+""",
+        "exception": configparser.Error
+    },
+    {
+        "test_name": "Not a Number",
+        "file_data": """[general]
+version = not-a-text-version-number
+""",
+        "exception": ValueError
+    }
+]
+
+##  Tests whether getting a version number from bad CFG files gives an
+#   exception.
+#
+#   \param data The parametrised data to test with. It contains a test name
+#   to debug with, the serialised contents of a CFG file and the class of
+#   exception it needs to throw.
+#   \param upgrader The instance of the upgrader to test.
+@pytest.mark.parametrize("data", test_cfg_version_bad_data)
+def test_cfg_version_bad(data, upgrader):
+    with pytest.raises(data["exception"]):
+        upgrader.getCfgVersion(data["file_data"])

--- a/plugins/VersionUpgrade/VersionUpgrade24to25/tests/TestVersionUpgrade24to25.py
+++ b/plugins/VersionUpgrade/VersionUpgrade24to25/tests/TestVersionUpgrade24to25.py
@@ -125,15 +125,24 @@ foo = bar
 #   version of preferences.
 @pytest.mark.parametrize("data", test_upgrade_preferences_removed_settings_data)
 def test_upgradePreferencesRemovedSettings(data, upgrader):
+    #Get the settings from the original file.
+    original_parser = configparser.ConfigParser(interpolation = None)
+    original_parser.read_string(data["file_data"])
+    settings = set()
+    if original_parser.has_section("general") and "visible_settings" in original_parser["general"]:
+        settings = set(original_parser["general"]["visible_settings"].split(";"))
+
+    #Perform the upgrade.
     _, upgraded_preferences = upgrader.upgradePreferences(data["file_data"], "<string>")
     upgraded_preferences = upgraded_preferences[0]
 
     #Find whether the removed setting is removed from the file now.
-    bad_setting = "start_layers_at_same_position" #One of the forbidden settings.
+    settings -= VersionUpgrade24to25._removed_settings
     parser = configparser.ConfigParser(interpolation = None)
     parser.read_string(upgraded_preferences)
-    if parser.has_section("general") and "visible_settings" in parser["general"]:
-        assert bad_setting not in parser["general"]["visible_settings"]
+    assert (parser.has_section("general") and "visible_settings" in parser["general"]) == (len(settings) > 0) #If there are settings, there must also be a preference.
+    if settings:
+        assert settings == set(parser["general"]["visible_settings"].split(";"))
 
 test_upgrade_instance_container_removed_settings_data = [
     {
@@ -161,12 +170,21 @@ type = instance_container
 #   version of instance containers.
 @pytest.mark.parametrize("data", test_upgrade_instance_container_removed_settings_data)
 def test_upgradeInstanceContainerRemovedSettings(data, upgrader):
+    #Get the settings from the original file.
+    original_parser = configparser.ConfigParser(interpolation = None)
+    original_parser.read_string(data["file_data"])
+    settings = set()
+    if original_parser.has_section("values"):
+        settings = set(original_parser["values"])
+
+    #Perform the upgrade.
     _, upgraded_container = upgrader.upgradeInstanceContainer(data["file_data"], "<string>")
     upgraded_container = upgraded_container[0]
 
     #Find whether the forbidden setting is still in the container.
-    bad_setting = "start_layers_at_same_position" #One of the forbidden settings.
+    settings -= VersionUpgrade24to25._removed_settings
     parser = configparser.ConfigParser(interpolation = None)
     parser.read_string(upgraded_container)
-    if parser.has_section("values"):
-        assert bad_setting not in parser["values"]
+    assert parser.has_section("values") == (len(settings) > 0) #If there are settings, there must also be the values category.
+    if settings:
+        assert settings == set(parser["values"])

--- a/plugins/VersionUpgrade/VersionUpgrade24to25/tests/TestVersionUpgrade24to25.py
+++ b/plugins/VersionUpgrade/VersionUpgrade24to25/tests/TestVersionUpgrade24to25.py
@@ -93,3 +93,44 @@ version = not-a-text-version-number
 def test_cfgVersionBad(data, upgrader):
     with pytest.raises(data["exception"]):
         upgrader.getCfgVersion(data["file_data"])
+
+test_removed_settings_data = [
+    {
+        "test_name": "Removed Setting",
+        "file_data": """[general]
+visible_settings = baby;you;know;how;I;like;to;start_layers_at_same_position
+""",
+    },
+    {
+        "test_name": "No Removed Setting",
+        "file_data": """[general]
+visible_settings = baby;you;now;how;I;like;to;eat;chocolate;muffins
+"""
+},
+    {
+        "test_name": "No Visible Settings Key",
+        "file_data": """[general]
+cura = cool
+"""
+    },
+    {
+        "test_name": "No General Category",
+        "file_data": """[foos]
+foo = bar
+"""
+    }
+]
+
+##  Tests whether the settings that should be removed are removed for the 2.5
+#   version of preferences.
+@pytest.mark.parametrize("data", test_removed_settings_data)
+def test_upgradePreferencesRemovedSettings(data, upgrader):
+    _, upgraded_preferences = upgrader.upgradePreferences(data["file_data"], "<string>")
+    upgraded_preferences = upgraded_preferences[0]
+
+    #Find whether the removed setting is removed from the file now.
+    bad_setting = "start_layers_at_same_position"
+    parser = configparser.ConfigParser(interpolation = None)
+    parser.read_string(upgraded_preferences)
+    if parser.has_section("general") and "visible_settings" in parser["general"]:
+        assert bad_setting not in parser["general"]["visible_settings"]

--- a/resources/quality/abax_pri3/apri3_pla_fast.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_fast.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_pri3
 

--- a/resources/quality/abax_pri3/apri3_pla_high.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_high.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = abax_pri3
 

--- a/resources/quality/abax_pri3/apri3_pla_normal.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_normal.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_pri3
 

--- a/resources/quality/abax_pri5/apri5_pla_fast.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_fast.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_pri5
 

--- a/resources/quality/abax_pri5/apri5_pla_high.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_high.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = abax_pri5
 

--- a/resources/quality/abax_pri5/apri5_pla_normal.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_normal.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_pri5
 

--- a/resources/quality/abax_titan/atitan_pla_fast.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_fast.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_titan
 

--- a/resources/quality/abax_titan/atitan_pla_high.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_high.inst.cfg
@@ -1,8 +1,8 @@
-
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = abax_titan
+
 [metadata]
 type = quality
 material = generic_pla

--- a/resources/quality/abax_titan/atitan_pla_normal.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_normal.inst.cfg
@@ -1,6 +1,5 @@
-
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = abax_titan
 

--- a/resources/quality/high.inst.cfg
+++ b/resources/quality/high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = fdmprinter
 

--- a/resources/quality/low.inst.cfg
+++ b/resources/quality/low.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Low Quality
 definition = fdmprinter
 

--- a/resources/quality/normal.inst.cfg
+++ b/resources/quality/normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = fdmprinter
 

--- a/resources/quality/ultimaker2_plus/pla_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/pla_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.4_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.4_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.6_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.6_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.8_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.25_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.6_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.8_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.25_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.25_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.4_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.6_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.6_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.8_draft.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.8_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.25_high.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.4_normal.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.6_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker2_plus
 

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_PVA_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PVA_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Superdraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Superdraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Verydraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Verydraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Superdraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Verydraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_ABS_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_ABS_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_CPE_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_CPE_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_Nylon_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_Nylon_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PLA_Not_Supported_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PLA_Not_Supported_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Not Supported
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Fast_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Draft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Superdraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Superdraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Verydraft_Print.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Verydraft Print
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_Draft_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Draft_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Draft Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Fast_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Fast Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_High_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = High Quality
 definition = ultimaker3
 

--- a/resources/quality/ultimaker3/um3_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Normal_Quality.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 2
+version = 3
 name = Normal Quality
 definition = ultimaker3
 

--- a/resources/variants/cartesio_0.25.inst.cfg
+++ b/resources/variants/cartesio_0.25.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.25 mm
-version = 2
+version = 3
 definition = cartesio
 
 [metadata]

--- a/resources/variants/cartesio_0.4.inst.cfg
+++ b/resources/variants/cartesio_0.4.inst.cfg
@@ -1,7 +1,6 @@
-
 [general]
 name = 0.4 mm
-version = 2
+version = 3
 definition = cartesio
 
 [metadata]

--- a/resources/variants/cartesio_0.8.inst.cfg
+++ b/resources/variants/cartesio_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.8 mm
-version = 2
+version = 3
 definition = cartesio
 
 [metadata]

--- a/resources/variants/ultimaker2_extended_plus_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.25.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.25 mm
-version = 2
+version = 3
 definition = ultimaker2_extended_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_extended_plus_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.4.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.4 mm
-version = 2
+version = 3
 definition = ultimaker2_extended_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_extended_plus_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.6.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.6 mm
-version = 2
+version = 3
 definition = ultimaker2_extended_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_extended_plus_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.8 mm
-version = 2
+version = 3
 definition = ultimaker2_extended_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_plus_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.25.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.25 mm
-version = 2
+version = 3
 definition = ultimaker2_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_plus_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.4.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.4 mm
-version = 2
+version = 3
 definition = ultimaker2_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_plus_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.6.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.6 mm
-version = 2
+version = 3
 definition = ultimaker2_plus
 
 [metadata]

--- a/resources/variants/ultimaker2_plus_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = 0.8 mm
-version = 2
+version = 3
 definition = ultimaker2_plus
 
 [metadata]

--- a/resources/variants/ultimaker3_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker3_aa0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = AA 0.8
-version = 2
+version = 3
 definition = ultimaker3
 
 [metadata]

--- a/resources/variants/ultimaker3_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_aa04.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = AA 0.4
-version = 2
+version = 3
 definition = ultimaker3
 
 [metadata]

--- a/resources/variants/ultimaker3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_bb0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = BB 0.8
-version = 2
+version = 3
 definition = ultimaker3
 
 [metadata]

--- a/resources/variants/ultimaker3_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_bb04.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = BB 0.4
-version = 2
+version = 3
 definition = ultimaker3
 
 [metadata]

--- a/resources/variants/ultimaker3_extended_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = AA 0.8
-version = 2
+version = 3
 definition = ultimaker3_extended
 
 [metadata]

--- a/resources/variants/ultimaker3_extended_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa04.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = AA 0.4
-version = 2
+version = 3
 definition = ultimaker3_extended
 
 [metadata]

--- a/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = BB 0.8
-version = 2
+version = 3
 definition = ultimaker3_extended
 
 [metadata]

--- a/resources/variants/ultimaker3_extended_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb04.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 name = BB 0.4
-version = 2
+version = 3
 definition = ultimaker3_extended
 
 [metadata]

--- a/tests/TestMachineAction.py
+++ b/tests/TestMachineAction.py
@@ -30,19 +30,19 @@ def test_addMachineAction():
         machine_manager.addMachineAction(test_action)
 
     # Check that the machine has no supported actions yet.
-    assert machine_manager.getSupportedActions(test_machine) == set()
+    assert machine_manager.getSupportedActions(test_machine) == list()
 
     # Check if adding a supported action works.
     machine_manager.addSupportedAction(test_machine, "test_action")
-    assert machine_manager.getSupportedActions(test_machine) == {test_action}
+    assert machine_manager.getSupportedActions(test_machine) == [test_action, ]
 
     # Check that adding a unknown action doesn't change anything.
     machine_manager.addSupportedAction(test_machine, "key_that_doesnt_exist")
-    assert machine_manager.getSupportedActions(test_machine) == {test_action}
+    assert machine_manager.getSupportedActions(test_machine) == [test_action, ]
 
     # Check if adding multiple supported actions works.
     machine_manager.addSupportedAction(test_machine, "test_action_2")
-    assert machine_manager.getSupportedActions(test_machine) == {test_action, test_action_2}
+    assert machine_manager.getSupportedActions(test_machine) == [test_action, test_action_2]
 
     # Check that the machine has no required actions yet.
     assert machine_manager.getRequiredActions(test_machine) == set()
@@ -53,11 +53,11 @@ def test_addMachineAction():
 
     ## Check if adding single required action works
     machine_manager.addRequiredAction(test_machine, "test_action")
-    assert machine_manager.getRequiredActions(test_machine) == {test_action}
+    assert machine_manager.getRequiredActions(test_machine) == [test_action, ]
 
     # Check if adding multiple required actions works.
     machine_manager.addRequiredAction(test_machine, "test_action_2")
-    assert machine_manager.getRequiredActions(test_machine) == {test_action, test_action_2}
+    assert machine_manager.getRequiredActions(test_machine) == [test_action, test_action_2]
 
     # Ensure that firstStart actions are empty by default.
     assert machine_manager.getFirstStartActions(test_machine) == []


### PR DESCRIPTION
These are unit tests for the version upgrade of 2.4 to 2.5. The actual version upgrade is done in the `feature_version_upgrade_2.5` branch. But these tests depend on the testing framework supporting tests in plug-ins, which did not make it for the 2.5 release.