### PR TITLE
Revert a previous change and allow the spiralize setting to be specified per model.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4990,7 +4990,7 @@
                     "description": "Spiralize smooths out the Z move of the outer edge. This will create a steady Z increase over the whole print. This feature turns a solid model into a single walled print with a solid bottom. This feature should only be enabled when each layer only contains a single part.",
                     "type": "bool",
                     "default_value": false,
-                    "settable_per_mesh": false,
+                    "settable_per_mesh": true,
                     "settable_per_extruder": false
                 },
                 "smooth_spiralized_contours":
@@ -5000,7 +5000,7 @@
                     "type": "bool",
                     "default_value": true,
                     "enabled": "magic_spiralize",
-                    "settable_per_mesh": false,
+                    "settable_per_mesh": true,
                     "settable_per_extruder": false
                 },
                 "relative_extrusion":


### PR DESCRIPTION

Also let the option to smooth the spiral be per-model.

This will allow people to print objects from layered meshes such as a vase with a solid base.

Like this (not very artistic!) test example:

![screenshot_2017-10-18_12-12-32](https://user-images.githubusercontent.com/585618/31716147-72d3adfc-b3fe-11e7-9ff8-5d43f32d77d1.png)
![screenshot_2017-10-18_12-12-09](https://user-images.githubusercontent.com/585618/31716149-72f116c6-b3fe-11e7-81d2-5ddb51f8d82e.png)
