### PR TITLE
Add tab navigation to sidebar

### DIFF
--- a/resources/qml/Settings/SettingCategory.qml
+++ b/resources/qml/Settings/SettingCategory.qml
@@ -14,10 +14,11 @@ Button {
 
     style: UM.Theme.styles.sidebar_category;
 
-    signal showTooltip(string text);
-    signal hideTooltip();
+    signal showTooltip(string text)
+    signal hideTooltip()
     signal contextMenuRequested()
     signal showAllHiddenInheritedSettings(string category_id)
+    signal focusReceived()
 
     text: definition.label
     iconSource: UM.Theme.getIcon(definition.icon)
@@ -25,7 +26,24 @@ Button {
     checkable: true
     checked: definition.expanded
 
-    onClicked: { forceActiveFocus(); definition.expanded ? settingDefinitionsModel.collapse(definition.key) : settingDefinitionsModel.expandAll(definition.key) }
+    onClicked:
+    {
+        forceActiveFocus();
+        if(definition.expanded)
+        {
+            settingDefinitionsModel.collapse(definition.key);
+        } else {
+            settingDefinitionsModel.expandAll(definition.key);
+        }
+    }
+    onActiveFocusChanged:
+    {
+        if(activeFocus)
+        {
+            base.focusReceived();
+        }
+    }
+
     UM.SimpleButton
     {
         id: settingsButton

--- a/resources/qml/Settings/SettingCategory.qml
+++ b/resources/qml/Settings/SettingCategory.qml
@@ -19,6 +19,9 @@ Button {
     signal contextMenuRequested()
     signal showAllHiddenInheritedSettings(string category_id)
     signal focusReceived()
+    signal setActiveFocusToNextSetting(bool forward)
+
+    property var focusItem: base
 
     text: definition.label
     iconSource: UM.Theme.getIcon(definition.icon)
@@ -42,6 +45,15 @@ Button {
         {
             base.focusReceived();
         }
+    }
+
+    Keys.onTabPressed:
+    {
+        base.setActiveFocusToNextSetting(true)
+    }
+    Keys.onBacktabPressed:
+    {
+        base.setActiveFocusToNextSetting(false)
     }
 
     UM.SimpleButton

--- a/resources/qml/Settings/SettingCheckBox.qml
+++ b/resources/qml/Settings/SettingCheckBox.qml
@@ -74,7 +74,7 @@ SettingItem
 
             color:
             {
-                if (!enabled)
+                if(!enabled)
                 {
                     return UM.Theme.getColor("setting_control_disabled")
                 }
@@ -82,14 +82,22 @@ SettingItem
                 {
                     return UM.Theme.getColor("setting_control_highlight")
                 }
-                else
-                {
-                    return UM.Theme.getColor("setting_control")
-                }
+                return UM.Theme.getColor("setting_control")
             }
 
             border.width: UM.Theme.getSize("default_lining").width
-            border.color: !enabled ? UM.Theme.getColor("setting_control_disabled_border") : control.containsMouse ? UM.Theme.getColor("setting_control_border_highlight") : UM.Theme.getColor("setting_control_border")
+            border.color:
+            {
+                if(!enabled)
+                {
+                    return UM.Theme.getColor("setting_control_disabled_border")
+                }
+                if(control.containsMouse || control.activeFocus)
+                {
+                    return UM.Theme.getColor("setting_control_border_highlight")
+                }
+                return UM.Theme.getColor("setting_control_border")
+            }
 
             UM.RecolorImage {
                 anchors.verticalCenter: parent.verticalCenter

--- a/resources/qml/Settings/SettingCheckBox.qml
+++ b/resources/qml/Settings/SettingCheckBox.qml
@@ -62,6 +62,14 @@ SettingItem
             propertyProvider.setPropertyValue("value", !checked);
         }
 
+        onActiveFocusChanged:
+        {
+            if(activeFocus)
+            {
+                base.focusReceived();
+            }
+        }
+
         Rectangle
         {
             anchors

--- a/resources/qml/Settings/SettingCheckBox.qml
+++ b/resources/qml/Settings/SettingCheckBox.qml
@@ -17,6 +17,7 @@ SettingItem
         id: control
         anchors.fill: parent
         hoverEnabled: true
+        activeFocusOnTab: true
 
         property bool checked:
         {
@@ -47,6 +48,12 @@ SettingItem
                 default:
                     return value;
             }
+        }
+
+        Keys.onSpacePressed:
+        {
+            forceActiveFocus();
+            propertyProvider.setPropertyValue("value", !checked);
         }
 
         onClicked:

--- a/resources/qml/Settings/SettingCheckBox.qml
+++ b/resources/qml/Settings/SettingCheckBox.qml
@@ -11,13 +11,13 @@ import UM 1.2 as UM
 SettingItem
 {
     id: base
+    property var focusItem: control
 
     contents: MouseArea
     {
         id: control
         anchors.fill: parent
         hoverEnabled: true
-        activeFocusOnTab: true
 
         property bool checked:
         {
@@ -60,6 +60,15 @@ SettingItem
         {
             forceActiveFocus();
             propertyProvider.setPropertyValue("value", !checked);
+        }
+
+        Keys.onTabPressed:
+        {
+            base.setActiveFocusToNextSetting(true)
+        }
+        Keys.onBacktabPressed:
+        {
+            base.setActiveFocusToNextSetting(false)
         }
 
         onActiveFocusChanged:

--- a/resources/qml/Settings/SettingComboBox.qml
+++ b/resources/qml/Settings/SettingComboBox.qml
@@ -94,7 +94,19 @@ SettingItem
             }
         }
 
-        onActivated: { forceActiveFocus(); propertyProvider.setPropertyValue("value", definition.options[index].key) }
+        onActivated:
+        {
+            forceActiveFocus();
+            propertyProvider.setPropertyValue("value", definition.options[index].key);
+        }
+
+        onActiveFocusChanged:
+        {
+            if(activeFocus)
+            {
+                base.focusReceived();
+            }
+        }
 
         Binding
         {

--- a/resources/qml/Settings/SettingComboBox.qml
+++ b/resources/qml/Settings/SettingComboBox.qml
@@ -10,6 +10,7 @@ import UM 1.1 as UM
 SettingItem
 {
     id: base
+    property var focusItem: control
 
     contents: ComboBox
     {
@@ -106,6 +107,15 @@ SettingItem
             {
                 base.focusReceived();
             }
+        }
+
+        Keys.onTabPressed:
+        {
+            base.setActiveFocusToNextSetting(true)
+        }
+        Keys.onBacktabPressed:
+        {
+            base.setActiveFocusToNextSetting(false)
         }
 
         Binding

--- a/resources/qml/Settings/SettingComboBox.qml
+++ b/resources/qml/Settings/SettingComboBox.qml
@@ -33,21 +33,29 @@ SettingItem
             {
                 color:
                 {
-                    if (!enabled)
+                    if(!enabled)
                     {
                         return UM.Theme.getColor("setting_control_disabled")
                     }
-                    if(control.hovered || base.activeFocus)
+                    if(control.hovered || control.activeFocus)
                     {
                         return UM.Theme.getColor("setting_control_highlight")
                     }
-                    else
-                    {
-                        return UM.Theme.getColor("setting_control")
-                    }
+                    return UM.Theme.getColor("setting_control")
                 }
-                border.width: UM.Theme.getSize("default_lining").width;
-                border.color: !enabled ? UM.Theme.getColor("setting_control_disabled_border") : control.hovered ? UM.Theme.getColor("setting_control_border_highlight") : UM.Theme.getColor("setting_control_border");
+                border.width: UM.Theme.getSize("default_lining").width
+                border.color:
+                {
+                    if(!enabled)
+                    {
+                        return UM.Theme.getColor("setting_control_disabled_border")
+                    }
+                    if(control.hovered || control.activeFocus)
+                    {
+                        return UM.Theme.getColor("setting_control_border_highlight")
+                    }
+                    return UM.Theme.getColor("setting_control_border")
+                }
             }
             label: Item
             {

--- a/resources/qml/Settings/SettingExtruder.qml
+++ b/resources/qml/Settings/SettingExtruder.qml
@@ -27,6 +27,14 @@ SettingItem
             propertyProvider.setPropertyValue("value", model.getItem(index).index);
         }
 
+        onActiveFocusChanged:
+        {
+            if(activeFocus)
+            {
+                base.focusReceived();
+            }
+        }
+
         currentIndex: propertyProvider.properties.value
 
         MouseArea

--- a/resources/qml/Settings/SettingExtruder.qml
+++ b/resources/qml/Settings/SettingExtruder.qml
@@ -53,7 +53,7 @@ SettingItem
             {
                 color:
                 {
-                    if (!enabled)
+                    if(!enabled)
                     {
                         return UM.Theme.getColor("setting_control_disabled");
                     }
@@ -61,23 +61,19 @@ SettingItem
                     {
                         return UM.Theme.getColor("setting_control_highlight");
                     }
-                    else
-                    {
-                        return UM.Theme.getColor("setting_control");
-                    }
+                    return UM.Theme.getColor("setting_control");
                 }
                 border.width: UM.Theme.getSize("default_lining").width
                 border.color:
                 {
                     if(!enabled)
                     {
-                        return UM.Theme.getColor("setting_control_disabled_border");
+                        return UM.Theme.getColor("setting_control_disabled_border")
                     }
-                    if(control.hovered || base.activeFocus)
+                    if(control.hovered || control.activeFocus)
                     {
-                        UM.Theme.getColor("setting_control_border_highlight")
+                        return UM.Theme.getColor("setting_control_border_highlight")
                     }
-
                     return UM.Theme.getColor("setting_control_border")
                 }
             }

--- a/resources/qml/Settings/SettingExtruder.qml
+++ b/resources/qml/Settings/SettingExtruder.qml
@@ -11,6 +11,7 @@ import Cura 1.0 as Cura
 SettingItem
 {
     id: base
+    property var focusItem: control
 
     contents: ComboBox
     {
@@ -33,6 +34,15 @@ SettingItem
             {
                 base.focusReceived();
             }
+        }
+
+        Keys.onTabPressed:
+        {
+            base.setActiveFocusToNextSetting(true)
+        }
+        Keys.onBacktabPressed:
+        {
+            base.setActiveFocusToNextSetting(false)
         }
 
         currentIndex: propertyProvider.properties.value

--- a/resources/qml/Settings/SettingItem.qml
+++ b/resources/qml/Settings/SettingItem.qml
@@ -33,6 +33,7 @@ Item {
     property var stackLevel: stackLevels[0]
 
     signal focusReceived()
+    signal setActiveFocusToNextSetting(bool forward)
     signal contextMenuRequested()
     signal showTooltip(string text)
     signal hideTooltip()

--- a/resources/qml/Settings/SettingItem.qml
+++ b/resources/qml/Settings/SettingItem.qml
@@ -32,9 +32,10 @@ Item {
     property var stackLevels: propertyProvider.stackLevels
     property var stackLevel: stackLevels[0]
 
+    signal focusReceived()
     signal contextMenuRequested()
-    signal showTooltip(string text);
-    signal hideTooltip();
+    signal showTooltip(string text)
+    signal hideTooltip()
     signal showAllHiddenInheritedSettings(string category_id)
     property string tooltipText:
     {

--- a/resources/qml/Settings/SettingOptionalExtruder.qml
+++ b/resources/qml/Settings/SettingOptionalExtruder.qml
@@ -72,31 +72,27 @@ SettingItem
             {
                 color:
                 {
-                    if (!enabled)
+                    if(!enabled)
                     {
                         return UM.Theme.getColor("setting_control_disabled");
                     }
-                    if(control.hovered || base.activeFocus)
+                    if(control.hovered || control.activeFocus)
                     {
                         return UM.Theme.getColor("setting_control_highlight");
                     }
-                    else
-                    {
-                        return UM.Theme.getColor("setting_control");
-                    }
+                    return UM.Theme.getColor("setting_control");
                 }
                 border.width: UM.Theme.getSize("default_lining").width
                 border.color:
                 {
                     if(!enabled)
                     {
-                        return UM.Theme.getColor("setting_control_disabled_border");
+                        return UM.Theme.getColor("setting_control_disabled_border")
                     }
-                    if(control.hovered || base.activeFocus)
+                    if(control.hovered || control.activeFocus)
                     {
-                        UM.Theme.getColor("setting_control_border_highlight")
+                        return UM.Theme.getColor("setting_control_border_highlight")
                     }
-
                     return UM.Theme.getColor("setting_control_border")
                 }
             }

--- a/resources/qml/Settings/SettingOptionalExtruder.qml
+++ b/resources/qml/Settings/SettingOptionalExtruder.qml
@@ -11,6 +11,7 @@ import Cura 1.0 as Cura
 SettingItem
 {
     id: base
+    property var focusItem: control
 
     contents: ComboBox
     {
@@ -37,6 +38,15 @@ SettingItem
             {
                 base.focusReceived();
             }
+        }
+
+        Keys.onTabPressed:
+        {
+            base.setActiveFocusToNextSetting(true)
+        }
+        Keys.onBacktabPressed:
+        {
+            base.setActiveFocusToNextSetting(false)
         }
 
         Binding

--- a/resources/qml/Settings/SettingOptionalExtruder.qml
+++ b/resources/qml/Settings/SettingOptionalExtruder.qml
@@ -31,6 +31,14 @@ SettingItem
             propertyProvider.setPropertyValue("value", model.getItem(index).index);
         }
 
+        onActiveFocusChanged:
+        {
+            if(activeFocus)
+            {
+                base.focusReceived();
+            }
+        }
+
         Binding
         {
             target: control

--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -9,6 +9,7 @@ import UM 1.1 as UM
 SettingItem
 {
     id: base
+    property var focusItem: input
 
     contents: Rectangle
     {
@@ -93,7 +94,15 @@ SettingItem
                 right: parent.right
                 verticalCenter: parent.verticalCenter
             }
-            activeFocusOnTab: true
+
+            Keys.onTabPressed:
+            {
+                base.setActiveFocusToNextSetting(true)
+            }
+            Keys.onBacktabPressed:
+            {
+                base.setActiveFocusToNextSetting(false)
+            }
 
             Keys.onReleased:
             {

--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -17,10 +17,21 @@ SettingItem
         anchors.fill: parent
 
         border.width: UM.Theme.getSize("default_lining").width
-        border.color: !enabled ? UM.Theme.getColor("setting_control_disabled_border") : hovered ? UM.Theme.getColor("setting_control_border_highlight") : UM.Theme.getColor("setting_control_border")
+        border.color:
+        {
+            if(!enabled)
+            {
+                return UM.Theme.getColor("setting_control_disabled_border")
+            }
+            if(hovered || input.activeFocus)
+            {
+                return UM.Theme.getColor("setting_control_border_highlight")
+            }
+            return UM.Theme.getColor("setting_control_border")
+        }
 
         color: {
-            if (!enabled)
+            if(!enabled)
             {
                 return UM.Theme.getColor("setting_control_disabled")
             }

--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -82,6 +82,7 @@ SettingItem
                 right: parent.right
                 verticalCenter: parent.verticalCenter
             }
+            activeFocusOnTab: true
 
             Keys.onReleased:
             {

--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -105,6 +105,14 @@ SettingItem
                 propertyProvider.setPropertyValue("value", text)
             }
 
+            onActiveFocusChanged:
+            {
+                if(activeFocus)
+                {
+                    base.focusReceived();
+                }
+            }
+
             color: !enabled ? UM.Theme.getColor("setting_control_disabled_text") : UM.Theme.getColor("setting_control_text")
             font: UM.Theme.getFont("default");
 

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -300,12 +300,22 @@ Item
                     }
                     onFocusReceived:
                     {
+                        animateContentY.from = contents.contentY;
                         contents.positionViewAtIndex(index, ListView.Contain);
+                        animateContentY.to = contents.contentY;
+                        animateContentY.running = true;
                     }
                 }
             }
 
             UM.I18nCatalog { id: catalog; name: "cura"; }
+
+            NumberAnimation {
+                id: animateContentY
+                target: contents
+                property: "contentY"
+                duration: 50
+            }
 
             add: Transition {
                 SequentialAnimation {

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -298,6 +298,10 @@ Item
                         }
                         Cura.SettingInheritanceManager.manualRemoveOverride(category_id)
                     }
+                    onFocusReceived:
+                    {
+                        contents.positionViewAtIndex(index, ListView.Contain);
+                    }
                 }
             }
 

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -168,6 +168,8 @@ Item
                 onVisibilityChanged: Cura.SettingInheritanceManager.forceUpdate()
             }
 
+            property var indexWithFocus: -1
+
             delegate: Loader
             {
                 id: delegate
@@ -300,10 +302,38 @@ Item
                     }
                     onFocusReceived:
                     {
+                        contents.indexWithFocus = index;
                         animateContentY.from = contents.contentY;
                         contents.positionViewAtIndex(index, ListView.Contain);
                         animateContentY.to = contents.contentY;
                         animateContentY.running = true;
+                    }
+                    onSetActiveFocusToNextSetting:
+                    {
+                        if(forward == undefined || forward)
+                        {
+                            contents.currentIndex = contents.indexWithFocus + 1;
+                            while(contents.currentItem && contents.currentItem.height <= 0)
+                            {
+                                contents.currentIndex++;
+                            }
+                            if(contents.currentItem)
+                            {
+                                contents.currentItem.item.focusItem.forceActiveFocus();
+                            }
+                        }
+                        else
+                        {
+                            contents.currentIndex = contents.indexWithFocus - 1;
+                            while(contents.currentItem && contents.currentItem.height <= 0)
+                            {
+                                contents.currentIndex--;
+                            }
+                            if(contents.currentItem)
+                            {
+                                contents.currentItem.item.focusItem.forceActiveFocus();
+                            }
+                        }
                     }
                 }
             }

--- a/resources/themes/cura/styles.qml
+++ b/resources/themes/cura/styles.qml
@@ -368,11 +368,11 @@ QtObject {
                     color: {
                         if(!control.enabled) {
                             return Theme.getColor("setting_category_disabled_border");
-                        } else if(control.hovered && control.checkable && control.checked) {
+                        } else if((control.hovered || control.activeFocus) && control.checkable && control.checked) {
                             return Theme.getColor("setting_category_active_hover_border");
                         } else if(control.pressed || (control.checkable && control.checked)) {
                             return Theme.getColor("setting_category_active_border");
-                        } else if(control.hovered) {
+                        } else if(control.hovered || control.activeFocus) {
                             return Theme.getColor("setting_category_hover_border");
                         } else {
                             return Theme.getColor("setting_category_border");
@@ -508,7 +508,7 @@ QtObject {
             {
                 color:
                 {
-                    if (!enabled)
+                    if(!enabled)
                     {
                         return UM.Theme.getColor("setting_control_disabled");
                     }


### PR DESCRIPTION
This PR adds tab-navigation between fields in the (custom) sidebar; it allows the user to tab/shift-tab between fields in the sidebar, making it quicker to make changes. Checkbox items can be operated with the spacebar, as can category headers. Comboboxes can be operated by the spacebar and/or up/down cursor keys.