### PR TITLE
add ConvexHullDecorator when grouping

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1182,6 +1182,7 @@ class CuraApplication(QtApplication):
         group_node = SceneNode()
         group_decorator = GroupDecorator()
         group_node.addDecorator(group_decorator)
+        group_node.addDecorator(ConvexHullDecorator())
         group_node.setParent(self.getController().getScene().getRoot())
         group_node.setSelectable(True)
         center = Selection.getSelectionCenter()


### PR DESCRIPTION
When grouping nodes, add a ConvexHullDecorator to the group SceneNode.
When multiplying the group it was crashing because it didn't have the ConvexHullDecorator.