### PR TITLE
Use .3mf on MacOS as project extension

### DIFF
--- a/plugins/3MFReader/__init__.py
+++ b/plugins/3MFReader/__init__.py
@@ -16,7 +16,7 @@ from UM.Platform import Platform
 catalog = i18nCatalog("cura")
 
 def getMetaData() -> Dict:
-    # Workarround for osx not supporting double file extensions correclty.
+    # Workarround for osx not supporting double file extensions correctly.
     if Platform.isOSX():
         workspace_extension = "3mf"
     else:

--- a/plugins/3MFWriter/__init__.py
+++ b/plugins/3MFWriter/__init__.py
@@ -10,10 +10,17 @@ except ImportError:
 from . import ThreeMFWorkspaceWriter
 
 from UM.i18n import i18nCatalog
+from UM.Platform import Platform
 
 i18n_catalog = i18nCatalog("uranium")
 
 def getMetaData():
+    # Workarround for osx not supporting double file extensions correctly.
+    if Platform.isOSX():
+        workspace_extension = "3mf"
+    else:
+        workspace_extension = "curaproject.3mf"
+
     metaData = {
         "plugin": {
             "name": i18n_catalog.i18nc("@label", "3MF Writer"),
@@ -35,7 +42,7 @@ def getMetaData():
         }
         metaData["workspace_writer"] = {
             "output": [{
-                "extension": "curaproject.3mf",
+                "extension": workspace_extension,
                 "description": i18n_catalog.i18nc("@item:inlistbox", "Cura Project 3MF file"),
                 "mime_type": "application/x-curaproject+xml",
                 "mode": ThreeMFWorkspaceWriter.ThreeMFWorkspaceWriter.OutputMode.BinaryMode


### PR DESCRIPTION
As MacOS has troubles understanding a dot in a file extension, this pull-request uses only .3mf as a project-extension on a Mac.
The biggest downside is that Mac-users can immediately identify a Cura-project file, but the upside is that we won't have weird file extensions (e.g. .curaproject.3mf.curaproject.3mf.curaproject.3mf)

CURA-3886