### PR TITLE
Improve Prusa i3 MK2 start GCode

### DIFF
--- a/resources/definitions/prusa_i3_mk2.def.json
+++ b/resources/definitions/prusa_i3_mk2.def.json
@@ -41,7 +41,7 @@
         "machine_max_jerk_e": { "default_value": 2.5 },
         "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
         "machine_start_gcode": {
-            "default_value": "G21 ; set units to millimeters\nG90 ; use absolute positioning\nM82 ; absolute extrusion mode\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nM104 S{material_print_temperature} ; set extruder temp\nM140 S{material_bed_temperature} ; set bed temp\nM190 S{material_bed_temperature} ; wait for bed temp\nM109 S{material_print_temperature} ; wait for extruder temp\nG92 E0.0 ; reset extruder distance position\nG1 Y-3.0 F1000.0 ; go outside print area\nG1 X60.0 E9.0 F1000.0 ; intro line\nG1 X100.0 E21.5 F1000.0 ; intro line\nG92 E0.0 ; reset extruder distance position"
+            "default_value": "G21 ; set units to millimeters\nG90 ; use absolute positioning\nM82 ; absolute extrusion mode\nM104 S{material_print_temperature} ; set extruder temp\nM140 S{material_bed_temperature} ; set bed temp\nM190 S{material_bed_temperature} ; wait for bed temp\nM109 S{material_print_temperature} ; wait for extruder temp\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nG92 E0.0 ; reset extruder distance position\nG1 Y-3.0 F1000.0 ; go outside print area\nG1 X60.0 E9.0 F1000.0 ; intro line\nG1 X100.0 E21.5 F1000.0 ; intro line\nG92 E0.0 ; reset extruder distance position"
         },
         "machine_end_gcode": {
             "default_value": "M104 S0 ; turn off extruder\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\nG1 X0 Y210; home X axis and push Y forward\nM84 ; disable motors"


### PR DESCRIPTION
The current Prusa i3 MK2 GCode in Cura first homes the extruder, then does mesh bed levelling, then heats the bed and extruder. This has a few issues:

1. When the bed and nozzle heats up, the nozzle increases in size slightly and the bed can change shape slightly. Also the PINDA probe used for bed levelling behaves differently when cold.This makes mesh bed levelling less accurate when cold, resulting in bad first layers, or worst case PEI-sheet damage.
2. The extruder is very close to the bed during nozzle and bed heating, because it just auto homed. When working with higher temperature materials, this can damage the relatively fragile PEI-sheet on the print bed.

So here's a pull request that changes the sequence: it first heats up the extruder and print bed, then waits for the temperature, then auto homes and performs mesh bed levelling, then prints the intro line and starts printing.
This is the same sequence as Prusa Research uses with their Slic3r version.