### PR TITLE
Prevent a possible memory leak while showing a stuck camera stream

### DIFF
--- a/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
@@ -326,6 +326,9 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
         return True
 
     def _stopCamera(self):
+        self._stream_buffer = b""
+        self._stream_buffer_start_index = -1
+
         if self._camera_timer.isActive():
             self._camera_timer.stop()
             if self._image_reply:
@@ -1164,6 +1167,12 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
         if self._image_reply is None:
             return
         self._stream_buffer += self._image_reply.readAll()
+
+        if len(self._stream_buffer) > 2000000: # No single camera frame should be 2 Mb or larger
+            Logger.log("w", "MJPEG buffer exceeds reasonable size. Restarting stream...")
+            self._stopCamera() # resets stream buffer and start index
+            self._startCamera()
+            return
 
         if self._stream_buffer_start_index == -1:
             self._stream_buffer_start_index = self._stream_buffer.indexOf(b'\xff\xd8')


### PR DESCRIPTION
This PR prevents a possible memory leak while showing a stuck camera stream by flushing the stream buffer and restarting the stream if the stream buffer gets unrealistically large.

Note: I don't have an UM3 to test this with. The 2000000 is an arbitrary number. I don't think any 800x600 jpg frame will realistically be larger than that.

Note 2: Interestingly I have not received any similar memory leak reports from OctoPrintPlugin users, though it uses the same code as UM3NetworkPrinting. It could be the specific version of mjpgstreamer in the UM3 that is acting up.