### PR TITLE
Just like magic_spiralize, smooth_spiralized_contours should not be settable per model/extruder.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4595,7 +4595,9 @@
                     "description": "Smooth the spiralized contours to reduce the visibility of the Z seam (the Z-seam should be barely visible on the print but will still be visible in the layer view). Note that smoothing will tend to blur fine surface details.",
                     "type": "bool",
                     "default_value": true,
-                    "enabled": "magic_spiralize"
+                    "enabled": "magic_spiralize",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
                 }
             }
         },


### PR DESCRIPTION
As simple as that.