### PR TITLE
trihex infill

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1354,7 +1354,7 @@
                             "default_value": 2,
                             "minimum_value": "0",
                             "minimum_value_warning": "infill_line_width",
-                            "value": "0 if infill_sparse_density == 0 else (infill_line_width * 100) / infill_sparse_density * (2 if infill_pattern == 'grid' else (3 if infill_pattern == 'triangles' or infill_pattern == 'cubic' or infill_pattern == 'cubicsubdiv' else (2 if infill_pattern == 'tetrahedral' or infill_pattern == 'quarter_cubic' else (1 if infill_pattern == 'cross' or infill_pattern == 'cross_3d' else 1))))",
+                            "value": "0 if infill_sparse_density == 0 else (infill_line_width * 100) / infill_sparse_density * (2 if infill_pattern == 'grid' else (3 if infill_pattern == 'triangles' or infill_pattern == 'trihexagon' or infill_pattern == 'cubic' or infill_pattern == 'cubicsubdiv' else (2 if infill_pattern == 'tetrahedral' or infill_pattern == 'quarter_cubic' else (1 if infill_pattern == 'cross' or infill_pattern == 'cross_3d' else 1))))",
                             "limit_to_extruder": "infill_extruder_nr",
                             "settable_per_mesh": true
                         }
@@ -1370,6 +1370,7 @@
                         "grid": "Grid",
                         "lines": "Lines",
                         "triangles": "Triangles",
+                        "trihexagon": "Tri-Hexagon",
                         "cubic": "Cubic",
                         "cubicsubdiv": "Cubic Subdivision",
                         "tetrahedral": "Octet",


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Trihexagonal_tiling

This is a very simple edit of Triangle infill: the same infill lines are just shifted a bit.

This pattern avoids the junctions where 3 lines meet. As such we can expect this pattern to fail less often.

Because it contains the same directions as triangle infill we can expect the structural properties to remain similar.

However, this hasn't been physically tested. At this moment we can't be 100% sure we can replace triangle infill with trihex infill.

Let's include it in Cura to test with it to see whether trihex infill is indeed as good as it theoretically seems to be.