### PR TITLE
[2.6] Don't send extruder stack to CuraEngine when there is only 1 extruder

### DIFF
--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -149,8 +149,9 @@ class StartSliceJob(Job):
             self._buildGlobalSettingsMessage(stack)
             self._buildGlobalInheritsStackMessage(stack)
 
-            for extruder_stack in ExtruderManager.getInstance().getMachineExtruders(stack.getId()):
-                self._buildExtruderMessage(extruder_stack)
+            if stack.getProperty("machine_extruder_count", "value") > 1:
+                for extruder_stack in ExtruderManager.getInstance().getMachineExtruders(stack.getId()):
+                    self._buildExtruderMessage(extruder_stack)
 
             for group in object_groups:
                 group_message = self._slice_message.addRepeatedMessage("object_lists")

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -149,6 +149,8 @@ class StartSliceJob(Job):
             self._buildGlobalSettingsMessage(stack)
             self._buildGlobalInheritsStackMessage(stack)
 
+            # Only add extruder stacks if there are multiple extruders
+            # Single extruder machines only use the global stack to store setting values
             if stack.getProperty("machine_extruder_count", "value") > 1:
                 for extruder_stack in ExtruderManager.getInstance().getMachineExtruders(stack.getId()):
                     self._buildExtruderMessage(extruder_stack)


### PR DESCRIPTION
This PR fixes an issue which causes settings to be ignored if a Custom FDM Printer is used with the number of extruders set to 1. Fixes https://github.com/Ultimaker/Cura/issues/2007

When there is 1 extruder, the frontend stores all settings in the global stack. Sending an extruder stack confuses CuraEngine into using the values of the extruder stack, which results in defaults being used.

Basically, single extrusion Custom FDM Printers are broken at the moment, so if there were a point-release for Cura 2.6 it would be great if this fix could be included.

Steps to reproduce:
* Add a Custom FDM Printer
* Keep number of extruders to 1, keep diameter at 2.85
* Slice an object, and note down the estimated length of material.
* Change the diameter to 1.75 in the sidebar
* Note that after slicing the estimated length has changed
* Save the gcode file, and inspect the last G1 before the end gcode

Expected:
The E-value for the last G1 reflects the changed amount of material

Actual:
The E-value for the last G1 reflects the original amount of material, for 2.85 mm diameter.