### PR TITLE
Use pyserial to list serial ports

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -91,6 +91,8 @@ class MachineManager(QObject):
 
         self._printer_output_devices = []
         Application.getInstance().getOutputDeviceManager().outputDevicesChanged.connect(self._onOutputDevicesChanged)
+        # There might already be some output devices by the time the signal is connected
+        self._onOutputDevicesChanged()
 
         if active_machine_id != "" and ContainerRegistry.getInstance().findContainerStacks(id = active_machine_id):
             # An active machine was saved, so restore it.


### PR DESCRIPTION
This PR replaces the homebrew platform-specific serial port enumeration with functionality provided by pySerial. This prevents us from having to chase all iterations of tty|cu.\*usb|rfcomm\*, and should make serial port detection work with more printers.

This PR is a backport of a fix in the Lulzbot edition of Cura (where it has been extensively tested): https://code.alephobjects.com/rCT14f9814802f4384ef255327afc26ac3156e9539d. It has also been tested here: https://github.com/Ultimaker/Cura/pull/1999#issuecomment-314276734. It is an alternative to https://github.com/Ultimaker/Cura/pull/1999