### PR TITLE
Hide the extruder button for Custom FDM Printers with 1 extruder

### DIFF
--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -74,7 +74,8 @@ Item
         Repeater
         {
             id: extruders
-            model: Cura.ExtrudersModel { id: extrudersModel }
+            property var _model: Cura.ExtrudersModel { id: extrudersModel }
+            model: _model.items.length > 1 ? _model : 0
             ExtruderButton { extruder: model }
         }
     }


### PR DESCRIPTION
This PR hides the extruder button in the toolbar if a Custom FDM Printer has its number of extruders set to 1 in Machine Settings. Before this PR, there would be a single extruder button to set the extruder of the currently selected object(s). For a single extrusion printer, this button serves no purpose.