### PR TITLE
Allow setting negative values on extruder offset x/y fields

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -341,7 +341,6 @@ Cura.MachineAction
                                     sourceComponent: numericTextFieldWithUnit
                                     property var propertyProvider: gantryHeightProvider
                                     property string unit: catalog.i18nc("@label", "mm")
-                                    property bool forceUpdateOnChange: false
                                 }
 
                                 Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
@@ -385,7 +384,6 @@ Cura.MachineAction
                                     sourceComponent: numericTextFieldWithUnit
                                     property var propertyProvider: materialDiameterProvider
                                     property string unit: catalog.i18nc("@label", "mm")
-                                    property bool forceUpdateOnChange: false
                                 }
                                 Label
                                 {
@@ -399,7 +397,6 @@ Cura.MachineAction
                                     sourceComponent: numericTextFieldWithUnit
                                     property var propertyProvider: machineNozzleSizeProvider
                                     property string unit: catalog.i18nc("@label", "mm")
-                                    property bool forceUpdateOnChange: false
                                 }
                             }
                         }
@@ -550,7 +547,6 @@ Cura.MachineAction
                                 sourceComponent: numericTextFieldWithUnit
                                 property var propertyProvider: extruderNozzleSizeProvider
                                 property string unit: catalog.i18nc("@label", "mm")
-                                property bool forceUpdateOnChange: false
                             }
 
                             Label
@@ -564,6 +560,7 @@ Cura.MachineAction
                                 property var propertyProvider: extruderOffsetXProvider
                                 property string unit: catalog.i18nc("@label", "mm")
                                 property bool forceUpdateOnChange: true
+                                property bool allowNegative: true
                             }
                             Label
                             {
@@ -576,6 +573,7 @@ Cura.MachineAction
                                 property var propertyProvider: extruderOffsetYProvider
                                 property string unit: catalog.i18nc("@label", "mm")
                                 property bool forceUpdateOnChange: true
+                                property bool allowNegative: true
                             }
                         }
 
@@ -655,17 +653,21 @@ Cura.MachineAction
         Item {
             height: textField.height
             width: textField.width
+
+            property bool _allowNegative: (typeof(allowNegative) === 'undefined') ? false : allowNegative
+            property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
+
             TextField
             {
                 id: textField
                 text: (propertyProvider.properties.value) ? propertyProvider.properties.value : ""
-                validator: RegExpValidator { regExp: /[0-9\.]{0,6}/ }
+                validator: RegExpValidator { regExp: _allowNegative ? /-?[0-9\.]{0,6}/ : /[0-9\.]{0,6}/ }
                 onEditingFinished:
                 {
                     if (propertyProvider && text != propertyProvider.properties.value)
                     {
                         propertyProvider.setPropertyValue("value", text);
-                        if(forceUpdateOnChange)
+                        if(_forceUpdateOnChange)
                         {
                             var extruderIndex = ExtruderManager.activeExtruderIndex;
                             manager.forceUpdate();


### PR DESCRIPTION
This PR lets users enter negative values for extruder nozzle x/y offsets.

Fixes https://github.com/Ultimaker/Cura/issues/1832