### PR TITLE
Empty Materials and Print Cores or Nozzle

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -354,11 +354,16 @@ class MachineManager(QObject):
         if containers:
             Application.getInstance().setGlobalContainerStack(containers[0])
 
+        self.activeQualityChanged.emit()
+        self.activeVariantChanged.emit()
+        self.activeMaterialChanged.emit()
+
     @pyqtSlot(str, str)
     def addMachine(self, name: str, definition_id: str) -> None:
         new_stack = CuraStackBuilder.createMachine(name, definition_id)
         if new_stack:
-            Application.getInstance().setGlobalContainerStack(new_stack)
+            # Instead of setting the global container stack here, we set the active machine and so the signals are emitted
+            self.setActiveMachine(new_stack.getId())
         else:
             Logger.log("w", "Failed creating a new machine!")
 

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -354,9 +354,7 @@ class MachineManager(QObject):
         if containers:
             Application.getInstance().setGlobalContainerStack(containers[0])
 
-        self.activeQualityChanged.emit()
-        self.activeVariantChanged.emit()
-        self.activeMaterialChanged.emit()
+        self.__onInstanceContainersChanged()
 
     @pyqtSlot(str, str)
     def addMachine(self, name: str, definition_id: str) -> None:

--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -67,6 +67,7 @@ Item
                     target: Cura.MachineManager
                     onActiveQualityChanged: qualityModel.update()
                     onActiveMaterialChanged: qualityModel.update()
+                    onActiveVariantChanged: qualityModel.update()
                 }
 
                 ListModel


### PR DESCRIPTION
Sometimes when loading a new project, the materials and print cores and nozzles appear as "empty". Even if the material, print cores or nozzles were properly selected, the UI doesn't update to the right value.

It also happens when creating a new "Custom FDM" or UM2+ or UM2E+:
**Reproduction Steps:** 
1. Add UM3.
2. Add UM2+
3. Check that material and nozzles, set to "empty"

This solves CURA-4377