### PR TITLE
Fix system-themed text rendering

### DIFF
--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -87,18 +87,18 @@ UM.Dialog
                 {
                     text: catalog.i18nc("@action:label", "Printer settings")
                     font.bold: true
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Item
                 {
                     // spacer
                     height: spacerHeight
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 UM.TooltipArea
                 {
                     id: machineResolveTooltip
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                     height: visible ? comboboxHeight : 0
                     visible: manager.machineConflict
                     text: catalog.i18nc("@info:tooltip", "How should the conflict in the machine be resolved?")
@@ -122,12 +122,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Type")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: manager.machineType
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
             }
 
@@ -138,12 +138,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Name")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: manager.machineName
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
             }
 
@@ -160,18 +160,18 @@ UM.Dialog
                 {
                     text: catalog.i18nc("@action:label", "Profile settings")
                     font.bold: true
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Item
                 {
                     // spacer
                     height: spacerHeight
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 UM.TooltipArea
                 {
                     id: qualityChangesResolveTooltip
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                     height: visible ? comboboxHeight : 0
                     visible: manager.qualityChangesConflict
                     text: catalog.i18nc("@info:tooltip", "How should the conflict in the profile be resolved?")
@@ -195,12 +195,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Name")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: manager.qualityName
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
             }
             Row
@@ -210,12 +210,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Not in profile")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: catalog.i18ncp("@action:label", "%1 override", "%1 overrides", manager.numUserSettings).arg(manager.numUserSettings)
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 visible: manager.numUserSettings != 0
             }
@@ -226,12 +226,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Derivative from")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: catalog.i18ncp("@action:label", "%1, %2 override", "%1, %2 overrides", manager.numSettingsOverridenByQualityChanges).arg(manager.qualityType).arg(manager.numSettingsOverridenByQualityChanges)
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 visible: manager.numSettingsOverridenByQualityChanges != 0
             }
@@ -248,18 +248,18 @@ UM.Dialog
                 {
                     text: catalog.i18nc("@action:label", "Material settings")
                     font.bold: true
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Item
                 {
                     // spacer
                     height: spacerHeight
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 UM.TooltipArea
                 {
                     id: materialResolveTooltip
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                     height: visible ? comboboxHeight : 0
                     visible: manager.materialConflict
                     text: catalog.i18nc("@info:tooltip", "How should the conflict in the material be resolved?")
@@ -287,12 +287,12 @@ UM.Dialog
                     Label
                     {
                         text: catalog.i18nc("@action:label", "Name")
-                        width: parent.width / 3
+                        width: (parent.width / 3) | 0
                     }
                     Label
                     {
                         text: modelData
-                        width: parent.width / 3
+                        width: (parent.width / 3) | 0
                     }
                 }
             }
@@ -315,12 +315,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Mode")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: manager.activeMode
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
             }
             Row
@@ -330,12 +330,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Visible settings:")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: catalog.i18nc("@action:label", "%1 out of %2" ).arg(manager.numVisibleSettings).arg(manager.totalNumberOfSettings)
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
             }
             Item // Spacer

--- a/plugins/ChangeLogPlugin/ChangeLog.qml
+++ b/plugins/ChangeLogPlugin/ChangeLog.qml
@@ -11,8 +11,8 @@ import UM 1.1 as UM
 UM.Dialog
 {
     id: base
-    minimumWidth: UM.Theme.getSize("modal_window_minimum").width * 0.75
-    minimumHeight: UM.Theme.getSize("modal_window_minimum").height * 0.75
+    minimumWidth: (UM.Theme.getSize("modal_window_minimum").width * 0.75) | 0
+    minimumHeight: (UM.Theme.getSize("modal_window_minimum").height * 0.75) | 0
     width: minimumWidth
     height: minimumHeight
     title: catalog.i18nc("@label", "Changelog")

--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -70,7 +70,7 @@ Cura.MachineAction
             anchors.top: pageTitle.bottom
             anchors.topMargin: UM.Theme.getSize("default_margin").height
 
-            property real columnWidth: Math.floor((width - 3 * UM.Theme.getSize("default_margin").width) / 2)
+            property real columnWidth: ((width - 3 * UM.Theme.getSize("default_margin").width) / 2) | 0
 
             Tab
             {

--- a/plugins/PerObjectSettingsTool/PerObjectCategory.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectCategory.qml
@@ -22,7 +22,7 @@ Button {
             UM.RecolorImage
             {
                 anchors.verticalCenter: parent.verticalCenter
-                height: label.height / 2
+                height: (label.height / 2) | 0
                 width: height
                 source: control.checked ? UM.Theme.getIcon("arrow_bottom") : UM.Theme.getIcon("arrow_right");
                 color: control.hovered ? palette.highlight : palette.buttonText

--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -110,10 +110,10 @@ Item {
 
                         Button
                         {
-                            width: UM.Theme.getSize("setting").height / 2;
-                            height: UM.Theme.getSize("setting").height;
+                            width: (UM.Theme.getSize("setting").height / 2) | 0
+                            height: UM.Theme.getSize("setting").height
 
-                            onClicked: addedSettingsModel.setVisible(model.key, false);
+                            onClicked: addedSettingsModel.setVisible(model.key, false)
 
                             style: ButtonStyle
                             {

--- a/plugins/UM3NetworkPrinting/DiscoverUM3Action.qml
+++ b/plugins/UM3NetworkPrinting/DiscoverUM3Action.qml
@@ -114,7 +114,7 @@ Cura.MachineAction
 
             Column
             {
-                width: parent.width * 0.5
+                width: (parent.width * 0.5) | 0
                 spacing: UM.Theme.getSize("default_margin").height
 
                 ScrollView
@@ -200,7 +200,7 @@ Cura.MachineAction
             }
             Column
             {
-                width: parent.width * 0.5
+                width: (parent.width * 0.5) | 0
                 visible: base.selectedPrinter ? true : false
                 spacing: UM.Theme.getSize("default_margin").height
                 Label
@@ -218,13 +218,13 @@ Cura.MachineAction
                     columns: 2
                     Label
                     {
-                        width: parent.width * 0.5
+                        width: (parent.width * 0.5) | 0
                         wrapMode: Text.WordWrap
                         text: catalog.i18nc("@label", "Type")
                     }
                     Label
                     {
-                        width: parent.width * 0.5
+                        width: (parent.width * 0.5) | 0
                         wrapMode: Text.WordWrap
                         text:
                         {
@@ -249,25 +249,25 @@ Cura.MachineAction
                     }
                     Label
                     {
-                        width: parent.width * 0.5
+                        width: (parent.width * 0.5) | 0
                         wrapMode: Text.WordWrap
                         text: catalog.i18nc("@label", "Firmware version")
                     }
                     Label
                     {
-                        width: parent.width * 0.5
+                        width: (parent.width * 0.5) | 0
                         wrapMode: Text.WordWrap
                         text: base.selectedPrinter ? base.selectedPrinter.firmwareVersion : ""
                     }
                     Label
                     {
-                        width: parent.width * 0.5
+                        width: (parent.width * 0.5) | 0
                         wrapMode: Text.WordWrap
                         text: catalog.i18nc("@label", "Address")
                     }
                     Label
                     {
-                        width: parent.width * 0.5
+                        width: (parent.width * 0.5) | 0
                         wrapMode: Text.WordWrap
                         text: base.selectedPrinter ? base.selectedPrinter.ipAddress : ""
                     }

--- a/plugins/UltimakerMachineActions/UMOCheckupMachineAction.qml
+++ b/plugins/UltimakerMachineActions/UMOCheckupMachineAction.qml
@@ -13,8 +13,8 @@ Cura.MachineAction
     {
         id: checkupMachineAction
         anchors.fill: parent;
-        property int leftRow: checkupMachineAction.width * 0.40
-        property int rightRow: checkupMachineAction.width * 0.60
+        property int leftRow: (checkupMachineAction.width * 0.40) | 0
+        property int rightRow: (checkupMachineAction.width * 0.60) | 0
         property bool heatupHotendStarted: false
         property bool heatupBedStarted: false
         property bool usbConnected: Cura.USBPrinterManager.connectedPrinterList.rowCount() > 0
@@ -166,7 +166,7 @@ Cura.MachineAction
             Label
             {
                 id: nozzleTempStatus
-                width: checkupMachineAction.rightRow * 0.4
+                width: (checkupMachineAction.rightRow * 0.4) | 0
                 anchors.top: nozzleTempLabel.top
                 anchors.left: nozzleTempLabel.right
                 wrapMode: Text.WordWrap
@@ -176,7 +176,7 @@ Cura.MachineAction
             Item
             {
                 id: nozzleTempButton
-                width: checkupMachineAction.rightRow * 0.3
+                width: (checkupMachineAction.rightRow * 0.3) | 0
                 height: childrenRect.height
                 anchors.top: nozzleTempLabel.top
                 anchors.left: bedTempStatus.right
@@ -205,7 +205,7 @@ Cura.MachineAction
                 anchors.top: nozzleTempLabel.top
                 anchors.left: nozzleTempButton.right
                 anchors.leftMargin: UM.Theme.getSize("default_margin").width
-                width: checkupMachineAction.rightRow * 0.2
+                width: (checkupMachineAction.rightRow * 0.2) | 0
                 wrapMode: Text.WordWrap
                 text: manager.hotendTemperature + "°C"
                 font.bold: true
@@ -227,7 +227,7 @@ Cura.MachineAction
             Label
             {
                 id: bedTempStatus
-                width: checkupMachineAction.rightRow * 0.4
+                width: (checkupMachineAction.rightRow * 0.4) | 0
                 anchors.top: bedTempLabel.top
                 anchors.left: bedTempLabel.right
                 wrapMode: Text.WordWrap
@@ -237,7 +237,7 @@ Cura.MachineAction
             Item
             {
                 id: bedTempButton
-                width: checkupMachineAction.rightRow * 0.3
+                width: (checkupMachineAction.rightRow * 0.3) | 0
                 height: childrenRect.height
                 anchors.top: bedTempLabel.top
                 anchors.left: bedTempStatus.right
@@ -263,7 +263,7 @@ Cura.MachineAction
             Label
             {
                 id: bedTemp
-                width: checkupMachineAction.rightRow * 0.2
+                width: (checkupMachineAction.rightRow * 0.2) | 0
                 anchors.top: bedTempLabel.top
                 anchors.left: bedTempButton.right
                 anchors.leftMargin: UM.Theme.getSize("default_margin").width

--- a/resources/qml/AboutDialog.qml
+++ b/resources/qml/AboutDialog.qml
@@ -22,15 +22,15 @@ UM.Dialog
     Image
     {
         id: logo
-        width: base.minimumWidth * 0.85
-        height: width * (1/4.25)
+        width: (base.minimumWidth * 0.85) | 0
+        height: (width * (1/4.25)) | 0
 
         source: UM.Theme.getImage("logo")
 
         sourceSize.width: width
         sourceSize.height: height
         anchors.top: parent.top
-        anchors.topMargin: (base.minimumWidth - width) / 2
+        anchors.topMargin: ((base.minimumWidth - width) / 2) | 0
         anchors.horizontalCenter: parent.horizontalCenter
 
         UM.I18nCatalog{id: catalog; name:"cura"}
@@ -44,7 +44,7 @@ UM.Dialog
         font: UM.Theme.getFont("large")
         anchors.right : logo.right
         anchors.top: logo.bottom
-        anchors.topMargin: UM.Theme.getSize("default_margin").height / 2
+        anchors.topMargin: (UM.Theme.getSize("default_margin").height / 2) | 0
     }
 
     Label

--- a/resources/qml/DiscardOrKeepProfileChangesDialog.qml
+++ b/resources/qml/DiscardOrKeepProfileChangesDialog.qml
@@ -109,20 +109,20 @@ UM.Dialog
                 role: "label"
                 title: catalog.i18nc("@title:column", "Profile settings")
                 delegate: labelDelegate
-                width: tableView.width * 0.4
+                width: (tableView.width * 0.4) | 0
             }
             TableViewColumn
             {
                 role: "original_value"
                 title: catalog.i18nc("@title:column", "Default")
-                width: tableView.width * 0.3
+                width: (tableView.width * 0.3) | 0
                 delegate: defaultDelegate
             }
             TableViewColumn
             {
                 role: "user_value"
                 title: catalog.i18nc("@title:column", "Customized")
-                width: tableView.width * 0.3 - 1
+                width: (tableView.width * 0.3) | 0
             }
             section.property: "category"
             section.delegate: Label

--- a/resources/qml/OpenFilesIncludingProjectsDialog.qml
+++ b/resources/qml/OpenFilesIncludingProjectsDialog.qml
@@ -59,7 +59,7 @@ UM.Dialog
         anchors.right: parent.right
         spacing: 10
 
-        Text
+        Label
         {
             text: catalog.i18nc("@text:window", "We have found one or more project file(s) within the files you have selected. You can open only one project file at a time. We suggest to only import models from those files. Would you like to proceed?")
             anchors.left: parent.left

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -66,7 +66,7 @@ UM.ManagementPage
         visible: base.currentItem != null
         anchors.fill: parent
 
-        Text
+        Label
         {
             id: machineName
             text: base.currentItem && base.currentItem.name ? base.currentItem.name : ""
@@ -146,34 +146,34 @@ UM.ManagementPage
             property var connectedPrinter: printerConnected ? Cura.MachineManager.printerOutputDevices[0] : null
             property bool printerAcceptsCommands: printerConnected && Cura.MachineManager.printerOutputDevices[0].acceptsCommands
 
-            Text
+            Label
             {
                 text: catalog.i18nc("@label", "Printer type:")
                 visible: base.currentItem && "definition_name" in base.currentItem.metadata
             }
-            Text
+            Label
             {
                 text: (base.currentItem && "definition_name" in base.currentItem.metadata) ? base.currentItem.metadata.definition_name : ""
             }
-            Text
+            Label
             {
                 text: catalog.i18nc("@label", "Connection:")
                 visible: base.currentItem && base.currentItem.id == Cura.MachineManager.activeMachineId
             }
-            Text
+            Label
             {
-                width: parent.width * 0.7
+                width: (parent.width * 0.7) | 0
                 text: machineInfo.printerConnected ? machineInfo.connectedPrinter.connectionText : catalog.i18nc("@info:status", "The printer is not connected.")
                 visible: base.currentItem && base.currentItem.id == Cura.MachineManager.activeMachineId
                 wrapMode: Text.WordWrap
             }
-            Text
+            Label
             {
                 text: catalog.i18nc("@label", "State:")
                 visible: base.currentItem && base.currentItem.id == Cura.MachineManager.activeMachineId && machineInfo.printerAcceptsCommands
             }
             Label {
-                width: parent.width * 0.7
+                width: (parent.width * 0.7) | 0
                 text:
                 {
                     if(!machineInfo.printerConnected || !machineInfo.printerAcceptsCommands) {

--- a/resources/qml/Preferences/MaterialView.qml
+++ b/resources/qml/Preferences/MaterialView.qml
@@ -16,8 +16,8 @@ TabView
 
     property bool editingEnabled: false;
     property string currency: UM.Preferences.getValue("cura/currency") ? UM.Preferences.getValue("cura/currency") : "€"
-    property real firstColumnWidth: width * 0.45
-    property real secondColumnWidth: width * 0.45
+    property real firstColumnWidth: (width * 0.45) | 0
+    property real secondColumnWidth: (width * 0.45) | 0
     property string containerId: ""
     property var materialPreferenceValues: UM.Preferences.getValue("cura/material_settings") ? JSON.parse(UM.Preferences.getValue("cura/material_settings")) : {}
 
@@ -53,7 +53,7 @@ TabView
             flickableItem.flickableDirection: Flickable.VerticalFlick
             frameVisible: true
 
-            property real columnWidth: Math.floor(viewport.width * 0.5) - UM.Theme.getSize("default_margin").width
+            property real columnWidth: (viewport.width * 0.5 - UM.Theme.getSize("default_margin").width) | 0
 
             Flow
             {
@@ -115,8 +115,8 @@ TabView
                         id: colorSelector
                         color: properties.color_code
 
-                        width: colorLabel.height * 0.75
-                        height: colorLabel.height * 0.75
+                        width: (colorLabel.height * 0.75) | 0
+                        height: (colorLabel.height * 0.75) | 0
                         border.width: UM.Theme.getSize("default_lining").height
 
                         anchors.verticalCenter: parent.verticalCenter

--- a/resources/qml/Preferences/MaterialsPage.qml
+++ b/resources/qml/Preferences/MaterialsPage.qml
@@ -53,21 +53,21 @@ UM.ManagementPage
 
         Row
         {
-            spacing: UM.Theme.getSize("default_margin").width / 2;
-            anchors.left: parent.left;
-            anchors.leftMargin: UM.Theme.getSize("default_margin").width;
-            anchors.right: parent.right;
+            spacing: (UM.Theme.getSize("default_margin").width / 2) | 0
+            anchors.left: parent.left
+            anchors.leftMargin: UM.Theme.getSize("default_margin").width
+            anchors.right: parent.right
             Rectangle
             {
-                width: parent.height * 0.8
-                height: parent.height * 0.8
+                width: (parent.height * 0.8) | 0
+                height: (parent.height * 0.8) | 0
                 color: model.metadata.color_code
                 border.color: isCurrentItem ? palette.highlightedText : palette.text;
                 anchors.verticalCenter: parent.verticalCenter
             }
             Label
             {
-                width: parent.width * 0.3
+                width: (parent.width * 0.3) | 0
                 text: model.metadata.material
                 elide: Text.ElideRight
                 font.italic: model.id == activeId

--- a/resources/qml/Preferences/ProfileTab.qml
+++ b/resources/qml/Preferences/ProfileTab.qml
@@ -51,14 +51,14 @@ Tab
         {
             role: "label"
             title: catalog.i18nc("@title:column", "Setting")
-            width: parent.width * 0.4
+            width: (parent.width * 0.4) | 0
             delegate: itemDelegate
         }
         TableViewColumn
         {
             role: "profile_value"
             title: catalog.i18nc("@title:column", "Profile")
-            width: parent.width * 0.18
+            width: (parent.width * 0.18) | 0
             delegate: itemDelegate
         }
         TableViewColumn
@@ -66,14 +66,14 @@ Tab
             role: "user_value"
             title: catalog.i18nc("@title:column", "Current");
             visible: quality == Cura.MachineManager.globalQualityId
-            width: parent.width * 0.18
+            width: (parent.width * 0.18) | 0
             delegate: itemDelegate
         }
         TableViewColumn
         {
             role: "unit"
             title: catalog.i18nc("@title:column", "Unit")
-            width: parent.width * 0.14
+            width: (parent.width * 0.14) | 0
             delegate: itemDelegate
         }
 

--- a/resources/qml/WorkspaceSummaryDialog.qml
+++ b/resources/qml/WorkspaceSummaryDialog.qml
@@ -95,12 +95,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Type")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: Cura.MachineManager.activeDefinitionName
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
             }
             Row
@@ -110,12 +110,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Name")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: Cura.MachineManager.activeMachineName
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
             }
 
@@ -142,12 +142,12 @@ UM.Dialog
                         Label
                         {
                             text: catalog.i18nc("@action:label", "%1 & material").arg(Cura.MachineManager.activeDefinitionVariantsName)
-                            width: parent.width / 3
+                            width: (parent.width / 3) | 0
                         }
                         Label
                         {
                             text: Cura.MachineManager.activeVariantNames[index] + ", " + modelData
-                            width: parent.width / 3
+                            width: (parent.width / 3) | 0
                         }
                     }
                 }
@@ -170,12 +170,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Not in profile")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: catalog.i18ncp("@action:label", "%1 override", "%1 overrides", Cura.MachineManager.numUserSettings).arg(Cura.MachineManager.numUserSettings)
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 visible: Cura.MachineManager.numUserSettings
             }
@@ -186,12 +186,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Name")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: Cura.MachineManager.activeQualityName
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
 
             }
@@ -214,12 +214,12 @@ UM.Dialog
                 Label
                 {
                     text: catalog.i18nc("@action:label", "Visible settings:")
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
                 Label
                 {
                     text: catalog.i18nc("@action:label", "%1 out of %2" ).arg(definitionsModel.visibleCount).arg(Cura.MachineManager.totalNumberOfSettings)
-                    width: parent.width / 3
+                    width: (parent.width / 3) | 0
                 }
             }
 


### PR DESCRIPTION
This PR fixes text rendering in system-themed qml by rounding fractional widths and heights.

Depending on window/dialog sizes, Label elements could be rendered at fractional pixel offsets. The Text.NativeRendering renderType does not handle that nicely, leading to ugly font rendering on Windows and OSX. In an attempt to fix this, some Labels were switched to Text (which uses Text.QtRendering rendertype). Unfortunately this leads to font-rendering that is distinctively non-native on Windows. Furthermore, Text does not use the system-themed colors used by Label, leading to unreadable text in dark-themed systems (black on black).

By rounding all widths/heights to whole pixels, Text.NativeRendering can be used without rendering problems.

Depends on https://github.com/Ultimaker/Uranium/pull/266
See #1748 for discussion.

Issue on dark system themes:
![image](https://user-images.githubusercontent.com/143551/28209630-9ce88812-6893-11e7-9759-47ce92658f78.png)