### PR TITLE
Fail gracefully when libSavitar is not found

### DIFF
--- a/plugins/3MFReader/__init__.py
+++ b/plugins/3MFReader/__init__.py
@@ -31,7 +31,7 @@ def getMetaData() -> Dict:
             "api": 3
         }
     }
-    if "ThreeMFReader" in sys.modules:
+    if "3MFReader.ThreeMFReader" in sys.modules:
         metaData["mesh_reader"] = [
             {
                 "extension": "3mf",
@@ -49,7 +49,7 @@ def getMetaData() -> Dict:
 
 
 def register(app):
-    if "ThreeMFReader" in sys.modules:
+    if "3MFReader.ThreeMFReader" in sys.modules:
         return {"mesh_reader": ThreeMFReader.ThreeMFReader(),
                 "workspace_reader": ThreeMFWorkspaceReader.ThreeMFWorkspaceReader()}
     else:

--- a/plugins/3MFReader/__init__.py
+++ b/plugins/3MFReader/__init__.py
@@ -1,9 +1,16 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the AGPLv3 or higher.
 from typing import Dict
+import sys
 
-from . import ThreeMFReader
+from UM.Logger import Logger
+try:
+    from . import ThreeMFReader
+except ImportError:
+    Logger.log("w", "Could not import ThreeMFReader; libSavitar may be missing")
+
 from . import ThreeMFWorkspaceReader
+
 from UM.i18n import i18nCatalog
 from UM.Platform import Platform
 catalog = i18nCatalog("cura")
@@ -14,30 +21,36 @@ def getMetaData() -> Dict:
         workspace_extension = "3mf"
     else:
         workspace_extension = "curaproject.3mf"
-    return {
+
+    metaData = {
         "plugin": {
             "name": catalog.i18nc("@label", "3MF Reader"),
             "author": "Ultimaker",
             "version": "1.0",
             "description": catalog.i18nc("@info:whatsthis", "Provides support for reading 3MF files."),
             "api": 3
-        },
-        "mesh_reader": [
+        }
+    }
+    if "ThreeMFReader" in sys.modules:
+        metaData["mesh_reader"] = [
             {
                 "extension": "3mf",
                 "description": catalog.i18nc("@item:inlistbox", "3MF File")
             }
-        ],
-        "workspace_reader":
-        [
+        ]
+        metaData["workspace_reader"] = [
             {
                 "extension": workspace_extension,
                 "description": catalog.i18nc("@item:inlistbox", "3MF File")
             }
         ]
-    }
+    
+    return metaData
 
 
 def register(app):
-    return {"mesh_reader": ThreeMFReader.ThreeMFReader(),
-            "workspace_reader": ThreeMFWorkspaceReader.ThreeMFWorkspaceReader()}
+    if "ThreeMFReader" in sys.modules:
+        return {"mesh_reader": ThreeMFReader.ThreeMFReader(),
+                "workspace_reader": ThreeMFWorkspaceReader.ThreeMFWorkspaceReader()}
+    else:
+        return {}

--- a/plugins/3MFWriter/__init__.py
+++ b/plugins/3MFWriter/__init__.py
@@ -1,30 +1,39 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Uranium is released under the terms of the AGPLv3 or higher.
+import sys
+
+from UM.Logger import Logger
+try:
+    from . import ThreeMFWriter
+except ImportError:
+    Logger.log("w", "Could not import ThreeMFWriter; libSavitar may be missing")
+from . import ThreeMFWorkspaceWriter
 
 from UM.i18n import i18nCatalog
-from . import ThreeMFWorkspaceWriter
-from . import ThreeMFWriter
 
 i18n_catalog = i18nCatalog("uranium")
 
 def getMetaData():
-    return {
+    metaData = {
         "plugin": {
             "name": i18n_catalog.i18nc("@label", "3MF Writer"),
             "author": "Ultimaker",
             "version": "1.0",
             "description": i18n_catalog.i18nc("@info:whatsthis", "Provides support for writing 3MF files."),
             "api": 3
-        },
-        "mesh_writer": {
+        }
+    }
+
+    if "ThreeMFWriter" in sys.modules:
+        metaData["mesh_writer"] = {
             "output": [{
                 "extension": "3mf",
                 "description": i18n_catalog.i18nc("@item:inlistbox", "3MF file"),
                 "mime_type": "application/vnd.ms-package.3dmanufacturing-3dmodel+xml",
                 "mode": ThreeMFWriter.ThreeMFWriter.OutputMode.BinaryMode
             }]
-        },
-        "workspace_writer": {
+        }
+        metaData["workspace_writer"] = {
             "output": [{
                 "extension": "curaproject.3mf",
                 "description": i18n_catalog.i18nc("@item:inlistbox", "Cura Project 3MF file"),
@@ -32,7 +41,12 @@ def getMetaData():
                 "mode": ThreeMFWorkspaceWriter.ThreeMFWorkspaceWriter.OutputMode.BinaryMode
             }]
         }
-    }
+
+    return metaData
 
 def register(app):
-    return {"mesh_writer": ThreeMFWriter.ThreeMFWriter(), "workspace_writer": ThreeMFWorkspaceWriter.ThreeMFWorkspaceWriter()}
+    if "ThreeMFWriter" in sys.modules:
+        return {"mesh_writer": ThreeMFWriter.ThreeMFWriter(), 
+                "workspace_writer": ThreeMFWorkspaceWriter.ThreeMFWorkspaceWriter()}
+    else:
+        return {}

--- a/plugins/3MFWriter/__init__.py
+++ b/plugins/3MFWriter/__init__.py
@@ -24,7 +24,7 @@ def getMetaData():
         }
     }
 
-    if "ThreeMFWriter" in sys.modules:
+    if "3MFWriter.ThreeMFWriter" in sys.modules:
         metaData["mesh_writer"] = {
             "output": [{
                 "extension": "3mf",
@@ -45,7 +45,7 @@ def getMetaData():
     return metaData
 
 def register(app):
-    if "ThreeMFWriter" in sys.modules:
+    if "3MFWriter.ThreeMFWriter" in sys.modules:
         return {"mesh_writer": ThreeMFWriter.ThreeMFWriter(), 
                 "workspace_writer": ThreeMFWorkspaceWriter.ThreeMFWorkspaceWriter()}
     else:


### PR DESCRIPTION
By catching the ImportError, this prevents the logs being clogged with exceptions in start and when the plugins preference page is touched.

This PR is useful to keep the barrier of entry for contributing to the Cura project low. I have still not managed to compile lib savitar, and the logs do quickly become clogged up with the exceptions caused by not having a working libsavitar.

Note: this must be tested, because I can only test the case where there is no libSavitar, not the case when there is a libSavitar.