### PR TITLE
Fix creating a new definition_changes container

### DIFF
--- a/plugins/UltimakerMachineActions/UMOUpgradeSelection.py
+++ b/plugins/UltimakerMachineActions/UMOUpgradeSelection.py
@@ -36,8 +36,8 @@ class UMOUpgradeSelection(MachineAction):
         global_container_stack = Application.getInstance().getGlobalContainerStack()
         if global_container_stack:
             # Make sure there is a definition_changes container to store the machine settings
-            definition_changes_container = global_container_stack.definition_changes
-            if not definition_changes_container:
+            definition_changes_container = global_container_stack.definitionChanges
+            if definition_changes_container == ContainerRegistry.getInstance().getEmptyInstanceContainer():
                 definition_changes_container = self._createDefinitionChangesContainer(global_container_stack)
 
             definition_changes_container.setProperty("machine_heated_bed", "value", heated_bed)
@@ -51,7 +51,7 @@ class UMOUpgradeSelection(MachineAction):
         definition_changes_container.addMetaDataEntry("type", "definition_changes")
         definition_changes_container.addMetaDataEntry("setting_version", CuraApplication.SettingVersion)
 
-        UM.Settings.ContainerRegistry.ContainerRegistry.getInstance().addContainer(definition_changes_container)
+        ContainerRegistry.getInstance().addContainer(definition_changes_container)
         global_container_stack.definitionChanges = definition_changes_container
 
         return definition_changes_container


### PR DESCRIPTION
This PR fixes setting the upgrade option (heated bed) for the UMO, which got broken here:
https://github.com/Ultimaker/Cura/commit/81e07b153071edb783d33f799785125cf58d6cf1#commitcomment-23006662

```global_container_stack.definitionChanges``` always returns a container, ```global_container_stack.findContainer({"type": "definition_changes"})``` does not (because an empty container does not have the type "definition_changes".