### PR TITLE
List model/x3d+xml in the desktop file

### DIFF
--- a/cura.desktop.in
+++ b/cura.desktop.in
@@ -10,6 +10,6 @@ TryExec=@CMAKE_INSTALL_FULL_BINDIR@/cura
 Icon=cura-icon
 Terminal=false
 Type=Application
-MimeType=application/sla;application/vnd.ms-3mfdocument;application/prs.wavefront-obj;image/bmp;image/gif;image/jpeg;image/png;
+MimeType=application/sla;application/vnd.ms-3mfdocument;application/prs.wavefront-obj;image/bmp;image/gif;image/jpeg;image/png;model/x3d+xml
 Categories=Graphics;
 Keywords=3D;Printing;


### PR DESCRIPTION
Add model/x3d+xml as a supported MIME type in the desktop file.

Fixes issue #2571.