### PR TITLE
Add settings to specify z offset for initial layer and number of layers over which offset reduces to zero

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4095,8 +4095,7 @@
                     "unit": "mm",
                     "type": "float",
                     "default_value": 0,
-                    "minimum_value": "-layer_height_0 * 0.5",
-                    "minimum_value_warning": "-layer_height_0 * 0.2",
+                    "minimum_value_warning": "0",
                     "maximum_value_warning": "layer_height_0",
                     "enabled": "resolveOrValue('adhesion_type') != 'raft'",
                     "settable_per_mesh": false,
@@ -4108,7 +4107,7 @@
                     "description": "When non-zero, the Z offset is reduced to 0 over that many layers. A value of 0 means that the Z offset remains constant for all the layers in the print.",
                     "type": "int",
                     "default_value": 0,
-                    "minimum_value": "0 if z_offset_layer_0 <= 0 or z_offset_taper_layers == 0 else max(1, round(5 * z_offset_layer_0 / layer_height + 0.5))",
+                    "minimum_value": "0",
                     "enabled": "resolveOrValue('adhesion_type') != 'raft' and z_offset_layer_0 != 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4090,7 +4090,7 @@
                 },
                 "z_offset_layer_0":
                 {
-                    "label": "Initial Layer Z Offset.",
+                    "label": "Initial Layer Z Offset",
                     "description": "The extruder is offset from the height of the first layer by this amount. It can be positive or negative. Some filament types adhere to the build plate better if the extruder is raised slightly.",
                     "unit": "mm",
                     "type": "float",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4088,6 +4088,28 @@
                     "settable_per_extruder": true,
                     "limit_to_extruder": "adhesion_extruder_nr"
                 },
+                "z_offset_layer_0":
+                {
+                    "label": "Initial Layer Z Offset.",
+                    "description": "The extruder is offset from the height of the first layer by this amount. It can be positive or negative. Some filament types adhere to the build plate better if the extruder is raised slightly.",
+                    "unit": "mm",
+                    "type": "float",
+                    "default_value": 0,
+                    "enabled": "resolveOrValue('adhesion_type') != 'raft'",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
+                },
+                "z_offset_taper_layers":
+                {
+                    "label": "Z Offset Taper Layers",
+                    "description": "Number of layers over which the Z offset is reduced to 0. A value of 0 means that the Z offset is not changed.",
+                    "type": "int",
+                    "default_value": 0,
+                    "minimum_value": "0",
+                    "enabled": "resolveOrValue('adhesion_type') != 'raft'",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
+                },
                 "raft_margin":
                 {
                     "label": "Raft Extra Margin",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4108,7 +4108,7 @@
                     "description": "When non-zero, the Z offset is reduced to 0 over that many layers. A value of 0 means that the Z offset remains constant for all the layers in the print.",
                     "type": "int",
                     "default_value": 0,
-                    "minimum_value": "0",
+                    "minimum_value": "0 if z_offset_layer_0 <= 0 or z_offset_taper_layers == 0 else max(1, round(5 * z_offset_layer_0 / layer_height + 0.5))",
                     "enabled": "resolveOrValue('adhesion_type') != 'raft' and z_offset_layer_0 != 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4091,7 +4091,7 @@
                 "z_offset_layer_0":
                 {
                     "label": "Initial Layer Z Offset",
-                    "description": "The extruder is offset from the height of the first layer by this amount. It can be positive or negative. Some filament types adhere to the build plate better if the extruder is raised slightly.",
+                    "description": "The extruder is offset from the normal height of the first layer by this amount. It can be positive (raised) or negative (lowered). Some filament types adhere to the build plate better if the extruder is raised slightly.",
                     "unit": "mm",
                     "type": "float",
                     "default_value": 0,
@@ -4102,7 +4102,7 @@
                 "z_offset_taper_layers":
                 {
                     "label": "Z Offset Taper Layers",
-                    "description": "Number of layers over which the Z offset is reduced to 0. A value of 0 means that the Z offset is not changed.",
+                    "description": "When non-zero, the Z offset is reduced to 0 over that many layers. A value of 0 means that the Z offset remains constant for all the layers in the print.",
                     "type": "int",
                     "default_value": 0,
                     "minimum_value": "0",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4095,6 +4095,9 @@
                     "unit": "mm",
                     "type": "float",
                     "default_value": 0,
+                    "minimum_value": "-layer_height_0 * 0.5",
+                    "minimum_value_warning": "-layer_height_0 * 0.2",
+                    "maximum_value_warning": "layer_height_0",
                     "enabled": "resolveOrValue('adhesion_type') != 'raft'",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4106,7 +4106,7 @@
                     "type": "int",
                     "default_value": 0,
                     "minimum_value": "0",
-                    "enabled": "resolveOrValue('adhesion_type') != 'raft'",
+                    "enabled": "resolveOrValue('adhesion_type') != 'raft' and z_offset_layer_0 != 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },


### PR DESCRIPTION
The rational behind this PR is that some filaments adhere to the build plate better if the extruder flies a little higher than the layer height. For example, when printing a 0.4mm thick initial layer using PETG it can ripple 
but if I increase the z height to 0.5mm (i.e. an offset of +0.1mm) the layer prints with no ripples and excellent adhesion to the build plate.
The PR includes another setting which is the number of layers over which the offset is tapered to zero. A value of 0 means that the offset is applied to all layers in the print.
