### PR TITLE
Fix setting machine head polygon in Machine Settings

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -824,7 +824,7 @@ Cura.MachineAction
                             polygon.push([-printHeadPolygon["x"]["min"], printHeadPolygon["y"]["max"]]);
                             polygon.push([-printHeadPolygon["x"]["min"],-printHeadPolygon["y"]["min"]]);
                             polygon.push([ printHeadPolygon["x"]["max"], printHeadPolygon["y"]["max"]]);
-                            polygon.push([ printHeadPolygon["x"]["max"],-printHeadPolygon["y"]["mìn"]]);
+                            polygon.push([ printHeadPolygon["x"]["max"],-printHeadPolygon["y"]["min"]]);
                             var polygon_string = JSON.stringify(polygon);
                             if(polygon_string != machineHeadPolygonProvider.properties.value)
                             {


### PR DESCRIPTION
This PR fixes a typo spotted by @McAJBen. It causes the machine head polygon to be written incorrectly when changing it in the Machine Settings dialog.

Fixes #2347