### PR TITLE
Remove home bed from abort sequence

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -622,8 +622,9 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
         self._sendCommand("M140 S0")
         self._sendCommand("M104 S0")
         self._sendCommand("M107")
+        # Home XY to prevent nozzle resting on aborted print
+        # Don't home bed because it may crash the printhead into the print on printers that home on the bottom
         self.homeHead()
-        self.homeBed()
         self._sendCommand("M84")
         self._is_printing = False
         self._is_paused = False


### PR DESCRIPTION
This PR removes homing the bed from the abort sequence. On printers that home the bed to the bottom (ie: printhead moves towards the bed), homing the bed when aborting a print could cause the printhead to crash into the aborted print.

Fixes #2307 and #2344