### PR TITLE
Added speed_print_layer_0_only_for_walls setting.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2250,6 +2250,14 @@
                             "maximum_value_warning": "300",
                             "settable_per_mesh": true
                         },
+                        "speed_print_layer_0_only_for_walls":
+                        {
+                            "label": "Only Use For Walls",
+                            "description": "Only use the Initial Layer Print Speed for the walls and not for the other features (e.g. skin).",
+                            "type": "bool",
+                            "default_value": false,
+                            "settable_per_mesh": true
+                        },
                         "speed_travel_layer_0":
                         {
                             "label": "Initial Layer Travel Speed",


### PR DESCRIPTION
This controls whether the speed_print_layer_0 is used for all features on layer 0 or just
the walls.

The rational behind this setting is that sometimes the layer 0 walls have to be printed very slowly to ensure that they adhere to the build plate well but the skin doesn't actually need to be printed as slowly. I think the skin can be printed faster because (a) the skin is made up of straight lines and not curves and (b) where the skin segments start, they are touching a wall and have something to anchor too as well as the build plate. If there is a lot of skin then it can take a long time to print at the speed required for good adhesion of the walls so I think being able to only slow down the walls is a good feature.
Engine PR is https://github.com/Ultimaker/CuraEngine/pull/583.