### PR TITLE
Fix selecting settings for Per Model Settings with single extrusion

### DIFF
--- a/plugins/PerObjectSettingsTool/PerObjectSettingVisibilityHandler.py
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingVisibilityHandler.py
@@ -63,17 +63,20 @@ class PerObjectSettingVisibilityHandler(UM.Settings.Models.SettingVisibilityHand
                     stack_nr = -1
                     stack = None
                     # Check from what stack we should copy the raw property of the setting from.
-                    if definition.limit_to_extruder != "-1" and self._stack.getProperty("machine_extruder_count", "value") > 1:
-                        # A limit to extruder function was set and it's a multi extrusion machine. Check what stack we do need to use.
-                        stack_nr = str(int(round(float(self._stack.getProperty(item, "limit_to_extruder")))))
+                    if self._stack.getProperty("machine_extruder_count", "value") > 1:
+                        if definition.limit_to_extruder != "-1":
+                            # A limit to extruder function was set and it's a multi extrusion machine. Check what stack we do need to use.
+                            stack_nr = str(int(round(float(self._stack.getProperty(item, "limit_to_extruder")))))
 
-                    # Check if the found stack_number is in the extruder list of extruders.
-                    if stack_nr not in ExtruderManager.getInstance().extruderIds and self._stack.getProperty("extruder_nr", "value") is not None:
-                        stack_nr = -1
+                        # Check if the found stack_number is in the extruder list of extruders.
+                        if stack_nr not in ExtruderManager.getInstance().extruderIds and self._stack.getProperty("extruder_nr", "value") is not None:
+                            stack_nr = -1
 
-                    # Use the found stack number to get the right stack to copy the value from.
-                    if stack_nr in ExtruderManager.getInstance().extruderIds:
-                        stack = ContainerRegistry.getInstance().findContainerStacks(id = ExtruderManager.getInstance().extruderIds[stack_nr])[0]
+                        # Use the found stack number to get the right stack to copy the value from.
+                        if stack_nr in ExtruderManager.getInstance().extruderIds:
+                            stack = ContainerRegistry.getInstance().findContainerStacks(id = ExtruderManager.getInstance().extruderIds[stack_nr])[0]
+                    else:
+                        stack = self._stack
 
                     # Use the raw property to set the value (so the inheritance doesn't break)
                     if stack is not None:


### PR DESCRIPTION
This PR fixes selecting settings for Per Model Settings when a single extrusion printer is active.

Steps to reproduce issue:
* Add an UM2+
* Load an object
* Go to Per Model Settings
* Select Settings
* Add "Infill Density"

Result:
```
2017-05-10 17:22:58,587 - CRITICAL - cura.CrashHandler.show [36]: An uncaught exception has occurred!
2017-05-10 17:22:58,602 - CRITICAL - cura.CrashHandler.show [39]: Traceback (most recent call last):
2017-05-10 17:22:58,603 - CRITICAL - cura.CrashHandler.show [39]:   File "C:\Users\Aldo\Documents\Code Projects\UM\Uranium\UM\Settings\Models\SettingDefinitionsModel.py", line 331, in setVisible
2017-05-10 17:22:58,607 - CRITICAL - cura.CrashHandler.show [39]:     self._visibility_handler.setVisible(self._visible)
2017-05-10 17:22:58,607 - CRITICAL - cura.CrashHandler.show [39]:   File "C:\Users\Aldo\Documents\Code Projects\UM\Cura\cura\..\plugins\PerObjectSettingsTool\PerObjectSettingVisibilityHandler.py", line 71, in setVisible
2017-05-10 17:22:58,609 - CRITICAL - cura.CrashHandler.show [39]:     if stack_nr not in ExtruderManager.getInstance().extruderIds and self._stack.getProperty("extruder_nr", "value") is not None:
2017-05-10 17:22:58,610 - CRITICAL - cura.CrashHandler.show [39]:   File "C:\Users\Aldo\Documents\Code Projects\UM\Cura\cura\Settings\ExtruderManager.py", line 75, in extruderIds
2017-05-10 17:22:58,611 - CRITICAL - cura.CrashHandler.show [39]:     for position in self._extruder_trains[Application.getInstance().getGlobalContainerStack().getId()]:
2017-05-10 17:22:58,612 - CRITICAL - cura.CrashHandler.show [39]: KeyError: 'Ultimaker 2+'
```