### PR TITLE
Up the limit of the maximum cost of a spool of filament

### DIFF
--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -153,7 +153,7 @@ TabView
                     value: base.getMaterialPreferenceValue(properties.guid, "spool_cost")
                     prefix: base.currency + " "
                     decimals: 2
-                    maximumValue: 1000
+                    maximumValue: 100000000
 
                     onValueChanged: {
                         base.setMaterialPreferenceValue(properties.guid, "spool_cost", parseFloat(value))


### PR DESCRIPTION
This is necessary for currencies such as Japanese Yen or South Korean Won, where prices can easily exceed 1000. This PR sets the limit to 100,000,000. If the price of a spool exceeds this amount, perhaps the user should consider moving to a more stable country.

Fixes https://github.com/Ultimaker/Cura/issues/1567