### PR TITLE
Refactor gcode flavors to better match the target firmwares

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -303,9 +303,9 @@
                     "type": "enum",
                     "options":
                     {
-                        "RepRap (Marlin/Sprinter)": "RepRap (Marlin/Sprinter)",
-                        "RepRap (RepRap)": "RepRap (RepRap)",
-                        "RepRap (Volumatric)": "RepRap (Volumetric)",
+                        "RepRap (Marlin/Sprinter)": "Marlin",
+                        "RepRap (Volumatric)": "Marlin (Volumetric)",
+                        "RepRap (RepRap)": "RepRap",
                         "UltiGCode": "Ultimaker 2",
                         "Griffin": "Griffin",
                         "Makerbot": "Makerbot",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -304,6 +304,7 @@
                     "options":
                     {
                         "RepRap (Marlin/Sprinter)": "RepRap (Marlin/Sprinter)",
+                        "RepRap (RepRap)": "RepRap (RepRap)",
                         "RepRap (Volumatric)": "RepRap (Volumetric)",
                         "UltiGCode": "Ultimaker 2",
                         "Griffin": "Griffin",


### PR DESCRIPTION
Due to the incompatibility of legacy Marlin gcode with the gcode that is supported by RepRap firmwares (as used by the Duet family of controllers), this new gcode flavor has been created to support the latter.
I don't think it should be called "RepRap (Duet)" because that ties it to a particular product. Instead, I think it should be "RepRap (RepRap)" so that it can be applicable to all firmwares that are based on the RepRap source (that is until they diverge!)