### PR TITLE
Horizontal Ironing

### DIFF
--- a/cura/LayerPolygon.py
+++ b/cura/LayerPolygon.py
@@ -1,4 +1,6 @@
-from UM.Math.Color import Color
+# Copyright (c) 2017 Ultimaker B.V.
+# Cura is released under the terms of the AGPLv3 or higher.
+
 from UM.Application import Application
 from typing import Any
 import numpy
@@ -16,8 +18,9 @@ class LayerPolygon:
     MoveCombingType = 8
     MoveRetractionType = 9
     SupportInterfaceType = 10
-    
-    __jump_map = numpy.logical_or(numpy.logical_or(numpy.arange(11) == NoneType, numpy.arange(11) == MoveCombingType), numpy.arange(11) == MoveRetractionType)
+    __number_of_types = 11
+
+    __jump_map = numpy.logical_or(numpy.logical_or(numpy.arange(__number_of_types) == NoneType, numpy.arange(__number_of_types) == MoveCombingType), numpy.arange(__number_of_types) == MoveRetractionType)
     
     ##  LayerPolygon, used in ProcessSlicedLayersJob
     #   \param extruder
@@ -28,6 +31,9 @@ class LayerPolygon:
     def __init__(self, extruder, line_types, data, line_widths, line_thicknesses):
         self._extruder = extruder
         self._types = line_types
+        for i in range(len(self._types)):
+            if self._types[i] >= self.__number_of_types: #Got faulty line data from the engine.
+                self._types[i] = self.NoneType
         self._data = data
         self._line_widths = line_widths
         self._line_thicknesses = line_thicknesses
@@ -36,11 +42,11 @@ class LayerPolygon:
         self._vertex_end = 0
         self._index_begin = 0
         self._index_end = 0
-        
+
         self._jump_mask = self.__jump_map[self._types]
         self._jump_count = numpy.sum(self._jump_mask)
-        self._mesh_line_count = len(self._types)-self._jump_count
-        self._vertex_count = self._mesh_line_count + numpy.sum( self._types[1:] == self._types[:-1])
+        self._mesh_line_count = len(self._types) - self._jump_count
+        self._vertex_count = self._mesh_line_count + numpy.sum(self._types[1:] == self._types[:-1])
 
         # Buffering the colors shouldn't be necessary as it is not 
         # re-used and can save alot of memory usage.

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5423,7 +5423,7 @@
                     "description": "The amount of material, relative to a normal skin line, to extrude during sanding. Keeping the nozzle filled helps filling some of the crevices of the top surface, but too much results in overextrusion and blips on the side of the surface.",
                     "type": "float",
                     "unit": "%",
-                    "default_value": 30.0,
+                    "default_value": 10.0,
                     "minimum_value": "0",
                     "maximum_value_warning": "50",
                     "enabled": "sanding_enabled",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2310,6 +2310,21 @@
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },
+                        "acceleration_sanding":
+                        {
+                            "label": "Sanding Acceleration",
+                            "description": "The acceleration with which sanding is performed.",
+                            "unit": "mm/s²",
+                            "type": "float",
+                            "minimum_value": "0.1",
+                            "minimum_value_warning": "100",
+                            "maximum_value_warning": "10000",
+                            "default_value": 3000,
+                            "value": "acceleration_topbottom",
+                            "enabled": "resolveOrValue('acceleration_enabled') and sanding_enabled",
+                            "limit_to_extruder": "top_bottom_extruder_nr",
+                            "settable_per_mesh": true
+                        },
                         "acceleration_support":
                         {
                             "label": "Support Acceleration",
@@ -2580,6 +2595,20 @@
                             "default_value": 20,
                             "value": "jerk_print",
                             "enabled": "resolveOrValue('jerk_enabled')",
+                            "limit_to_extruder": "top_bottom_extruder_nr",
+                            "settable_per_mesh": true
+                        },
+                        "jerk_sanding":
+                        {
+                            "label": "Sanding Jerk",
+                            "description": "The maximum instantaneous velocity change while performing sanding.",
+                            "unit": "mm/s",
+                            "type": "float",
+                            "minimum_value": "0.1",
+                            "maximum_value_warning": "50",
+                            "default_value": 20,
+                            "value": "jerk_topbottom",
+                            "enabled": "resolveOrValue('jerk_enabled') and sanding_enabled",
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5387,7 +5387,7 @@
                 },
                 "sanding_enabled":
                 {
-                    "label": "Enable Sanding",
+                    "label": "Enable Ironing",
                     "description": "Go over the top surface one additional time, but without extruding material. This is meant to melt the plastic on top further, creating a smoother surface.",
                     "type": "bool",
                     "default_value": false,
@@ -5396,8 +5396,8 @@
                 },
                 "sanding_pattern":
                 {
-                    "label": "Sanding Pattern",
-                    "description": "The pattern to use for sanding top surfaces.",
+                    "label": "Ironing Pattern",
+                    "description": "The pattern to use for ironing top surfaces.",
                     "type": "enum",
                     "options":
                     {
@@ -5411,8 +5411,8 @@
                 },
                 "sanding_line_spacing":
                 {
-                    "label": "Sanding Line Spacing",
-                    "description": "The distance between the lines of sanding.",
+                    "label": "Ironing Line Spacing",
+                    "description": "The distance between the lines of ironing.",
                     "type": "float",
                     "unit": "mm",
                     "default_value": 0.1,
@@ -5424,8 +5424,8 @@
                 },
                 "sanding_flow":
                 {
-                    "label": "Sanding Flow",
-                    "description": "The amount of material, relative to a normal skin line, to extrude during sanding. Keeping the nozzle filled helps filling some of the crevices of the top surface, but too much results in overextrusion and blips on the side of the surface.",
+                    "label": "Ironing Flow",
+                    "description": "The amount of material, relative to a normal skin line, to extrude during ironing. Keeping the nozzle filled helps filling some of the crevices of the top surface, but too much results in overextrusion and blips on the side of the surface.",
                     "type": "float",
                     "unit": "%",
                     "default_value": 10.0,
@@ -5437,8 +5437,8 @@
                 },
                 "sanding_inset":
                 {
-                    "label": "Sanding Inset",
-                    "description": "A distance to keep from the edges of the model. Sanding all the way to the edge of the mesh may result in a jagged edge on your print.",
+                    "label": "Ironing Inset",
+                    "description": "A distance to keep from the edges of the model. Ironing all the way to the edge of the mesh may result in a jagged edge on your print.",
                     "type": "float",
                     "unit": "mm",
                     "default_value": 0.35,

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1970,7 +1970,7 @@
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },
-                        "speed_sanding":
+                        "speed_ironing":
                         {
                             "label": "Ironing Speed",
                             "description": "The speed at which to pass over the top surface.",
@@ -1981,7 +1981,7 @@
                             "minimum_value": "0.001",
                             "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                             "maximum_value_warning": "100",
-                            "enabled": "sanding_enabled",
+                            "enabled": "ironing_enabled",
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },
@@ -2311,7 +2311,7 @@
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },
-                        "acceleration_sanding":
+                        "acceleration_ironing":
                         {
                             "label": "Ironing Acceleration",
                             "description": "The acceleration with which ironing is performed.",
@@ -2322,7 +2322,7 @@
                             "maximum_value_warning": "10000",
                             "default_value": 3000,
                             "value": "acceleration_topbottom",
-                            "enabled": "resolveOrValue('acceleration_enabled') and sanding_enabled",
+                            "enabled": "resolveOrValue('acceleration_enabled') and ironing_enabled",
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5363,6 +5363,18 @@
                     "default_value": "lines",
                     "enabled": "sanding_enabled",
                     "settable_per_mesh": true
+                },
+                "sanding_flow":
+                {
+                    "label": "Sanding Flow",
+                    "description": "The amount of material, relative to a normal skin line, to extrude during sanding. Keeping the nozzle filled helps filling some of the crevices of the top surface, but too much results in overextrusion and blips on the side of the surface.",
+                    "type": "float",
+                    "unit": "%",
+                    "default_value": 30.0,
+                    "minimum_value": "0",
+                    "maximum_value_warning": "50",
+                    "enabled": "sanding_enabled",
+                    "settable_per_mesh": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1977,6 +1977,7 @@
                             "type": "float",
                             "unit": "mm/s",
                             "default_value": 20.0,
+                            "value": "speed_topbottom * 20 / 30",
                             "minimum_value": "0.001",
                             "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                             "maximum_value_warning": "100",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5402,7 +5402,7 @@
                         "concentric": "Concentric",
                         "zigzag": "Zig Zag"
                     },
-                    "default_value": "lines",
+                    "default_value": "zigzag",
                     "enabled": "sanding_enabled",
                     "settable_per_mesh": true
                 },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2599,7 +2599,7 @@
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },
-                        "jerk_sanding":
+                        "jerk_ironing":
                         {
                             "label": "Ironing Jerk",
                             "description": "The maximum instantaneous velocity change while performing ironing.",
@@ -2609,7 +2609,7 @@
                             "maximum_value_warning": "50",
                             "default_value": 20,
                             "value": "jerk_topbottom",
-                            "enabled": "resolveOrValue('jerk_enabled') and sanding_enabled",
+                            "enabled": "resolveOrValue('jerk_enabled') and ironing_enabled",
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },
@@ -5385,7 +5385,7 @@
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false
                 },
-                "sanding_enabled":
+                "ironing_enabled":
                 {
                     "label": "Enable Ironing",
                     "description": "Go over the top surface one additional time, but without extruding material. This is meant to melt the plastic on top further, creating a smoother surface.",
@@ -5394,7 +5394,7 @@
                     "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
-                "sanding_pattern":
+                "ironing_pattern":
                 {
                     "label": "Ironing Pattern",
                     "description": "The pattern to use for ironing top surfaces.",
@@ -5405,11 +5405,11 @@
                         "zigzag": "Zig Zag"
                     },
                     "default_value": "zigzag",
-                    "enabled": "sanding_enabled",
+                    "enabled": "ironing_enabled",
                     "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
-                "sanding_line_spacing":
+                "ironing_line_spacing":
                 {
                     "label": "Ironing Line Spacing",
                     "description": "The distance between the lines of ironing.",
@@ -5418,11 +5418,11 @@
                     "default_value": 0.1,
                     "minimum_value": "0.001",
                     "maximum_value_warning": "machine_nozzle_tip_outer_diameter",
-                    "enabled": "sanding_enabled",
+                    "enabled": "ironing_enabled",
                     "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
-                "sanding_flow":
+                "ironing_flow":
                 {
                     "label": "Ironing Flow",
                     "description": "The amount of material, relative to a normal skin line, to extrude during ironing. Keeping the nozzle filled helps filling some of the crevices of the top surface, but too much results in overextrusion and blips on the side of the surface.",
@@ -5431,11 +5431,11 @@
                     "default_value": 10.0,
                     "minimum_value": "0",
                     "maximum_value_warning": "50",
-                    "enabled": "sanding_enabled",
+                    "enabled": "ironing_enabled",
                     "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
-                "sanding_inset":
+                "ironing_inset":
                 {
                     "label": "Ironing Inset",
                     "description": "A distance to keep from the edges of the model. Ironing all the way to the edge of the mesh may result in a jagged edge on your print.",
@@ -5445,7 +5445,7 @@
                     "value": "wall_line_width_0 / 2",
                     "minimum_value_warning": "0",
                     "maximum_value_warning": "wall_line_width_0",
-                    "enabled": "sanding_enabled",
+                    "enabled": "ironing_enabled",
                     "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5436,7 +5436,7 @@
                     "type": "float",
                     "unit": "mm",
                     "default_value": 0.35,
-                    "value": "skin_line_width",
+                    "value": "wall_line_width_0 / 2",
                     "minimum_value_warning": "0",
                     "maximum_value_warning": "wall_line_width_0",
                     "enabled": "sanding_enabled",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5356,7 +5356,6 @@
                     "type": "enum",
                     "options":
                     {
-                        "lines": "Lines",
                         "concentric": "Concentric",
                         "zigzag": "Zig Zag"
                     },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5428,6 +5428,19 @@
                     "maximum_value_warning": "50",
                     "enabled": "sanding_enabled",
                     "settable_per_mesh": true
+                },
+                "sanding_inset":
+                {
+                    "label": "Sanding Inset",
+                    "description": "A distance to keep from the edges of the model. Sanding all the way to the edge of the mesh may result in a jagged edge on your print.",
+                    "type": "float",
+                    "unit": "mm",
+                    "default_value": 0.35,
+                    "value": "skin_line_width",
+                    "minimum_value_warning": "0",
+                    "maximum_value_warning": "wall_line_width_0",
+                    "enabled": "sanding_enabled",
+                    "settable_per_mesh": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5363,6 +5363,17 @@
                     "enabled": "sanding_enabled",
                     "settable_per_mesh": true
                 },
+                "sanding_line_spacing":
+                {
+                    "label": "Sanding Line Spacing",
+                    "description": "The distance between the lines of sanding.",
+                    "type": "float",
+                    "unit": "mm",
+                    "default_value": 0.1,
+                    "minimum_value": "0.001",
+                    "maximum_value_warning": "machine_nozzle_tip_outer_diameter",
+                    "settable_per_mesh": true
+                },
                 "sanding_flow":
                 {
                     "label": "Sanding Flow",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5340,6 +5340,14 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false
+                },
+                "sanding_enabled":
+                {
+                    "label": "Enable Sanding",
+                    "description": "Go over the top surface one additional time, but without extruding material. This is meant to melt the plastic on top further, creating a smoother surface.",
+                    "type": "bool",
+                    "default_value": false,
+                    "settable_per_mesh": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1970,6 +1970,19 @@
                             "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },
+                        "speed_sanding":
+                        {
+                            "label": "Sanding Speed",
+                            "description": "The speed at which to pass over the top surface.",
+                            "type": "float",
+                            "unit": "mm/s",
+                            "default_value": 20.0,
+                            "minimum_value": "0.001",
+                            "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
+                            "maximum_value_warning": "100",
+                            "enabled": "sanding_enabled",
+                            "settable_per_mesh": true
+                        },
                         "speed_support":
                         {
                             "label": "Support Speed",
@@ -5383,19 +5396,6 @@
                     "default_value": 30.0,
                     "minimum_value": "0",
                     "maximum_value_warning": "50",
-                    "enabled": "sanding_enabled",
-                    "settable_per_mesh": true
-                },
-                "speed_sanding":
-                {
-                    "label": "Sanding Speed",
-                    "description": "The speed at which to pass over the top surface.",
-                    "type": "float",
-                    "unit": "mm/s",
-                    "default_value": 20.0,
-                    "minimum_value": "0.001",
-                    "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
-                    "maximum_value_warning": "100",
                     "enabled": "sanding_enabled",
                     "settable_per_mesh": true
                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5418,6 +5418,7 @@
                     "default_value": 0.1,
                     "minimum_value": "0.001",
                     "maximum_value_warning": "machine_nozzle_tip_outer_diameter",
+                    "enabled": "sanding_enabled",
                     "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5385,6 +5385,19 @@
                     "maximum_value_warning": "50",
                     "enabled": "sanding_enabled",
                     "settable_per_mesh": true
+                },
+                "speed_sanding":
+                {
+                    "label": "Sanding Speed",
+                    "description": "The speed at which to pass over the top surface.",
+                    "type": "float",
+                    "unit": "mm/s",
+                    "default_value": 20.0,
+                    "minimum_value": "0.001",
+                    "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
+                    "maximum_value_warning": "100",
+                    "enabled": "sanding_enabled",
+                    "settable_per_mesh": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1972,7 +1972,7 @@
                         },
                         "speed_sanding":
                         {
-                            "label": "Sanding Speed",
+                            "label": "Ironing Speed",
                             "description": "The speed at which to pass over the top surface.",
                             "type": "float",
                             "unit": "mm/s",
@@ -2313,8 +2313,8 @@
                         },
                         "acceleration_sanding":
                         {
-                            "label": "Sanding Acceleration",
-                            "description": "The acceleration with which sanding is performed.",
+                            "label": "Ironing Acceleration",
+                            "description": "The acceleration with which ironing is performed.",
                             "unit": "mm/s²",
                             "type": "float",
                             "minimum_value": "0.1",
@@ -2601,8 +2601,8 @@
                         },
                         "jerk_sanding":
                         {
-                            "label": "Sanding Jerk",
-                            "description": "The maximum instantaneous velocity change while performing sanding.",
+                            "label": "Ironing Jerk",
+                            "description": "The maximum instantaneous velocity change while performing ironing.",
                             "unit": "mm/s",
                             "type": "float",
                             "minimum_value": "0.1",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5348,6 +5348,21 @@
                     "type": "bool",
                     "default_value": false,
                     "settable_per_mesh": true
+                },
+                "sanding_pattern":
+                {
+                    "label": "Sanding Pattern",
+                    "description": "The pattern to use for sanding top surfaces.",
+                    "type": "enum",
+                    "options":
+                    {
+                        "lines": "Lines",
+                        "concentric": "Concentric",
+                        "zigzag": "Zig Zag"
+                    },
+                    "default_value": "lines",
+                    "enabled": "sanding_enabled",
+                    "settable_per_mesh": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1982,6 +1982,7 @@
                             "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                             "maximum_value_warning": "100",
                             "enabled": "sanding_enabled",
+                            "limit_to_extruder": "top_bottom_extruder_nr",
                             "settable_per_mesh": true
                         },
                         "speed_support":
@@ -5390,6 +5391,7 @@
                     "description": "Go over the top surface one additional time, but without extruding material. This is meant to melt the plastic on top further, creating a smoother surface.",
                     "type": "bool",
                     "default_value": false,
+                    "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
                 "sanding_pattern":
@@ -5404,6 +5406,7 @@
                     },
                     "default_value": "zigzag",
                     "enabled": "sanding_enabled",
+                    "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
                 "sanding_line_spacing":
@@ -5415,6 +5418,7 @@
                     "default_value": 0.1,
                     "minimum_value": "0.001",
                     "maximum_value_warning": "machine_nozzle_tip_outer_diameter",
+                    "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
                 "sanding_flow":
@@ -5427,6 +5431,7 @@
                     "minimum_value": "0",
                     "maximum_value_warning": "50",
                     "enabled": "sanding_enabled",
+                    "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
                 "sanding_inset":
@@ -5440,6 +5445,7 @@
                     "minimum_value_warning": "0",
                     "maximum_value_warning": "wall_line_width_0",
                     "enabled": "sanding_enabled",
+                    "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 }
             }


### PR DESCRIPTION
This implements the basic ironing technique: Just horizontal ironing.

Ironing causes the nozzle to go over the top surface once again while extruding only very little material. This makes the top surface very smooth.

These settings are now in the Experimental category. As far as I'm concerned they can be put in the normal Shell category, since the technique is reliable.

See also the accompanying pull request in the engine: https://github.com/Ultimaker/CuraEngine/pull/534

Implements CURA-3903.