### PR TITLE
Add further options to z_seam_type.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1262,14 +1262,14 @@
                 "z_seam_corner":
                 {
                     "label": "Seam Corner Preference",
-                    "description": "Control whether corners on the model outline influence the position of the seam.",
+                    "description": "Control whether corners on the model outline influence the position of the seam. None means that corners have no influence on the seam position. Hide Seam makes the seam more likely to occur on an inside corner. Expose Seam makes the seam more likely to occur on an outside corner. Hide or Expose Seam makes the seam more likely to occur at an inside or outside corner.",
                     "type": "enum",
                     "options":
                     {
-                        "z_seam_corner_none":  "Ignore Corners",
-                        "z_seam_corner_inner": "Inner Corners",
-                        "z_seam_corner_outer": "Outer Corners",
-                        "z_seam_corner_any":   "Any Corner"
+                        "z_seam_corner_none":  "None",
+                        "z_seam_corner_inner": "Hide Seam",
+                        "z_seam_corner_outer": "Expose Seam",
+                        "z_seam_corner_any":   "Hide or Expose Seam"
                     },
                     "default_value": "z_seam_corner_inner",
                     "enabled": "z_seam_type != 'random'",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1272,7 +1272,7 @@
                         "z_seam_corner_any":   "Any Corner"
                     },
                     "default_value": "z_seam_corner_inner",
-                    "enabled": "z_seam_type == 'back' or z_seam_type == 'sharpest_corner'",
+                    "enabled": "z_seam_type != 'random'",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
                 },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1228,10 +1228,7 @@
                     {
                         "back": "User Specified",
                         "shortest": "Shortest",
-                        "random": "Random",
-                        "most_curvature_convex":  "Most Convex Region",
-                        "most_curvature_concave": "Most Concave Region",
-                        "most_curvature":         "Most Curved Region"
+                        "random": "Random"
                     },
                     "default_value": "shortest",
                     "limit_to_extruder": "wall_0_extruder_nr",
@@ -1257,6 +1254,23 @@
                     "type": "float",
                     "default_value": 100.0,
                     "value": "machine_depth * 3",
+                    "enabled": "z_seam_type == 'back'",
+                    "limit_to_extruder": "wall_0_extruder_nr",
+                    "settable_per_mesh": true
+                },
+                "z_seam_corner":
+                {
+                    "label": "Z Seam Corner Preference",
+                    "description": "Control whether corners on the model outline influence the position of the Z-seam.",
+                    "type": "enum",
+                    "options":
+                    {
+                        "z_seam_corner_none":  "Ignore Corners",
+                        "z_seam_corner_inner": "Inner Corners",
+                        "z_seam_corner_outer": "Outer corners",
+                        "z_seam_corner_any":   "Any Corner"
+                    },
+                    "default_value": "z_seam_corner_inner",
                     "enabled": "z_seam_type == 'back'",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1228,7 +1228,8 @@
                     {
                         "back": "User Specified",
                         "shortest": "Shortest",
-                        "random": "Random"
+                        "random": "Random",
+                        "sharpest_corner": "Sharpest Corner"
                     },
                     "default_value": "shortest",
                     "limit_to_extruder": "wall_0_extruder_nr",
@@ -1271,7 +1272,7 @@
                         "z_seam_corner_any":   "Any Corner"
                     },
                     "default_value": "z_seam_corner_inner",
-                    "enabled": "z_seam_type == 'back'",
+                    "enabled": "z_seam_type == 'back' or z_seam_type == 'sharpest_corner'",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
                 },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1228,7 +1228,10 @@
                     {
                         "back": "User Specified",
                         "shortest": "Shortest",
-                        "random": "Random"
+                        "random": "Random",
+                        "most_curvature_convex":  "Most Convex Region",
+                        "most_curvature_concave": "Most Concave Region",
+                        "most_curvature":         "Most Curved Region"
                     },
                     "default_value": "shortest",
                     "limit_to_extruder": "wall_0_extruder_nr",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1262,14 +1262,14 @@
                 "z_seam_corner":
                 {
                     "label": "Seam Corner Preference",
-                    "description": "Control whether corners on the model outline influence the position of the seam. When set to Hide Seam, the seam will be located at a nearby inside corner. When set to Expose Seam, the seam will be located at a nearby outside corner. When set to Hide or Expose Seam, the seam will be located at any nearby corner.",
+                    "description": "Control whether corners on the model outline influence the position of the seam.",
                     "type": "enum",
                     "options":
                     {
-                        "z_seam_corner_none":  "No Influence",
-                        "z_seam_corner_inner": "Hide Seam",
-                        "z_seam_corner_outer": "Expose Seam",
-                        "z_seam_corner_any":   "Hide or Expose Seam"
+                        "z_seam_corner_none":  "Ignore Corners",
+                        "z_seam_corner_inner": "Inner Corners",
+                        "z_seam_corner_outer": "Outer Corners",
+                        "z_seam_corner_any":   "Any Corner"
                     },
                     "default_value": "z_seam_corner_inner",
                     "enabled": "z_seam_type != 'random'",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1260,14 +1260,14 @@
                 },
                 "z_seam_corner":
                 {
-                    "label": "Z Seam Corner Preference",
-                    "description": "Control whether corners on the model outline influence the position of the Z-seam.",
+                    "label": "Seam Corner Preference",
+                    "description": "Control whether corners on the model outline influence the position of the seam.",
                     "type": "enum",
                     "options":
                     {
                         "z_seam_corner_none":  "Ignore Corners",
                         "z_seam_corner_inner": "Inner Corners",
-                        "z_seam_corner_outer": "Outer corners",
+                        "z_seam_corner_outer": "Outer Corners",
                         "z_seam_corner_any":   "Any Corner"
                     },
                     "default_value": "z_seam_corner_inner",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1262,14 +1262,14 @@
                 "z_seam_corner":
                 {
                     "label": "Seam Corner Preference",
-                    "description": "Control whether corners on the model outline influence the position of the seam.",
+                    "description": "Control whether corners on the model outline influence the position of the seam. When set to Hide Seam, the seam will be located at a nearby inside corner. When set to Expose Seam, the seam will be located at a nearby outside corner. When set to Hide or Expose Seam, the seam will be located at any nearby corner.",
                     "type": "enum",
                     "options":
                     {
-                        "z_seam_corner_none":  "Ignore Corners",
-                        "z_seam_corner_inner": "Inner Corners",
-                        "z_seam_corner_outer": "Outer Corners",
-                        "z_seam_corner_any":   "Any Corner"
+                        "z_seam_corner_none":  "No Influence",
+                        "z_seam_corner_inner": "Hide Seam",
+                        "z_seam_corner_outer": "Expose Seam",
+                        "z_seam_corner_any":   "Hide or Expose Seam"
                     },
                     "default_value": "z_seam_corner_inner",
                     "enabled": "z_seam_type != 'random'",


### PR DESCRIPTION
Can now specify that the z-seam should be located in either the most concave region of the
outline, the most convex region or the most curved (concave or convex) region.

See https://github.com/Ultimaker/CuraEngine/pull/590.
