### PR TITLE
Improve plugin browser ui

### DIFF
--- a/plugins/PluginBrowser/PluginBrowser.py
+++ b/plugins/PluginBrowser/PluginBrowser.py
@@ -141,6 +141,17 @@ class PluginBrowser(QObject, Extension):
         self.setIsDownloading(True)
         self._download_plugin_reply.downloadProgress.connect(self._onDownloadPluginProgress)
 
+    @pyqtSlot()
+    def cancelDownload(self):
+        Logger.log("i", "user cancelled the download of a plugin")
+        self._download_plugin_reply.abort()
+        self._download_plugin_reply.downloadProgress.disconnect(self._onDownloadPluginProgress)
+        self._download_plugin_reply = None
+        self._download_plugin_request = None
+
+        self.setDownloadProgress(0)
+        self.setIsDownloading(False)
+
     @pyqtProperty(QObject, notify=pluginsMetadataChanged)
     def pluginsModel(self):
         if self._plugins_model is None:

--- a/plugins/PluginBrowser/PluginBrowser.qml
+++ b/plugins/PluginBrowser/PluginBrowser.qml
@@ -67,7 +67,7 @@ UM.Dialog
                 anchors.left:parent.left
                 anchors.right: closeButton.left
                 anchors.rightMargin: UM.Theme.getSize("default_margin").width
-                value: manager.downloadProgress
+                value: manager.isDownloading ? manager.downloadProgress : 0
             }
 
             Button
@@ -121,7 +121,18 @@ UM.Dialog
                     Button
                     {
                         id: downloadButton
-                        text: (model.already_installed && model.can_upgrade) ? catalog.i18nc("@action:button", "Upgrade") : catalog.i18nc("@action:button", "Download")
+                        text:
+                        {
+                            if (model.already_installed)
+                            {
+                                if (model.can_upgrade)
+                                {
+                                    return catalog.i18nc("@action:button", "Upgrade");
+                                }
+                                return catalog.i18nc("@action:button", "Installed");
+                            }
+                            return catalog.i18nc("@action:button", "Download");
+                        }
                         onClicked: manager.downloadAndInstallPlugin(model.file_location)
                         anchors.right: parent.right
                         anchors.rightMargin: UM.Theme.getSize("default_margin").width

--- a/plugins/PluginBrowser/PluginBrowser.qml
+++ b/plugins/PluginBrowser/PluginBrowser.qml
@@ -62,13 +62,11 @@ UM.Dialog
             {
                 id: progressbar
                 anchors.bottom: parent.bottom
-                style: UM.Theme.styles.progressbar
                 minimumValue: 0;
                 maximumValue: 100
                 anchors.left:parent.left
                 anchors.right: closeButton.left
                 anchors.rightMargin: UM.Theme.getSize("default_margin").width
-                height: 10
                 value: manager.downloadProgress
             }
 


### PR DESCRIPTION
This PR improves the plugin browser UI in a couple of ways:
* Uses a proper system-styled progress bar instead of a Cura-styled progressbar, since the dialog uses the system style
* Adds a way to cancel long downloads and properly cancels download when closing the window during a download
* Shows why a download button is disabled when a plugin is already installed 

It would be nice to be able to open the plugin browser through the Plugins page of the preferences, but that is tricky because that is a Uranium page and Uranium does not know about the Plugin Browser.