### PR TITLE
Install cura icon on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ if(NOT APPLE AND NOT WIN32)
             DESTINATION lib/python${PYTHON_VERSION_MAJOR}/dist-packages/cura)
     install(FILES ${CMAKE_BINARY_DIR}/cura.desktop
             DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+    install(FILES ${CMAKE_SOURCE_DIR}/resources/images/cura-icon.png
+            DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps/)
     install(FILES cura.appdata.xml
             DESTINATION ${CMAKE_INSTALL_DATADIR}/appdata)
     install(FILES cura.sharedmimeinfo


### PR DESCRIPTION
This commit is needed for https://github.com/probonopd/Cura/commit/b9970d57b48b31f217f08fb652e5e39f1e55f3bb
Never tested it, but believing the author of the commit that this change will work.