### PR TITLE
Add smooth_spiralized_contours setting to control smoothing of contours when spiralizing.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4565,7 +4565,17 @@
                     "type": "bool",
                     "default_value": false,
                     "settable_per_mesh": false,
-                    "settable_per_extruder": false
+                    "settable_per_extruder": false,
+                    "children":
+                    {
+                        "smooth_spiralized_contours":
+                        {
+                            "label": "Smooth Spiralized Contours",
+                            "description": "Smooth the spiralized contours to reduce the visibility of the Z seam (the Z-seam should be barely visible on the print but will still be visible in the layer view). Note that smoothing will tend to blur fine surface details.",
+                            "type": "bool",
+                            "default_value": true
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION

Smoothing the contours minimises the visibility of the z-seam and for most models is
probably a good idea. Where it is less good is when the model has a fine surface details
which will get mangled by the smoothing. So we should let the user decide whether they
want to smooth or not. The default is true as most of the time it's a good thing.

Relates to https://github.com/Ultimaker/CuraEngine/issues/507.