### PR TITLE
Remove debian/ from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,6 @@ cura.desktop
 .pydevproject
 .settings
 
-# Debian packaging
-debian*
-
 #Externally located plug-ins.
 plugins/Doodle3D-cura-plugin
 plugins/GodMode


### PR DESCRIPTION
`gitignore` contains the directory `debian/`, which is normally used for storing Debian packaging information.

This directory is not part of Cura and will probably never be. However, adding it to `gitignore` interferes with out-of-tree modifications, as it will mask changes to files in this directory. This is not a problem for Cura developers, but a major problem for anyone who works with packaging information.

I propose the removal of this directory from `gitignore`. It is the responsibility of all Cura developers to make sure there are not inadvertent commits to the project.

Thank you!