### PR TITLE
Find a material with the correct diameter when adding a printer

### DIFF
--- a/cura/Settings/CuraContainerStack.py
+++ b/cura/Settings/CuraContainerStack.py
@@ -432,6 +432,7 @@ class CuraContainerStack(ContainerStack):
     #   - If the machine definition has a metadata entry "has_machine_materials", the definition of the material should
     #     be the same as the machine definition for this stack. Otherwise, the definition should be "fdmprinter".
     #   - The container should have a metadata entry "type" with value "material".
+    #   - The material should have an approximate diameter that matches the machine
     #   - If the machine definition has a metadata entry "has_variants" and set to True, the "variant" metadata entry of
     #     the material should be the same as the ID of the variant in the stack. Only applies if "has_machine_materials" is also True.
     #   - If the stack currently has a material set, try to find a material that matches the current material by name.
@@ -459,6 +460,9 @@ class CuraContainerStack(ContainerStack):
             preferred_material = definition.getMetaDataEntry("preferred_material")
             if preferred_material:
                 search_criteria["id"] = preferred_material
+
+        approximate_material_diameter = str(round(self.getProperty("material_diameter", "value")))
+        search_criteria["approximate_diameter"] = approximate_material_diameter
 
         materials = ContainerRegistry.getInstance().findInstanceContainers(**search_criteria)
         if not materials:


### PR DESCRIPTION
This PR fixes the issue that a 1.75mm printer more often than not gets a 2.85mm material assigned by default.

Fixes this: https://github.com/Ultimaker/Cura/issues/2270#issuecomment-323577901

Probably a good idea to cherry-pick this to 2.7, but I don't know if this fix is still in time.