### PR TITLE
CURA-4195 New crash report dialog that sends data directly to developers

### DIFF
--- a/cura/CrashHandler.py
+++ b/cura/CrashHandler.py
@@ -32,7 +32,6 @@ else:
         from cura.CuraVersion import CuraDebugMode
     except ImportError:
         CuraDebugMode = False  # [CodeStyle: Reflecting imported value]
-CuraDebugMode = True ## TODO Remove when done. Just for debug purposes
 
 # List of exceptions that should be considered "fatal" and abort the program.
 # These are primarily some exception types that we simply cannot really recover from
@@ -168,6 +167,7 @@ class CrashHandler:
         # Look for plugins. If it's not a plugin, the current cura version is set
         isPlugin = False
         module_version = self.cura_version
+        module_name = "Cura"
         if split_path.__contains__("plugins"):
             isPlugin = True
             # Look backwards until plugin.json is found
@@ -181,16 +181,18 @@ class CrashHandler:
                     try:
                         metadata = json.loads(f.read())
                         module_version = metadata["version"]
+                        module_name = metadata["name"]
                     except json.decoder.JSONDecodeError:
-                        # Not through new exceptions
+                        # Not throw new exceptions
                         Logger.logException("e", "Failed to parse plugin.json for plugin %s", name)
             except:
-                # Not through new exceptions
+                # Not throw new exceptions
                 pass
 
         exception_dict = dict()
         exception_dict["traceback"] = {"summary": summary, "full_trace": trace}
-        exception_dict["location"] = {"path": filepath, "file": filename, "function": function, "code": code, "line": line, "version": module_version, "is_plugin": isPlugin}
+        exception_dict["location"] = {"path": filepath, "file": filename, "function": function, "code": code, "line": line,
+                                      "module_name": module_name, "version": module_version, "is_plugin": isPlugin}
         self.data["exception"] = exception_dict
 
         return group

--- a/cura/CrashHandler.py
+++ b/cura/CrashHandler.py
@@ -5,14 +5,15 @@ import webbrowser
 import faulthandler
 import tempfile
 import os
-import urllib
 
-from PyQt5.QtCore import QT_VERSION_STR, PYQT_VERSION_STR, Qt, QCoreApplication
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QHBoxLayout, QVBoxLayout, QLabel, QTextEdit
+from PyQt5.QtCore import QT_VERSION_STR, PYQT_VERSION_STR, QCoreApplication
+from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout, QLabel, QTextEdit, QGroupBox
+from PyQt5.QtNetwork import QHttpMultiPart, QHttpPart, QNetworkRequest, QNetworkAccessManager, QNetworkReply
 
 from UM.Logger import Logger
+from UM.View.GL.OpenGL import OpenGL
 from UM.i18n import i18nCatalog
+
 catalog = i18nCatalog("cura")
 
 MYPY = False
@@ -23,6 +24,7 @@ else:
         from cura.CuraVersion import CuraDebugMode
     except ImportError:
         CuraDebugMode = False  # [CodeStyle: Reflecting imported value]
+CuraDebugMode = True ## TODO Remove when done. Just for debug purposes
 
 # List of exceptions that should be considered "fatal" and abort the program.
 # These are primarily some exception types that we simply cannot really recover from
@@ -35,83 +37,145 @@ fatal_exception_types = [
     SystemError,
 ]
 
-def show(exception_type, value, tb):
-    Logger.log("c", "An uncaught exception has occurred!")
-    for line in traceback.format_exception(exception_type, value, tb):
-        for part in line.rstrip("\n").split("\n"):
-            Logger.log("c", part)
+class CrashHandler:
 
-    if not CuraDebugMode and exception_type not in fatal_exception_types:
-        return
+    def __init__(self, exception_type, value, tb):
 
-    application = QCoreApplication.instance()
-    if not application:
+        self.exception_type = exception_type
+        self.value = value
+        self.traceback = tb
+
+        Logger.log("c", "An uncaught exception has occurred!")
+        for line in traceback.format_exception(exception_type, value, tb):
+            for part in line.rstrip("\n").split("\n"):
+                Logger.log("c", part)
+
+        if not CuraDebugMode and exception_type not in fatal_exception_types:
+            return
+
+        application = QCoreApplication.instance()
+        if not application:
+            sys.exit(1)
+
+        self._createDialog()
+
+    ##  Creates a modal dialog.
+    def _createDialog(self):
+
+        self.dialog = QDialog()
+        self.dialog.setMinimumWidth(640)
+        self.dialog.setMinimumHeight(640)
+        self.dialog.setWindowTitle(catalog.i18nc("@title:window", "Crash Report"))
+
+        layout = QVBoxLayout(self.dialog)
+
+        layout.addWidget(self._messageWidget())
+        layout.addWidget(self._informationWidget())
+        layout.addWidget(self._exceptionInfoWidget())
+        layout.addWidget(self._logInfoWidget())
+        layout.addWidget(self._userDescriptionWidget())
+        layout.addWidget(self._buttonsWidget())
+
+    def _messageWidget(self):
+        label = QLabel()
+        label.setText(catalog.i18nc("@label", """<p><b>A fatal exception has occurred that we could not recover from!</p></b>
+            <p>Please use the button below to post a bug report automatically to our servers</p>
+        """))
+
+        return label
+
+    def _informationWidget(self):
+        group = QGroupBox()
+        group.setTitle("System information")
+        layout = QVBoxLayout()
+        label = QLabel()
+
+        try:
+            from UM.Application import Application
+            version = Application.getInstance().getVersion()
+        except:
+            version = "Unknown"
+
+        crash_info = "<b>Version:</b> {0}<br/><b>Platform:</b> {1}<br/><b>Qt:</b> {2}<br/><b>PyQt:</b> {3}<br/><b>OpenGL:</b> {4}"
+        crash_info = crash_info.format(version, platform.platform(), QT_VERSION_STR, PYQT_VERSION_STR, self._getOpenGLInfo())
+        label.setText(crash_info)
+
+        layout.addWidget(label)
+        group.setLayout(layout)
+
+        return group
+
+    def _exceptionInfoWidget(self):
+        group = QGroupBox()
+        group.setTitle("Exception traceback")
+        layout = QVBoxLayout()
+
+        text_area = QTextEdit()
+        trace = "".join(traceback.format_exception(self.exception_type, self.value, self.traceback))
+        text_area.setText(trace)
+
+        layout.addWidget(text_area)
+        group.setLayout(layout)
+
+        return group
+
+    def _logInfoWidget(self):
+        group = QGroupBox()
+        group.setTitle("Logs")
+        layout = QVBoxLayout()
+
+        text_area = QTextEdit()
+        tmp_file_fd, tmp_file_path = tempfile.mkstemp(prefix = "cura-crash", text = True)
+        os.close(tmp_file_fd)
+        with open(tmp_file_path, "w") as f:
+            faulthandler.dump_traceback(f, all_threads=True)
+        with open(tmp_file_path, "r") as f:
+            data = f.read()
+
+        text_area.setText(data)
+
+        layout.addWidget(text_area)
+        group.setLayout(layout)
+
+        return group
+
+
+    def _userDescriptionWidget(self):
+        group = QGroupBox()
+        group.setTitle("User description")
+        layout = QVBoxLayout()
+
+        text_area = QTextEdit()
+
+        layout.addWidget(text_area)
+        group.setLayout(layout)
+
+        return group
+
+    def _buttonsWidget(self):
+        buttons = QDialogButtonBox()
+        buttons.addButton(QDialogButtonBox.Close)
+        buttons.addButton(catalog.i18nc("@action:button", "Send to developers"), QDialogButtonBox.AcceptRole)
+        buttons.rejected.connect(self.dialog.close)
+        buttons.accepted.connect(self._sendCrashReport)
+
+        return buttons
+
+    def _getOpenGLInfo(self):
+        info = "<ul><li>OpenGL Version: {0}</li><li>OpenGL Vendor: {1}</li><li>OpenGL Renderer: {2}</li></ul>"
+        info =  info.format(OpenGL.getInstance().getGPUVersion(), OpenGL.getInstance().getGPUVendorName(), OpenGL.getInstance().getGPUType())
+        return info
+
+    def _sendCrashReport(self):
+        print("Hello")
+        # _manager = QNetworkAccessManager()
+        # api_url = QUrl("url")
+        # put_request = QNetworkRequest(api_url)
+        # put_request.setHeader(QNetworkRequest.ContentTypeHeader, "text/plain")
+        # _manager.put(put_request, crash_info.encode())
+        #
+        # sys.exit(1)
+
+    def show(self):
+        self.dialog.exec_()
         sys.exit(1)
-
-    dialog = QDialog()
-    dialog.setMinimumWidth(640)
-    dialog.setMinimumHeight(640)
-    dialog.setWindowTitle(catalog.i18nc("@title:window", "Crash Report"))
-
-    layout = QVBoxLayout(dialog)
-
-    #label = QLabel(dialog)
-    #pixmap = QPixmap()
-    #try:
-    #    data = urllib.request.urlopen("http://www.randomkittengenerator.com/cats/rotator.php").read()
-    #    pixmap.loadFromData(data)
-    #except:
-    #    try:
-    #        from UM.Resources import Resources
-    #        path = Resources.getPath(Resources.Images, "kitten.jpg")
-    #        pixmap.load(path)
-    #    except:
-    #        pass
-    #pixmap = pixmap.scaled(150, 150)
-    #label.setPixmap(pixmap)
-    #label.setAlignment(Qt.AlignCenter)
-    #layout.addWidget(label)
-
-    label = QLabel(dialog)
-    layout.addWidget(label)
-
-    #label.setScaledContents(True)
-    label.setText(catalog.i18nc("@label", """<p>A fatal exception has occurred that we could not recover from!</p>
-        <p>Please use the information below to post a bug report at <a href=\"http://github.com/Ultimaker/Cura/issues\">http://github.com/Ultimaker/Cura/issues</a></p>
-    """))
-
-    textarea = QTextEdit(dialog)
-    layout.addWidget(textarea)
-
-    try:
-        from UM.Application import Application
-        version = Application.getInstance().getVersion()
-    except:
-        version = "Unknown"
-
-    trace = "".join(traceback.format_exception(exception_type, value, tb))
-
-    crash_info = "Version: {0}\nPlatform: {1}\nQt: {2}\nPyQt: {3}\n\nException:\n{4}"
-    crash_info = crash_info.format(version, platform.platform(), QT_VERSION_STR, PYQT_VERSION_STR, trace)
-
-    tmp_file_fd, tmp_file_path = tempfile.mkstemp(prefix = "cura-crash", text = True)
-    os.close(tmp_file_fd)
-    with open(tmp_file_path, "w") as f:
-        faulthandler.dump_traceback(f, all_threads=True)
-    with open(tmp_file_path, "r") as f:
-        data = f.read()
-
-    msg = "-------------------------\n"
-    msg += data
-    crash_info += "\n\n" + msg
-
-    textarea.setText(crash_info)
-
-    buttons = QDialogButtonBox(QDialogButtonBox.Close, dialog)
-    layout.addWidget(buttons)
-    buttons.addButton(catalog.i18nc("@action:button", "Open Web Page"), QDialogButtonBox.HelpRole)
-    buttons.rejected.connect(dialog.close)
-    buttons.helpRequested.connect(lambda: webbrowser.open("http://github.com/Ultimaker/Cura/issues"))
-
-    dialog.exec_()
-    sys.exit(1)

--- a/cura/CrashHandler.py
+++ b/cura/CrashHandler.py
@@ -90,8 +90,8 @@ class CrashHandler:
 
     def _messageWidget(self):
         label = QLabel()
-        label.setText(catalog.i18nc("@label crash message", """<p><b>A fatal exception has occurred that we could not recover from!</p></b>
-            <p>Please use the button below to post a bug report automatically to our servers</p>
+        label.setText(catalog.i18nc("@label crash message", """<p><b>A fatal exception has occurred. Please send us this Crash Report to fix the problem</p></b>
+            <p>Please use the "Send report" button to post a bug report automatically to our servers</p>
         """))
 
         return label
@@ -244,7 +244,7 @@ class CrashHandler:
     def _buttonsWidget(self):
         buttons = QDialogButtonBox()
         buttons.addButton(QDialogButtonBox.Close)
-        buttons.addButton(catalog.i18nc("@action:button", "Send to developers"), QDialogButtonBox.AcceptRole)
+        buttons.addButton(catalog.i18nc("@action:button", "Send report"), QDialogButtonBox.AcceptRole)
         buttons.rejected.connect(self.dialog.close)
         buttons.accepted.connect(self._sendCrashReport)
 

--- a/cura_app.py
+++ b/cura_app.py
@@ -41,8 +41,9 @@ if "PYTHONPATH" in os.environ.keys():                       # If PYTHONPATH is u
         sys.path.insert(1, PATH_real)                       # Insert it at 1 after os.curdir, which is 0.
 
 def exceptHook(hook_type, value, traceback):
-    import cura.CrashHandler
-    cura.CrashHandler.show(hook_type, value, traceback)
+    from cura.CrashHandler import CrashHandler
+    _crash_handler = CrashHandler(hook_type, value, traceback)
+    _crash_handler.show()
 
 sys.excepthook = exceptHook
 


### PR DESCRIPTION
As a new feature, a new crash report dialog was created in order to allow users to directly "Send to developers" the information collected in the crash, such as traceback, last logs, platform information, module (or plugin) that causes the crash, ... and even some user comments.
All this data is formatted as a JSON file and send via POST to the server, where the core developers can constantly check.