### PR TITLE
Use screenScaleFactor to consistently adapt sizes to display pixel ratio

### DIFF
--- a/cura/CuraSplashScreen.py
+++ b/cura/CuraSplashScreen.py
@@ -10,7 +10,6 @@ from PyQt5.QtWidgets import QSplashScreen
 from UM.Resources import Resources
 from UM.Application import Application
 
-
 class CuraSplashScreen(QSplashScreen):
     def __init__(self):
         super().__init__()
@@ -61,7 +60,7 @@ class CuraSplashScreen(QSplashScreen):
 
         # draw version text
         font = QFont()  # Using system-default font here
-        font.setPointSize(28)
+        font.setPixelSize(37)
         painter.setFont(font)
         painter.drawText(220, 66, 330 * self._scale, 230 * self._scale, Qt.AlignLeft | Qt.AlignTop, version[0])
         if len(version) > 1:
@@ -81,7 +80,7 @@ class CuraSplashScreen(QSplashScreen):
         # draw message text
         if self._current_message:
             font = QFont()  # Using system-default font here
-            font.setPointSize(10)
+            font.setPixelSize(13)
             pen = QPen()
             pen.setColor(QColor(255, 255, 255, 255))
             painter.setPen(pen)
@@ -107,5 +106,3 @@ class CuraSplashScreen(QSplashScreen):
         self._to_stop = True
         self._change_timer.stop()
         super().close()
-
-

--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -13,7 +13,7 @@ UM.Dialog
     title: catalog.i18nc("@title:window", "Open Project")
 
     minimumWidth: 500 * screenScaleFactor
-    minumumHeight: 400 * screenScaleFactor
+    minimumHeight: 400 * screenScaleFactor
     width: minimumWidth
     height: minumumHeight
 

--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -12,11 +12,13 @@ UM.Dialog
 {
     title: catalog.i18nc("@title:window", "Open Project")
 
-    width: 500
-    height: 400
+    minimumWidth: 500 * screenScaleFactor
+    minumumHeight: 400 * screenScaleFactor
+    width: minimumWidth
+    height: minumumHeight
 
-    property int comboboxHeight: 15
-    property int spacerHeight: 10
+    property int comboboxHeight: 15 * screenScaleFactor
+    property int spacerHeight: 10 * screenScaleFactor
 
     onClosing: manager.notifyClosed()
     onVisibleChanged:
@@ -31,7 +33,7 @@ UM.Dialog
     Item
     {
         anchors.fill: parent
-        anchors.margins: 20
+        anchors.margins: 20 * screenScaleFactor
 
         UM.I18nCatalog
         {
@@ -59,7 +61,7 @@ UM.Dialog
         Column
         {
             anchors.fill: parent
-            spacing: 2
+            spacing: 2 * screenScaleFactor
             Label
             {
                 id: titleLabel
@@ -373,7 +375,7 @@ UM.Dialog
             enabled: true
             anchors.bottom: parent.bottom
             anchors.right: ok_button.left
-            anchors.rightMargin:2
+            anchors.rightMargin: 2 * screenScaleFactor
         }
          Button
         {

--- a/plugins/ImageReader/ConfigUI.qml
+++ b/plugins/ImageReader/ConfigUI.qml
@@ -10,11 +10,11 @@ import UM 1.1 as UM
 
 UM.Dialog
 {
-    width: 350 * Screen.devicePixelRatio;
-    minimumWidth: 350 * Screen.devicePixelRatio;
+    width: minimumWidth;
+    minimumWidth: 350 * screenScaleFactor;
 
-    height: 250 * Screen.devicePixelRatio;
-    minimumHeight: 250 * Screen.devicePixelRatio;
+    height: minimumHeight;
+    minimumHeight: 250 * screenScaleFactor;
 
     title: catalog.i18nc("@title:window", "Convert Image...")
 
@@ -23,8 +23,8 @@ UM.Dialog
         UM.I18nCatalog{id: catalog; name:"cura"}
         anchors.fill: parent;
         Layout.fillWidth: true
-        columnSpacing: 16
-        rowSpacing: 4
+        columnSpacing: 16 * screenScaleFactor
+        rowSpacing: 4 * screenScaleFactor
         columns: 1
 
         UM.TooltipArea {
@@ -36,7 +36,7 @@ UM.Dialog
 
                 Label {
                     text: catalog.i18nc("@action:label","Height (mm)")
-                    width: 150
+                    width: 150 * screenScaleFactor
                     anchors.verticalCenter: parent.verticalCenter
                 }
 
@@ -44,7 +44,7 @@ UM.Dialog
                     id: peak_height
                     objectName: "Peak_Height"
                     validator: DoubleValidator {notation: DoubleValidator.StandardNotation; bottom: -500; top: 500;}
-                    width: 180
+                    width: 180 * screenScaleFactor
                     onTextChanged: { manager.onPeakHeightChanged(text) }
                 }
             }
@@ -59,7 +59,7 @@ UM.Dialog
 
                 Label {
                     text: catalog.i18nc("@action:label","Base (mm)")
-                    width: 150
+                    width: 150 * screenScaleFactor
                     anchors.verticalCenter: parent.verticalCenter
                 }
 
@@ -67,7 +67,7 @@ UM.Dialog
                     id: base_height
                     objectName: "Base_Height"
                     validator: DoubleValidator {notation: DoubleValidator.StandardNotation; bottom: 0; top: 500;}
-                    width: 180
+                    width: 180 * screenScaleFactor
                     onTextChanged: { manager.onBaseHeightChanged(text) }
                 }
             }
@@ -82,7 +82,7 @@ UM.Dialog
 
                 Label {
                     text: catalog.i18nc("@action:label","Width (mm)")
-                    width: 150
+                    width: 150 * screenScaleFactor
                     anchors.verticalCenter: parent.verticalCenter
                 }
 
@@ -91,7 +91,7 @@ UM.Dialog
                     objectName: "Width"
                     focus: true
                     validator: DoubleValidator {notation: DoubleValidator.StandardNotation; bottom: 1; top: 500;}
-                    width: 180
+                    width: 180 * screenScaleFactor
                     onTextChanged: { manager.onWidthChanged(text) }
                 }
             }
@@ -106,7 +106,7 @@ UM.Dialog
 
                 Label {
                     text: catalog.i18nc("@action:label","Depth (mm)")
-                    width: 150
+                    width: 150 * screenScaleFactor
                     anchors.verticalCenter: parent.verticalCenter
                 }
                 TextField {
@@ -114,7 +114,7 @@ UM.Dialog
                     objectName: "Depth"
                     focus: true
                     validator: DoubleValidator {notation: DoubleValidator.StandardNotation; bottom: 1; top: 500;}
-                    width: 180
+                    width: 180 * screenScaleFactor
                     onTextChanged: { manager.onDepthChanged(text) }
                 }
             }
@@ -130,14 +130,14 @@ UM.Dialog
                 //Empty label so 2 column layout works.
                 Label {
                     text: ""
-                    width: 150
+                    width: 150 * screenScaleFactor
                     anchors.verticalCenter: parent.verticalCenter
                 }
                 ComboBox {
                     id: image_color_invert
                     objectName: "Image_Color_Invert"
                     model: [ catalog.i18nc("@item:inlistbox","Lighter is higher"), catalog.i18nc("@item:inlistbox","Darker is higher") ]
-                    width: 180
+                    width: 180 * screenScaleFactor
                     onCurrentIndexChanged: { manager.onImageColorInvertChanged(currentIndex) }
                 }
             }
@@ -152,13 +152,13 @@ UM.Dialog
 
                 Label {
                     text: catalog.i18nc("@action:label","Smoothing")
-                    width: 150
+                    width: 150 * screenScaleFactor
                     anchors.verticalCenter: parent.verticalCenter
                 }
 
                 Item {
-                    width: 180
-                    height: 20
+                    width: 180 * screenScaleFactor
+                    height: 20 * screenScaleFactor
                     Layout.fillWidth: true
 
                     Slider {

--- a/plugins/LayerView/LayerView.qml
+++ b/plugins/LayerView/LayerView.qml
@@ -111,7 +111,7 @@ Item
                 visible: !UM.LayerView.compatibilityMode
                 style: UM.Theme.styles.combobox
                 anchors.right: parent.right
-                anchors.rightMargin: 10
+                anchors.rightMargin: 10 * screenScaleFactor
 
                 onActivated:
                 {
@@ -602,7 +602,7 @@ Item
                     anchors.leftMargin: UM.Theme.getSize("default_margin").width / 2;
                     anchors.verticalCenter: parent.verticalCenter;
 
-                    width: Math.max(UM.Theme.getSize("line").width * maxValue.length + 2, 20);
+                    width: Math.max(UM.Theme.getSize("line").width * maxValue.length + 2 * screenScaleFactor, 20);
                     style: TextFieldStyle
                     {
                         textColor: UM.Theme.getColor("setting_control_text");

--- a/plugins/LayerView/LayerView.qml
+++ b/plugins/LayerView/LayerView.qml
@@ -353,7 +353,7 @@ Item
             property real minimumRangeHandleSize: UM.Theme.getSize("slider_handle").width / 2
             property real trackThickness: UM.Theme.getSize("slider_groove").width
             property real trackRadius: trackThickness / 2
-            property real trackBorderWidth: UM.Theme.getSize("default_lining").width / 2
+            property real trackBorderWidth: UM.Theme.getSize("default_lining").width
             property color upperHandleColor: UM.Theme.getColor("slider_handle")
             property color lowerHandleColor: UM.Theme.getColor("slider_handle")
             property color rangeHandleColor: UM.Theme.getColor("slider_groove_fill")
@@ -602,7 +602,7 @@ Item
                     anchors.leftMargin: UM.Theme.getSize("default_margin").width / 2;
                     anchors.verticalCenter: parent.verticalCenter;
 
-                    width: Math.max(UM.Theme.getSize("line").width * maxValue.length + 2 * screenScaleFactor, 20);
+                    width: Math.max(UM.Theme.getSize("line").width * maxValue.length + 2 * screenScaleFactor, 20 * screenScaleFactor);
                     style: TextFieldStyle
                     {
                         textColor: UM.Theme.getColor("setting_control_text");

--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -30,7 +30,7 @@ Item {
         {
             // This is to ensure that the panel is first increasing in size up to 200 and then shows a scrollbar.
             // It kinda looks ugly otherwise (big panel, no content on it)
-            property int maximumHeight: 200 * Screen.devicePixelRatio
+            property int maximumHeight: 200 * screenScaleFactor
             height: Math.min(contents.count * (UM.Theme.getSize("section").height + UM.Theme.getSize("default_lining").height), maximumHeight)
 
             ScrollView
@@ -246,7 +246,7 @@ Item {
         id: settingPickDialog
 
         title: catalog.i18nc("@title:window", "Select Settings to Customize for this model")
-        width: Screen.devicePixelRatio * 360;
+        width: screenScaleFactor * 360;
 
         property string labelFilter: ""
 

--- a/plugins/PluginBrowser/PluginBrowser.qml
+++ b/plugins/PluginBrowser/PluginBrowser.qml
@@ -9,10 +9,10 @@ UM.Dialog
     id: base
 
     title: catalog.i18nc("@title:window", "Find & Update plugins")
-    width: 600 * Screen.devicePixelRatio
-    height: 450 * Screen.devicePixelRatio
-    minimumWidth: 350 * Screen.devicePixelRatio
-    minimumHeight: 350 * Screen.devicePixelRatio
+    width: 600 * screenScaleFactor
+    height: 450 * screenScaleFactor
+    minimumWidth: 350 * screenScaleFactor
+    minimumHeight: 350 * screenScaleFactor
     Item
     {
         anchors.fill: parent

--- a/plugins/UM3NetworkPrinting/DiscoverUM3Action.qml
+++ b/plugins/UM3NetworkPrinting/DiscoverUM3Action.qml
@@ -298,8 +298,8 @@ Cura.MachineAction
 
         title: catalog.i18nc("@title:window", "Printer Address")
 
-        minimumWidth: 400 * Screen.devicePixelRatio
-        minimumHeight: 120 * Screen.devicePixelRatio
+        minimumWidth: 400 * screenScaleFactor
+        minimumHeight: 120 * screenScaleFactor
         width: minimumWidth
         height: minimumHeight
 

--- a/plugins/USBPrinting/FirmwareUpdateWindow.qml
+++ b/plugins/USBPrinting/FirmwareUpdateWindow.qml
@@ -11,10 +11,10 @@ UM.Dialog
 {
     id: base;
 
-    width: 500 * Screen.devicePixelRatio;
-    minimumWidth: 500 * Screen.devicePixelRatio;
-    height: 100 * Screen.devicePixelRatio;
-    minimumHeight: 100 * Screen.devicePixelRatio;
+    width: minimumWidth;
+    minimumWidth: 500 * screenScaleFactor;
+    height: minimumHeight;
+    minimumHeight: 100 * screenScaleFactor;
 
     visible: true;
     modality: Qt.ApplicationModal;

--- a/resources/qml/AboutDialog.qml
+++ b/resources/qml/AboutDialog.qml
@@ -14,8 +14,8 @@ UM.Dialog
     //: About dialog title
     title: catalog.i18nc("@title:window","About Cura")
 
-    minimumWidth: 500
-    minimumHeight: 650
+    minimumWidth: 500 * screenScaleFactor
+    minimumHeight: 650 * screenScaleFactor
     width: minimumWidth
     height: minimumHeight
 

--- a/resources/qml/AskOpenAsProjectOrModelsDialog.qml
+++ b/resources/qml/AskOpenAsProjectOrModelsDialog.qml
@@ -18,8 +18,8 @@ UM.Dialog
     id: base
 
     title: catalog.i18nc("@title:window", "Open project file")
-    width: 450
-    height: 150
+    width: 450 * screenScaleFactor
+    height: 150 * screenScaleFactor
 
     maximumHeight: height
     maximumWidth: width
@@ -61,10 +61,10 @@ UM.Dialog
     Column
     {
         anchors.fill: parent
-        anchors.leftMargin: 20
-        anchors.rightMargin: 20
-        anchors.bottomMargin: 20
-        spacing: 10
+        anchors.leftMargin: 20 * screenScaleFactor
+        anchors.rightMargin: 20 * screenScaleFactor
+        anchors.bottomMargin: 20 * screenScaleFactor
+        spacing: 10 * screenScaleFactor
 
         Label
         {

--- a/resources/qml/DiscardOrKeepProfileChangesDialog.qml
+++ b/resources/qml/DiscardOrKeepProfileChangesDialog.qml
@@ -14,8 +14,8 @@ UM.Dialog
     id: base
     title: catalog.i18nc("@title:window", "Discard or Keep changes")
 
-    width: 800
-    height: 400
+    width: 800 * screenScaleFactor
+    height: 400 * screenScaleFactor
     property var changesModel: Cura.UserChangesModel{ id: userChangesModel}
     onVisibilityChanged:
     {

--- a/resources/qml/ExtruderButton.qml
+++ b/resources/qml/ExtruderButton.qml
@@ -67,7 +67,7 @@ Button
         height: UM.Theme.getSize("extruder_button_material").height
         radius: width / 2
 
-        border.width: 1
+        border.width: UM.Theme.getSize("default_lining").width
         border.color: UM.Theme.getColor("extruder_button_material_border")
 
         opacity: !base.enabled ? 0.2 : 1.0

--- a/resources/qml/OpenFilesIncludingProjectsDialog.qml
+++ b/resources/qml/OpenFilesIncludingProjectsDialog.qml
@@ -17,8 +17,8 @@ UM.Dialog
     id: base
 
     title: catalog.i18nc("@title:window", "Open file(s)")
-    width: 420
-    height: 170
+    width: 420 * screenScaleFactor
+    height: 170 * screenScaleFactor
 
     maximumHeight: height
     maximumWidth: width
@@ -28,7 +28,7 @@ UM.Dialog
     modality: UM.Application.platform == "linux" ? Qt.NonModal : Qt.WindowModal;
 
     property var fileUrls: []
-    property int spacerHeight: 10
+    property int spacerHeight: 10 * screenScaleFactor
 
     function loadProjectFile(projectFile)
     {
@@ -52,12 +52,12 @@ UM.Dialog
     Column
     {
         anchors.fill: parent
-        anchors.leftMargin: 20
-        anchors.rightMargin: 20
-        anchors.bottomMargin: 20
+        anchors.leftMargin: 20 * screenScaleFactor
+        anchors.rightMargin: 20 * screenScaleFactor
+        anchors.bottomMargin: 20 * screenScaleFactor
         anchors.left: parent.left
         anchors.right: parent.right
-        spacing: 10
+        spacing: 10 * screenScaleFactor
 
         Label
         {

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -513,7 +513,7 @@ UM.PreferencesPage
 
                 Column
                 {
-                    spacing: 4
+                    spacing: 4 * screenScaleFactor
 
                     Label
                     {
@@ -523,7 +523,7 @@ UM.PreferencesPage
                     ComboBox
                     {
                         id: choiceOnOpenProjectDropDownButton
-                        width: 200
+                        width: 200 * screenScaleFactor
 
                         model: ListModel
                         {
@@ -572,7 +572,7 @@ UM.PreferencesPage
 
                 Column
                 {
-                    spacing: 4
+                    spacing: 4 * screenScaleFactor
 
                     Label
                     {
@@ -583,7 +583,7 @@ UM.PreferencesPage
                     ComboBox
                     {
                         id: choiceOnProfileOverrideDropDownButton
-                        width: 200
+                        width: 200 * screenScaleFactor
 
                         model: ListModel
                         {

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -91,7 +91,7 @@ UM.ManagementPage
 
                 Item
                 {
-                    width: childrenRect.width + 2
+                    width: childrenRect.width + 2 * screenScaleFactor
                     height: childrenRect.height
                     Button
                     {
@@ -112,8 +112,6 @@ UM.ManagementPage
         {
             id: actionDialog
             property var content
-            minimumWidth: 350
-            minimumHeight: 350
             onContentChanged:
             {
                 contents = content;
@@ -257,8 +255,8 @@ UM.ManagementPage
         UM.RenameDialog
         {
             id: renameDialog;
-            width: 300
-            height: 150
+            width: 300 * screenScaleFactor
+            height: 150 * screenScaleFactor
             object: base.currentItem && base.currentItem.name ? base.currentItem.name : "";
             property var machine_name_validator: Cura.MachineNameValidator { }
             validName: renameDialog.newName.match(renameDialog.machine_name_validator.machineNameRegex) != null;

--- a/resources/qml/Settings/SettingCheckBox.qml
+++ b/resources/qml/Settings/SettingCheckBox.qml
@@ -119,8 +119,8 @@ SettingItem
             UM.RecolorImage {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width/2.5
-                height: parent.height/2.5
+                width: parent.width / 2.5
+                height: parent.height / 2.5
                 sourceSize.width: width
                 sourceSize.height: width
                 color: !enabled ? UM.Theme.getColor("setting_control_disabled_text") : UM.Theme.getColor("setting_control_text");

--- a/resources/qml/Settings/SettingComboBox.qml
+++ b/resources/qml/Settings/SettingComboBox.qml
@@ -86,8 +86,8 @@ SettingItem
                     source: UM.Theme.getIcon("arrow_bottom")
                     width: UM.Theme.getSize("standard_arrow").width
                     height: UM.Theme.getSize("standard_arrow").height
-                    sourceSize.width: width + 5
-                    sourceSize.height: width + 5
+                    sourceSize.width: width + 5 * screenScaleFactor
+                    sourceSize.height: width + 5 * screenScaleFactor
 
                     color: UM.Theme.getColor("setting_control_text");
 

--- a/resources/qml/Settings/SettingExtruder.qml
+++ b/resources/qml/Settings/SettingExtruder.qml
@@ -137,8 +137,8 @@ SettingItem
                     source: UM.Theme.getIcon("arrow_bottom")
                     width: UM.Theme.getSize("standard_arrow").width
                     height: UM.Theme.getSize("standard_arrow").height
-                    sourceSize.width: width + 5
-                    sourceSize.height: width + 5
+                    sourceSize.width: width + 5 * screenScaleFactor
+                    sourceSize.height: width + 5 * screenScaleFactor
 
                     color: UM.Theme.getColor("setting_control_text")
                 }

--- a/resources/qml/Settings/SettingOptionalExtruder.qml
+++ b/resources/qml/Settings/SettingOptionalExtruder.qml
@@ -156,8 +156,8 @@ SettingItem
                     source: UM.Theme.getIcon("arrow_bottom")
                     width: UM.Theme.getSize("standard_arrow").width
                     height: UM.Theme.getSize("standard_arrow").height
-                    sourceSize.width: width + 5
-                    sourceSize.height: width + 5
+                    sourceSize.width: width + 5 * screenScaleFactor
+                    sourceSize.height: width + 5 * screenScaleFactor
 
                     color: UM.Theme.getColor("setting_control_text")
                 }

--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -208,7 +208,7 @@ Item
                     {
                         id: groovechildrect
                         width: base.width * 0.55
-                        height: 2
+                        height: 2 * screenScaleFactor
                         color: UM.Theme.getColor("quality_slider_unavailable")
                         anchors.verticalCenter: qualitySlider.verticalCenter
                         x: 0
@@ -224,8 +224,8 @@ Item
                         {
                             anchors.verticalCenter: parent.verticalCenter
                             color: Cura.ProfilesModel.getItem(index).available ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")
-                            width: 1
-                            height: 6
+                            width: 1 * screenScaleFactor
+                            height: 6 * screenScaleFactor
                             y: 0
                             x: qualityModel.qualitySliderStepWidth * index
                         }
@@ -255,18 +255,18 @@ Item
                         {
                             //Draw Available line
                             groove: Rectangle {
-                                implicitHeight: 2
+                                implicitHeight: 2 * screenScaleFactor
                                 color: UM.Theme.getColor("quality_slider_available")
-                                radius: 1
+                                radius: 1 * screenScaleFactor
                             }
                             handle: Item {
                                 Rectangle {
                                     id: qualityhandleButton
                                     anchors.centerIn: parent
                                     color: control.enabled ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")
-                                    implicitWidth: 10
-                                    implicitHeight: 10
-                                    radius: 10
+                                    implicitWidth: 10 * screenScaleFactor
+                                    implicitHeight: 10 * screenScaleFactor
+                                    radius: 10 * screenScaleFactor
                                 }
                             }
                         }
@@ -367,7 +367,7 @@ Item
 
                     //anchors.top: parent.top
                     anchors.left: infillSlider.left
-                    anchors.leftMargin: (infillSlider.value / infillSlider.stepSize) * (infillSlider.width / (infillSlider.maximumValue / infillSlider.stepSize)) - 10
+                    anchors.leftMargin: (infillSlider.value / infillSlider.stepSize) * (infillSlider.width / (infillSlider.maximumValue / infillSlider.stepSize)) - 10 * screenScaleFactor
                     anchors.right: parent.right
 
                     text: infillSlider.value + "%"
@@ -421,7 +421,7 @@ Item
                                 color: control.enabled ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")
                                 implicitWidth: 10 * screenScaleFactor
                                 implicitHeight: 10 * screenScaleFactor
-                                radius: 10
+                                radius: 10 * screenScaleFactor
                             }
                         }
 

--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -408,8 +408,8 @@ Item
 
                         groove: Rectangle {
                             id: groove
-                            implicitWidth: 200
-                            implicitHeight: 2
+                            implicitWidth: 200 * screenScaleFactor
+                            implicitHeight: 2 * screenScaleFactor
                             color: control.enabled ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")
                             radius: 1
                         }
@@ -419,8 +419,8 @@ Item
                                 id: handleButton
                                 anchors.centerIn: parent
                                 color: control.enabled ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")
-                                implicitWidth: 10
-                                implicitHeight: 10
+                                implicitWidth: 10 * screenScaleFactor
+                                implicitHeight: 10 * screenScaleFactor
                                 radius: 10
                             }
                         }
@@ -431,8 +431,8 @@ Item
                             Rectangle {
                                 anchors.verticalCenter: parent.verticalCenter
                                 color: control.enabled ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")
-                                width: 1
-                                height: 6
+                                width: 1 * screenScaleFactor
+                                height: 6 * screenScaleFactor
                                 y: 0
                                 x: styleData.handleWidth / 2 + index * ((repeater.width - styleData.handleWidth) / (repeater.count-1))
                             }
@@ -484,7 +484,7 @@ Item
 
                             UM.RecolorImage {
                                 anchors.fill: parent
-                                anchors.margins: 2
+                                anchors.margins: 2 * screenScaleFactor
                                 sourceSize.width: width
                                 sourceSize.height: width
                                 source: UM.Theme.getIcon(model.icon)

--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -67,7 +67,7 @@ Item
             }
         }
 
-        Item { height: UM.Theme.getSize("default_margin").height; width: UM.Theme.getSize("default_lining"); visible: extruders.count > 0 }
+        Item { height: UM.Theme.getSize("default_margin").height; width: UM.Theme.getSize("default_lining").width; visible: extruders.count > 0 }
 
         Repeater
         {

--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -67,7 +67,7 @@ Item
             }
         }
 
-        Item { height: UM.Theme.getSize("default_margin").height; width: 1; visible: extruders.count > 0 }
+        Item { height: UM.Theme.getSize("default_margin").height; width: UM.Theme.getSize("default_lining"); visible: extruders.count > 0 }
 
         Repeater
         {

--- a/resources/qml/WorkspaceSummaryDialog.qml
+++ b/resources/qml/WorkspaceSummaryDialog.qml
@@ -13,10 +13,12 @@ UM.Dialog
 {
     title: catalog.i18nc("@title:window", "Save Project")
 
-    width: 500
-    height: 400
+    minimumWidth: 500 * screenScaleFactor
+    minimumHeight: 400 * screenScaleFactor
+    width: minimumWidth
+    height: minimumHeight
 
-    property int spacerHeight: 10
+    property int spacerHeight: 10 * screenScaleFactor
 
     property bool dontShowAgain: true
 
@@ -63,7 +65,7 @@ UM.Dialog
         Column
         {
             anchors.fill: parent
-            spacing: 2
+            spacing: 2 * screenScaleFactor
             Label
             {
                 id: titleLabel

--- a/resources/themes/cura-light/styles.qml
+++ b/resources/themes/cura-light/styles.qml
@@ -309,7 +309,7 @@ QtObject {
                     }
                     Behavior on color { ColorAnimation { duration: 50; } }
 
-                    border.width: (control.hasOwnProperty("needBorder") && control.needBorder) ? 2 : 0
+                    border.width: (control.hasOwnProperty("needBorder") && control.needBorder) ? 2 * screenScaleFactor : 0
                     border.color: Theme.getColor("tool_button_border")
 
                     UM.RecolorImage {
@@ -506,8 +506,8 @@ QtObject {
                         source: control.iconSource;
                         width: Theme.getSize("section_icon").width;
                         height: Theme.getSize("section_icon").height;
-                        sourceSize.width: width + 15
-                        sourceSize.height: width + 15
+                        sourceSize.width: width + 15 * screenScaleFactor
+                        sourceSize.height: width + 15 * screenScaleFactor
                     }
                 }
 
@@ -648,8 +648,8 @@ QtObject {
                     source: Theme.getIcon("arrow_bottom")
                     width: Theme.getSize("standard_arrow").width
                     height: Theme.getSize("standard_arrow").height
-                    sourceSize.width: width + 5
-                    sourceSize.height: width + 5
+                    sourceSize.width: width + 5 * screenScaleFactor
+                    sourceSize.height: width + 5 * screenScaleFactor
 
                     color: Theme.getColor("setting_control_text");
                 }
@@ -707,8 +707,8 @@ QtObject {
                     source: UM.Theme.getIcon("arrow_bottom")
                     width: UM.Theme.getSize("standard_arrow").width
                     height: UM.Theme.getSize("standard_arrow").height
-                    sourceSize.width: width + 5
-                    sourceSize.height: width + 5
+                    sourceSize.width: width + 5 * screenScaleFactor
+                    sourceSize.height: width + 5 * screenScaleFactor
 
                     color: UM.Theme.getColor("setting_control_text")
                 }
@@ -734,8 +734,8 @@ QtObject {
                 UM.RecolorImage {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter
-                    width: parent.width/2.5
-                    height: parent.height/2.5
+                    width: parent.width / 2.5
+                    height: parent.height / 2.5
                     sourceSize.width: width
                     sourceSize.height: width
                     color: Theme.getColor("checkbox_mark")


### PR DESCRIPTION
This PR attempts to solve the Hi DPI issues on both OSX and Windows. OSX apparently no longer needs the Screen.devicePixelRatio workaround when specifying pixel sizes, but Windows certainly does.

This PR is for testing an approach where instead of using Screen.devicePixelRatio, we use a Uranium-supplied screenScaleFactor. This context variable was introduced a couple of releases ago, but never used.

This PR requires https://github.com/Ultimaker/Uranium/pull/285

For additional discussion see https://github.com/Ultimaker/Cura/commit/7bc715a9bd5e61efcfef4b54f7d004b3f6248f5a#commitcomment-24539576
