### PR TITLE
Add definition for Tevo Tarantula printer

### DIFF
--- a/resources/definitions/tevo_tarantula.def.json
+++ b/resources/definitions/tevo_tarantula.def.json
@@ -1,0 +1,73 @@
+{
+    "id": "tevo_tarantula",
+    "version": 2,
+    "name": "Tevo Tarantula",
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": true,
+        "author": "TheAssassin",
+        "manufacturer": "Tevo",
+        "file_formats": "text/x-gcode",
+        "icon": "icon_ultimaker2",
+        "platform": "prusai3_platform.stl"
+    },
+
+    "overrides": {
+        "machine_name": {
+            "default_value": "Tevo Tarantula"
+        },
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "machine_width": {
+            "default_value": 200
+        },
+        "machine_height": {
+            "default_value": 200
+        },
+        "machine_depth": {
+            "default_value": 200
+        },
+        "machine_center_is_zero": {
+            "default_value": false
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        },
+        "machine_head_polygon": {
+            "default_value": [
+                [-75, -18],
+                [-75, 35],
+                [18, 35],
+                [18, -18]
+            ]
+        },
+        "gantry_height": {
+            "default_value": 55
+        },
+        "machine_gcode_flavor": {
+            "default_value": "RepRap (Marlin/Sprinter)"
+        },
+        "machine_acceleration": {
+            "default_value": 500
+        },
+        "machine_max_jerk_xy": {
+            "default_value": 4.0
+        },
+        "machine_max_jerk_z": {
+            "default_value": 0.2
+        },
+        "machine_max_jerk_e": {
+            "default_value": 2.5
+        },
+        "machine_start_gcode": {
+            "default_value": "G21 ;metric values\nG90 ;absolute positioning\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG28 X0 Y0 ;move X/Y to min endstops\nG28 Z0 ;move Z to min endstops\nG1 Z15.0 F9000 ;move the platform down 15mm\nG92 E0 ;zero the extruded length\nG1 F200 E3 ;extrude 3mm of feed stock\nG92 E0 ;zero the extruded length again\nG1 F9000\n;Put printing message on LCD screen\nM117 Printing..."
+        },
+        "machine_end_gcode": {
+            "default_value": "M104 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300  ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 X-20 Y-20 F9000 ;move Z up a bit and retract filament even more\nG28 X0 Y0 ;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nG90 ;absolute positioning\nG1 Y200 F3600 ;move baseplate to front for easier access to printed object"
+        }
+    }
+}


### PR DESCRIPTION
Modified version of the Prusa i3's definition. While the i3 values work, the print time estimations were horribly imprecise (often the print takes 2x to 3x as long as Cura estimated). Therefore, I inspected the problem, and found a Reddit thread [1] about it. Instead of hacking my own installation, I just wrote a defition including the correct acceleration/jerk values that work with my firmware (custom build of Marlin based on https://github.com/JimBrown/MarlinTarantula/).

There's downsides however. I don't know how it performs with the stock firmware (although I doubt there'd be many differences). Furthermore, the `jerk_xy` is set to 4 in my definition, but that's only true for the `x`value,the Marlin firmware has a `y` jerk value of 7. That leads to minor differences in the printing time (e.g., just finished a print which Cura estimated with 13h 30m, but it took 12h 50m).

Feedback from stock firmware users is therefore highly welcome. Also, if someone could provide information about the jerk values and help improving those inaccuracies, that'd be awesome.

[1] https://www.reddit.com/r/3Dprinting/comments/5wz0xs/