### PR TITLE
Make the general settings page options draggable only vertically

### DIFF
--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -95,6 +95,8 @@ UM.PreferencesPage
         width: parent.width
         height: parent.height
 
+        flickableItem.flickableDirection: Flickable.VerticalFlick;
+
         Column
         {
             //: Model used to check if a plugin exists


### PR DESCRIPTION
This PR disables flicking the general settings page in the horizontal direction, to match other scrollviews. 

Fixes #1723