### PR TITLE
Revert "The magic_spiralize setting is no longer settable per mesh (or extruder)."

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4178,8 +4178,7 @@
                     "description": "Spiralize smooths out the Z move of the outer edge. This will create a steady Z increase over the whole print. This feature turns a solid model into a single walled print with a solid bottom. This feature used to be called Joris in older versions.",
                     "type": "bool",
                     "default_value": false,
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": false
+                    "settable_per_mesh": true
                 }
             }
         },


### PR DESCRIPTION
Reverts Ultimaker/Cura#1660

This shouldn't have been merged to 2.5, but to master.

It's too late to merge anything to 2.5; we're too far into the release process.