### PR TITLE
Hide gradual infill if its setting is disabled

### DIFF
--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -360,7 +360,7 @@ Item
             {
                 id: infillCellRight
 
-                height: infillSlider.height + enableGradualInfillCheckBox.height + (UM.Theme.getSize("sidebar_margin").height * 2)
+                height: infillSlider.height + UM.Theme.getSize("sidebar_margin").height + enableGradualInfillCheckBox.visible * (enableGradualInfillCheckBox.height + UM.Theme.getSize("sidebar_margin").height)
                 width: UM.Theme.getSize("sidebar").width * .55
 
                 anchors.left: infillCellLeft.right
@@ -510,6 +510,7 @@ Item
 
                     style: UM.Theme.styles.checkbox
                     enabled: base.settingsEnabled
+                    visible: infillSteps.properties.enabled == "True"
                     checked: parseInt(infillSteps.properties.value) > 0
 
                     MouseArea {
@@ -849,7 +850,7 @@ Item
                 id: infillSteps
                 containerStackId: Cura.MachineManager.activeStackId
                 key: "gradual_infill_steps"
-                watchedProperties: ["value"]
+                watchedProperties: ["value", "enabled"]
                 storeIndex: 0
             }
 


### PR DESCRIPTION
This PR hides the gradual infill checbox from the simple mode tab, if the "gradual_infill_steps" setting is disabled by the current machine definition.

Followup to https://github.com/Ultimaker/Cura/pull/2335