### PR TITLE
Adapt camera image to available space

### DIFF
--- a/cura/PrinterOutputDevice.py
+++ b/cura/PrinterOutputDevice.py
@@ -144,6 +144,9 @@ class PrinterOutputDevice(QObject, OutputDevice):
         return self._control_item
 
     def _createControlViewFromQML(self):
+        if not self._control_view_qml_path:
+            return
+
         path = QUrl.fromLocalFile(self._control_view_qml_path)
 
         # Because of garbage collection we need to keep this referenced by python.

--- a/plugins/UM3NetworkPrinting/MonitorItem.qml
+++ b/plugins/UM3NetworkPrinting/MonitorItem.qml
@@ -9,9 +9,20 @@ Component
     Image
     {
         id: cameraImage
-        width: sourceSize.width
-        height: sourceSize.height * width / sourceSize.width
+        property bool proportionalHeight:
+        {
+            if(sourceSize.height == 0 || maximumHeight == 0)
+            {
+                return true;
+            }
+            return (sourceSize.width / sourceSize.height) > (maximumWidth / maximumHeight);
+        }
+        property real _width: Math.min(maximumWidth, sourceSize.width)
+        property real _height: Math.min(maximumHeight, sourceSize.height)
+        width: proportionalHeight ? _width : sourceSize.width * _height / sourceSize.height
+        height: !proportionalHeight ? _height : sourceSize.height * _width / sourceSize.width
         anchors.horizontalCenter: parent.horizontalCenter
+
         onVisibleChanged:
         {
             if(visible)

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -466,6 +466,8 @@ UM.MainWindow
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenterOffset: - UM.Theme.getSize("sidebar").width / 2
+                property real maximumWidth: viewportOverlay.width
+                property real maximumHeight: viewportOverlay.height
             }
 
             UM.MessageStack

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -466,6 +466,7 @@ UM.MainWindow
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenterOffset: - UM.Theme.getSize("sidebar").width / 2
+                anchors.verticalCenterOffset: UM.Theme.getSize("sidebar_header").height / 2
                 property real maximumWidth: viewportOverlay.width
                 property real maximumHeight: viewportOverlay.height
             }


### PR DESCRIPTION
This PR makes sure the camera image adapts to the available size in the window. Cura 2.6 did the same thing, but this was missing since the refactor of the camera image in Cura 2.7.

Steps to reproduce the issue: 
switch to the monitor view and make the window as small as it will go.
Result:
the image will be cut off, and could even overlap the topbar (making it hard to return to the "prepare" tab. 

The issue is even more of a problem for users of the OctoPrint plugin, where the camera image can be much larger than the UM3 image (eg 1920x1080). A separate fix for the OctoPrint plugin is in preparation, but it relies on this PR.

It would be nice if this could be cherry picked for Cura 2.7.