### PR TITLE
Fix TypeError in JobSpec.qml due to material cost being undefined

### DIFF
--- a/resources/qml/JobSpecs.qml
+++ b/resources/qml/JobSpecs.qml
@@ -212,8 +212,9 @@ Item {
                             {
                                 lengths.push(base.printMaterialLengths[index].toFixed(2));
                                 weights.push(String(Math.floor(base.printMaterialWeights[index])));
-                                costs.push(base.printMaterialCosts[index].toFixed(2));
-                                if(base.printMaterialCosts[index] > 0)
+                                var cost = base.printMaterialCosts[index] == undefined ? 0 : base.printMaterialCosts[index].toFixed(2);
+                                costs.push(cost);
+                                if(cost > 0)
                                 {
                                     someCostsKnown = true;
                                 }


### PR DESCRIPTION
Fixes this error:
```
file:///.../Cura/resources/qml/JobSpecs.qml:215: TypeError: Cannot call method 'toFixed' of undefined
```