### PR TITLE
Add menu item to reset the camera

### DIFF
--- a/cura/CuraActions.py
+++ b/cura/CuraActions.py
@@ -36,6 +36,15 @@ class CuraActions(QObject):
         event = CallFunctionEvent(self._openUrl, [QUrl("http://github.com/Ultimaker/Cura/issues")], {})
         Application.getInstance().functionEvent(event)
 
+    ##  Reset camera position and direction to default
+    @pyqtSlot()
+    def homeCamera(self) -> None:
+        scene = Application.getInstance().getController().getScene()
+        camera = scene.getActiveCamera()
+        camera.setPosition(Vector(-80, 250, 700))
+        camera.setPerspective(True)
+        camera.lookAt(Vector(0, 0, 0))
+
     ##  Center all objects in the selection
     @pyqtSlot()
     def centerSelection(self) -> None:

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -17,6 +17,8 @@ Item
     property alias undo: undoAction;
     property alias redo: redoAction;
 
+    property alias homeCamera: homeCameraAction;
+
     property alias deleteSelection: deleteSelectionAction;
     property alias centerSelection: centerSelectionAction;
     property alias multiplySelection: multiplySelectionAction;
@@ -94,6 +96,13 @@ Item
         text: catalog.i18nc("@action:inmenu menubar:file","&Quit");
         iconName: "application-exit";
         shortcut: StandardKey.Quit;
+    }
+
+    Action
+    {
+        id: homeCameraAction;
+        text: catalog.i18nc("@action:inmenu menubar:view","&Reset camera position");
+        onTriggered: CuraActions.homeCamera();
     }
 
     Action

--- a/resources/qml/Menus/ViewMenu.qml
+++ b/resources/qml/Menus/ViewMenu.qml
@@ -27,4 +27,7 @@ Menu
         onObjectRemoved: menu.removeItem(object)
     }
     ExclusiveGroup { id: group; }
+
+    MenuSeparator {}
+    MenuItem { action: Cura.Actions.homeCamera; }
 }


### PR DESCRIPTION
This PR adds a menu item to the view menu to reset the camera position and lookat, homing the camera. This can be used when the user "looses" the buildplate from the view.

Fixes #2411 and contributes to #2361
