### PR TITLE
Add setting to only iron the highest layer of a mesh

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5712,6 +5712,16 @@
                     "limit_to_extruder": "top_bottom_extruder_nr",
                     "settable_per_mesh": true
                 },
+                "ironing_only_highest_layer":
+                {
+                    "label": "Iron Only Highest Layer",
+                    "description": "Only perform ironing on the very last layer of the mesh. This saves time if the lower layers don't need a smooth surface finish.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": "ironing_enabled",
+                    "limit_to_extruder": "top_bottom_extruder_nr",
+                    "settable_per_mesh": true
+                },
                 "ironing_pattern":
                 {
                     "label": "Ironing Pattern",


### PR DESCRIPTION
This can save some time if only the highest layer of your print needs to be smooth.

See also https://github.com/Ultimaker/CuraEngine/pull/603 for the implementation of this setting.