### PR TITLE
Add support for Peopoly Moai (SLA)

### DIFF
--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -1,0 +1,49 @@
+{
+    "id": "peopoly_moai",
+    "version": 2,
+    "name": "Moai",
+    "inherits": "ultimaker",
+    "metadata": {
+        "visible": true,
+        "author": "Aldo Hoeben",
+        "manufacturer": "Peopoly",
+        "category": "Other",
+        "file_formats": "text/x-gcode",
+        "has_machine_quality": true,
+        "has_materials": false
+    },
+
+    "overrides": {
+        "machine_name": { "default_value": "Moai" },
+        "machine_width": {
+            "default_value": 130
+        },
+        "machine_height": {
+            "default_value": 180
+        },
+        "machine_depth": {
+            "default_value": 130
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.067
+        },
+        "machine_head_with_fans_polygon":
+        {
+            "default_value": [
+                [ -20, 10 ],
+                [ -20, -10 ],
+                [ 10, 10 ],
+                [ 10, -10 ]
+            ]
+        },
+        "machine_gcode_flavor": {
+            "default_value": "RepRap (Marlin/Sprinter)"
+        },
+        "machine_start_gcode": {
+            "default_value": "G28 ;Home"
+        },
+        "machine_end_gcode": {
+            "default_value": "M104 S0\nM140 S0\nG28 X0 Y0\nM84"
+        }
+    }
+}

--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -5,7 +5,7 @@
     "inherits": "ultimaker",
     "metadata": {
         "visible": true,
-        "author": "Aldo Hoeben",
+        "author": "fieldOfView",
         "manufacturer": "Peopoly",
         "category": "Other",
         "file_formats": "text/x-gcode",
@@ -47,16 +47,16 @@
         },
 
         "layer_height": {
-        	"maximum_value_warning": "0.5"	
+            "maximum_value_warning": "0.5"
         },
         "layer_height_0": {
-        	"maximum_value_warning": "0.5"	
+            "maximum_value_warning": "0.5"
         },
         "top_bottom_thickness": {
-        	"minimum_value_warning": "0.1"	
+            "minimum_value_warning": "0.1"
         },
         "infill_sparse_thickness": {
-        	"maximum_value_warning": "0.5"	
+            "maximum_value_warning": "0.5"
         },
 
         "acceleration_enabled": {
@@ -83,12 +83,12 @@
             "value": "False"
         },
         "retraction_enable": {
-            "enabled": false, 
+            "enabled": false,
             "value": "False"
         },
         "retraction_combing": {
-        	"enabled": false,
-        	"value": "'off'"
+            "enabled": false,
+            "value": "'off'"
         },
         "retract_at_layer_change": {
             "enabled": false

--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -1,7 +1,7 @@
 {
     "id": "peopoly_moai",
     "version": 2,
-    "name": "Moai",
+    "name": "Peopoly Moai",
     "inherits": "ultimaker",
     "metadata": {
         "visible": true,
@@ -46,17 +46,55 @@
             "default_value": "M104 S0\nM140 S0\nG28 X0 Y0\nM84"
         },
 
+        "line_width": {
+            "minimum_value_warning": "machine_nozzle_size"
+        },
+        "wall_line_width": {
+            "minimum_value_warning": "machine_nozzle_size"
+        },
+        "wall_line_width_x": {
+            "minimum_value_warning": "machine_nozzle_size"
+        },
+        "skin_line_width": {
+            "minimum_value_warning": "machine_nozzle_size"
+        },
+        "infill_line_width": {
+            "minimum_value_warning": "machine_nozzle_size"
+        },
+        "skirt_brim_line_width": {
+            "minimum_value_warning": "machine_nozzle_size"
+        },
         "layer_height": {
-            "maximum_value_warning": "0.5"
+            "maximum_value_warning": "0.5",
+            "minimum_value_warning": "0.02"
         },
         "layer_height_0": {
-            "maximum_value_warning": "0.5"
+            "maximum_value_warning": "0.5",
+            "minimum_value_warning": "0.02"
         },
         "top_bottom_thickness": {
             "minimum_value_warning": "0.1"
         },
         "infill_sparse_thickness": {
             "maximum_value_warning": "0.5"
+        },
+        "speed_print": {
+            "maximum_value_warning": "300"
+        },
+        "speed_infill": {
+            "maximum_value_warning": "300"
+        },
+        "speed_wall": {
+            "maximum_value_warning": "300"
+        },
+        "speed_wall_0": {
+            "maximum_value_warning": "300"
+        },
+        "speed_wall_x": {
+            "maximum_value_warning": "300"
+        },
+        "speed_topbottom": {
+            "maximum_value_warning": "300"
         },
 
         "acceleration_enabled": {

--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -46,6 +46,9 @@
             "default_value": "M104 S0\nM140 S0\nG28 X0 Y0\nM84"
         },
 
+        "acceleration_enabled": {
+            "value": "False"
+        },
         "print_sequence": {
             "enabled": false
         },
@@ -59,7 +62,8 @@
             "enabled": false
         },
         "material_diameter": {
-            "enabled": false
+            "enabled": false,
+            "value": "1.75"
         },
         "cool_fan_enabled": {
             "enabled": false,
@@ -68,7 +72,11 @@
         "retraction_enable": {
             "enabled": false, 
             "value": "False"
-        }, 
+        },
+        "retraction_combing": {
+        	"enabled": false,
+        	"value": "'off'"
+        },
         "retract_at_layer_change": {
             "enabled": false
         },

--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -46,6 +46,19 @@
             "default_value": "M104 S0\nM140 S0\nG28 X0 Y0\nM84"
         },
 
+        "layer_height": {
+        	"maximum_value_warning": "0.5"	
+        },
+        "layer_height_0": {
+        	"maximum_value_warning": "0.5"	
+        },
+        "top_bottom_thickness": {
+        	"minimum_value_warning": "0.1"	
+        },
+        "infill_sparse_thickness": {
+        	"maximum_value_warning": "0.5"	
+        },
+
         "acceleration_enabled": {
             "value": "False"
         },

--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -2,7 +2,6 @@
     "id": "peopoly_moai",
     "version": 2,
     "name": "Peopoly Moai",
-    "inherits": "ultimaker",
     "metadata": {
         "visible": true,
         "author": "fieldOfView",

--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -44,6 +44,42 @@
         },
         "machine_end_gcode": {
             "default_value": "M104 S0\nM140 S0\nG28 X0 Y0\nM84"
+        },
+
+        "print_sequence": {
+            "enabled": false
+        },
+        "support_enable": {
+            "enabled": false
+        },
+        "machine_nozzle_temp_enabled": {
+            "value": "False"
+        },
+        "material_bed_temperature": {
+            "enabled": false
+        },
+        "material_diameter": {
+            "enabled": false
+        },
+        "cool_fan_enabled": {
+            "enabled": false,
+            "value": "False"
+        },
+        "retraction_enable": {
+            "enabled": false, 
+            "value": "False"
+        }, 
+        "retract_at_layer_change": {
+            "enabled": false
+        },
+        "cool_min_layer_time_fan_speed_max": {
+            "enabled": false
+        },
+        "cool_fan_full_at_height": {
+            "enabled": false
+        },
+        "cool_fan_full_layer": {
+            "enabled": false
         }
     }
 }

--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -14,7 +14,9 @@
     },
 
     "overrides": {
-        "machine_name": { "default_value": "Moai" },
+        "machine_name": {
+            "default_value": "Moai"
+        },
         "machine_width": {
             "default_value": 130
         },
@@ -70,7 +72,8 @@
         },
         "layer_height_0": {
             "maximum_value_warning": "0.5",
-            "minimum_value_warning": "0.02"
+            "minimum_value_warning": "0.02",
+            "value": "0.1"
         },
         "top_bottom_thickness": {
             "minimum_value_warning": "0.1"
@@ -85,16 +88,31 @@
             "maximum_value_warning": "300"
         },
         "speed_wall": {
-            "maximum_value_warning": "300"
+            "maximum_value_warning": "300",
+            "value": "speed_print"
         },
         "speed_wall_0": {
             "maximum_value_warning": "300"
         },
         "speed_wall_x": {
-            "maximum_value_warning": "300"
+            "maximum_value_warning": "300",
+            "value": "speed_print"
         },
         "speed_topbottom": {
-            "maximum_value_warning": "300"
+            "maximum_value_warning": "300",
+            "value": "speed_print"
+        },
+        "speed_travel": {
+            "value": "300"
+        },
+        "speed_travel_layer_0": {
+            "value": "300"
+        },
+        "speed_layer_0": {
+            "value": "5"
+        },
+        "speed_slowdown_layers": {
+            "value": "2"
         },
 
         "acceleration_enabled": {

--- a/resources/quality/peopoly_moai/peopoly_moai_high.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_high.inst.cfg
@@ -1,24 +1,24 @@
 [general]
 version = 2
-name = Normal Quality
+name = High Quality
 definition = peopoly_moai
 
 [metadata]
 type = quality
-weight = 0
-quality_type = normal
+weight = 1
+quality_type = high
 
 [values]
 infill_sparse_density = 70
-layer_height = 0.1
+layer_height = 0.05
 layer_height_0 = 0.1
 top_bottom_thickness = 0.4
 wall_thickness = 0.4
 speed_layer_0 = 5
-speed_print = 100
+speed_print = 150
 speed_slowdown_layers = 2
-speed_topbottom = 100
+speed_topbottom = 150
 speed_travel = 300
 speed_travel_layer_0 = 300
-speed_wall = 100
-speed_wall_x = 100
+speed_wall = 150
+speed_wall_x = 150

--- a/resources/quality/peopoly_moai/peopoly_moai_high.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_high.inst.cfg
@@ -11,14 +11,6 @@ quality_type = high
 [values]
 infill_sparse_density = 70
 layer_height = 0.05
-layer_height_0 = 0.1
 top_bottom_thickness = 0.4
 wall_thickness = 0.4
-speed_layer_0 = 5
 speed_print = 150
-speed_slowdown_layers = 2
-speed_topbottom = 150
-speed_travel = 300
-speed_travel_layer_0 = 300
-speed_wall = 150
-speed_wall_x = 150

--- a/resources/quality/peopoly_moai/peopoly_moai_max.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_max.inst.cfg
@@ -11,14 +11,6 @@ quality_type = extra_high
 [values]
 infill_sparse_density = 70
 layer_height = 0.025
-layer_height_0 = 0.1
 top_bottom_thickness = 0.4
 wall_thickness = 0.4
-speed_layer_0 = 5
 speed_print = 200
-speed_slowdown_layers = 2
-speed_topbottom = 200
-speed_travel = 300
-speed_travel_layer_0 = 300
-speed_wall = 200
-speed_wall_x = 200

--- a/resources/quality/peopoly_moai/peopoly_moai_max.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_max.inst.cfg
@@ -1,24 +1,24 @@
 [general]
 version = 2
-name = Normal Quality
+name = Maximum Quality
 definition = peopoly_moai
 
 [metadata]
 type = quality
-weight = 0
-quality_type = normal
+weight = 2
+quality_type = extra_high
 
 [values]
 infill_sparse_density = 70
-layer_height = 0.1
+layer_height = 0.025
 layer_height_0 = 0.1
 top_bottom_thickness = 0.4
 wall_thickness = 0.4
 speed_layer_0 = 5
-speed_print = 100
+speed_print = 200
 speed_slowdown_layers = 2
-speed_topbottom = 100
+speed_topbottom = 200
 speed_travel = 300
 speed_travel_layer_0 = 300
-speed_wall = 100
-speed_wall_x = 100
+speed_wall = 200
+speed_wall_x = 200

--- a/resources/quality/peopoly_moai/peopoly_moai_normal.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_normal.inst.cfg
@@ -11,14 +11,6 @@ quality_type = normal
 [values]
 infill_sparse_density = 70
 layer_height = 0.1
-layer_height_0 = 0.1
 top_bottom_thickness = 0.4
 wall_thickness = 0.4
-speed_layer_0 = 5
 speed_print = 100
-speed_slowdown_layers = 2
-speed_topbottom = 100
-speed_travel = 300
-speed_travel_layer_0 = 300
-speed_wall = 100
-speed_wall_x = 100

--- a/resources/quality/peopoly_moai/peopoly_moai_normal.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_normal.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+version = 2
+name = Normal Quality
+definition = peopoly_moai
+
+[metadata]
+type = quality
+weight = 0
+quality_type = normal
+
+[values]
+infill_sparse_density = 50
+layer_height_0 = 0.1
+top_bottom_thickness = 0.4
+wall_thickness = 0.4
+speed_layer_0 = 5
+speed_print = 100
+speed_slowdown_layers = 2
+speed_topbottom = 100
+speed_travel = 300
+speed_travel_layer_0 = 300
+speed_wall = 100
+speed_wall_x = 100


### PR DESCRIPTION
This PR adds a definition and a set of quality profiles for the upcoming Peopoly Moai:
https://www.kickstarter.com/projects/1554809440/moai-affordable-high-resolution-laser-sla-3d-print

Note that this printer is an SLA printer. Because of this the definition disables/hides a number of features (materials, temperatures (nozzle, buildplate), fan cooling, retraction, supports). Supports are intended to be added using a different tool before slicing.  

In cooperation with Shu (Mark) Peng from Peopoly