### PR TITLE
LayerView: Set color for comp. mode text

### DIFF
--- a/plugins/LayerView/LayerView.qml
+++ b/plugins/LayerView/LayerView.qml
@@ -142,6 +142,7 @@ Item
                 id: compatibilityModeLabel
                 anchors.left: parent.left
                 text: catalog.i18nc("@label","Compatibility Mode")
+                color: UM.Theme.getColor("text")
                 visible: UM.LayerView.compatibilityMode
                 Layout.fillWidth: true
                 Layout.preferredHeight: UM.Theme.getSize("layerview_row").height


### PR DESCRIPTION
Before it was using the system's default, which is not that nicely visible, if you are using a dark theme.

Now it looks like this:
![image](https://user-images.githubusercontent.com/1847437/28560974-dd8a8a28-711c-11e7-98d9-0991980cdcdf.png)

Belongs to no JIRA issue.