### PR TITLE
Extend the zoomrange to cater for smaller and larger buildvolumes

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -619,7 +619,9 @@ class CuraApplication(QtApplication):
         camera.lookAt(Vector(0, 0, 0))
         controller.getScene().setActiveCamera("3d")
 
-        self.getController().getTool("CameraTool").setOrigin(Vector(0, 100, 0))
+        camera_tool = self.getController().getTool("CameraTool")
+        camera_tool.setOrigin(Vector(0, 100, 0))
+        camera_tool.setZoomRange(0.1, 200000)
 
         self._camera_animation = CameraAnimation.CameraAnimation()
         self._camera_animation.setCameraTool(self.getController().getTool("CameraTool"))


### PR DESCRIPTION
This PR extends the zoomrange of the cameratool to better support printers with a buildvolume that is much larger or much smaller than the originally intended (UMO) printer.

See eg https://ultimaker.com/en/community/49326-cura-needs-to-zoom-out-further