### PR TITLE
Speed up sidebar-settings scrolling

### DIFF
--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -142,6 +142,7 @@ Item
 
         style: UM.Theme.styles.scrollview;
         flickableItem.flickableDirection: Flickable.VerticalFlick;
+        __wheelAreaScrollSpeed: 75; // Scroll three lines in one scroll event
 
         ListView
         {


### PR DESCRIPTION
Scrolling the sidebar feels rather slow one line at a time (at least when using the scroll wheel; my Ubuntu laptop is able to use the "fling" mechanics with the touchpad).

This PR adjusts the scroll to be three lines/rows at once (the default scroll speed in Windows). If it seems a bit too fast, two lines (`50`) would be my fallback.

Comparison GIFs:
#### Old scroll (requiring much wheel spinning)
![2017-07-06_16-08-09](https://user-images.githubusercontent.com/18742096/27912474-bba13242-6265-11e7-9a4a-1d26d077736b.gif)

#### New scroll (fast & easy on your wheel-finger)
![2017-07-06_16-06-34](https://user-images.githubusercontent.com/18742096/27912346-3c10baf2-6265-11e7-9da9-4c7e911b8555.gif)
