### PR TITLE
Fix layerview on small windows

### DIFF
--- a/plugins/LayerView/LayerView.qml
+++ b/plugins/LayerView/LayerView.qml
@@ -11,6 +11,7 @@ import Cura 1.0 as Cura
 
 Item
 {
+    id: base
     width: {
         if (UM.LayerView.compatibilityMode) {
             return UM.Theme.getSize("layerview_menu_size_compatibility").width;
@@ -25,8 +26,12 @@ Item
             return UM.Theme.getSize("layerview_menu_size").height + UM.LayerView.extruderCount * (UM.Theme.getSize("layerview_row").height + UM.Theme.getSize("layerview_row_spacing").height)
         }
     }
+    property var buttonTarget: {
+        var force_binding = parent.y; // ensure this gets reevaluated when the panel moves
+        return base.mapFromItem(parent.parent, parent.buttonTarget.x, parent.buttonTarget.y);
+    }
 
-    Rectangle {
+    UM.PointingRectangle {
         id: layerViewMenu
         anchors.left: parent.left
         anchors.top: parent.top
@@ -34,6 +39,9 @@ Item
         height: parent.height
         z: slider.z - 1
         color: UM.Theme.getColor("tool_panel_background")
+
+        target: parent.buttonTarget
+        arrowSize: UM.Theme.getSize("default_arrow").width
 
         ColumnLayout {
             id: view_settings

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -306,9 +306,12 @@ UM.MainWindow
             {
                 id: view_panel
 
-                anchors.top: viewModeButton.bottom
-                anchors.topMargin: UM.Theme.getSize("default_margin").height;
+                property bool hugBottom: parent.height < viewModeButton.y + viewModeButton.height + height + UM.Theme.getSize("default_margin").height
+
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: hugBottom ? 0 : parent.height - (viewModeButton.y + viewModeButton.height + height + UM.Theme.getSize("default_margin").height)
                 anchors.left: viewModeButton.left;
+                anchors.leftMargin: hugBottom ? viewModeButton.width + UM.Theme.getSize("default_margin").width : 0
 
                 height: childrenRect.height;
 

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -308,10 +308,12 @@ UM.MainWindow
 
                 property bool hugBottom: parent.height < viewModeButton.y + viewModeButton.height + height + UM.Theme.getSize("default_margin").height
 
-                anchors.bottom: parent.bottom
+                anchors.bottom: parent.bottom // panel is always anchored to the bottom only, because dynamically switching between bottom and top results in stretching the height
                 anchors.bottomMargin: hugBottom ? 0 : parent.height - (viewModeButton.y + viewModeButton.height + height + UM.Theme.getSize("default_margin").height)
                 anchors.left: viewModeButton.left;
                 anchors.leftMargin: hugBottom ? viewModeButton.width + UM.Theme.getSize("default_margin").width : 0
+
+                property var buttonTarget: Qt.point(viewModeButton.x + viewModeButton.width / 2, viewModeButton.y + viewModeButton.height / 2)
 
                 height: childrenRect.height;
 


### PR DESCRIPTION
This PR makes the layerview panel hug the bottom, when the window is to small to vertically fit the panel underneath the view mode button.

Fixes #2013 

![image](https://user-images.githubusercontent.com/143551/27435363-4a40b140-575c-11e7-9862-277dd34552b5.png)
