### PR TITLE
Filter materials by diameter

### DIFF
--- a/cura/Settings/ExtruderManager.py
+++ b/cura/Settings/ExtruderManager.py
@@ -244,7 +244,13 @@ class ExtruderManager(QObject):
                 material = materials[0]
             preferred_material_id = machine_definition.getMetaDataEntry("preferred_material")
             if preferred_material_id:
-                search_criteria = { "type": "material",  "id": preferred_material_id}
+                global_stack = ContainerRegistry.getInstance().findContainerStacks(id = machine_id)
+                if global_stack:
+                    approximate_material_diameter = round(global_stack[0].getProperty("material_diameter", "value"))
+                else:
+                    approximate_material_diameter = round(machine_definition.getProperty("material_diameter", "value"))
+
+                search_criteria = { "type": "material",  "id": preferred_material_id, "approximate_diameter": approximate_material_diameter}
                 if machine_definition.getMetaDataEntry("has_machine_materials"):
                     search_criteria["definition"] = machine_definition_id
 

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -332,7 +332,7 @@ class MachineManager(QObject):
             container_registry.addContainer(new_global_stack)
 
             variant_instance_container = self._updateVariantContainer(definition)
-            material_instance_container = self._updateMaterialContainer(definition, variant_instance_container)
+            material_instance_container = self._updateMaterialContainer(definition, new_global_stack, variant_instance_container)
             quality_instance_container = self._updateQualityContainer(definition, variant_instance_container, material_instance_container)
 
             current_settings_instance_container = InstanceContainer(name + "_current_settings")
@@ -760,7 +760,7 @@ class MachineManager(QObject):
                 if old_material:
                     preferred_material_name = old_material.getName()
 
-                self.setActiveMaterial(self._updateMaterialContainer(self._global_container_stack.getBottom(), containers[0], preferred_material_name).id)
+                self.setActiveMaterial(self._updateMaterialContainer(self._global_container_stack.getBottom(), self._global_container_stack, containers[0], preferred_material_name).id)
             else:
                 Logger.log("w", "While trying to set the active variant, no variant was found to replace.")
 
@@ -1110,11 +1110,12 @@ class MachineManager(QObject):
 
         return self._empty_variant_container
 
-    def _updateMaterialContainer(self, definition, variant_container = None, preferred_material_name = None):
+    def _updateMaterialContainer(self, stack, definition, variant_container = None, preferred_material_name = None):
         if not definition.getMetaDataEntry("has_materials"):
             return self._empty_material_container
 
-        search_criteria = { "type": "material" }
+        approximate_material_diameter = round(stack.getProperty("material_diameter", "value"))
+        search_criteria = { "type": "material", "approximate_diameter": approximate_material_diameter }
 
         if definition.getMetaDataEntry("has_machine_materials"):
             search_criteria["definition"] = self.getQualityDefinitionId(definition)

--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -118,6 +118,7 @@ class XmlMaterialProfile(InstanceContainer):
         metadata.pop("variant", "")
         metadata.pop("type", "")
         metadata.pop("base_file", "")
+        metadata.pop("approximate_diameter", "")
 
         ## Begin Name Block
         builder.start("name")
@@ -437,6 +438,7 @@ class XmlMaterialProfile(InstanceContainer):
                 Logger.log("d", "Unsupported material setting %s", key)
         self._cached_values = global_setting_values
 
+        meta_data["approximate_diameter"] = round(diameter)
         meta_data["compatible"] = global_compatibility
         self.setMetaData(meta_data)
         self._dirty = False

--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -15,6 +15,15 @@ Menu
     property int extruderIndex: 0
     property bool printerConnected: Cura.MachineManager.printerOutputDevices.length != 0
 
+    UM.SettingPropertyProvider
+    {
+        id: materialDiameterProvider
+
+        containerStackId: Cura.MachineManager.activeMachineId
+        key: "material_diameter"
+        watchedProperties: [ "value" ]
+    }
+
     MenuItem
     {
         id: automaticMaterial
@@ -141,7 +150,7 @@ Menu
 
     function materialFilter()
     {
-        var result = { "type": "material" };
+        var result = { "type": "material", "approximate_diameter": Math.round(materialDiameterProvider.properties.value) };
         if(Cura.MachineManager.filterMaterialsByMachine)
         {
             result.definition = Cura.MachineManager.activeQualityDefinitionId;

--- a/resources/qml/Preferences/MaterialsPage.qml
+++ b/resources/qml/Preferences/MaterialsPage.qml
@@ -18,7 +18,7 @@ UM.ManagementPage
     {
         filter:
         {
-            var result = { "type": "material" }
+            var result = { "type": "material", "approximate_diameter": Math.round(materialDiameterProvider.properties.value) }
             if(Cura.MachineManager.filterMaterialsByMachine)
             {
                 result.definition = Cura.MachineManager.activeQualityDefinitionId;
@@ -325,6 +325,15 @@ UM.ManagementPage
         MessageDialog
         {
             id: messageDialog
+        }
+
+        UM.SettingPropertyProvider
+        {
+            id: materialDiameterProvider
+
+            containerStackId: Cura.MachineManager.activeMachineId
+            key: "material_diameter"
+            watchedProperties: [ "value" ]
         }
 
         UM.I18nCatalog { id: catalog; name: "cura"; }


### PR DESCRIPTION
In Cura, material diameters set in (xml) material profiles override the material diameter set in the machine or variant definition. This causes 1.75mm printers to switch to 2.85mm when selecting eg "Generic PLA". Additionally, 2.85mm machines may show a lot of materials that don't apply to these printers since the merge of a set of materials into the fdm_materials repository.

This PR applies filters to the listed materials so they only show those materials that have relevant diameters. To be robust to 1.75/1.74 and 2.85/3.0 mm materials, the PR takes an approximated material_diameter defined in the printer definition and compares that to the same approximation of the material_diameter defined in the material definition. 

See https://github.com/Ultimaker/Cura/issues/1441#issuecomment-281120017 and https://github.com/Ultimaker/Cura/issues/1308#issuecomment-277666289 for discussion