### PR TITLE
Fix hover state of Monitor button in the topbar

### DIFF
--- a/resources/themes/cura-light/styles.qml
+++ b/resources/themes/cura-light/styles.qml
@@ -107,7 +107,7 @@ QtObject {
                     anchors.bottom: parent.bottom
                     width: parent.width
                     height: Theme.getSize("sidebar_header_highlight").height
-                    color: control.checked ? UM.Theme.getColor("sidebar_header_highlight") : "transparent"
+                    color: control.checked ? UM.Theme.getColor("sidebar_header_highlight") : UM.Theme.getColor("sidebar_header_highlight_hover")
                     visible: control.hovered || control.checked
                 }
             }


### PR DESCRIPTION
This PR makes the Monitor button have the same behavior as the Prepare button, in regards to its hover state. Before this PR, the Monitor has no underline when hovered, while the Prepare button does.