### PR TITLE
Fix crash when editing material diameter

### DIFF
--- a/cura/PrintInformation.py
+++ b/cura/PrintInformation.py
@@ -126,6 +126,7 @@ class PrintInformation(QObject):
             return
 
         # Material amount is sent as an amount of mm^3, so calculate length from that
+        radius = Application.getInstance().getGlobalContainerStack().getProperty("material_diameter", "value") / 2
         self._material_lengths = []
         self._material_weights = []
         self._material_costs = []
@@ -160,7 +161,6 @@ class PrintInformation(QObject):
                     else:
                         cost = 0
 
-            radius = Application.getInstance().getGlobalContainerStack().getProperty("material_diameter", "value") / 2
             if radius != 0:
                 length = round((amount / (math.pi * radius ** 2)) / 1000, 2)
             else:

--- a/cura/PrintInformation.py
+++ b/cura/PrintInformation.py
@@ -126,7 +126,6 @@ class PrintInformation(QObject):
             return
 
         # Material amount is sent as an amount of mm^3, so calculate length from that
-        r = Application.getInstance().getGlobalContainerStack().getProperty("material_diameter", "value") / 2
         self._material_lengths = []
         self._material_weights = []
         self._material_costs = []
@@ -161,8 +160,13 @@ class PrintInformation(QObject):
                     else:
                         cost = 0
 
+            radius = Application.getInstance().getGlobalContainerStack().getProperty("material_diameter", "value") / 2
+            if radius != 0:
+                length = round((amount / (math.pi * radius ** 2)) / 1000, 2)
+            else:
+                length = 0
             self._material_weights.append(weight)
-            self._material_lengths.append(round((amount / (math.pi * r ** 2)) / 1000, 2))
+            self._material_lengths.append(length)
             self._material_costs.append(cost)
 
         self.materialLengthsChanged.emit()


### PR DESCRIPTION
While editing the diameter value in the materials pane, it can happen that the radius evaluates to 0. This led to a division by zero.

Fixes https://github.com/Ultimaker/Cura/issues/1582

This needs to be cherrypicked to the 2.5 branch