### PR TITLE
Fix multiextruder menus

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -504,16 +504,6 @@ class MachineManager(QObject):
 
         return result
 
-    @pyqtProperty("QVariantList", notify = activeVariantChanged)
-    def activeMaterialIds(self):
-        result = []
-        if ExtruderManager.getInstance().getActiveGlobalAndExtruderStacks() is not None:
-            for stack in ExtruderManager.getInstance().getActiveGlobalAndExtruderStacks():
-                if stack.variant and stack.variant != self._empty_variant_container:
-                    result.append(stack.variant.getId())
-
-        return result
-
     @pyqtProperty("QVariantList", notify = activeMaterialChanged)
     def activeMaterialNames(self):
         result = []

--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -39,17 +39,20 @@ Menu
         visible: printerConnected && Cura.MachineManager.printerOutputDevices[0].materialNames.length > extruderIndex
         onTriggered:
         {
-            var material_id = Cura.MachineManager.printerOutputDevices[0].materialIds[extruderIndex];
+            var activeExtruderIndex = ExtruderManager.activeExtruderIndex;
+            ExtruderManager.setActiveExtruderIndex(extruderIndex);
+            var materialId = Cura.MachineManager.printerOutputDevices[0].materialIds[extruderIndex];
             var items = materialsModel.items;
             // materialsModel.find cannot be used because we need to look inside the metadata property of items
             for(var i in items)
             {
-                if (items[i]["metadata"]["GUID"] == material_id)
+                if (items[i]["metadata"]["GUID"] == materialId)
                 {
                     Cura.MachineManager.setActiveMaterial(items[i].id);
                     break;
                 }
             }
+            ExtruderManager.setActiveExtruderIndex(activeExtruderIndex);
         }
     }
 
@@ -64,12 +67,15 @@ Menu
         MenuItem
         {
             text: model.name
-            checkable: true;
-            checked: model.id == Cura.MachineManager.activeMaterialId;
-            exclusiveGroup: group;
+            checkable: true
+            checked: model.id == Cura.MachineManager.allActiveMaterialIds[ExtruderManager.extruderIds[extruderIndex]]
+            exclusiveGroup: group
             onTriggered:
             {
+                var activeExtruderIndex = ExtruderManager.activeExtruderIndex;
+                ExtruderManager.setActiveExtruderIndex(extruderIndex);
                 Cura.MachineManager.setActiveMaterial(model.id);
+                ExtruderManager.setActiveExtruderIndex(activeExtruderIndex);
             }
         }
         onObjectAdded: menu.insertItem(index, object)
@@ -102,12 +108,15 @@ Menu
                         MenuItem
                         {
                             text: model.name
-                            checkable: true;
-                            checked: model.id == Cura.MachineManager.activeMaterialId;
-                            exclusiveGroup: group;
+                            checkable: true
+                            checked: model.id == Cura.MachineManager.allActiveMaterialIds[ExtruderManager.extruderIds[extruderIndex]]
+                            exclusiveGroup: group
                             onTriggered:
                             {
+                                var activeExtruderIndex = ExtruderManager.activeExtruderIndex;
+                                ExtruderManager.setActiveExtruderIndex(extruderIndex);
                                 Cura.MachineManager.setActiveMaterial(model.id);
+                                ExtruderManager.setActiveExtruderIndex(activeExtruderIndex);
                             }
                         }
                         onObjectAdded: brandMaterialsMenu.insertItem(index, object)

--- a/resources/qml/Menus/NozzleMenu.qml
+++ b/resources/qml/Menus/NozzleMenu.qml
@@ -30,12 +30,15 @@ Menu
         visible: printerConnected && Cura.MachineManager.printerOutputDevices[0].hotendIds.length > extruderIndex
         onTriggered:
         {
+            var activeExtruderIndex = ExtruderManager.activeExtruderIndex;
+            ExtruderManager.setActiveExtruderIndex(extruderIndex);
             var hotendId = Cura.MachineManager.printerOutputDevices[0].hotendIds[extruderIndex];
             var itemIndex = nozzleInstantiator.model.find("name", hotendId);
             if(itemIndex > -1)
             {
-                Cura.MachineManager.setActiveVariant(nozzleInstantiator.model.getItem(itemIndex).id)
+                Cura.MachineManager.setActiveVariant(nozzleInstantiator.model.getItem(itemIndex).id);
             }
+            ExtruderManager.setActiveExtruderIndex(activeExtruderIndex);
         }
     }
 
@@ -56,11 +59,17 @@ Menu
             }
         }
         MenuItem {
-            text: model.name;
-            checkable: true;
-            checked: model.id == Cura.MachineManager.activeVariantId;
+            text: model.name
+            checkable: true
+            checked: model.id == Cura.MachineManager.allActiveVariantIds[ExtruderManager.extruderIds[extruderIndex]]
             exclusiveGroup: group
-            onTriggered: Cura.MachineManager.setActiveVariant(model.id)
+            onTriggered:
+            {
+                var activeExtruderIndex = ExtruderManager.activeExtruderIndex;
+                ExtruderManager.setActiveExtruderIndex(extruderIndex);
+                Cura.MachineManager.setActiveVariant(model.id);
+                ExtruderManager.setActiveExtruderIndex(activeExtruderIndex);
+            }
         }
         onObjectAdded: menu.insertItem(index, object)
         onObjectRemoved: menu.removeItem(object)


### PR DESCRIPTION
This PR fixes the application menus for materials and variants for multiextrusion printers. All extruder menus would always act on the currently active extruder only, instead of acting on the extruder suggested by the menu. 

**Reproduce steps:**
* Add a new UM3 printer to Cura, do not connect it
* Note that both extruders have PLA for material and that Extruder **1** is the selected extruder tab in the sidebar.
* From the Settings application menu, choose Extruder **2** -> Material -> ABS

**Expected result:**
The material of Extruder 2 (2nd tab) changes

**Actual result:**
The material of Extruder 1 (1st tab) changes instead

The PR fixes #1641, an issue that has been open since Cura 2.3. It may or may not have gotten a JIRA ticket nr.