### PR TITLE
Get a list of available themes instead of the hardcoded list

### DIFF
--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -218,7 +218,11 @@ UM.PreferencesPage
                         id: themeList
 
                         Component.onCompleted: {
-                            append({ text: catalog.i18nc("@item:inlistbox", "Ultimaker"), code: "cura" })
+                            var themes = UM.Theme.getThemes()
+                            for (var i = 0; i < themes.length; i++)
+                            {
+                                append({ text: themes[i].name.toString(), code: themes[i].id.toString() });
+                            }
                         }
                     }
 

--- a/resources/themes/cura/theme.json
+++ b/resources/themes/cura/theme.json
@@ -1,4 +1,7 @@
 {
+    "metadata": {
+        "name": "Ultimaker"
+    },
     "fonts": {
         "large": {
             "size": 1.25,


### PR DESCRIPTION
This PR builds on https://github.com/Ultimaker/Uranium/pull/252 to show a list of available plugins instead of the current "list" that is hardcoded in GeneralPage.qml