### PR TITLE
Make Solid View a required plugin

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -211,7 +211,7 @@ class CuraApplication(QtApplication):
 
         self.setRequiredPlugins([
             "CuraEngineBackend",
-            "MeshView",
+            "SolidView",
             "LayerView",
             "STLReader",
             "SelectionTool",


### PR DESCRIPTION
This PR makes "Solid View" a required plugin. Without Solid View, Cura will start with a blank viewport and spew lots of critical errors because the "view" is None.

Note: There is no plugin with the id "MeshView".

Prevents https://ultimaker.com/en/community/51244-cura-27-3d-interface-is-gone