### PR TITLE
Move text back to label and remove unused font

### DIFF
--- a/resources/qml/SaveButton.qml
+++ b/resources/qml/SaveButton.qml
@@ -43,7 +43,7 @@ Item {
         }
     }
 
-    Text {
+    Label {
         id: statusLabel
         width: parent.width - 2 * UM.Theme.getSize("sidebar_margin").width
         anchors.top: parent.top

--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -114,7 +114,7 @@ Rectangle
         }
     }
 
-    Text {
+    Label {
         id: settingsModeLabel
         text: !hideSettings ? catalog.i18nc("@label:listbox", "Print Setup") : catalog.i18nc("@label:listbox","Print Setup disabled\nG-code files cannot be modified");
         anchors.left: parent.left

--- a/resources/qml/SidebarHeader.qml
+++ b/resources/qml/SidebarHeader.qml
@@ -363,7 +363,7 @@ Column
                 visible: !Cura.MachineManager.isCurrentSetupSupported
             }
 
-            Text {
+            Label {
                 id: materialInfoLabel
                 wrapMode: Text.WordWrap
                 text: catalog.i18nc("@label", "<a href='%1'>Check material compatibility</a>")

--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -154,7 +154,7 @@ Item
                     }
                 }
 
-                Text
+                Label
                 {
                     id: qualityRowTitle
                     text: catalog.i18nc("@label", "Layer Height")
@@ -171,11 +171,11 @@ Item
                     {
                         model: qualityModel
 
-                        Text
+                        Label
                         {
                             anchors.verticalCenter: parent.verticalCenter
                             anchors.top: parent.top
-                            anchors.topMargin: UM.Theme.getSize("sidebar_margin").height / 2
+                            anchors.topMargin: parseInt(UM.Theme.getSize("sidebar_margin").height / 2)
                             color: (Cura.MachineManager.activeMachine != null && Cura.ProfilesModel.getItem(index).available) ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")
                             text:
                             {
@@ -194,13 +194,13 @@ Item
                                 // Make sure the text aligns correctly with each tick
                                 if (qualityModel.totalTicks == 0) {
                                     // If there is only one tick, align it centrally
-                                    return ((base.width * 0.55) - width) / 2
+                                    return parseInt(((base.width * 0.55) - width) / 2)
                                 } else if (index == 0) {
                                     return (base.width * 0.55 / qualityModel.totalTicks) * index
                                 } else if (index == qualityModel.totalTicks) {
                                     return (base.width * 0.55 / qualityModel.totalTicks) * index - width
                                 } else {
-                                    return (base.width * 0.55 / qualityModel.totalTicks) * index - (width / 2)
+                                    return parseInt((base.width * 0.55 / qualityModel.totalTicks) * index - (width / 2))
                                 }
                             }
                         }
@@ -310,7 +310,7 @@ Item
                     }
                 }
 
-                Text
+                Label
                 {
                     id: speedLabel
                     anchors.top: speedSlider.bottom
@@ -322,7 +322,7 @@ Item
                     color: UM.Theme.getColor("text")
                 }
 
-                Text
+                Label
                 {
                     anchors.bottom: speedLabel.bottom
                     anchors.left: speedSlider.left
@@ -333,7 +333,7 @@ Item
                     horizontalAlignment: Text.AlignLeft
                 }
 
-                Text
+                Label
                 {
                     anchors.bottom: speedLabel.bottom
                     anchors.right: speedSlider.right
@@ -360,7 +360,7 @@ Item
 
                 width: UM.Theme.getSize("sidebar").width * .45 - UM.Theme.getSize("sidebar_margin").width
 
-                Text
+                Label
                 {
                     id: infillLabel
                     text: catalog.i18nc("@label", "Infill")
@@ -482,7 +482,7 @@ Item
 
                     anchors.right: parent.right
                     anchors.top: parent.top
-                    anchors.topMargin: UM.Theme.getSize("sidebar_margin").height / 2
+                    anchors.topMargin: parseInt(UM.Theme.getSize("sidebar_margin").height / 2)
 
                     // we loop over all density icons and only show the one that has the current density and steps
                     Repeater
@@ -533,7 +533,7 @@ Item
                     property alias _hovered: enableGradualInfillMouseArea.containsMouse
 
                     anchors.top: infillSlider.bottom
-                    anchors.topMargin: UM.Theme.getSize("sidebar_margin").height / 2 // closer to slider since it belongs to the same category
+                    anchors.topMargin: parseInt(UM.Theme.getSize("sidebar_margin").height / 2) // closer to slider since it belongs to the same category
                     anchors.left: infillCellRight.left
 
                     style: UM.Theme.styles.checkbox
@@ -566,7 +566,7 @@ Item
                     Label {
                         id: gradualInfillLabel
                         anchors.left: enableGradualInfillCheckBox.right
-                        anchors.leftMargin: UM.Theme.getSize("sidebar_margin").width / 2
+                        anchors.leftMargin: parseInt(UM.Theme.getSize("sidebar_margin").width / 2)
                         text: catalog.i18nc("@label", "Enable gradual")
                         font: UM.Theme.getFont("default")
                         color: UM.Theme.getColor("text")
@@ -621,13 +621,13 @@ Item
             //
             //  Enable support
             //
-            Text
+            Label
             {
                 id: enableSupportLabel
                 visible: enableSupportCheckBox.visible
 
                 anchors.top: infillCellRight.bottom
-                anchors.topMargin: UM.Theme.getSize("sidebar_margin").height * 1.5
+                anchors.topMargin: parseInt(UM.Theme.getSize("sidebar_margin").height * 1.5)
                 anchors.left: parent.left
                 anchors.leftMargin: UM.Theme.getSize("sidebar_margin").width
                 anchors.verticalCenter: enableSupportCheckBox.verticalCenter
@@ -674,7 +674,7 @@ Item
                 }
             }
 
-            Text
+            Label
             {
                 id: supportExtruderLabel
                 visible: supportExtruderCombobox.visible
@@ -750,7 +750,7 @@ Item
 
             }
 
-            Text
+            Label
             {
                 id: adhesionHelperLabel
                 visible: adhesionCheckBox.visible
@@ -836,12 +836,12 @@ Item
             {
                 id: tipsCell
                 anchors.top: adhesionCheckBox.visible ? adhesionCheckBox.bottom : (enableSupportCheckBox.visible ? supportExtruderCombobox.bottom : infillCellRight.bottom)
-                anchors.topMargin: UM.Theme.getSize("sidebar_margin").height * 2
+                anchors.topMargin: parseInt(UM.Theme.getSize("sidebar_margin").height * 2)
                 anchors.left: parent.left
                 width: parent.width
                 height: tipsText.contentHeight * tipsText.lineCount
 
-                Text
+                Label
                 {
                     id: tipsText
                     anchors.left: parent.left

--- a/resources/qml/SidebarSimple.qml
+++ b/resources/qml/SidebarSimple.qml
@@ -385,7 +385,7 @@ Item
                 anchors.top: infillCellLeft.top
                 anchors.topMargin: UM.Theme.getSize("sidebar_margin").height
 
-                Text {
+                Label {
                     id: selectedInfillRateText
 
                     //anchors.top: parent.top
@@ -563,7 +563,7 @@ Item
                         }
                     }
 
-                    Text {
+                    Label {
                         id: gradualInfillLabel
                         anchors.left: enableGradualInfillCheckBox.right
                         anchors.leftMargin: UM.Theme.getSize("sidebar_margin").width / 2

--- a/resources/qml/SidebarTooltip.qml
+++ b/resources/qml/SidebarTooltip.qml
@@ -43,7 +43,7 @@ UM.PointingRectangle {
         base.opacity = 0;
     }
 
-    Text {
+    Label {
         id: label;
         anchors {
             top: parent.top;

--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -17,10 +17,6 @@
             "size": 1.15,
             "family": "Open Sans"
         },
-        "default_little_big": {
-            "size": 1.17,
-            "family": "Open Sans"
-        },
         "default_bold": {
             "size": 1.15,
             "bold": true,


### PR DESCRIPTION
This should be merged together with an Uranium pull request:

https://github.com/Ultimaker/Uranium/pull/287

I replaced the qml Texts by Labels (yes @fieldOfView you were right) and in the Uranium PR the font sizes are then set to point size instead of pixel size. Pixel size seems to be messed up on high DPI screens.