### PR TITLE
Change renderType for TextInput elements

### DIFF
--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -442,6 +442,7 @@ Column
                 anchors.leftMargin: UM.Theme.getSize("setting_unit_margin").width
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
+                renderType: Text.NativeRendering
 
                 Component.onCompleted:
                 {

--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -102,6 +102,7 @@ SettingItem
                 right: parent.right
                 verticalCenter: parent.verticalCenter
             }
+            renderType: Text.NativeRendering
 
             Keys.onTabPressed:
             {

--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -152,7 +152,7 @@ Rectangle
             Button {
                 height: settingsModeSelection.height
                 anchors.left: parent.left
-                anchors.leftMargin: model.index * (settingsModeSelection.width / 2)
+                anchors.leftMargin: model.index * Math.floor(settingsModeSelection.width / 2)
                 anchors.verticalCenter: parent.verticalCenter
                 width: Math.floor(0.5 * parent.width)
                 text: model.text


### PR DESCRIPTION
This PR changes the renderType of TextInput elements to be the same as other text elements (Label and native elements such as comboboxes).

Unlike Label elements, which are defined to use Text.NativeRendering, TextInput uses Qt text rendering by default. This can lead to differences in font rendering between input fields and other texts.

Probably fixes https://ultimaker.com/en/community/51334-cura-fonts-garbled-on-macos-high-sierra?page=1#reply-190665

Edit: it also fixes one more occurrence of a fractional pixel offset affecting the placement of text: the Recommended/Custom switch.