### PR TITLE
Move the quality indicator to the center when there is only one quality

### DIFF
--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -226,7 +226,7 @@ Item
                     Repeater
                     {
                         id: qualityRepeater
-                        model: qualityModel.availableTotalTicks > 0 ? qualityModel : 0
+                        model: qualityModel.totalTicks > 0 ? qualityModel : 0
 
                         Rectangle
                         {

--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -254,7 +254,8 @@ Item
                         id: qualitySlider
                         height: UM.Theme.getSize("sidebar_margin").height
                         anchors.bottom: speedSlider.bottom
-                        visible: qualityModel.availableTotalTicks > 0
+                        enabled: qualityModel.availableTotalTicks > 0
+                        visible: qualityModel.totalTicks > 0
                         updateValueWhileDragging : false
 
                         minimumValue: qualityModel.qualitySliderAvailableMin >= 0 ? qualityModel.qualitySliderAvailableMin : 0

--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -186,7 +186,10 @@ Item
 
                             x: {
                                 // Make sure the text aligns correctly with each tick
-                                if (index == 0) {
+                                if (qualityModel.totalTicks == 0) {
+                                    // If there is only one tick, align it centrally
+                                    return ((base.width * 0.55) - width) / 2
+                                } else if (index == 0) {
                                     return (base.width * 0.55 / qualityModel.totalTicks) * index
                                 } else if (index == qualityModel.totalTicks) {
                                     return (base.width * 0.55 / qualityModel.totalTicks) * index - width
@@ -223,7 +226,7 @@ Item
                     Repeater
                     {
                         id: qualityRepeater
-                        model: qualityModel
+                        model: qualityModel.availableTotalTicks > 0 ? qualityModel : 0
 
                         Rectangle
                         {
@@ -236,13 +239,22 @@ Item
                         }
                     }
 
+                    Rectangle {
+                        id: disabledHandleButton
+                        visible: !qualitySlider.visible
+                        anchors.centerIn: parent
+                        color: UM.Theme.getColor("quality_slider_unavailable")
+                        implicitWidth: 10 * screenScaleFactor
+                        implicitHeight: implicitWidth
+                        radius: width / 2
+                    }
 
                     Slider
                     {
                         id: qualitySlider
                         height: UM.Theme.getSize("sidebar_margin").height
                         anchors.bottom: speedSlider.bottom
-                        enabled: qualityModel.availableTotalTicks > 0
+                        visible: qualityModel.availableTotalTicks > 0
                         updateValueWhileDragging : false
 
                         minimumValue: qualityModel.qualitySliderAvailableMin >= 0 ? qualityModel.qualitySliderAvailableMin : 0
@@ -262,16 +274,16 @@ Item
                             groove: Rectangle {
                                 implicitHeight: 2 * screenScaleFactor
                                 color: UM.Theme.getColor("quality_slider_available")
-                                radius: 1 * screenScaleFactor
+                                radius: height / 2
                             }
                             handle: Item {
                                 Rectangle {
                                     id: qualityhandleButton
                                     anchors.centerIn: parent
-                                    color: control.enabled ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")
+                                    color: UM.Theme.getColor("quality_slider_available")
                                     implicitWidth: 10 * screenScaleFactor
-                                    implicitHeight: 10 * screenScaleFactor
-                                    radius: 10 * screenScaleFactor
+                                    implicitHeight: implicitWidth
+                                    radius: implicitWidth / 2
                                 }
                             }
                         }


### PR DESCRIPTION
This PR fixes a UX issue where if only a single quality is available, it always shows a "Slower". If a single quality is available, the quality indicator (handle) is now moved to the center of the slider.

Fixes #2485
CURA-4383