### PR TITLE
Fix USB printing with Marlin/Sprinter compatible printers

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
+++ b/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
@@ -82,7 +82,7 @@ class USBPrinterOutputDeviceManager(QObject, OutputDevicePlugin, Extension):
 
     def _updateThread(self):
         while self._check_updates:
-            result = self.getSerialPortList(only_list_usb = True)
+            result = self.getSerialPortList(only_list_usb = False)
             self._addRemovePorts(result)
             time.sleep(5)
 


### PR DESCRIPTION
Fixes serial port enumeration with the latest version of the Windows 10 64-bit FTDI USB serial port adapter driver which will be automatically installed. Has been tested on Windows 10 1703 64-bit, only, using an ATmega2560 based GT2560 board.
Relevant issues: #1244, #1777, #1434, #1321, #736, #1049, #1271

An option to select the COM port or enumerate printer UUIDs and mapping them to printer configurations would probably be ideal (auto-detection breaks with multiple connected printers otherwise). See #1049.