### PR TITLE
Fix delays when settings change from error to valid

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -2,7 +2,7 @@
 # Cura is released under the terms of the AGPLv3 or higher.
 from typing import Union
 
-from PyQt5.QtCore import QObject, pyqtProperty, pyqtSignal
+from PyQt5.QtCore import QObject, pyqtProperty, pyqtSignal, QTimer
 from UM.FlameProfiler import pyqtSlot
 from PyQt5.QtWidgets import QMessageBox
 from UM import Util
@@ -82,6 +82,11 @@ class MachineManager(QObject):
 
         self._material_incompatible_message = Message(catalog.i18nc("@info:status",
                                               "The selected material is incompatible with the selected machine or configuration."))
+
+        self._error_check_timer = QTimer()
+        self._error_check_timer.setInterval(250)
+        self._error_check_timer.setSingleShot(True)
+        self._error_check_timer.timeout.connect(self._updateStacksHaveErrors)
 
     globalContainerChanged = pyqtSignal() # Emitted whenever the global stack is changed (ie: when changing between printers, changing a global profile, but not when changing a value)
     activeMaterialChanged = pyqtSignal()
@@ -306,33 +311,7 @@ class MachineManager(QObject):
             self.activeStackValueChanged.emit()
 
         elif property_name == "validationState":
-            if not self._stacks_have_errors:
-                # fast update, we only have to look at the current changed property
-                if self._global_container_stack.getProperty("machine_extruder_count", "value") > 1 and self._active_container_stack.getProperty(key, "settable_per_extruder"):
-                    extruder_index = int(self._active_container_stack.getProperty(key, "limit_to_extruder"))
-                    if extruder_index >= 0: #We have to look up the value from a different extruder.
-                        stack = ExtruderManager.getInstance().getExtruderStack(str(extruder_index))
-                    else:
-                        stack = self._active_container_stack
-                else:
-                    stack = self._global_container_stack
-                changed_validation_state = stack.getProperty(key, property_name)
-
-                if changed_validation_state is None:
-                    # Setting is not validated. This can happen if there is only a setting definition.
-                    # We do need to validate it, because a setting defintions value can be set by a function, which could
-                    # be an invalid setting.
-                    definition = self._active_container_stack.getSettingDefinition(key)
-                    validator_type = SettingDefinition.getValidatorForType(definition.type)
-                    if validator_type:
-                        validator = validator_type(key)
-                        changed_validation_state = validator(self._active_container_stack)
-                if changed_validation_state in (ValidatorState.Exception, ValidatorState.MaximumError, ValidatorState.MinimumError):
-                    self._stacks_have_errors = True
-                    self.stacksValidationChanged.emit()
-            else:
-                # Normal check
-                self._updateStacksHaveErrors()
+            self._error_check_timer.start()
 
     @pyqtSlot(str)
     def setActiveMachine(self, stack_id: str) -> None:


### PR DESCRIPTION
This pulls the checkStackHaveErrors code out of the critical path when
editing settings, instead moving it to be handled later. This greatly
reduces the delay that happens when editing settings, most noticeably the layer height.

Fixes CURA-3653
Contributes to #1631