### PR TITLE
The magic_spiralize setting is no longer settable per mesh (or extruder).

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4178,7 +4178,8 @@
                     "description": "Spiralize smooths out the Z move of the outer edge. This will create a steady Z increase over the whole print. This feature turns a solid model into a single walled print with a solid bottom. This feature used to be called Joris in older versions.",
                     "type": "bool",
                     "default_value": false,
-                    "settable_per_mesh": true
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
                 }
             }
         },


### PR DESCRIPTION
New PR created as the original was corrupted somehow (based on wrong parent, perhaps?)