### PR TITLE
Fix size of "beta" classifier on splash screen for HiDPI screens

### DIFF
--- a/cura/CuraSplashScreen.py
+++ b/cura/CuraSplashScreen.py
@@ -62,7 +62,7 @@ class CuraSplashScreen(QSplashScreen):
         painter.setFont(font)
         painter.drawText(215, 66, 330 * self._scale, 230 * self._scale, Qt.AlignLeft | Qt.AlignTop, version[0])
         if len(version) > 1:
-            font.setPointSize(12)
+            font.setPixelSize(16)
             painter.setFont(font)
             painter.setPen(QColor(200, 200, 200, 255))
             painter.drawText(247, 105, 330 * self._scale, 255 * self._scale, Qt.AlignLeft | Qt.AlignTop, version[1])


### PR DESCRIPTION
This PR changes the size of secondary version "elements" (such as "BETA") to use a pixel size instead of a font size, so they scale correctly with the splash screen. This likely only shows on Windows.