### PR TITLE
[WIP] Added settings for slow start bottom walls feature.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4245,6 +4245,53 @@
                             "limit_to_extruder": "adhesion_extruder_nr"
                         }
                     }
+                },
+                "slow_start_walls":
+                {
+                    "label": "Start Bottom Layer Walls Slowly",
+                    "description": "Whether to print the start of a bottom layer wall slowly to help adhesion.",
+                    "type": "bool",
+                    "default_value": false,
+                    "settable_per_mesh": true,
+                    "settable_per_extruder": true
+                },
+                "slow_start_wall_length":
+                {
+                    "label": "Reduced Speed Length",
+                    "description": "The distance printed at a reduced speed.",
+                    "unit": "mm",
+                    "type": "float",
+                    "minimum_value": "0",
+                    "default_value": 3,
+                    "enabled": "slow_start_walls",
+                    "settable_per_mesh": true,
+                    "settable_per_extruder": true
+                },
+                "slow_start_wall_speed_percentage":
+                {
+                    "label": "Reduced Speed Percentage Speed",
+                    "description": "The percentage of the normal speed to use when printing the start of the wall.",
+                    "unit": "%",
+                    "type": "float",
+                    "minimum_value": "5",
+                    "maximum_value": "100",
+                    "default_value": 50,
+                    "enabled": "slow_start_walls",
+                    "settable_per_mesh": true,
+                    "settable_per_extruder": true
+                },
+                "slow_start_wall_flow_percentage":
+                {
+                    "label": "Reduced Speed Percentage Flow",
+                    "description": "The percentage of the normal extrusion rate to use when printing the start of the wall.",
+                    "unit": "%",
+                    "type": "float",
+                    "minimum_value": "5",
+                    "maximum_value": "100",
+                    "default_value": 100,
+                    "enabled": "slow_start_walls",
+                    "settable_per_mesh": true,
+                    "settable_per_extruder": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4246,50 +4246,50 @@
                         }
                     }
                 },
-                "slow_start_walls":
+                "modify_wall_starts":
                 {
-                    "label": "Start Bottom Layer Walls Slowly",
-                    "description": "Whether to print the start of a bottom layer wall slowly to help adhesion.",
+                    "label": "Modify Start Of Walls",
+                    "description": "Whether to modify the print speed or filament flow rate at the start of bottom layer walls. Using a slower print speed or higher flow rate may help adhesion.",
                     "type": "bool",
                     "default_value": false,
                     "settable_per_mesh": true,
                     "settable_per_extruder": true
                 },
-                "slow_start_wall_length":
+                "modify_wall_starts_distance":
                 {
-                    "label": "Reduced Speed Length",
-                    "description": "The distance printed at a reduced speed.",
+                    "label": "Distance Walls Are Modified",
+                    "description": "The distance bottom layer walls are modified.",
                     "unit": "mm",
                     "type": "float",
                     "minimum_value": "0",
                     "default_value": 3,
-                    "enabled": "slow_start_walls",
+                    "enabled": "modify_wall_starts",
                     "settable_per_mesh": true,
                     "settable_per_extruder": true
                 },
-                "slow_start_wall_speed_percentage":
+                "modify_wall_starts_speed_percentage":
                 {
-                    "label": "Reduced Speed Percentage Speed",
-                    "description": "The percentage of the normal speed to use when printing the start of the wall.",
+                    "label": "Wall Start Percentage Speed",
+                    "description": "The percentage of the normal speed to use when printing the start of the bottom layer walls.",
                     "unit": "%",
                     "type": "float",
                     "minimum_value": "5",
-                    "maximum_value": "100",
-                    "default_value": 50,
-                    "enabled": "slow_start_walls",
-                    "settable_per_mesh": true,
-                    "settable_per_extruder": true
-                },
-                "slow_start_wall_flow_percentage":
-                {
-                    "label": "Reduced Speed Percentage Flow",
-                    "description": "The percentage of the normal extrusion rate to use when printing the start of the wall.",
-                    "unit": "%",
-                    "type": "float",
-                    "minimum_value": "5",
-                    "maximum_value": "100",
+                    "maximum_value": "500",
                     "default_value": 100,
-                    "enabled": "slow_start_walls",
+                    "enabled": "modify_wall_starts",
+                    "settable_per_mesh": true,
+                    "settable_per_extruder": true
+                },
+                "modify_wall_starts_flow_percentage":
+                {
+                    "label": "Wall Start Percentage Flow",
+                    "description": "The percentage of the normal extrusion rate to use when printing the start of the bottom layer walls.",
+                    "unit": "%",
+                    "type": "float",
+                    "minimum_value": "1",
+                    "maximum_value": "500",
+                    "default_value": 100,
+                    "enabled": "modify_wall_starts",
                     "settable_per_mesh": true,
                     "settable_per_extruder": true
                 }


### PR DESCRIPTION
Still very much WIP, the idea is that with some filaments, build plate adhesion can be marginal and when
starting a new bottom layer wall, the extrusion can fail to stick right at the start of the extrude. So by going
a bit slower for the first couple of mm, it should increase the chance of the filament sticking to the bed without
having to do the whole wall at that super slow speed.

See https://github.com/Ultimaker/CuraEngine/pull/531.