### PR TITLE
Add Upgraded Parts action for UM2 to add support for Olsson block

### DIFF
--- a/plugins/UltimakerMachineActions/UM2UpgradeSelection.py
+++ b/plugins/UltimakerMachineActions/UM2UpgradeSelection.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Ultimaker B.V.
+# Uranium is released under the terms of the AGPLv3 or higher.
+
+from UM.Settings.ContainerRegistry import ContainerRegistry
+from UM.Settings.InstanceContainer import InstanceContainer
+from cura.MachineAction import MachineAction
+from PyQt5.QtCore import pyqtSlot, pyqtSignal, pyqtProperty
+
+from UM.i18n import i18nCatalog
+from UM.Application import Application
+catalog = i18nCatalog("cura")
+
+import UM.Settings.InstanceContainer
+
+
+##  The Ultimaker 2 can have a few revisions & upgrades.
+class UM2UpgradeSelection(MachineAction):
+    def __init__(self):
+        super().__init__("UM2UpgradeSelection", catalog.i18nc("@action", "Select upgrades"))
+        self._qml_url = "UM2UpgradeSelectionMachineAction.qml"
+
+        self._container_registry = ContainerRegistry.getInstance()
+
+    def _reset(self):
+        self.hasVariantsChanged.emit()
+
+    hasVariantsChanged = pyqtSignal()
+
+    @pyqtProperty(bool, notify = hasVariantsChanged)
+    def hasVariants(self):
+        global_container_stack = Application.getInstance().getGlobalContainerStack()
+        if global_container_stack:
+            return global_container_stack.getMetaDataEntry("has_variants", "false") == "True"
+
+    @pyqtSlot(bool)
+    def setHasVariants(self, has_variants = True):
+        global_container_stack = Application.getInstance().getGlobalContainerStack()
+        if global_container_stack:
+            variant_container = global_container_stack.findContainer({"type": "variant"})
+            variant_index = global_container_stack.getContainerIndex(variant_container)
+
+            if has_variants:
+                if "has_variants" in global_container_stack.getMetaData():
+                    global_container_stack.setMetaDataEntry("has_variants", True)
+                else:
+                    global_container_stack.addMetaDataEntry("has_variants", True)
+
+                # Set the variant container to a sane default
+                if variant_container.getId() == "empty_variant":
+                    search_criteria = { "type": "variant", "definition": "ultimaker2", "id": "*0.4*" }
+                    containers = self._container_registry.findInstanceContainers(**search_criteria)
+                    if containers:
+                        global_container_stack.replaceContainer(variant_index, containers[0])
+            else:
+                # The metadata entry is stored in an ini, and ini files are parsed as strings only.
+                # Because any non-empty string evaluates to a boolean True, we have to remove the entry to make it False.
+                if "has_variants" in global_container_stack.getMetaData():
+                    global_container_stack.removeMetaDataEntry("has_variants")
+
+                # Set the variant container to an empty variant
+                if variant_container.getId() == "empty_variant":
+                    global_container_stack.replaceContainer(variant_index, self._container_registry.findInstanceContainers(id="empty_variant")[0])
+
+            Application.getInstance().globalContainerStackChanged.emit()

--- a/plugins/UltimakerMachineActions/UM2UpgradeSelectionMachineAction.qml
+++ b/plugins/UltimakerMachineActions/UM2UpgradeSelectionMachineAction.qml
@@ -1,0 +1,52 @@
+// Copyright (c) 2016 Ultimaker B.V.
+// Cura is released under the terms of the AGPLv3 or higher.
+
+import QtQuick 2.2
+import QtQuick.Controls 1.1
+import QtQuick.Layouts 1.1
+import QtQuick.Window 2.1
+
+import UM 1.2 as UM
+import Cura 1.0 as Cura
+
+
+Cura.MachineAction
+{
+    anchors.fill: parent;
+    Item
+    {
+        id: upgradeSelectionMachineAction
+        anchors.fill: parent
+
+        Label
+        {
+            id: pageTitle
+            width: parent.width
+            text: catalog.i18nc("@title", "Select Printer Upgrades")
+            wrapMode: Text.WordWrap
+            font.pointSize: 18;
+        }
+
+        Label
+        {
+            id: pageDescription
+            anchors.top: pageTitle.bottom
+            anchors.topMargin: UM.Theme.getSize("default_margin").height
+            width: parent.width
+            wrapMode: Text.WordWrap
+            text: catalog.i18nc("@label","Please select any upgrades made to this Ultimaker 2");
+        }
+
+        CheckBox
+        {
+            anchors.top: pageDescription.bottom
+            anchors.topMargin: UM.Theme.getSize("default_margin").height
+
+            text: catalog.i18nc("@label", "Olsson Block")
+            checked: manager.hasVariants
+            onClicked: manager.setHasVariants(checked)
+        }
+
+        UM.I18nCatalog { id: catalog; name: "cura"; }
+    }
+}

--- a/plugins/UltimakerMachineActions/__init__.py
+++ b/plugins/UltimakerMachineActions/__init__.py
@@ -5,6 +5,7 @@ from . import BedLevelMachineAction
 from . import UpgradeFirmwareMachineAction
 from . import UMOCheckupMachineAction
 from . import UMOUpgradeSelection
+from . import UM2UpgradeSelection
 
 from UM.i18n import i18nCatalog
 catalog = i18nCatalog("cura")
@@ -21,4 +22,10 @@ def getMetaData():
     }
 
 def register(app):
-    return { "machine_action": [BedLevelMachineAction.BedLevelMachineAction(), UpgradeFirmwareMachineAction.UpgradeFirmwareMachineAction(), UMOCheckupMachineAction.UMOCheckupMachineAction(), UMOUpgradeSelection.UMOUpgradeSelection()]}
+    return { "machine_action": [
+        BedLevelMachineAction.BedLevelMachineAction(),
+        UpgradeFirmwareMachineAction.UpgradeFirmwareMachineAction(),
+        UMOCheckupMachineAction.UMOCheckupMachineAction(),
+        UMOUpgradeSelection.UMOUpgradeSelection(),
+        UM2UpgradeSelection.UM2UpgradeSelection()
+    ]}

--- a/resources/definitions/ultimaker2.def.json
+++ b/resources/definitions/ultimaker2.def.json
@@ -15,7 +15,8 @@
         "platform_texture": "Ultimaker2backplate.png",
         "platform_offset": [9, 0, 0],
         "has_materials": false,
-        "supported_actions":["UpgradeFirmware"]
+        "first_start_actions": ["UM2UpgradeSelection"],
+        "supported_actions":["UM2UpgradeSelection", "UpgradeFirmware"]
     },
     "overrides": {
         "machine_name": { "default_value": "Ultimaker 2" },

--- a/resources/definitions/ultimaker2_plus.def.json
+++ b/resources/definitions/ultimaker2_plus.def.json
@@ -16,6 +16,7 @@
         "has_materials": true,
         "has_machine_materials": true,
         "has_machine_quality": true,
+        "first_start_actions": [],
         "supported_actions":["UpgradeFirmware"]
     },
 

--- a/resources/variants/ultimaker2_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_0.25.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.25 mm
+version = 2
+definition = ultimaker2
+
+[metadata]
+author = Ultimaker
+type = variant
+
+[values]
+machine_nozzle_size = 0.25
+machine_nozzle_tip_outer_diameter = 0.8

--- a/resources/variants/ultimaker2_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_0.4.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.4 mm
+version = 2
+definition = ultimaker2
+
+[metadata]
+author = Ultimaker
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+machine_nozzle_tip_outer_diameter = 1.05

--- a/resources/variants/ultimaker2_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6 mm
+version = 2
+definition = ultimaker2
+
+[metadata]
+author = Ultimaker
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+machine_nozzle_tip_outer_diameter = 1.25

--- a/resources/variants/ultimaker2_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8 mm
+version = 2
+definition = ultimaker2
+
+[metadata]
+author = Ultimaker
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+machine_nozzle_tip_outer_diameter = 1.35


### PR DESCRIPTION
This PR adds a set of variants that just set the nozzle diameter and nozzle tip diameter. These variants are not used until the machine action sets the has_variants metadata entry.

See https://github.com/Ultimaker/Cura/issues/775#issuecomment-297284176 for discussion