### PR TITLE
Only update the target bed temperature, without submitting it to the printer. To prevent race conditions.

### DIFF
--- a/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
@@ -283,10 +283,8 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
     #
     #   /param temperature The new target temperature of the bed.
     def _setTargetBedTemperature(self, temperature):
-        if self._target_bed_temperature == temperature:
+        if not self._updateTargetBedTemperature(temperature):
             return
-        self._target_bed_temperature = temperature
-        self.targetBedTemperatureChanged.emit()
 
         url = QUrl("http://" + self._address + self._api_prefix + "printer/bed/temperature/target")
         data = str(temperature)
@@ -297,11 +295,13 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
     ##  Updates the target bed temperature from the printer, and emit a signal if it was changed.
     #
     #   /param temperature The new target temperature of the bed.
+    #   /return boolean, True if the temperature was changed, false if the new temperature has the same value as the already stored temperature
     def _updateTargetBedTemperature(self, temperature):
         if self._target_bed_temperature == temperature:
-            return
+            return False
         self._target_bed_temperature = temperature
         self.targetBedTemperatureChanged.emit()
+        return True
 
     def _stopCamera(self):
         self._camera_timer.stop()

--- a/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
@@ -294,6 +294,15 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
         put_request.setHeader(QNetworkRequest.ContentTypeHeader, "application/json")
         self._manager.put(put_request, data.encode())
 
+    ##  Updates the target bed temperature from the printer, and emit a signal if it was changed.
+    #
+    #   /param temperature The new target temperature of the bed.
+    def _updateTargetBedTemperature(self, temperature):
+        if self._target_bed_temperature == temperature:
+            return
+        self._target_bed_temperature = temperature
+        self.targetBedTemperatureChanged.emit()
+
     def _stopCamera(self):
         self._camera_timer.stop()
         if self._image_reply:
@@ -528,7 +537,7 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
         bed_temperature = self._json_printer_state["bed"]["temperature"]["current"]
         self._setBedTemperature(bed_temperature)
         target_bed_temperature = self._json_printer_state["bed"]["temperature"]["target"]
-        self._setTargetBedTemperature(target_bed_temperature)
+        self._updateTargetBedTemperature(target_bed_temperature)
 
         head_x = self._json_printer_state["heads"][0]["position"]["x"]
         head_y = self._json_printer_state["heads"][0]["position"]["y"]


### PR DESCRIPTION
This fix no longer sends a temperature update to the printer when Cura receives a bed temperature update from the printer.
We had race conditions where the bed was not shut off at the end of a printer, and Cura is the only possible source of this problem.
CURA-3702