### PR TITLE
Fix default Line Width float value representation for UM3

### DIFF
--- a/resources/definitions/ultimaker3.def.json
+++ b/resources/definitions/ultimaker3.def.json
@@ -103,7 +103,7 @@
         "layer_height_0": { "value": "round(machine_nozzle_size / 1.5, 2)" },
         "layer_start_x": { "value": "sum(extruderValues('machine_extruder_start_pos_x')) / len(extruderValues('machine_extruder_start_pos_x'))" },
         "layer_start_y": { "value": "sum(extruderValues('machine_extruder_start_pos_y')) / len(extruderValues('machine_extruder_start_pos_y'))" },
-        "line_width": { "value": "machine_nozzle_size * 0.875" },
+        "line_width": { "value": "round(machine_nozzle_size * 0.875, 3)" },
         "machine_min_cool_heat_time_window": { "value": "15" },
         "default_material_print_temperature": { "value": "200" },
         "material_print_temperature_layer_0": { "value": "material_print_temperature + 5" },


### PR DESCRIPTION
Due to certain [python floating point limitations](https://docs.python.org/3.5/tutorial/floatingpoint.html), we have a float value representation issue for the original value of "Line Width" for UM3 (see screenshot). This is a small fix for it.
![image](https://cloud.githubusercontent.com/assets/2630468/25700730/419c8532-30c9-11e7-8ed4-1623f7bdcf82.png)

**How to reproduce:**
- Show all custom settings
- Change Line Width value
- Switch profile and get the settings override dialog
- Screenshot above