### PR TITLE
Update camera 'viewport_overlay' color > GREY

### DIFF
--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -59,7 +59,7 @@
     "colors": {
         "sidebar": [255, 255, 255, 255],
         "lining": [192, 193, 194, 255],
-        "viewport_overlay": [24, 41, 77, 192],
+        "viewport_overlay": [0, 0, 0, 192],
 
         "primary": [12, 169, 227, 255],
         "primary_hover": [48, 182, 231, 255],


### PR DESCRIPTION
This will apply to all UMO+, UM2, UM2+ and UM3 with old firmware users, which look at the camera view. The background changed from blue > grey.