### PR TITLE
Fix Marlin (Volumetric) flavor

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -304,7 +304,7 @@
                     "options":
                     {
                         "RepRap (Marlin/Sprinter)": "Marlin",
-                        "RepRap (Volumetric)": "Marlin (Volumetric)",
+                        "RepRap (Volumatric)": "Marlin (Volumetric)",
                         "RepRap (RepRap)": "RepRap",
                         "UltiGCode": "Ultimaker 2",
                         "Griffin": "Griffin",


### PR DESCRIPTION
This PR reverts commit 500211941a36a25a372c675334d7fe7dc3312460.

The Volumatric typo is a historic typo, and CuraEngine relies on this typo.

The key (which has the typo) is what is sent to CuraEngine, the value (which has the correct spelling) is what the user sees. A typo in the key is not critical, as long as CuraEngine expects the typo. CuraEngine specifically checks for the key with the typo: https://github.com/Ultimaker/CuraEngine/blob/f5cc0cd2d851c998a5c66abc877389f86c19c4f2/src/settings/settings.cpp#L352

Note that fixing CuraEngine to check the correct spelling may sound like a better solution in the long run, but it would mean that every user who currently has "RepRap (Volumetric)" selected would have to reselect that (or we would have to introduce an upgrade step for that). It is my opinion that this is too much work (with too much risk of regression) to fix a historic typo that the normal user will never see.