### PR TITLE
Fix loading material diameter and GUID from XML file

### DIFF
--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -235,6 +235,31 @@ class ContainerManager(QObject):
 
         return True
 
+    ##  Set a metadata entry of the specified container.
+    #
+    #   \param container_id \type{str} The ID of the container to change.
+    #   \param setting_key \type{str} The key of the setting.
+    #   \param property_name \type{str} The name of the property, eg "value".
+    #   \param property_value \type{str} The new value of the property.
+    #
+    #   \return True if successful, False if not.
+    @pyqtSlot(str, str, str, str, result = bool)
+    def setContainerProperty(self, container_id, setting_key, property_name, value_value):
+        containers = self._container_registry.findContainers(None, id = container_id)
+        if not containers:
+            Logger.log("w", "Could not set properties of container %s because it was not found.", container_id)
+            return False
+
+        container = containers[0]
+
+        if container.isReadOnly():
+            Logger.log("w", "Cannot set properties of read-only container %s.", container_id)
+            return False
+
+        container.setProperty(setting_key, property_name, value_value)
+
+        return True
+
     ##  Set the name of the specified container.
     @pyqtSlot(str, str, result = bool)
     def setContainerName(self, container_id, new_name):

--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -264,7 +264,6 @@ class ContainerManager(QObject):
 
         basefile = container.getMetaDataEntry("base_file", container_id)
         for sibbling_container in ContainerRegistry.getInstance().findInstanceContainers(base_file = basefile):
-            print(sibbling_container.getId())
             if sibbling_container != container:
                 sibbling_container.setProperty(setting_key, property_name, property_value)
 

--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -237,6 +237,10 @@ class ContainerManager(QObject):
 
     ##  Set a metadata entry of the specified container.
     #
+    #   This will set the specified property of the specified setting of the container
+    #   and all containers that share the same base_file (if any). The latter only
+    #   happens for material containers.
+    #
     #   \param container_id \type{str} The ID of the container to change.
     #   \param setting_key \type{str} The key of the setting.
     #   \param property_name \type{str} The name of the property, eg "value".
@@ -244,7 +248,7 @@ class ContainerManager(QObject):
     #
     #   \return True if successful, False if not.
     @pyqtSlot(str, str, str, str, result = bool)
-    def setContainerProperty(self, container_id, setting_key, property_name, value_value):
+    def setContainerProperty(self, container_id, setting_key, property_name, property_value):
         containers = self._container_registry.findContainers(None, id = container_id)
         if not containers:
             Logger.log("w", "Could not set properties of container %s because it was not found.", container_id)
@@ -256,7 +260,13 @@ class ContainerManager(QObject):
             Logger.log("w", "Cannot set properties of read-only container %s.", container_id)
             return False
 
-        container.setProperty(setting_key, property_name, value_value)
+        container.setProperty(setting_key, property_name, property_value)
+
+        basefile = container.getMetaDataEntry("base_file", container_id)
+        for sibbling_container in ContainerRegistry.getInstance().findInstanceContainers(base_file = basefile):
+            print(sibbling_container.getId())
+            if sibbling_container != container:
+                sibbling_container.setProperty(setting_key, property_name, property_value)
 
         return True
 

--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -746,7 +746,7 @@ class ContainerManager(QObject):
         if not global_stack:
             return ""
 
-        approximate_diameter = round(global_stack.getProperty("material_diameter", "value"))
+        approximate_diameter = str(round(global_stack.getProperty("material_diameter", "value")))
         containers = self._container_registry.findInstanceContainers(id = "generic_pla*", approximate_diameter = approximate_diameter)
         if not containers:
             Logger.log("d", "Unable to create a new material by cloning Generic PLA, because it cannot be found for the material diameter for this machine.")

--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -235,7 +235,7 @@ class ContainerManager(QObject):
 
         return True
 
-    ##  Set a metadata entry of the specified container.
+    ##  Set a setting property value of the specified container.
     #
     #   This will set the specified property of the specified setting of the container
     #   and all containers that share the same base_file (if any). The latter only

--- a/cura/Settings/ExtruderManager.py
+++ b/cura/Settings/ExtruderManager.py
@@ -310,9 +310,9 @@ class ExtruderManager(QObject):
             if preferred_material_id:
                 global_stack = ContainerRegistry.getInstance().findContainerStacks(id = machine_id)
                 if global_stack:
-                    approximate_material_diameter = round(global_stack[0].getProperty("material_diameter", "value"))
+                    approximate_material_diameter = str(round(global_stack[0].getProperty("material_diameter", "value")))
                 else:
-                    approximate_material_diameter = round(machine_definition.getProperty("material_diameter", "value"))
+                    approximate_material_diameter = str(round(machine_definition.getProperty("material_diameter", "value")))
 
                 search_criteria = { "type": "material",  "id": preferred_material_id, "approximate_diameter": approximate_material_diameter}
                 if machine_definition.getMetaDataEntry("has_machine_materials"):

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -1124,7 +1124,7 @@ class MachineManager(QObject):
         if not definition.getMetaDataEntry("has_materials"):
             return self._empty_material_container
 
-        approximate_material_diameter = round(stack.getProperty("material_diameter", "value"))
+        approximate_material_diameter = str(round(stack.getProperty("material_diameter", "value")))
         search_criteria = { "type": "material", "approximate_diameter": approximate_material_diameter }
 
         if definition.getMetaDataEntry("has_machine_materials"):

--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -486,7 +486,7 @@ class XmlMaterialProfile(InstanceContainer):
             if tag_name in self.__material_properties_setting_map:
                 common_setting_values[self.__material_properties_setting_map[tag_name]] = entry.text
 
-        meta_data["approximate_diameter"] = round(float(property_values.get("diameter", 2.85))) # In mm
+        meta_data["approximate_diameter"] = str(round(float(property_values.get("diameter", 2.85)))) # In mm
         meta_data["properties"] = property_values
 
         self.setDefinition(ContainerRegistry.getInstance().findDefinitionContainers(id = "fdmprinter")[0])

--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -55,16 +55,14 @@ class XmlMaterialProfile(InstanceContainer):
     def setMetaDataEntry(self, key, value):
         if self.isReadOnly():
             return
-        if self.getMetaDataEntry(key, None) == value:
-            # Prevent recursion caused by for loop.
-            return
 
         super().setMetaDataEntry(key, value)
 
         basefile = self.getMetaDataEntry("base_file", self._id)  #if basefile is self.id, this is a basefile.
-        # Update all containers that share GUID and basefile
+        # Update all containers that share basefile
         for container in ContainerRegistry.getInstance().findInstanceContainers(base_file = basefile):
-            container.setMetaDataEntry(key, value)
+            if container.getMetaDataEntry(key, None) != value: # Prevent recursion
+                container.setMetaDataEntry(key, value)
 
     ##  Overridden from InstanceContainer, similar to setMetaDataEntry.
     #   without this function the setName would only set the name of the specific nozzle / material / machine combination container

--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -110,7 +110,7 @@ class XmlMaterialProfile(InstanceContainer):
     #             container.setDirty(True)
 
     ##  Overridden from InstanceContainer
-    # base file: global settings + supported machines
+    # base file: common settings + supported machines
     # machine / variant combination: only changes for itself.
     def serialize(self):
         registry = ContainerRegistry.getInstance()
@@ -439,7 +439,7 @@ class XmlMaterialProfile(InstanceContainer):
         meta_data["base_file"] = self.id
         meta_data["status"] = "unknown"  # TODO: Add material verfication
 
-        global_setting_values = {}
+        common_setting_values = {}
 
         inherits = data.find("./um:inherits", self.__namespaces)
         if inherits is not None:
@@ -471,7 +471,7 @@ class XmlMaterialProfile(InstanceContainer):
             meta_data[tag_name] = entry.text
 
             if tag_name in self.__material_metadata_setting_map:
-                global_setting_values[self.__material_metadata_setting_map[tag_name]] = entry.text
+                common_setting_values[self.__material_metadata_setting_map[tag_name]] = entry.text
 
         if "description" not in meta_data:
             meta_data["description"] = ""
@@ -486,33 +486,33 @@ class XmlMaterialProfile(InstanceContainer):
             property_values[tag_name] = entry.text
 
             if tag_name in self.__material_properties_setting_map:
-                global_setting_values[self.__material_properties_setting_map[tag_name]] = entry.text
+                common_setting_values[self.__material_properties_setting_map[tag_name]] = entry.text
 
         meta_data["approximate_diameter"] = round(float(property_values.get("diameter", 2.85))) # In mm
         meta_data["properties"] = property_values
 
         self.setDefinition(ContainerRegistry.getInstance().findDefinitionContainers(id = "fdmprinter")[0])
 
-        global_compatibility = True
+        common_compatibility = True
         settings = data.iterfind("./um:settings/um:setting", self.__namespaces)
         for entry in settings:
             key = entry.get("key")
             if key in self.__material_settings_setting_map:
-                global_setting_values[self.__material_settings_setting_map[key]] = entry.text
+                common_setting_values[self.__material_settings_setting_map[key]] = entry.text
             elif key in self.__unmapped_settings:
                 if key == "hardware compatible":
-                    global_compatibility = parseBool(entry.text)
+                    common_compatibility = parseBool(entry.text)
             else:
                 Logger.log("d", "Unsupported material setting %s", key)
-        self._cached_values = global_setting_values
+        self._cached_values = common_setting_values # from InstanceContainer ancestor
 
-        meta_data["compatible"] = global_compatibility
+        meta_data["compatible"] = common_compatibility
         self.setMetaData(meta_data)
         self._dirty = False
 
         machines = data.iterfind("./um:settings/um:machine", self.__namespaces)
         for machine in machines:
-            machine_compatibility = global_compatibility
+            machine_compatibility = common_compatibility
             machine_setting_values = {}
             settings = machine.iterfind("./um:setting", self.__namespaces)
             for entry in settings:
@@ -525,7 +525,7 @@ class XmlMaterialProfile(InstanceContainer):
                 else:
                     Logger.log("d", "Unsupported material setting %s", key)
 
-            cached_machine_setting_properties = global_setting_values.copy()
+            cached_machine_setting_properties = common_setting_values.copy()
             cached_machine_setting_properties.update(machine_setting_values)
 
             identifiers = machine.iterfind("./um:machine_identifier", self.__namespaces)

--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -150,7 +150,7 @@ Menu
 
     function materialFilter()
     {
-        var result = { "type": "material", "approximate_diameter": Math.round(materialDiameterProvider.properties.value) };
+        var result = { "type": "material", "approximate_diameter": Math.round(materialDiameterProvider.properties.value).toString() };
         if(Cura.MachineManager.filterMaterialsByMachine)
         {
             result.definition = Cura.MachineManager.activeQualityDefinitionId;

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -166,6 +166,8 @@ TabView
 
                     onEditingFinished:
                     {
+                        // This does not use a SettingPropertyProvider, because we need to make the change to all containers
+                        // which derive from the same base_file
                         Cura.ContainerManager.setContainerProperty(base.containerId, "material_diameter", "value", value)
                         base.setMetaDataEntry("properties/diameter", properties.diameter, value)
                     }

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -164,7 +164,11 @@ TabView
                     stepSize: 0.01
                     readOnly: !base.editingEnabled
 
-                    onEditingFinished: base.setMetaDataEntry("properties/diameter", properties.diameter, value)
+                    onEditingFinished:
+                    {
+                        Cura.ContainerManager.setContainerProperty(base.containerId, "material_diameter", "value", value)
+                        base.setMetaDataEntry("properties/diameter", properties.diameter, value)
+                    }
                     onValueChanged: updateCostPerMeter()
                 }
 

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -168,8 +168,9 @@ TabView
                     {
                         // This does not use a SettingPropertyProvider, because we need to make the change to all containers
                         // which derive from the same base_file
-                        Cura.ContainerManager.setContainerProperty(base.containerId, "material_diameter", "value", value)
-                        base.setMetaDataEntry("properties/diameter", properties.diameter, value)
+                        base.setMetaDataEntry("approximate_diameter", properties.approximate_diameter, Math.round(value).toString());
+                        base.setMetaDataEntry("properties/diameter", properties.diameter, value);
+                        Cura.ContainerManager.setContainerProperty(base.containerId, "material_diameter", "value", value);
                     }
                     onValueChanged: updateCostPerMeter()
                 }

--- a/resources/qml/Preferences/MaterialsPage.qml
+++ b/resources/qml/Preferences/MaterialsPage.qml
@@ -24,7 +24,7 @@ UM.ManagementPage
     {
         filter:
         {
-            var result = { "type": "material", "approximate_diameter": Math.round(materialDiameterProvider.properties.value) }
+            var result = { "type": "material", "approximate_diameter": Math.round(materialDiameterProvider.properties.value).toString() }
             if(Cura.MachineManager.filterMaterialsByMachine)
             {
                 result.definition = Cura.MachineManager.activeQualityDefinitionId;
@@ -253,6 +253,7 @@ UM.ManagementPage
 
             property real density: 0.0;
             property real diameter: 0.0;
+            property string approximate_diameter: "0";
 
             property real spool_cost: 0.0;
             property real spool_weight: 0.0;
@@ -397,11 +398,13 @@ UM.ManagementPage
             {
                 materialProperties.density = currentItem.metadata.properties.density ? currentItem.metadata.properties.density : 0.0;
                 materialProperties.diameter = currentItem.metadata.properties.diameter ? currentItem.metadata.properties.diameter : 0.0;
+                materialProperties.approximate_diameter = currentItem.metadata.approximate_diameter ? currentItem.metadata.approximate_diameter : "0";
             }
             else
             {
                 materialProperties.density = 0.0;
                 materialProperties.diameter = 0.0;
+                materialProperties.approximate_diameter = "0";
             }
 
         }


### PR DESCRIPTION
This PR fixes loading the material diameter from xml material files. Diameters were previously only shown, but not used as values.

Fixes #1886 

While I was at it, I also added loading the GUID into the material_guid setting. This setting would never be filled in.