### PR TITLE
Fix setting the Gantry height setting in Machine Settings

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -233,6 +233,7 @@ Cura.MachineAction
                                 property string label: catalog.i18nc("@label", "Gantry height")
                                 property string unit: catalog.i18nc("@label", "mm")
                                 property string tooltip: catalog.i18nc("@tooltip", "The height difference between the tip of the nozzle and the gantry system (X and Y axes). Used to prevent collisions between previous prints and the gantry when printing \"One at a Time\".")
+                                property bool forceUpdateOnChange: true
                             }
 
                             Item { width: UM.Theme.getSize("default_margin").width; height: UM.Theme.getSize("default_margin").height }


### PR DESCRIPTION
This PR fixes setting the Gantry height setting in Machine Settings. Before this PR, the setting would be correctly added to the definition_changes container, but the buildvolume would not be updated. That means that Cura needs to be restarted, or the active stack needs to be switched before the buildvolume updates.

Fixes an issue uncovered here:
http://elb-v2-prod-615036279.eu-west-1.elb.amazonaws.com/en/community/50595-cura-27-beta?page=4&sort=#reply-187977

Would be nice if this could still make it in to 2.7, but I understand if it doesn't. There are workarounds for the bug.