### PR TITLE
initial layer flow

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1874,7 +1874,6 @@
                     "minimum_value": "5",
                     "minimum_value_warning": "50",
                     "maximum_value_warning": "150",
-                    "enabled": "machine_gcode_flavor != \"UltiGCode\"",
                     "settable_per_mesh": true
                 },
                 "retraction_enable":

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1863,6 +1863,20 @@
                     "enabled": "machine_gcode_flavor != \"UltiGCode\"",
                     "settable_per_mesh": true
                 },
+                "material_flow_layer_0":
+                {
+                    "label": "Initial Layer Flow",
+                    "description": "Flow compensation for the first layer: the amount of material extruded on the initial layer is multiplied by this value.",
+                    "unit": "%",
+                    "default_value": 100,
+                    "value": "material_flow",
+                    "type": "float",
+                    "minimum_value": "5",
+                    "minimum_value_warning": "50",
+                    "maximum_value_warning": "150",
+                    "enabled": "machine_gcode_flavor != \"UltiGCode\"",
+                    "settable_per_mesh": true
+                },
                 "retraction_enable":
                 {
                     "label": "Enable Retraction",


### PR DESCRIPTION
The initial layer has a different layer height and so the actual rounding of a line conforms to the naive square model CuraEngine uses in a different way.

In order to compensate for that you would want a different flow rate on the initial layer.