### PR TITLE
Show target hotend temperatures

### DIFF
--- a/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
@@ -312,6 +312,18 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
         self.targetBedTemperatureChanged.emit()
         return True
 
+    ##  Updates the target hotend temperature from the printer, and emit a signal if it was changed.
+    #
+    #   /param index The index of the hotend.
+    #   /param temperature The new target temperature of the hotend.
+    #   /return boolean, True if the temperature was changed, false if the new temperature has the same value as the already stored temperature
+    def _updateTargetHotendTemperature(self, index, temperature):
+        if self._target_hotend_temperatures[index] == temperature:
+            return False
+        self._target_hotend_temperatures[index] = temperature
+        self.targetHotendTemperaturesChanged.emit()
+        return True
+
     def _stopCamera(self):
         if self._camera_timer.isActive():
             self._camera_timer.stop()
@@ -534,8 +546,9 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
     def _spliceJSONData(self):
         # Check for hotend temperatures
         for index in range(0, self._num_extruders):
-            temperature = self._json_printer_state["heads"][0]["extruders"][index]["hotend"]["temperature"]["current"]
-            self._setHotendTemperature(index, temperature)
+            temperatures = self._json_printer_state["heads"][0]["extruders"][index]["hotend"]["temperature"]
+            self._setHotendTemperature(index, temperatures["current"])
+            self._updateTargetHotendTemperature(index, temperatures["target"])
             try:
                 material_id = self._json_printer_state["heads"][0]["extruders"][index]["active_material"]["guid"]
             except KeyError:
@@ -547,10 +560,9 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
                 hotend_id = ""
             self._setHotendId(index, hotend_id)
 
-        bed_temperature = self._json_printer_state["bed"]["temperature"]["current"]
-        self._setBedTemperature(bed_temperature)
-        target_bed_temperature = self._json_printer_state["bed"]["temperature"]["target"]
-        self._updateTargetBedTemperature(target_bed_temperature)
+        bed_temperatures = self._json_printer_state["bed"]["temperature"]
+        self._setBedTemperature(bed_temperatures["current"])
+        self._updateTargetBedTemperature(bed_temperatures["target"])
 
         head_x = self._json_printer_state["heads"][0]["position"]["x"]
         head_y = self._json_printer_state["heads"][0]["position"]["y"]

--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -94,13 +94,46 @@ Column
                         anchors.top: parent.top
                         anchors.margins: UM.Theme.getSize("default_margin").width
                     }
+
+                    Text //Target temperature.
+                    {
+                        id: extruderTargetTemperature
+                        text: (connectedPrinter != null && connectedPrinter.hotendIds[index] != null && connectedPrinter.targetHotendTemperatures[index] != null) ? Math.round(connectedPrinter.targetHotendTemperatures[index]) + "°C" : ""
+                        font: UM.Theme.getFont("small")
+                        color: UM.Theme.getColor("text_inactive")
+                        anchors.right: parent.right
+                        anchors.rightMargin: UM.Theme.getSize("default_margin").width
+                        anchors.bottom: extruderTemperature.bottom
+
+                        MouseArea //For tooltip.
+                        {
+                            id: extruderTargetTemperatureTooltipArea
+                            hoverEnabled: true
+                            anchors.fill: parent
+                            onHoveredChanged:
+                            {
+                                if (containsMouse)
+                                {
+                                    base.showTooltip(
+                                        base,
+                                        {x: 0, y: extruderTargetTemperature.mapToItem(base, 0, -parent.height / 4).y},
+                                        catalog.i18nc("@tooltip", "The target temperature of the hotend. The hotend will heat up or cool down towards this temperature. If this is 0, the hotend heating is turned off.")
+                                    );
+                                }
+                                else
+                                {
+                                    base.hideTooltip();
+                                }
+                            }
+                        }
+                    }
                     Text //Temperature indication.
                     {
                         id: extruderTemperature
                         text: (connectedPrinter != null && connectedPrinter.hotendIds[index] != null && connectedPrinter.hotendTemperatures[index] != null) ? Math.round(connectedPrinter.hotendTemperatures[index]) + "°C" : ""
                         color: UM.Theme.getColor("text")
                         font: UM.Theme.getFont("large")
-                        anchors.right: parent.right
+                        anchors.right: extruderTargetTemperature.left
                         anchors.top: parent.top
                         anchors.margins: UM.Theme.getSize("default_margin").width
 
@@ -116,7 +149,7 @@ Column
                                     base.showTooltip(
                                         base,
                                         {x: 0, y: parent.mapToItem(base, 0, -parent.height / 4).y},
-                                        catalog.i18nc("@tooltip", "The current temperature of this extruder.")
+                                        catalog.i18nc("@tooltip", "The current temperature of this hotend.")
                                     );
                                 }
                                 else


### PR DESCRIPTION
This PR shows the target hotend temperature(s) in the print monitor, similar to how the target temperature for the bed is shown.

![image](https://user-images.githubusercontent.com/143551/29813522-9adacc16-8caa-11e7-8e0c-f69f328e191c.png)


Note: I don't have an UM3. I have tested this PR with the OctoPrintPlugin. The code change for the UM3 is fairly trivial, but untested.