### PR TITLE
Fix qml error when there is no connected printer

### DIFF
--- a/plugins/UM3NetworkPrinting/UM3InfoComponents.qml
+++ b/plugins/UM3NetworkPrinting/UM3InfoComponents.qml
@@ -119,11 +119,17 @@ Item
             onClicked: manager.loadConfigurationFromPrinter()
 
             function isClusterPrinter() {
-                var clusterSize = Cura.MachineManager.printerOutputDevices[0].clusterSize
-                // This is a non cluster printer or the cluster it is just one printer
-                if (typeof clusterSize == "undefined" || clusterSize == 1)
-                    return false
-                return true
+                if(Cura.MachineManager.printerOutputDevices.length == 0)
+                {
+                    return false;
+                }
+                var clusterSize = Cura.MachineManager.printerOutputDevices[0].clusterSize;
+                // This is not a cluster printer or the cluster it is just one printer
+                if(clusterSize == undefined || clusterSize == 1)
+                {
+                    return false;
+                }
+                return true;
             }
         }
     }

--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -16,11 +16,17 @@ Menu
     property bool printerConnected: Cura.MachineManager.printerOutputDevices.length != 0
     property bool isClusterPrinter:
     {
-        var clusterSize = Cura.MachineManager.printerOutputDevices[0].clusterSize
-        // This is a non cluster printer or the cluster it is just one printer
-        if (typeof clusterSize == "undefined" || clusterSize == 1)
-            return false
-        return true
+        if(Cura.MachineManager.printerOutputDevices.length == 0)
+        {
+            return false;
+        }
+        var clusterSize = Cura.MachineManager.printerOutputDevices[0].clusterSize;
+        // This is not a cluster printer or the cluster it is just one printer
+        if(clusterSize == undefined || clusterSize == 1)
+        {
+            return false;
+        }
+        return true;
     }
 
     UM.SettingPropertyProvider

--- a/resources/qml/Menus/NozzleMenu.qml
+++ b/resources/qml/Menus/NozzleMenu.qml
@@ -16,11 +16,17 @@ Menu
     property bool printerConnected: Cura.MachineManager.printerOutputDevices.length != 0
     property bool isClusterPrinter:
     {
-        var clusterSize = Cura.MachineManager.printerOutputDevices[0].clusterSize
-        // This is a non cluster printer or the cluster it is just one printer
-        if (typeof clusterSize == "undefined" || clusterSize == 1)
-            return false
-        return true
+        if(Cura.MachineManager.printerOutputDevices.length == 0)
+        {
+            return false;
+        }
+        var clusterSize = Cura.MachineManager.printerOutputDevices[0].clusterSize;
+        // This is not a cluster printer or the cluster it is just one printer
+        if(clusterSize == undefined || clusterSize == 1)
+        {
+            return false;
+        }
+        return true;
     }
 
     MenuItem


### PR DESCRIPTION
This PR fixes the following qml errors on startup:
```
.../Cura/resources/qml/Menus/NozzleMenu.qml:19: TypeError: Cannot read property 'clusterSize' of undefined
.../Cura/resources/qml/Menus/MaterialMenu.qml:19: TypeError: Cannot read property 'clusterSize' of undefined
.../Cura/resources/qml/Menus/MaterialMenu.qml:19: TypeError: Cannot read property 'clusterSize' of undefined
.../Cura/resources/qml/Menus/NozzleMenu.qml:19: TypeError: Cannot read property 'clusterSize' of undefined
```

Also fixes code style