### PR TITLE
refine abort sequence

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -119,7 +119,8 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
         self._sendCommand("G0 Y%s F%s" % (z, speed))
 
     def _homeHead(self):
-        self._sendCommand("G28")
+        self._sendCommand("G28 X")
+        self._sendCommand("G28 Y")
 
     def _homeBed(self):
         self._sendCommand("G28 Z")


### PR DESCRIPTION
#2307 homing the head with "G28" does not work on my printer for some reason. "G28 X" and "G28 Y" however do.
this fix should not break behaviour on other printers as "G28" is just a shortcut.