### PR TITLE
Remove WirelessPrinting Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Third party plugins
 * [X3G Writer](https://github.com/Ghostkeeper/X3GWriter): Adds support for exporting X3G files.
 * [Auto orientation](https://github.com/nallath/CuraOrientationPlugin): Calculate the optimal orientation for a model.
 * [OctoPrint Plugin](https://github.com/fieldofview/OctoPrintPlugin): Send printjobs directly to OctoPrint and monitor their progress in Cura.
-* [WirelessPrinting Plugin](https://github.com/probonopd/WirelessPrinting): Print wirelessly from Cura to your 3D printer connected to an ESP8266 module.
 * [Electric Print Cost Calculator Plugin](https://github.com/zoff99/ElectricPrintCostCalculator): Calculate the electric costs of a print.
 
 Making profiles for other printers


### PR DESCRIPTION
[WirelessPrinting](https://github.com/probonopd/WirelessPrinting) now uses a subset of the OctoPrint protocol because this is supported by Cura by default now