### PR TITLE
First refactor for Z parse section to increase verbosity

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -563,19 +563,19 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
             line = line[:line.find(";")]
         line = line.strip()
 
-        # Don't send empty lines. But we do have to send something, so send m105 instead.
-        if line == "":
+        # Don't send empty lines. But we do have to send something, so send
+        # m105 instead.
+        # Don't send the M0 or M1 to the machine, as M0 and M1 are handled as
+        # an LCD menu pause.
+        if line == "" or line == "M1" or line == "M1":
             line = "M105"
-
         try:
-            if line == "M0" or line == "M1":
-                line = "M105"  # Don't send the M0 or M1 to the machine, as M0 and M1 are handled as an LCD menu pause.
             if ("G0" in line or "G1" in line) and "Z" in line:
                 z = float(re.search("Z([0-9\.]*)", line).group(1))
                 if self._current_z != z:
                     self._current_z = z
         except Exception as e:
-            Logger.log("e", "Unexpected error with printer connection: %s" % e)
+            Logger.log("e", "Unexpected error with printer connection, could not parse current Z: %s: %s" % (e, line))
             self._setErrorState("Unexpected error: %s" %e)
         checksum = functools.reduce(lambda x,y: x^y, map(ord, "N%d%s" % (self._gcode_position, line)))
 


### PR DESCRIPTION
Moved translated M105s (blank, M0, or M1) above and outside of exception block.
Clarified the error message and added the line to it.

Related to https://github.com/Ultimaker/Cura/pull/1615 conversation.
