### PR TITLE
Add tooltips to Machine Settings and fix setting diameter

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsAction.py
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.py
@@ -30,7 +30,6 @@ class MachineSettingsAction(MachineAction):
 
         self._global_container_stack = None
         self._container_index = 0
-        self._extruder_container_index = 0
 
         self._container_registry = ContainerRegistry.getInstance()
         self._container_registry.containerAdded.connect(self._onContainerAdded)
@@ -91,12 +90,6 @@ class MachineSettingsAction(MachineAction):
         if definition_changes_container == self._empty_container:
             definition_changes_container = self._createDefinitionChangesContainer(extruder_container_stack, extruder_container_stack.getId() + "_settings")
 
-        # Notify the UI in which container to store the machine settings data
-        container_index = extruder_container_stack.getContainerIndex(definition_changes_container)
-        if container_index != self._extruder_container_index:
-            self._extruder_container_index = container_index
-            self.extruderContainerIndexChanged.emit()
-
     def _createDefinitionChangesContainer(self, container_stack, container_name, container_index = None):
         definition_changes_container = InstanceContainer(container_name)
         definition = container_stack.getBottom()
@@ -114,13 +107,6 @@ class MachineSettingsAction(MachineAction):
     @pyqtProperty(int, notify = containerIndexChanged)
     def containerIndex(self):
         return self._container_index
-
-    extruderContainerIndexChanged = pyqtSignal()
-
-    @pyqtProperty(int, notify = extruderContainerIndexChanged)
-    def extruderContainerIndex(self):
-        return self._extruder_container_index
-
 
     def _onGlobalContainerChanged(self):
         self._global_container_stack = Application.getInstance().getGlobalContainerStack()

--- a/plugins/MachineSettingsAction/MachineSettingsAction.py
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.py
@@ -257,7 +257,6 @@ class MachineSettingsAction(MachineAction):
         has_materials = self._global_container_stack.getProperty("machine_gcode_flavor", "value") != "UltiGCode"
 
         material_container = self._global_container_stack.material
-        material_index = self._global_container_stack.getContainerIndex(material_container)
 
         if has_materials:
             if "has_materials" in self._global_container_stack.getMetaData():
@@ -266,11 +265,11 @@ class MachineSettingsAction(MachineAction):
                 self._global_container_stack.addMetaDataEntry("has_materials", True)
 
             # Set the material container to a sane default
-            if material_container.getId() == "empty_material":
-                search_criteria = { "type": "material", "definition": "fdmprinter", "id": "*pla*"}
-                containers = self._container_registry.findInstanceContainers(**search_criteria)
-                if containers:
-                    self._global_container_stack.replaceContainer(material_index, containers[0])
+            if material_container.getId() == "empty":
+                search_criteria = { "type": "material", "definition": "fdmprinter", "id": self._global_container_stack.getMetaDataEntry("preferred_material")}
+                materials = self._container_registry.findInstanceContainers(**search_criteria)
+                if materials:
+                    self._global_container_stack.material = materials[0]
         else:
             # The metadata entry is stored in an ini, and ini files are parsed as strings only.
             # Because any non-empty string evaluates to a boolean True, we have to remove the entry to make it False.

--- a/plugins/MachineSettingsAction/MachineSettingsAction.py
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.py
@@ -48,8 +48,8 @@ class MachineSettingsAction(MachineAction):
     def _onContainerRemoved(self, container):
         # Remove definition_changes containers when a stack is removed
         if container.getMetaDataEntry("type") in ["machine", "extruder_train"]:
-            definition_changes_container = container.findContainer({"type": "definition_changes"})
-            if not definition_changes_container:
+            definition_changes_container = container.definitionChanges
+            if definition_changes_container.id == "empty":
                 return
 
             self._container_registry.removeContainer(definition_changes_container.getId())
@@ -59,8 +59,8 @@ class MachineSettingsAction(MachineAction):
             return
 
         # Make sure there is a definition_changes container to store the machine settings
-        definition_changes_container = self._global_container_stack.findContainer({"type": "definition_changes"})
-        if not definition_changes_container:
+        definition_changes_container = self._global_container_stack.definitionChanges
+        if definition_changes_container.id == "empty":
             definition_changes_container = self._createDefinitionChangesContainer(self._global_container_stack, self._global_container_stack.getName() + "_settings")
 
         # Notify the UI in which container to store the machine settings data
@@ -85,8 +85,8 @@ class MachineSettingsAction(MachineAction):
             return
 
         # Make sure there is a definition_changes container to store the machine settings
-        definition_changes_container = extruder_container_stack.findContainer({"type": "definition_changes"})
-        if not definition_changes_container:
+        definition_changes_container = extruder_container_stack.definitionChanges
+        if definition_changes_container.id == "empty":
             definition_changes_container = self._createDefinitionChangesContainer(extruder_container_stack, extruder_container_stack.getId() + "_settings")
 
         # Notify the UI in which container to store the machine settings data
@@ -140,8 +140,8 @@ class MachineSettingsAction(MachineAction):
         machine_manager = Application.getInstance().getMachineManager()
         extruder_manager = ExtruderManager.getInstance()
 
-        definition_changes_container = self._global_container_stack.findContainer({"type": "definition_changes"})
-        if not self._global_container_stack or not definition_changes_container:
+        definition_changes_container = self._global_container_stack.definitionChanges
+        if not self._global_container_stack or definition_changes_container.id == "empty":
             return
 
         previous_extruder_count = self._global_container_stack.getProperty("machine_extruder_count", "value")

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -135,27 +135,23 @@ Cura.MachineAction
                                     property string unit: catalog.i18nc("@label", "mm")
                                     property bool forceUpdateOnChange: true
                                 }
-                            }
 
-                            Column
-                            {
-                                Row
+                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+
+                                Label
                                 {
-                                    spacing: UM.Theme.getSize("default_margin").width
-
-                                    Label
-                                    {
-                                        text: catalog.i18nc("@label", "Build Plate Shape")
-                                    }
-
-                                    Loader
-                                    {
-                                        id: shapeComboBox
-                                        sourceComponent: comboBoxWithOptions
-                                        property string settingKey: "machine_shape"
-                                        property bool forceUpdateOnChange: true
-                                    }
+                                    text: catalog.i18nc("@label", "Build Plate Shape")
                                 }
+
+                                Loader
+                                {
+                                    id: shapeComboBox
+                                    sourceComponent: comboBoxWithOptions
+                                    property string settingKey: "machine_shape"
+                                    property bool forceUpdateOnChange: true
+                                }
+
                                 Loader
                                 {
                                     id: centerIsZeroCheckBox
@@ -164,6 +160,7 @@ Cura.MachineAction
                                     property string settingKey: "machine_center_is_zero"
                                     property bool forceUpdateOnChange: true
                                 }
+                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
                                 Loader
                                 {
                                     id: heatedBedCheckBox
@@ -172,11 +169,10 @@ Cura.MachineAction
                                     property var settingKey: "machine_heated_bed"
                                     property bool forceUpdateOnChange: true
                                 }
-                            }
+                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
 
-                            Row
-                            {
-                                spacing: UM.Theme.getSize("default_margin").width
+                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
 
                                 Label
                                 {

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -31,11 +31,17 @@ Cura.MachineAction
         target: dialog ? dialog : null
         ignoreUnknownSignals: true
         // Any which way this action dialog is dismissed, make sure it is properly finished
-        onNextClicked: manager.onFinishAction()
-        onBackClicked: manager.onFinishAction()
-        onAccepted: manager.onFinishAction()
-        onRejected: manager.onFinishAction()
-        onClosing: manager.onFinishAction()
+        onNextClicked: finishAction()
+        onBackClicked: finishAction()
+        onAccepted: finishAction()
+        onRejected: finishAction()
+        onClosing: finishAction()
+    }
+
+    function finishAction()
+    {
+        forceActiveFocus();
+        manager.onFinishAction();
     }
 
     anchors.fill: parent;

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -285,28 +285,36 @@ Cura.MachineAction
                                 Label
                                 {
                                     text: catalog.i18nc("@label", "Number of Extruders")
-                                    visible: extruderCountComboBox.visible
+                                    visible: extruderCountControl.visible
                                 }
 
-                                ComboBox
+                                UM.TooltipArea
                                 {
-                                    id: extruderCountComboBox
+                                    id: extruderCountControl
                                     visible: manager.definedExtruderCount > 1
-                                    model: ListModel
+                                    height: extruderCountComboBox.height
+                                    width: extruderCountComboBox.width
+                                    text: machineExtruderCountProvider.properties.description
+
+                                    ComboBox
                                     {
-                                        id: extruderCountModel
-                                        Component.onCompleted:
+                                        id: extruderCountComboBox
+                                        model: ListModel
                                         {
-                                            for(var i = 0; i < manager.definedExtruderCount; i++)
+                                            id: extruderCountModel
+                                            Component.onCompleted:
                                             {
-                                                extruderCountModel.append({text: String(i + 1), value: i});
+                                                for(var i = 0; i < manager.definedExtruderCount; i++)
+                                                {
+                                                    extruderCountModel.append({text: String(i + 1), value: i});
+                                                }
                                             }
                                         }
-                                    }
-                                    currentIndex: machineExtruderCountProvider.properties.value - 1
-                                    onActivated:
-                                    {
-                                        manager.setMachineExtruderCount(index + 1);
+                                        currentIndex: machineExtruderCountProvider.properties.value - 1
+                                        onActivated:
+                                        {
+                                            manager.setMachineExtruderCount(index + 1);
+                                        }
                                     }
                                 }
 
@@ -867,7 +875,7 @@ Cura.MachineAction
 
         containerStackId: Cura.MachineManager.activeMachineId
         key: "machine_head_with_fans_polygon"
-        watchedProperties: [ "value", "description" ]
+        watchedProperties: [ "value" ]
         storeIndex: manager.containerIndex
     }
 }

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -320,7 +320,8 @@ Cura.MachineAction
                                     sourceComponent: numericTextFieldWithUnit
                                     property string settingKey: "material_diameter"
                                     property string unit: catalog.i18nc("@label", "mm")
-                                    property string tooltip: catalog.i18nc("@tooltip", "The nominal diameter of filament supported by the printer.")
+                                    property string tooltip: catalog.i18nc("@tooltip", "The nominal diameter of filament supported by the printer. The exact diameter will be overridden by the material and/or the profile.")
+                                    property string afterOnEditingFinished: "manager.updateMaterialForDiameter()"
                                 }
                                 Label
                                 {
@@ -578,6 +579,7 @@ Cura.MachineAction
 
             property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _allowNegative: (typeof(allowNegative) === 'undefined') ? false : allowNegative
+            property string _afterOnEditingFinished: (typeof(afterOnEditingFinished) === 'undefined') ? "": afterOnEditingFinished
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
             property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
@@ -619,6 +621,10 @@ Cura.MachineAction
                             {
                                 ExtruderManager.setActiveExtruderIndex(extruderIndex)
                             }
+                        }
+                        if(_afterOnEditingFinished != "")
+                        {
+                            eval(_afterOnEditingFinished);
                         }
                     }
                 }

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -41,7 +41,7 @@ Cura.MachineAction
     anchors.fill: parent;
     Item
     {
-        id: bedLevelMachineAction
+        id: machineSettingsAction
         anchors.fill: parent;
 
         UM.I18nCatalog { id: catalog; name: "cura"; }
@@ -233,7 +233,6 @@ Cura.MachineAction
 
                             UM.TooltipArea
                             {
-                                id: extruderCountControl
                                 visible: manager.definedExtruderCount > 1
                                 height: childrenRect.height
                                 width: childrenRect.width
@@ -246,6 +245,8 @@ Cura.MachineAction
                                     Label
                                     {
                                         text: catalog.i18nc("@label", "Number of Extruders")
+                                        elide: Text.ElideRight
+                                        width: Math.max(0, settingsTabs.columnWidth - 2 * UM.Theme.getSize("default_margin").width - extruderCountComboBox.width)
                                         anchors.verticalCenter: extruderCountComboBox.verticalCenter
                                     }
                                     ComboBox
@@ -553,6 +554,8 @@ Cura.MachineAction
                 {
                     text: _label
                     visible: _label != ""
+                    elide: Text.ElideRight
+                    width: Math.max(0, settingsTabs.columnWidth - 2 * UM.Theme.getSize("default_margin").width - textFieldWithUnit.width)
                     anchors.verticalCenter: textFieldWithUnit.verticalCenter
                 }
 
@@ -644,7 +647,9 @@ Cura.MachineAction
                 {
                     text: _label
                     visible: _label != ""
-                    anchors.verticalCenter: textFieldWithUnit.verticalCenter
+                    elide: Text.ElideRight
+                    width: Math.max(0, settingsTabs.columnWidth - 2 * UM.Theme.getSize("default_margin").width - comboBox.width)
+                    anchors.verticalCenter: comboBox.verticalCenter
                 }
                 ComboBox
                 {
@@ -774,11 +779,14 @@ Cura.MachineAction
                 {
                     text: _label
                     visible: _label != ""
+                    elide: Text.ElideRight
+                    width: Math.max(0, settingsTabs.columnWidth - 2 * UM.Theme.getSize("default_margin").width - textFieldWithUnit.width)
                     anchors.verticalCenter: textFieldWithUnit.verticalCenter
                 }
 
                 Item
                 {
+                    id: textFieldWithUnit
                     width: textField.width
                     height: textField.height
 

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -221,7 +221,7 @@ Cura.MachineAction
                                     sourceComponent: headPolygonTextField
                                     property string axis: "x"
                                     property string side: "min"
-                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the left of the printhead to the center of the nozzle. Used to prevent colissions between the print and the printhead.")
+                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the left of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
                                 }
 
                                 Label
@@ -234,7 +234,7 @@ Cura.MachineAction
                                     sourceComponent: headPolygonTextField
                                     property string axis: "y"
                                     property string side: "min"
-                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the front of the printhead to the center of the nozzle. Used to prevent colissions between the print and the printhead.")
+                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the front of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
                                 }
 
                                 Label
@@ -247,7 +247,7 @@ Cura.MachineAction
                                     sourceComponent: headPolygonTextField
                                     property string axis: "x"
                                     property string side: "max"
-                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the right of the printhead to the center of the nozzle. Used to prevent colissions between the print and the printhead.")
+                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the right of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
                                 }
 
                                 Label
@@ -260,7 +260,7 @@ Cura.MachineAction
                                     sourceComponent: headPolygonTextField
                                     property string axis: "y"
                                     property string side: "max"
-                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the rear of the printhead to the center of the nozzle. Used to prevent colissions between the print and the printhead.")
+                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the rear of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
                                 }
 
                                 Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
@@ -276,6 +276,7 @@ Cura.MachineAction
                                     sourceComponent: numericTextFieldWithUnit
                                     property string settingKey: "gantry_height"
                                     property string unit: catalog.i18nc("@label", "mm")
+                                    property string tooltip: catalog.i18nc("@tooltip", "The height difference between the tip of the nozzle and the gantry system (X and Y axes). Used to prevent collisions between previous prints and the gantry when printing \"One at a Time\".")
                                 }
 
                                 Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
@@ -319,6 +320,7 @@ Cura.MachineAction
                                     sourceComponent: numericTextFieldWithUnit
                                     property string settingKey: "material_diameter"
                                     property string unit: catalog.i18nc("@label", "mm")
+                                    property string tooltip: catalog.i18nc("@tooltip", "The nominal diameter of filament supported by the printer.")
                                 }
                                 Label
                                 {
@@ -359,6 +361,7 @@ Cura.MachineAction
                                 property int areaWidth: parent.width
                                 property int areaHeight: parent.height - y
                                 property string settingKey: "machine_start_gcode"
+                                property string tooltip: catalog.i18nc("@tooltip", "Gcode commands to be executed at the very start.")
                             }
                         }
 
@@ -377,6 +380,7 @@ Cura.MachineAction
                                 property int areaWidth: parent.width
                                 property int areaHeight: parent.height - y
                                 property string settingKey: "machine_end_gcode"
+                                property string tooltip: catalog.i18nc("@tooltip", "Gcode commands to be executed at the very end.")
                             }
                         }
                     }
@@ -520,10 +524,11 @@ Cura.MachineAction
         {
             height: checkBox.height
             width: checkBox.width
-            text: propertyProvider.properties.description
+            text: _tooltip
 
             property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
+            property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
             UM.SettingPropertyProvider
             {
@@ -569,11 +574,12 @@ Cura.MachineAction
         {
             height: textField.height
             width: textField.width
-            text: propertyProvider.properties.description
+            text: _tooltip
 
             property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _allowNegative: (typeof(allowNegative) === 'undefined') ? false : allowNegative
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
+            property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
             UM.SettingPropertyProvider
             {
@@ -635,11 +641,12 @@ Cura.MachineAction
         {
             height: comboBox.height
             width: comboBox.width
-            text: propertyProvider.properties.description
+            text: _tooltip
 
             property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
             property string _afterOnActivate: (typeof(afterOnActivate) === 'undefined') ? "": afterOnActivate
+            property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
             UM.SettingPropertyProvider
             {
@@ -722,9 +729,10 @@ Cura.MachineAction
         {
             height: gcodeArea.height
             width: gcodeArea.width
-            text: propertyProvider.properties.description
+            text: _tooltip
 
             property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
+            property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
             UM.SettingPropertyProvider
             {

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -348,24 +348,13 @@ Cura.MachineAction
                                 text: catalog.i18nc("@label", "Start Gcode")
                                 font.bold: true
                             }
-                            TextArea
+                            Loader
                             {
                                 id: machineStartGcodeField
-                                width: parent.width
-                                height: parent.height - y
-                                font: UM.Theme.getFont("fixed")
-                                text: machineStartGcodeProvider.properties.value
-                                onActiveFocusChanged:
-                                {
-                                    if(!activeFocus)
-                                    {
-                                        machineStartGcodeProvider.setPropertyValue("value", machineStartGcodeField.text)
-                                    }
-                                }
-                                Component.onCompleted:
-                                {
-                                    wrapMode = TextEdit.NoWrap;
-                                }
+                                sourceComponent: gcodeTextArea
+                                property int areaWidth: parent.width
+                                property int areaHeight: parent.height - y
+                                property string settingKey: "machine_start_gcode"
                             }
                         }
 
@@ -377,24 +366,13 @@ Cura.MachineAction
                                 text: catalog.i18nc("@label", "End Gcode")
                                 font.bold: true
                             }
-                            TextArea
+                            Loader
                             {
                                 id: machineEndGcodeField
-                                width: parent.width
-                                height: parent.height - y
-                                font: UM.Theme.getFont("fixed")
-                                text: machineEndGcodeProvider.properties.value
-                                onActiveFocusChanged:
-                                {
-                                    if(!activeFocus)
-                                    {
-                                        machineEndGcodeProvider.setPropertyValue("value", machineEndGcodeField.text)
-                                    }
-                                }
-                                Component.onCompleted:
-                                {
-                                    wrapMode = TextEdit.NoWrap;
-                                }
+                                sourceComponent: gcodeTextArea
+                                property int areaWidth: parent.width
+                                property int areaHeight: parent.height - y
+                                property string settingKey: "machine_end_gcode"
                             }
                         }
                     }
@@ -526,25 +504,15 @@ Cura.MachineAction
                                     text: catalog.i18nc("@label", "Extruder Start Gcode")
                                     font.bold: true
                                 }
-                                TextArea
+                                Loader
                                 {
                                     id: extruderStartGcodeField
-                                    width: parent.width
-                                    height: parent.height - y
-                                    font: UM.Theme.getFont("fixed")
-                                    text: (extruderStartGcodeProvider.properties.value) ? extruderStartGcodeProvider.properties.value : ""
-                                    onActiveFocusChanged:
-                                    {
-                                        if(!activeFocus)
-                                        {
-                                            extruderStartGcodeProvider.setPropertyValue("value", extruderStartGcodeField.text)
-                                        }
-                                    }
-                                    Component.onCompleted:
-                                    {
-                                        wrapMode = TextEdit.NoWrap;
-                                    }
-                                }
+                                    sourceComponent: gcodeTextArea
+                                    property int areaWidth: parent.width
+                                    property int areaHeight: parent.height - y
+                                    property string settingKey: "machine_extruder_start_code"
+                                    property bool isExtruderSetting: true
+                            }
                             }
                             Column {
                                 height: parent.height
@@ -554,24 +522,14 @@ Cura.MachineAction
                                     text: catalog.i18nc("@label", "Extruder End Gcode")
                                     font.bold: true
                                 }
-                                TextArea
+                                Loader
                                 {
                                     id: extruderEndGcodeField
-                                    width: parent.width
-                                    height: parent.height - y
-                                    font: UM.Theme.getFont("fixed")
-                                    text: (extruderEndGcodeProvider.properties.value) ? extruderEndGcodeProvider.properties.value : ""
-                                    onActiveFocusChanged:
-                                    {
-                                        if(!activeFocus)
-                                        {
-                                            extruderEndGcodeProvider.setPropertyValue("value", extruderEndGcodeField.text)
-                                        }
-                                    }
-                                    Component.onCompleted:
-                                    {
-                                        wrapMode = TextEdit.NoWrap;
-                                    }
+                                    sourceComponent: gcodeTextArea
+                                    property int areaWidth: parent.width
+                                    property int areaHeight: parent.height - y
+                                    property string settingKey: "machine_extruder_end_code"
+                                    property bool isExtruderSetting: true
                                 }
                             }
                         }
@@ -782,6 +740,60 @@ Cura.MachineAction
         }
     }
 
+    Component
+    {
+        id: gcodeTextArea
+
+        UM.TooltipArea
+        {
+            height: gcodeArea.height
+            width: gcodeArea.width
+            text: propertyProvider.properties.description
+
+            property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
+
+            UM.SettingPropertyProvider
+            {
+                id: propertyProvider
+
+                containerStackId: {
+                    if(_isExtruderSetting)
+                    {
+                        if(settingsTabs.currentIndex > 0)
+                        {
+                            return Cura.MachineManager.activeStackId;
+                        }
+                        return "";
+                    }
+                    return Cura.MachineManager.activeMachineId;
+                }
+                key: settingKey
+                watchedProperties: [ "value", "description" ]
+                storeIndex: manager.containerIndex
+            }
+
+            TextArea
+            {
+                id: gcodeArea
+                width: areaWidth
+                height: areaHeight
+                font: UM.Theme.getFont("fixed")
+                text: (propertyProvider.properties.value) ? propertyProvider.properties.value : ""
+                onActiveFocusChanged:
+                {
+                    if(!activeFocus)
+                    {
+                        propertyProvider.setPropertyValue("value", gcodeField.text)
+                    }
+                }
+                Component.onCompleted:
+                {
+                    wrapMode = TextEdit.NoWrap;
+                }
+            }
+        }
+    }
+
     UM.SettingPropertyProvider
     {
         id: machineExtruderCountProvider
@@ -798,47 +810,6 @@ Cura.MachineAction
 
         containerStackId: Cura.MachineManager.activeMachineId
         key: "machine_head_with_fans_polygon"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-
-    UM.SettingPropertyProvider
-    {
-        id: machineStartGcodeProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_start_gcode"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: machineEndGcodeProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_end_gcode"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: extruderStartGcodeProvider
-
-        containerStackId: settingsTabs.currentIndex > 0 ? Cura.MachineManager.activeStackId : ""
-        key: "machine_extruder_start_code"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: extruderEndGcodeProvider
-
-        containerStackId: settingsTabs.currentIndex > 0 ? Cura.MachineManager.activeStackId : ""
-        key: "machine_extruder_end_code"
         watchedProperties: [ "value", "description" ]
         storeIndex: manager.containerIndex
     }

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -83,7 +83,7 @@ Cura.MachineAction
                         Column
                         {
                             width: settingsTabs.columnWidth
-                            spacing: UM.Theme.getSize("default_margin").height
+                            spacing: UM.Theme.getSize("default_lining").height
 
                             Label
                             {
@@ -91,109 +91,83 @@ Cura.MachineAction
                                 font.bold: true
                             }
 
-                            Grid
+                            Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+
+                            Loader
                             {
-                                columns: 2
-                                columnSpacing: UM.Theme.getSize("default_margin").width
-                                rowSpacing: UM.Theme.getSize("default_lining").width
+                                id: buildAreaWidthField
+                                sourceComponent: numericTextFieldWithUnit
+                                property string settingKey: "machine_width"
+                                property string label: catalog.i18nc("@label", "X (Width)")
+                                property string unit: catalog.i18nc("@label", "mm")
+                                property bool forceUpdateOnChange: true
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "X (Width)")
-                                }
-                                Loader
-                                {
-                                    id: buildAreaWidthField
-                                    sourceComponent: numericTextFieldWithUnit
-                                    property string settingKey: "machine_width"
-                                    property string unit: catalog.i18nc("@label", "mm")
-                                    property bool forceUpdateOnChange: true
-                                }
+                            Loader
+                            {
+                                id: buildAreaDepthField
+                                sourceComponent: numericTextFieldWithUnit
+                                property string settingKey: "machine_depth"
+                                property string label: catalog.i18nc("@label", "Y (Depth)")
+                                property string unit: catalog.i18nc("@label", "mm")
+                                property bool forceUpdateOnChange: true
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "Y (Depth)")
-                                }
-                                Loader
-                                {
-                                    id: buildAreaDepthField
-                                    sourceComponent: numericTextFieldWithUnit
-                                    property string settingKey: "machine_depth"
-                                    property string unit: catalog.i18nc("@label", "mm")
-                                    property bool forceUpdateOnChange: true
-                                }
+                            Loader
+                            {
+                                id: buildAreaHeightField
+                                sourceComponent: numericTextFieldWithUnit
+                                property string settingKey: "machine_height"
+                                property string label: catalog.i18nc("@label", "Z (Height)")
+                                property string unit: catalog.i18nc("@label", "mm")
+                                property bool forceUpdateOnChange: true
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "Z (Height)")
-                                }
-                                Loader
-                                {
-                                    id: buildAreaHeightField
-                                    sourceComponent: numericTextFieldWithUnit
-                                    property string settingKey: "machine_height"
-                                    property string unit: catalog.i18nc("@label", "mm")
-                                    property bool forceUpdateOnChange: true
-                                }
+                            Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
 
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+                            Loader
+                            {
+                                id: shapeComboBox
+                                sourceComponent: comboBoxWithOptions
+                                property string settingKey: "machine_shape"
+                                property string label: catalog.i18nc("@label", "Build plate shape")
+                                property bool forceUpdateOnChange: true
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "Build Plate Shape")
-                                }
+                            Loader
+                            {
+                                id: centerIsZeroCheckBox
+                                sourceComponent: simpleCheckBox
+                                property string settingKey: "machine_center_is_zero"
+                                property string label: catalog.i18nc("@option:check", "Origin at center")
+                                property bool forceUpdateOnChange: true
+                            }
+                            Loader
+                            {
+                                id: heatedBedCheckBox
+                                sourceComponent: simpleCheckBox
+                                property var settingKey: "machine_heated_bed"
+                                property string label: catalog.i18nc("@option:check", "Heated bed")
+                                property bool forceUpdateOnChange: true
+                            }
 
-                                Loader
-                                {
-                                    id: shapeComboBox
-                                    sourceComponent: comboBoxWithOptions
-                                    property string settingKey: "machine_shape"
-                                    property bool forceUpdateOnChange: true
-                                }
+                            Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
 
-                                Loader
-                                {
-                                    id: centerIsZeroCheckBox
-                                    sourceComponent: simpleCheckBox
-                                    property string label: catalog.i18nc("@option:check", "Machine Center is Zero")
-                                    property string settingKey: "machine_center_is_zero"
-                                    property bool forceUpdateOnChange: true
-                                }
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
-                                Loader
-                                {
-                                    id: heatedBedCheckBox
-                                    sourceComponent: simpleCheckBox
-                                    property string label: catalog.i18nc("@option:check", "Heated Bed")
-                                    property var settingKey: "machine_heated_bed"
-                                    property bool forceUpdateOnChange: true
-                                }
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
-
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
-
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "GCode Flavor")
-                                }
-
-                                Loader
-                                {
-                                    id: gcodeFlavorComboBox
-                                    sourceComponent: comboBoxWithOptions
-                                    property string settingKey: "machine_gcode_flavor"
-                                    property bool forceUpdateOnChange: true
-                                    property var afterOnActivate: manager.updateHasMaterialsMetadata
-                                }
+                            Loader
+                            {
+                                id: gcodeFlavorComboBox
+                                sourceComponent: comboBoxWithOptions
+                                property string settingKey: "machine_gcode_flavor"
+                                property string label: catalog.i18nc("@label", "GCode flavor")
+                                property bool forceUpdateOnChange: true
+                                property var afterOnActivate: manager.updateHasMaterialsMetadata
                             }
                         }
 
                         Column
                         {
                             width: settingsTabs.columnWidth
-                            spacing: UM.Theme.getSize("default_margin").height
+                            spacing: UM.Theme.getSize("default_lining").height
 
                             Label
                             {
@@ -201,97 +175,79 @@ Cura.MachineAction
                                 font.bold: true
                             }
 
-                            Grid
+                            Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+
+                            Loader
                             {
-                                columns: 2
-                                columnSpacing: UM.Theme.getSize("default_margin").width
-                                rowSpacing: UM.Theme.getSize("default_lining").width
+                                id: printheadXMinField
+                                sourceComponent: headPolygonTextField
+                                property string label: catalog.i18nc("@label", "X min")
+                                property string tooltip: catalog.i18nc("@tooltip", "Distance from the left of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
+                                property string axis: "x"
+                                property string side: "min"
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "X min")
-                                }
-                                Loader
-                                {
-                                    id: printheadXMinField
-                                    sourceComponent: headPolygonTextField
-                                    property string axis: "x"
-                                    property string side: "min"
-                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the left of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
-                                }
+                            Loader
+                            {
+                                id: printheadYMinField
+                                sourceComponent: headPolygonTextField
+                                property string label: catalog.i18nc("@label", "Y min")
+                                property string tooltip: catalog.i18nc("@tooltip", "Distance from the front of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
+                                property string axis: "y"
+                                property string side: "min"
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "Y min")
-                                }
-                                Loader
-                                {
-                                    id: printheadYMinField
-                                    sourceComponent: headPolygonTextField
-                                    property string axis: "y"
-                                    property string side: "min"
-                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the front of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
-                                }
+                            Loader
+                            {
+                                id: printheadXMaxField
+                                sourceComponent: headPolygonTextField
+                                property string label: catalog.i18nc("@label", "X max")
+                                property string tooltip: catalog.i18nc("@tooltip", "Distance from the right of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
+                                property string axis: "x"
+                                property string side: "max"
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "X max")
-                                }
-                                Loader
-                                {
-                                    id: printheadXMaxField
-                                    sourceComponent: headPolygonTextField
-                                    property string axis: "x"
-                                    property string side: "max"
-                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the right of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
-                                }
+                            Loader
+                            {
+                                id: printheadYMaxField
+                                sourceComponent: headPolygonTextField
+                                property string label: catalog.i18nc("@label", "Y max")
+                                property string tooltip: catalog.i18nc("@tooltip", "Distance from the rear of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
+                                property string axis: "y"
+                                property string side: "max"
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "Y max")
-                                }
-                                Loader
-                                {
-                                    id: printheadYMaxField
-                                    sourceComponent: headPolygonTextField
-                                    property string axis: "y"
-                                    property string side: "max"
-                                    property string tooltip: catalog.i18nc("@tooltip", "Distance from the rear of the printhead to the center of the nozzle. Used to prevent colissions between previous prints and the printhead when printing \"One at a Time\".")
-                                }
+                            Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
 
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+                            Loader
+                            {
+                                id: gantryHeightField
+                                sourceComponent: numericTextFieldWithUnit
+                                property string settingKey: "gantry_height"
+                                property string label: catalog.i18nc("@label", "Gantry height")
+                                property string unit: catalog.i18nc("@label", "mm")
+                                property string tooltip: catalog.i18nc("@tooltip", "The height difference between the tip of the nozzle and the gantry system (X and Y axes). Used to prevent collisions between previous prints and the gantry when printing \"One at a Time\".")
+                            }
 
-                                Label
+                            Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+
+                            UM.TooltipArea
+                            {
+                                id: extruderCountControl
+                                visible: manager.definedExtruderCount > 1
+                                height: childrenRect.height
+                                width: childrenRect.width
+                                text: machineExtruderCountProvider.properties.description
+
+                                Row
                                 {
-                                    text: catalog.i18nc("@label", "Gantry height")
-                                }
-                                Loader
-                                {
-                                    id: gantryHeightField
-                                    sourceComponent: numericTextFieldWithUnit
-                                    property string settingKey: "gantry_height"
-                                    property string unit: catalog.i18nc("@label", "mm")
-                                    property string tooltip: catalog.i18nc("@tooltip", "The height difference between the tip of the nozzle and the gantry system (X and Y axes). Used to prevent collisions between previous prints and the gantry when printing \"One at a Time\".")
-                                }
+                                    spacing: UM.Theme.getSize("default_margin").width
 
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
-                                Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
-
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "Number of Extruders")
-                                    visible: extruderCountControl.visible
-                                }
-
-                                UM.TooltipArea
-                                {
-                                    id: extruderCountControl
-                                    visible: manager.definedExtruderCount > 1
-                                    height: extruderCountComboBox.height
-                                    width: extruderCountComboBox.width
-                                    text: machineExtruderCountProvider.properties.description
-
+                                    Label
+                                    {
+                                        text: catalog.i18nc("@label", "Number of Extruders")
+                                        anchors.verticalCenter: extruderCountComboBox.verticalCenter
+                                    }
                                     ComboBox
                                     {
                                         id: extruderCountComboBox
@@ -313,33 +269,26 @@ Cura.MachineAction
                                         }
                                     }
                                 }
+                            }
 
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "Material Diameter")
-                                }
-                                Loader
-                                {
-                                    id: materialDiameterField
-                                    sourceComponent: numericTextFieldWithUnit
-                                    property string settingKey: "material_diameter"
-                                    property string unit: catalog.i18nc("@label", "mm")
-                                    property string tooltip: catalog.i18nc("@tooltip", "The nominal diameter of filament supported by the printer. The exact diameter will be overridden by the material and/or the profile.")
-                                    property var afterOnEditingFinished: manager.updateMaterialForDiameter
-                                }
-                                Label
-                                {
-                                    text: catalog.i18nc("@label", "Nozzle size")
-                                    visible: nozzleSizeField.visible
-                                }
-                                Loader
-                                {
-                                    id: nozzleSizeField
-                                    visible: !Cura.MachineManager.hasVariants && machineExtruderCountProvider.properties.value == 1
-                                    sourceComponent: numericTextFieldWithUnit
-                                    property string settingKey: "machine_nozzle_size"
-                                    property string unit: catalog.i18nc("@label", "mm")
-                                }
+                            Loader
+                            {
+                                id: materialDiameterField
+                                sourceComponent: numericTextFieldWithUnit
+                                property string settingKey: "material_diameter"
+                                property string unit: catalog.i18nc("@label", "mm")
+                                property string tooltip: catalog.i18nc("@tooltip", "The nominal diameter of filament supported by the printer. The exact diameter will be overridden by the material and/or the profile.")
+                                property var afterOnEditingFinished: manager.updateMaterialForDiameter
+                                property string label: catalog.i18nc("@label", "Material diameter")
+                            }
+                            Loader
+                            {
+                                id: nozzleSizeField
+                                visible: !Cura.MachineManager.hasVariants && machineExtruderCountProvider.properties.value == 1
+                                sourceComponent: numericTextFieldWithUnit
+                                property string settingKey: "machine_nozzle_size"
+                                property string label: catalog.i18nc("@label", "Nozzle size")
+                                property string unit: catalog.i18nc("@label", "mm")
                             }
                         }
                     }
@@ -413,7 +362,7 @@ Cura.MachineAction
 
                     Column
                     {
-                        spacing: UM.Theme.getSize("default_margin").width
+                        spacing: UM.Theme.getSize("default_lining").width
 
                         Label
                         {
@@ -421,56 +370,44 @@ Cura.MachineAction
                             font.bold: true
                         }
 
-                        Grid
+                        Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
+
+                        Loader
                         {
-                            columns: 2
-                            columnSpacing: UM.Theme.getSize("default_margin").width
-                            rowSpacing: UM.Theme.getSize("default_lining").width
-
-                            Label
-                            {
-                                text: catalog.i18nc("@label", "Nozzle size")
-                                visible: extruderNozzleSizeField.visible
-                            }
-                            Loader
-                            {
-                                id: extruderNozzleSizeField
-                                visible: !Cura.MachineManager.hasVariants
-                                sourceComponent: numericTextFieldWithUnit
-                                property string settingKey: "machine_nozzle_size"
-                                property bool isExtruderSetting: true
-                                property string unit: catalog.i18nc("@label", "mm")
-                            }
-
-                            Label
-                            {
-                                text: catalog.i18nc("@label", "Nozzle offset X")
-                            }
-                            Loader
-                            {
-                                id: extruderOffsetXField
-                                sourceComponent: numericTextFieldWithUnit
-                                property string settingKey: "machine_nozzle_offset_x"
-                                property string unit: catalog.i18nc("@label", "mm")
-                                property bool isExtruderSetting: true
-                                property bool forceUpdateOnChange: true
-                                property bool allowNegative: true
-                            }
-                            Label
-                            {
-                                text: catalog.i18nc("@label", "Nozzle offset Y")
-                            }
-                            Loader
-                            {
-                                id: extruderOffsetYField
-                                sourceComponent: numericTextFieldWithUnit
-                                property string settingKey: "machine_nozzle_offset_y"
-                                property string unit: catalog.i18nc("@label", "mm")
-                                property bool isExtruderSetting: true
-                                property bool forceUpdateOnChange: true
-                                property bool allowNegative: true
-                            }
+                            id: extruderNozzleSizeField
+                            visible: !Cura.MachineManager.hasVariants
+                            sourceComponent: numericTextFieldWithUnit
+                            property string settingKey: "machine_nozzle_size"
+                            property string label: catalog.i18nc("@label", "Nozzle size")
+                            property string unit: catalog.i18nc("@label", "mm")
+                            property bool isExtruderSetting: true
                         }
+
+                        Loader
+                        {
+                            id: extruderOffsetXField
+                            sourceComponent: numericTextFieldWithUnit
+                            property string settingKey: "machine_nozzle_offset_x"
+                            property string label: catalog.i18nc("@label", "Nozzle offset X")
+                            property string unit: catalog.i18nc("@label", "mm")
+                            property bool isExtruderSetting: true
+                            property bool forceUpdateOnChange: true
+                            property bool allowNegative: true
+                        }
+
+                        Loader
+                        {
+                            id: extruderOffsetYField
+                            sourceComponent: numericTextFieldWithUnit
+                            property string settingKey: "machine_nozzle_offset_y"
+                            property string label: catalog.i18nc("@label", "Nozzle offset Y")
+                            property string unit: catalog.i18nc("@label", "mm")
+                            property bool isExtruderSetting: true
+                            property bool forceUpdateOnChange: true
+                            property bool allowNegative: true
+                        }
+
+                        Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }
 
                         Row
                         {
@@ -577,14 +514,15 @@ Cura.MachineAction
         id: numericTextFieldWithUnit
         UM.TooltipArea
         {
-            height: textField.height
-            width: textField.width
+            height: childrenRect.height
+            width: childrenRect.width
             text: _tooltip
 
             property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _allowNegative: (typeof(allowNegative) === 'undefined') ? false : allowNegative
             property var _afterOnEditingFinished: (typeof(afterOnEditingFinished) === 'undefined') ? undefined : afterOnEditingFinished
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false : forceUpdateOnChange
+            property string _label: (typeof(label) === 'undefined') ? "" : label
             property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
             UM.SettingPropertyProvider
@@ -607,39 +545,58 @@ Cura.MachineAction
                 storeIndex: manager.containerIndex
             }
 
-            TextField
+            Row
             {
-                id: textField
-                text: (propertyProvider.properties.value) ? propertyProvider.properties.value : ""
-                validator: RegExpValidator { regExp: _allowNegative ? /-?[0-9\.]{0,6}/ : /[0-9\.]{0,6}/ }
-                onEditingFinished:
+                spacing: UM.Theme.getSize("default_margin").width
+
+                Label
                 {
-                    if (propertyProvider && text != propertyProvider.properties.value)
+                    text: _label
+                    visible: _label != ""
+                    anchors.verticalCenter: textFieldWithUnit.verticalCenter
+                }
+
+                Item
+                {
+                    width: textField.width
+                    height: textField.height
+
+                    id: textFieldWithUnit
+                    TextField
                     {
-                        propertyProvider.setPropertyValue("value", text);
-                        if(_forceUpdateOnChange)
+                        id: textField
+                        text: (propertyProvider.properties.value) ? propertyProvider.properties.value : ""
+                        validator: RegExpValidator { regExp: _allowNegative ? /-?[0-9\.]{0,6}/ : /[0-9\.]{0,6}/ }
+                        onEditingFinished:
                         {
-                            var extruderIndex = ExtruderManager.activeExtruderIndex;
-                            manager.forceUpdate();
-                            if(ExtruderManager.activeExtruderIndex != extruderIndex)
+                            if (propertyProvider && text != propertyProvider.properties.value)
                             {
-                                ExtruderManager.setActiveExtruderIndex(extruderIndex)
+                                propertyProvider.setPropertyValue("value", text);
+                                if(_forceUpdateOnChange)
+                                {
+                                    var extruderIndex = ExtruderManager.activeExtruderIndex;
+                                    manager.forceUpdate();
+                                    if(ExtruderManager.activeExtruderIndex != extruderIndex)
+                                    {
+                                        ExtruderManager.setActiveExtruderIndex(extruderIndex)
+                                    }
+                                }
+                                if(_afterOnEditingFinished)
+                                {
+                                    _afterOnEditingFinished();
+                                }
                             }
                         }
-                        if(_afterOnEditingFinished)
-                        {
-                            _afterOnEditingFinished();
-                        }
+                    }
+
+                    Label
+                    {
+                        text: unit
+                        anchors.right: textField.right
+                        anchors.rightMargin: y - textField.y
+                        anchors.verticalCenter: textField.verticalCenter
                     }
                 }
-            }
-
-            Label
-            {
-                text: unit
-                anchors.right: textField.right
-                anchors.rightMargin: y - textField.y
-                anchors.verticalCenter: textField.verticalCenter
             }
         }
     }
@@ -649,13 +606,14 @@ Cura.MachineAction
         id: comboBoxWithOptions
         UM.TooltipArea
         {
-            height: comboBox.height
-            width: comboBox.width
+            height: childrenRect.height
+            width: childrenRect.width
             text: _tooltip
 
             property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false : isExtruderSetting
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false : forceUpdateOnChange
             property var _afterOnActivate: (typeof(afterOnActivate) === 'undefined') ? undefined : afterOnActivate
+            property string _label: (typeof(label) === 'undefined') ? "" : label
             property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
             UM.SettingPropertyProvider
@@ -678,52 +636,63 @@ Cura.MachineAction
                 storeIndex: manager.containerIndex
             }
 
-            ComboBox
+            Row
             {
-                id: comboBox
-                model: ListModel
+                spacing: UM.Theme.getSize("default_margin").width
+
+                Label
                 {
-                    id: optionsModel
-                    Component.onCompleted:
+                    text: _label
+                    visible: _label != ""
+                    anchors.verticalCenter: textFieldWithUnit.verticalCenter
+                }
+                ComboBox
+                {
+                    id: comboBox
+                    model: ListModel
                     {
-                        // Options come in as a string-representation of an OrderedDict
-                        var options = propertyProvider.properties.options.match(/^OrderedDict\(\[\((.*)\)\]\)$/);
-                        if(options)
+                        id: optionsModel
+                        Component.onCompleted:
                         {
-                            options = options[1].split("), (")
-                            for(var i = 0; i < options.length; i++)
+                            // Options come in as a string-representation of an OrderedDict
+                            var options = propertyProvider.properties.options.match(/^OrderedDict\(\[\((.*)\)\]\)$/);
+                            if(options)
                             {
-                                var option = options[i].substring(1, options[i].length - 1).split("', '")
-                                optionsModel.append({text: option[1], value: option[0]});
+                                options = options[1].split("), (")
+                                for(var i = 0; i < options.length; i++)
+                                {
+                                    var option = options[i].substring(1, options[i].length - 1).split("', '")
+                                    optionsModel.append({text: option[1], value: option[0]});
+                                }
                             }
                         }
                     }
-                }
-                currentIndex:
-                {
-                    var currentValue = propertyProvider.properties.value;
-                    var index = 0;
-                    for(var i = 0; i < optionsModel.count; i++)
+                    currentIndex:
                     {
-                        if(optionsModel.get(i).value == currentValue) {
-                            index = i;
-                            break;
+                        var currentValue = propertyProvider.properties.value;
+                        var index = 0;
+                        for(var i = 0; i < optionsModel.count; i++)
+                        {
+                            if(optionsModel.get(i).value == currentValue) {
+                                index = i;
+                                break;
+                            }
                         }
+                        return index
                     }
-                    return index
-                }
-                onActivated:
-                {
-                    if(propertyProvider.properties.value != optionsModel.get(index).value)
+                    onActivated:
                     {
-                        propertyProvider.setPropertyValue("value", optionsModel.get(index).value);
-                        if(_forceUpdateOnChange)
+                        if(propertyProvider.properties.value != optionsModel.get(index).value)
                         {
-                            manager.forceUpdate();
-                        }
-                        if(_afterOnActivate)
-                        {
-                            _afterOnActivate();
+                            propertyProvider.setPropertyValue("value", optionsModel.get(index).value);
+                            if(_forceUpdateOnChange)
+                            {
+                                manager.forceUpdate();
+                            }
+                            if(_afterOnActivate)
+                            {
+                                _afterOnActivate();
+                            }
                         }
                     }
                 }
@@ -795,49 +764,69 @@ Cura.MachineAction
             width: textField.width
             text: tooltip
 
-            TextField
+            property string _label: (typeof(label) === 'undefined') ? "" : label
+
+            Row
             {
-                id: textField
-                text:
+                spacing: UM.Theme.getSize("default_margin").width
+
+                Label
                 {
-                    var polygon = JSON.parse(machineHeadPolygonProvider.properties.value);
-                    var item = (axis == "x") ? 0 : 1
-                    var result = polygon[0][item];
-                    for(var i = 1; i < polygon.length; i++) {
-                        if (side == "min") {
-                            result = Math.min(result, polygon[i][item]);
-                        } else {
-                            result = Math.max(result, polygon[i][item]);
+                    text: _label
+                    visible: _label != ""
+                    anchors.verticalCenter: textFieldWithUnit.verticalCenter
+                }
+
+                Item
+                {
+                    width: textField.width
+                    height: textField.height
+
+                    TextField
+                    {
+                        id: textField
+                        text:
+                        {
+                            var polygon = JSON.parse(machineHeadPolygonProvider.properties.value);
+                            var item = (axis == "x") ? 0 : 1
+                            var result = polygon[0][item];
+                            for(var i = 1; i < polygon.length; i++) {
+                                if (side == "min") {
+                                    result = Math.min(result, polygon[i][item]);
+                                } else {
+                                    result = Math.max(result, polygon[i][item]);
+                                }
+                            }
+                            result = Math.abs(result);
+                            printHeadPolygon[axis][side] = result;
+                            return result;
+                        }
+                        validator: RegExpValidator { regExp: /[0-9\.]{0,6}/ }
+                        onEditingFinished:
+                        {
+                            printHeadPolygon[axis][side] = parseFloat(textField.text);
+                            var polygon = [];
+                            polygon.push([-printHeadPolygon["x"]["min"], printHeadPolygon["y"]["max"]]);
+                            polygon.push([-printHeadPolygon["x"]["min"],-printHeadPolygon["y"]["min"]]);
+                            polygon.push([ printHeadPolygon["x"]["max"], printHeadPolygon["y"]["max"]]);
+                            polygon.push([ printHeadPolygon["x"]["max"],-printHeadPolygon["y"]["mìn"]]);
+                            var polygon_string = JSON.stringify(polygon);
+                            if(polygon_string != machineHeadPolygonProvider.properties.value)
+                            {
+                                machineHeadPolygonProvider.setPropertyValue("value", polygon_string);
+                                manager.forceUpdate();
+                            }
                         }
                     }
-                    result = Math.abs(result);
-                    printHeadPolygon[axis][side] = result;
-                    return result;
-                }
-                validator: RegExpValidator { regExp: /[0-9\.]{0,6}/ }
-                onEditingFinished:
-                {
-                    printHeadPolygon[axis][side] = parseFloat(textField.text);
-                    var polygon = [];
-                    polygon.push([-printHeadPolygon["x"]["min"], printHeadPolygon["y"]["max"]]);
-                    polygon.push([-printHeadPolygon["x"]["min"],-printHeadPolygon["y"]["min"]]);
-                    polygon.push([ printHeadPolygon["x"]["max"], printHeadPolygon["y"]["max"]]);
-                    polygon.push([ printHeadPolygon["x"]["max"],-printHeadPolygon["y"]["mìn"]]);
-                    var polygon_string = JSON.stringify(polygon);
-                    if(polygon_string != machineHeadPolygonProvider.properties.value)
+
+                    Label
                     {
-                        machineHeadPolygonProvider.setPropertyValue("value", polygon_string);
-                        manager.forceUpdate();
+                        text: catalog.i18nc("@label", "mm")
+                        anchors.right: textField.right
+                        anchors.rightMargin: y - textField.y
+                        anchors.verticalCenter: textField.verticalCenter
                     }
                 }
-            }
-
-            Label
-            {
-                text: catalog.i18nc("@label", "mm")
-                anchors.right: textField.right
-                anchors.rightMargin: y - textField.y
-                anchors.verticalCenter: textField.verticalCenter
             }
         }
     }

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -164,7 +164,7 @@ Cura.MachineAction
                                 id: gcodeFlavorComboBox
                                 sourceComponent: comboBoxWithOptions
                                 property string settingKey: "machine_gcode_flavor"
-                                property string label: catalog.i18nc("@label", "GCode flavor")
+                                property string label: catalog.i18nc("@label", "Gcode flavor")
                                 property bool forceUpdateOnChange: true
                                 property var afterOnActivate: manager.updateHasMaterialsMetadata
                             }

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -189,7 +189,7 @@ Cura.MachineAction
                                     sourceComponent: comboBoxWithOptions
                                     property string settingKey: "machine_gcode_flavor"
                                     property bool forceUpdateOnChange: true
-                                    property string afterOnActivate: "manager.updateHasMaterialsMetadata()"
+                                    property var afterOnActivate: manager.updateHasMaterialsMetadata
                                 }
                             }
                         }
@@ -329,7 +329,7 @@ Cura.MachineAction
                                     property string settingKey: "material_diameter"
                                     property string unit: catalog.i18nc("@label", "mm")
                                     property string tooltip: catalog.i18nc("@tooltip", "The nominal diameter of filament supported by the printer. The exact diameter will be overridden by the material and/or the profile.")
-                                    property string afterOnEditingFinished: "manager.updateMaterialForDiameter()"
+                                    property var afterOnEditingFinished: manager.updateMaterialForDiameter
                                 }
                                 Label
                                 {
@@ -587,8 +587,8 @@ Cura.MachineAction
 
             property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _allowNegative: (typeof(allowNegative) === 'undefined') ? false : allowNegative
-            property string _afterOnEditingFinished: (typeof(afterOnEditingFinished) === 'undefined') ? "": afterOnEditingFinished
-            property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
+            property var _afterOnEditingFinished: (typeof(afterOnEditingFinished) === 'undefined') ? undefined : afterOnEditingFinished
+            property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false : forceUpdateOnChange
             property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
             UM.SettingPropertyProvider
@@ -630,9 +630,9 @@ Cura.MachineAction
                                 ExtruderManager.setActiveExtruderIndex(extruderIndex)
                             }
                         }
-                        if(_afterOnEditingFinished != "")
+                        if(_afterOnEditingFinished)
                         {
-                            eval(_afterOnEditingFinished);
+                            _afterOnEditingFinished();
                         }
                     }
                 }
@@ -657,9 +657,9 @@ Cura.MachineAction
             width: comboBox.width
             text: _tooltip
 
-            property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
-            property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
-            property string _afterOnActivate: (typeof(afterOnActivate) === 'undefined') ? "": afterOnActivate
+            property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false : isExtruderSetting
+            property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false : forceUpdateOnChange
+            property var _afterOnActivate: (typeof(afterOnActivate) === 'undefined') ? undefined : afterOnActivate
             property string _tooltip: (typeof(tooltip) === 'undefined') ? propertyProvider.properties.description : tooltip
 
             UM.SettingPropertyProvider
@@ -725,9 +725,9 @@ Cura.MachineAction
                         {
                             manager.forceUpdate();
                         }
-                        if(_afterOnActivate != "")
+                        if(_afterOnActivate)
                         {
-                            eval(_afterOnActivate);
+                            _afterOnActivate();
                         }
                     }
                 }

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -105,7 +105,7 @@ Cura.MachineAction
                                 {
                                     id: buildAreaWidthField
                                     sourceComponent: numericTextFieldWithUnit
-                                    property var propertyProvider: machineWidthProvider
+                                    property string settingKey: "machine_width"
                                     property string unit: catalog.i18nc("@label", "mm")
                                     property bool forceUpdateOnChange: true
                                 }
@@ -118,7 +118,7 @@ Cura.MachineAction
                                 {
                                     id: buildAreaDepthField
                                     sourceComponent: numericTextFieldWithUnit
-                                    property var propertyProvider: machineDepthProvider
+                                    property string settingKey: "machine_depth"
                                     property string unit: catalog.i18nc("@label", "mm")
                                     property bool forceUpdateOnChange: true
                                 }
@@ -131,7 +131,7 @@ Cura.MachineAction
                                 {
                                     id: buildAreaHeightField
                                     sourceComponent: numericTextFieldWithUnit
-                                    property var propertyProvider: machineHeightProvider
+                                    property string settingKey: "machine_height"
                                     property string unit: catalog.i18nc("@label", "mm")
                                     property bool forceUpdateOnChange: true
                                 }
@@ -152,7 +152,7 @@ Cura.MachineAction
                                     {
                                         id: shapeComboBox
                                         sourceComponent: comboBoxWithOptions
-                                        property var propertyProvider: machineShapeProvider
+                                        property string settingKey: "machine_shape"
                                         property bool forceUpdateOnChange: true
                                     }
                                 }
@@ -161,7 +161,7 @@ Cura.MachineAction
                                     id: centerIsZeroCheckBox
                                     sourceComponent: simpleCheckBox
                                     property string label: catalog.i18nc("@option:check", "Machine Center is Zero")
-                                    property var propertyProvider: machineCenterIsZeroProvider
+                                    property string settingKey: "machine_center_is_zero"
                                     property bool forceUpdateOnChange: true
                                 }
                                 Loader
@@ -169,7 +169,7 @@ Cura.MachineAction
                                     id: heatedBedCheckBox
                                     sourceComponent: simpleCheckBox
                                     property string label: catalog.i18nc("@option:check", "Heated Bed")
-                                    property var propertyProvider: machineHeatedBedProvider
+                                    property var settingKey: "machine_heated_bed"
                                     property bool forceUpdateOnChange: true
                                 }
                             }
@@ -187,7 +187,7 @@ Cura.MachineAction
                                 {
                                     id: gcodeFlavorComboBox
                                     sourceComponent: comboBoxWithOptions
-                                    property var propertyProvider: machineGCodeFlavorProvider
+                                    property string settingKey: "machine_gcode_flavor"
                                     property bool forceUpdateOnChange: true
                                     property string afterOnActivate: "manager.updateHasMaterialsMetadata()"
                                 }
@@ -270,7 +270,7 @@ Cura.MachineAction
                                 {
                                     id: gantryHeightField
                                     sourceComponent: numericTextFieldWithUnit
-                                    property var propertyProvider: gantryHeightProvider
+                                    property string settingKey: "gantry_height"
                                     property string unit: catalog.i18nc("@label", "mm")
                                 }
 
@@ -313,7 +313,7 @@ Cura.MachineAction
                                 {
                                     id: materialDiameterField
                                     sourceComponent: numericTextFieldWithUnit
-                                    property var propertyProvider: materialDiameterProvider
+                                    property string settingKey: "material_diameter"
                                     property string unit: catalog.i18nc("@label", "mm")
                                 }
                                 Label
@@ -326,7 +326,7 @@ Cura.MachineAction
                                     id: nozzleSizeField
                                     visible: !Cura.MachineManager.hasVariants && machineExtruderCountProvider.properties.value == 1
                                     sourceComponent: numericTextFieldWithUnit
-                                    property var propertyProvider: machineNozzleSizeProvider
+                                    property string settingKey: "machine_nozzle_size"
                                     property string unit: catalog.i18nc("@label", "mm")
                                 }
                             }
@@ -476,7 +476,8 @@ Cura.MachineAction
                                 id: extruderNozzleSizeField
                                 visible: !Cura.MachineManager.hasVariants
                                 sourceComponent: numericTextFieldWithUnit
-                                property var propertyProvider: extruderNozzleSizeProvider
+                                property string settingKey: "machine_nozzle_size"
+                                property bool isExtruderSetting: true
                                 property string unit: catalog.i18nc("@label", "mm")
                             }
 
@@ -488,8 +489,9 @@ Cura.MachineAction
                             {
                                 id: extruderOffsetXField
                                 sourceComponent: numericTextFieldWithUnit
-                                property var propertyProvider: extruderOffsetXProvider
+                                property string settingKey: "machine_nozzle_offset_x"
                                 property string unit: catalog.i18nc("@label", "mm")
+                                property bool isExtruderSetting: true
                                 property bool forceUpdateOnChange: true
                                 property bool allowNegative: true
                             }
@@ -501,8 +503,9 @@ Cura.MachineAction
                             {
                                 id: extruderOffsetYField
                                 sourceComponent: numericTextFieldWithUnit
-                                property var propertyProvider: extruderOffsetYProvider
+                                property string settingKey: "machine_nozzle_offset_y"
                                 property string unit: catalog.i18nc("@label", "mm")
+                                property bool isExtruderSetting: true
                                 property bool forceUpdateOnChange: true
                                 property bool allowNegative: true
                             }
@@ -587,7 +590,28 @@ Cura.MachineAction
             width: checkBox.width
             text: propertyProvider.properties.description
 
+            property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
+
+            UM.SettingPropertyProvider
+            {
+                id: propertyProvider
+
+                containerStackId: {
+                    if(_isExtruderSetting)
+                    {
+                        if(settingsTabs.currentIndex > 0)
+                        {
+                            return Cura.MachineManager.activeStackId;
+                        }
+                        return "";
+                    }
+                    return Cura.MachineManager.activeMachineId;
+                }
+                key: settingKey
+                watchedProperties: [ "value", "description" ]
+                storeIndex: manager.containerIndex
+            }
 
             CheckBox
             {
@@ -602,7 +626,6 @@ Cura.MachineAction
                             manager.forceUpdate();
                         }
                 }
-
             }
         }
     }
@@ -616,8 +639,29 @@ Cura.MachineAction
             width: textField.width
             text: propertyProvider.properties.description
 
+            property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _allowNegative: (typeof(allowNegative) === 'undefined') ? false : allowNegative
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
+
+            UM.SettingPropertyProvider
+            {
+                id: propertyProvider
+
+                containerStackId: {
+                    if(_isExtruderSetting)
+                    {
+                        if(settingsTabs.currentIndex > 0)
+                        {
+                            return Cura.MachineManager.activeStackId;
+                        }
+                        return "";
+                    }
+                    return Cura.MachineManager.activeMachineId;
+                }
+                key: settingKey
+                watchedProperties: [ "value", "description" ]
+                storeIndex: manager.containerIndex
+            }
 
             TextField
             {
@@ -661,8 +705,29 @@ Cura.MachineAction
             width: comboBox.width
             text: propertyProvider.properties.description
 
+            property bool _isExtruderSetting: (typeof(isExtruderSetting) === 'undefined') ? false: isExtruderSetting
             property bool _forceUpdateOnChange: (typeof(forceUpdateOnChange) === 'undefined') ? false: forceUpdateOnChange
             property string _afterOnActivate: (typeof(afterOnActivate) === 'undefined') ? "": afterOnActivate
+
+            UM.SettingPropertyProvider
+            {
+                id: propertyProvider
+
+                containerStackId: {
+                    if(_isExtruderSetting)
+                    {
+                        if(settingsTabs.currentIndex > 0)
+                        {
+                            return Cura.MachineManager.activeStackId;
+                        }
+                        return "";
+                    }
+                    return Cura.MachineManager.activeMachineId;
+                }
+                key: settingKey
+                watchedProperties: [ "value", "options", "description" ]
+                storeIndex: manager.containerIndex
+            }
 
             ComboBox
             {
@@ -719,110 +784,10 @@ Cura.MachineAction
 
     UM.SettingPropertyProvider
     {
-        id: machineWidthProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_width"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: machineDepthProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_depth"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: machineHeightProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_height"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: machineShapeProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_shape"
-        watchedProperties: [ "value", "options", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: machineHeatedBedProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_heated_bed"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: machineCenterIsZeroProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_center_is_zero"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: machineGCodeFlavorProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_gcode_flavor"
-        watchedProperties: [ "value", "options", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: materialDiameterProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "material_diameter"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: machineNozzleSizeProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "machine_nozzle_size"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
         id: machineExtruderCountProvider
 
         containerStackId: Cura.MachineManager.activeMachineId
         key: "machine_extruder_count"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: gantryHeightProvider
-
-        containerStackId: Cura.MachineManager.activeMachineId
-        key: "gantry_height"
         watchedProperties: [ "value", "description" ]
         storeIndex: manager.containerIndex
     }
@@ -854,36 +819,6 @@ Cura.MachineAction
 
         containerStackId: Cura.MachineManager.activeMachineId
         key: "machine_end_gcode"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: extruderNozzleSizeProvider
-
-        containerStackId: settingsTabs.currentIndex > 0 ? Cura.MachineManager.activeStackId : ""
-        key: "machine_nozzle_size"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: extruderOffsetXProvider
-
-        containerStackId: settingsTabs.currentIndex > 0 ? Cura.MachineManager.activeStackId : ""
-        key: "machine_nozzle_offset_x"
-        watchedProperties: [ "value", "description" ]
-        storeIndex: manager.containerIndex
-    }
-
-    UM.SettingPropertyProvider
-    {
-        id: extruderOffsetYProvider
-
-        containerStackId: settingsTabs.currentIndex > 0 ? Cura.MachineManager.activeStackId : ""
-        key: "machine_nozzle_offset_y"
         watchedProperties: [ "value", "description" ]
         storeIndex: manager.containerIndex
     }


### PR DESCRIPTION
This PR adds tooltips to the Machine Settings dialog to clarify some of its settings. It also fixes setting the nominal diameter of the machine.

In 2.6.x, the material diameter set in the Machine Settings would always be overridden by the diameter set in the material container. In this PR, the material container is switched to an appropriate material when changing the material diameter field.

Most tooltips are directly from the property provider, though some tooltips are overridden for clarity in the context of the machine settings dialog.

The code has been restructured for less verbosity, using reusable components instead of repeating the same QML code over and over.
