### PR TITLE
Pirate Speak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 docs/html
 *.log
 resources/i18n/en
+resources/i18n/7s
 resources/i18n/x-test
 resources/firmware
 resources/materials

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -161,6 +161,12 @@ UM.PreferencesPage
                             append({ text: "Português do Brasil", code: "ptbr" })
                             append({ text: "Русский", code: "ru" })
                             append({ text: "Türkçe", code: "tr" })
+
+                            var date_object = new Date();
+                            if (date_object.getUTCMonth() == 8 && date_object.getUTCDate() == 19) //Only add Pirate on the 19th of September.
+                            {
+                                append({ text: "Pirate", code: "7s" })
+                            }
                         }
                     }
 


### PR DESCRIPTION
This be addin' the Pirate language to Cura, in the spirit of Talk Like a Pirate Day.

The Pirate language be only selected on the 19th of September in Cura's UI. Yowl, after selecting it the language be not deactivated automatically or anything, once the 19th has passed. Ye can also counterfeit yer cura.cfg file if ye be a scallywag like that, by setting the language to `7s`, the language code fer the Seven Seas.

Commandeer requests to keep in yer spyglass too:

* https://github.com/Ultimaker/Uranium/pull/273
* https://github.com/Ultimaker/cura-binary-data/pull/7