### PR TITLE
Fix the OpenGL shader for older (legacy?) OpenGL.

### DIFF
--- a/resources/shaders/grid.shader
+++ b/resources/shaders/grid.shader
@@ -31,10 +31,10 @@ fragment =
         vec4 minorGridColor = mix(u_plateColor, u_gridColor1, 1.0 - min(minorLine, 1.0));
 
         // Compute anti-aliased world-space major grid lines
-        vec2 majorGrid = abs(fract(coord / 10 - 0.5) - 0.5) / fwidth(coord / 10);
+        vec2 majorGrid = abs(fract(coord / 10.0 - 0.5) - 0.5) / fwidth(coord / 10.0);
         float majorLine = min(majorGrid.x, majorGrid.y);
 
-        frag_color = mix(minorGridColor, u_gridColor0, 1.0 - min(majorLine, 1.0));
+        gl_FragColor = mix(minorGridColor, u_gridColor0, 1.0 - min(majorLine, 1.0));
     }
 
 vertex41core =
@@ -72,7 +72,7 @@ fragment41core =
         vec4 minorGridColor = mix(u_plateColor, u_gridColor1, 1.0 - min(minorLine, 1.0));
 
         // Compute anti-aliased world-space major grid lines
-        vec2 majorGrid = abs(fract(coord / 10 - 0.5) - 0.5) / fwidth(coord / 10);
+        vec2 majorGrid = abs(fract(coord / 10.0 - 0.5) - 0.5) / fwidth(coord / 10.0);
         float majorLine = min(majorGrid.x, majorGrid.y);
 
         frag_color = mix(minorGridColor, u_gridColor0, 1.0 - min(majorLine, 1.0));


### PR DESCRIPTION
The patch to do the grid rendering from a shader wasn't done a 100% right, as the "legacy" shader wasn't compiling. I also fixed a warning that the intel driver is reporting.
After this fix the grid renders again on my Intel HD 3000 master-of-disaster rendering device.

@fieldOfView still love you ;-)