### PR TITLE
Fix missing setting_version after translation

### DIFF
--- a/plugins/LegacyProfileReader/LegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/LegacyProfileReader.py
@@ -141,4 +141,5 @@ class LegacyProfileReader(ProfileReader):
         profile.setDirty(True)
         profile.addMetaDataEntry("type", "quality_changes")
         profile.addMetaDataEntry("quality_type", "normal")
+        profile.addMetaDataEntry("setting_version", 2)
         return profile


### PR DESCRIPTION
Resolves #2117.
https://github.com/Ultimaker/Cura/commit/0f5814e52f8b7ae2373dede03c16c0883589ba67 implemented a check against the "setting_version" metadata when importing profiles. Legacy profile translation does not add this entry, which leads to Cura failing to import the translated profile.