### PR TITLE
Fix create material for printers that use 1.75mm materials

### DIFF
--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -712,14 +712,14 @@ class ContainerManager(QObject):
         if not global_stack:
             return ""
 
-        approximate_diameter = round(global_stack.getProperty("material_diameter","value"))
-        containers = self._container_registry.findInstanceContainers(id="generic_pla*", approximate_diameter=approximate_diameter)
+        approximate_diameter = round(global_stack.getProperty("material_diameter", "value"))
+        containers = self._container_registry.findInstanceContainers(id = "generic_pla*", approximate_diameter = approximate_diameter)
         if not containers:
             Logger.log("d", "Unable to create a new material by cloning Generic PLA, because it cannot be found for the material diameter for this machine.")
             return ""
 
         base_file = containers[0].getMetaDataEntry("base_file")
-        containers = self._container_registry.findInstanceContainers(id=base_file)
+        containers = self._container_registry.findInstanceContainers(id = base_file)
         if not containers:
             Logger.log("d", "Unable to create a new material by cloning Generic PLA, because the base file for Generic PLA for this machine can not be found.")
             return ""

--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -708,6 +708,10 @@ class ContainerManager(QObject):
         # Ensure all settings are saved.
         Application.getInstance().saveSettings()
 
+        global_stack = Application.getInstance().getGlobalContainerStack()
+        if not global_stack:
+            return ""
+
         containers = self._container_registry.findInstanceContainers(id="generic_pla")
         if not containers:
             Logger.log("d", "Unable to create a new material by cloning generic_pla, because it doesn't exist.")
@@ -728,6 +732,13 @@ class ContainerManager(QObject):
         duplicated_container.setMetaDataEntry("brand", catalog.i18nc("@label", "Custom"))
         duplicated_container.setMetaDataEntry("material", catalog.i18nc("@label", "Custom"))
         duplicated_container.setName(catalog.i18nc("@label", "Custom Material"))
+
+        # Set new material diameter to match the current machine, or it will not be listed
+        material_diameter = global_stack.getProperty("material_diameter", "value")
+        properties = duplicated_container.getMetaDataEntry("properties", {})
+        properties["diameter"] = str(material_diameter)
+        duplicated_container.setMetaDataEntry("properties", properties)
+        duplicated_container.setMetaDataEntry("approximate_diameter", round(material_diameter))
 
         self._container_registry.addContainer(duplicated_container)
         return self._getMaterialContainerIdForActiveMachine(new_id)


### PR DESCRIPTION
This PR is a followup to #1757. It fixes the problem that if the user has a 1.75mm printer active, the Create button would clone the 2.85mm generic PLA which would then be invisible for the current machine.

The fix is to clone the generic PLA material for the current approximate material diameter instead.