### PR TITLE
Cleanup save/monitor button area

### DIFF
--- a/cura/PrintInformation.py
+++ b/cura/PrintInformation.py
@@ -56,6 +56,7 @@ class PrintInformation(QObject):
         self._material_lengths = []
         self._material_weights = []
         self._material_costs = []
+        self._material_names = []
 
         self._pre_sliced = False
 
@@ -139,6 +140,12 @@ class PrintInformation(QObject):
     def materialCosts(self):
         return self._material_costs
 
+    materialNamesChanged = pyqtSignal()
+
+    @pyqtProperty("QVariantList", notify = materialNamesChanged)
+    def materialNames(self):
+        return self._material_names
+
     def _onPrintDurationMessage(self, print_time, material_amounts):
 
         self._updateTotalPrintTimePerFeature(print_time)
@@ -170,6 +177,7 @@ class PrintInformation(QObject):
         self._material_lengths = []
         self._material_weights = []
         self._material_costs = []
+        self._material_names = []
 
         material_preference_values = json.loads(Preferences.getInstance().getValue("cura/material_settings"))
 
@@ -208,10 +216,12 @@ class PrintInformation(QObject):
             self._material_weights.append(weight)
             self._material_lengths.append(length)
             self._material_costs.append(cost)
+            self._material_names.append(material.getName())
 
         self.materialLengthsChanged.emit()
         self.materialWeightsChanged.emit()
         self.materialCostsChanged.emit()
+        self.materialNamesChanged.emit()
 
     def _onPreferencesChanged(self, preference):
         if preference != "cura/material_settings":

--- a/resources/qml/JobSpecs.qml
+++ b/resources/qml/JobSpecs.qml
@@ -18,7 +18,6 @@ Item {
     UM.I18nCatalog { id: catalog; name:"cura"}
 
     height: childrenRect.height
-    width: childrenRect.width
 
     Connections
     {

--- a/resources/qml/MonitorButton.qml
+++ b/resources/qml/MonitorButton.qml
@@ -188,7 +188,11 @@ Item
     Item {
         id: buttonsRow
         height: abortButton.height
-        width: Math.min(childrenRect.width, base.width - 2 * UM.Theme.getSize("sidebar_margin").width)
+        width: {
+            // using childrenRect.width directly causes a binding loop, because setting the width affects the childrenRect
+            var children_width = additionalComponentsRow.width + pauseResumeButton.width + abortButton.width + 3 * UM.Theme.getSize("default_margin").width;
+            return Math.min(children_width, base.width - 2 * UM.Theme.getSize("sidebar_margin").width);
+        }
         anchors.top: progressBar.bottom
         anchors.topMargin: UM.Theme.getSize("sidebar_margin").height
         anchors.right: parent.right

--- a/resources/qml/MonitorButton.qml
+++ b/resources/qml/MonitorButton.qml
@@ -185,17 +185,20 @@ Item
         anchors.leftMargin: UM.Theme.getSize("sidebar_margin").width;
     }
 
-    Row {
+    Item {
         id: buttonsRow
         height: abortButton.height
+        width: Math.min(childrenRect.width, base.width - 2 * UM.Theme.getSize("sidebar_margin").width)
         anchors.top: progressBar.bottom
         anchors.topMargin: UM.Theme.getSize("sidebar_margin").height
         anchors.right: parent.right
         anchors.rightMargin: UM.Theme.getSize("sidebar_margin").width
-        spacing: UM.Theme.getSize("default_margin").width
+        clip: true
 
         Row {
             id: additionalComponentsRow
+            anchors.right: pauseResumeButton.left
+            anchors.rightMargin: UM.Theme.getSize("default_margin").width
             spacing: UM.Theme.getSize("default_margin").width
         }
 
@@ -215,6 +218,8 @@ Item
         {
             id: pauseResumeButton
 
+            anchors.right: abortButton.left
+            anchors.rightMargin: UM.Theme.getSize("default_margin").width
             height: UM.Theme.getSize("save_button_save_to_button").height
 
             property bool userClicked: false
@@ -260,6 +265,8 @@ Item
         Button
         {
             id: abortButton
+
+            anchors.right: parent.right
 
             visible: printerConnected && Cura.MachineManager.printerOutputDevices[0].canAbort
             enabled: printerConnected && Cura.MachineManager.printerOutputDevices[0].acceptsCommands &&

--- a/resources/qml/SaveButton.qml
+++ b/resources/qml/SaveButton.qml
@@ -18,6 +18,8 @@ Item {
     property var backend: CuraApplication.getBackend();
     property bool activity: CuraApplication.platformActivity;
 
+    property alias buttonRowWidth: saveRow.width
+
     property string fileBaseName
     property string statusText:
     {
@@ -89,11 +91,12 @@ Item {
 
     Item {
         id: saveRow
-        width: base.width
+        width: Math.min(childrenRect.width + UM.Theme.getSize("sidebar_margin").width, base.width - UM.Theme.getSize("sidebar_margin").width)
         height: saveToButton.height
         anchors.bottom: parent.bottom
         anchors.bottomMargin: UM.Theme.getSize("sidebar_margin").height
-        anchors.left: parent.left
+        anchors.right: parent.right
+        clip: true
 
         Row {
             id: additionalComponentsRow

--- a/resources/qml/SaveButton.qml
+++ b/resources/qml/SaveButton.qml
@@ -91,7 +91,19 @@ Item {
 
     Item {
         id: saveRow
-        width: Math.min(childrenRect.width + UM.Theme.getSize("sidebar_margin").width, base.width - UM.Theme.getSize("sidebar_margin").width)
+        width: {
+            // using childrenRect.width directly causes a binding loop, because setting the width affects the childrenRect
+            var children_width = UM.Theme.getSize("default_margin").width;
+            for (var index in children)
+            {
+                var child = children[index];
+                if(child.visible)
+                {
+                    children_width += child.width + child.anchors.rightMargin;
+                }
+            }
+            return Math.min(children_width, base.width - UM.Theme.getSize("sidebar_margin").width);
+        }
         height: saveToButton.height
         anchors.bottom: parent.bottom
         anchors.bottomMargin: UM.Theme.getSize("sidebar_margin").height
@@ -102,7 +114,7 @@ Item {
             id: additionalComponentsRow
             anchors.top: parent.top
             anchors.right: saveToButton.visible ? saveToButton.left : parent.right
-            anchors.rightMargin: UM.Theme.getSize("sidebar_margin").width
+            anchors.rightMargin: UM.Theme.getSize("default_margin").width
 
             spacing: UM.Theme.getSize("default_margin").width
         }

--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -30,6 +30,7 @@ Rectangle
     property variant printMaterialLengths: PrintInformation.materialLengths
     property variant printMaterialWeights: PrintInformation.materialWeights
     property variant printMaterialCosts: PrintInformation.materialCosts
+    property variant printMaterialNames: PrintInformation.materialNames
 
     color: UM.Theme.getColor("sidebar")
     UM.I18nCatalog { id: catalog; name:"cura"}
@@ -392,11 +393,13 @@ Rectangle
                 var costs = [];
                 var total_cost = 0;
                 var some_costs_known = false;
+                var names = [];
                 if(base.printMaterialLengths) {
                     for(var index = 0; index < base.printMaterialLengths.length; index++)
                     {
                         if(base.printMaterialLengths[index] > 0)
                         {
+                            names.push(base.printMaterialNames[index]);
                             lengths.push(base.printMaterialLengths[index].toFixed(2));
                             weights.push(String(Math.floor(base.printMaterialWeights[index])));
                             var cost = base.printMaterialCosts[index] == undefined ? 0 : base.printMaterialCosts[index].toFixed(2);
@@ -423,7 +426,7 @@ Rectangle
                 for(var index = 0; index < lengths.length; index++)
                 {
                     var item_strings = [
-                        catalog.i18nc("@label", "Extruder %1:").arg(index + 1),
+                        "%1:".arg(names[index]),
                         catalog.i18nc("@label m for meter", "%1m").arg(lengths[index]),
                         catalog.i18nc("@label g for grams", "%1g").arg(weights[index]),
                         "%1 %2".arg(UM.Preferences.getValue("cura/currency")).arg(costs[index]),

--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -313,31 +313,32 @@ Rectangle
         anchors.bottomMargin: Math.floor(UM.Theme.getSize("sidebar_margin").height * 2 + UM.Theme.getSize("progressbar").height + UM.Theme.getFont("default_bold").pixelSize)
     }
 
-    Rectangle
+    Item
     {
         id: printSpecs
         anchors.left: parent.left
         anchors.bottom: parent.bottom
         anchors.leftMargin: UM.Theme.getSize("sidebar_margin").width
         anchors.bottomMargin: UM.Theme.getSize("sidebar_margin").height
-        height: timeDetails.height + timeSpecDescription.height + lengthSpec.height
+        height: timeDetails.height + costSpec.height
+        width: base.width - (saveButton.buttonRowWidth + UM.Theme.getSize("sidebar_margin").width)
         visible: !monitoringPrint
+        clip: true
 
         Label
         {
             id: timeDetails
             anchors.left: parent.left
-            anchors.bottom: timeSpecDescription.top
+            anchors.bottom: costSpec.top
             font: UM.Theme.getFont("large")
             color: UM.Theme.getColor("text_subtext")
             text: (!base.printDuration || !base.printDuration.valid) ? catalog.i18nc("@label Hours and minutes", "00h 00min") : base.printDuration.getDisplayString(UM.DurationFormat.Short)
 
             MouseArea
             {
-                id: infillMouseArea
+                id: timeDetailsMouseArea
                 anchors.fill: parent
                 hoverEnabled: true
-                //enabled: base.settingsEnabled
 
                 onEntered:
                 {
@@ -345,19 +346,24 @@ Rectangle
                     if(base.printDuration.valid && !base.printDuration.isTotalDurationZero)
                     {
                         // All the time information for the different features is achieved
-                        var print_time = PrintInformation.getFeaturePrintTimes()
+                        var print_time = PrintInformation.getFeaturePrintTimes();
+                        var total_seconds = parseInt(base.printDuration.getDisplayString(UM.DurationFormat.Seconds))
 
                         // A message is created and displayed when the user hover the time label
-                        var content = catalog.i18nc("@tooltip", "<b>Time information</b>")
+                        var content = catalog.i18nc("@tooltip", "<b>Time specification</b><br/><table>");
                         for(var feature in print_time)
                         {
                             if(!print_time[feature].isTotalDurationZero)
                             {
-                                content += "<br /><i>" + feature + "</i>: " + print_time[feature].getDisplayString(UM.DurationFormat.Short)
+                                content += "<tr><td>" + feature +
+                                    "&nbsp;&nbsp;</td><td>" + print_time[feature].getDisplayString(UM.DurationFormat.Short) +
+                                    "&nbsp;&nbsp;</td><td>" + Math.round(100 * parseInt(print_time[feature].getDisplayString(UM.DurationFormat.Seconds)) / total_seconds) + "%" +
+                                    "</td></tr>";
                             }
                         }
+                        content += "</table>";
 
-                        base.showTooltip(parent, Qt.point(-UM.Theme.getSize("sidebar_margin").width, 0), content)
+                        base.showTooltip(parent, Qt.point(-UM.Theme.getSize("sidebar_margin").width, 0), content);
                     }
                 }
                 onExited:
@@ -369,20 +375,13 @@ Rectangle
 
         Label
         {
-            id: timeSpecDescription
-            anchors.left: parent.left
-            anchors.bottom: lengthSpec.top
-            font: UM.Theme.getFont("very_small")
-            color: UM.Theme.getColor("text_subtext")
-            text: catalog.i18nc("@description", "Print time")
-        }
-        Label
-        {
-            id: lengthSpec
+            id: costSpec
             anchors.left: parent.left
             anchors.bottom: parent.bottom
             font: UM.Theme.getFont("very_small")
             color: UM.Theme.getColor("text_subtext")
+            elide: Text.ElideMiddle
+            width: parent.width
             text:
             {
                 var lengths = [];
@@ -419,6 +418,33 @@ Rectangle
                 else
                 {
                     return catalog.i18nc("@label Print estimates: m for meters, g for grams", "%1m / ~ %2g").arg(lengths.join(" + ")).arg(weights.join(" + "));
+                }
+            }
+            MouseArea
+            {
+                id: costSpecMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+
+                onEntered:
+                {
+
+                    if(base.printDuration.valid && !base.printDuration.isTotalDurationZero)
+                    {
+                        // All the time information for the different features is achieved
+                        var print_time = PrintInformation.getFeaturePrintTimes();
+                        var total_seconds = parseInt(base.printDuration.getDisplayString(UM.DurationFormat.Seconds))
+
+                        // A message is created and displayed when the user hover the time label
+                        var content = catalog.i18nc("@tooltip", "<b>Cost specification</b><br/><table>");
+                        content += "</table>";
+
+                        base.showTooltip(parent, Qt.point(-UM.Theme.getSize("sidebar_margin").width, 0), content);
+                    }
+                }
+                onExited:
+                {
+                    base.hideTooltip();
                 }
             }
         }

--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -382,7 +382,7 @@ Rectangle
             color: UM.Theme.getColor("text_subtext")
             elide: Text.ElideMiddle
             width: parent.width
-            property string tooltipText: "test"
+            property string tooltipText
             text:
             {
                 var lengths = [];
@@ -419,15 +419,32 @@ Rectangle
                     costs = ["0.00"];
                 }
 
-                tooltipText = catalog.i18nc("@tooltip", "<b>Cost specification</b><br/><table>");
+                var tooltip_html = "<b>%1</b><br/><table>".arg(catalog.i18nc("@label", "Cost specification"));
                 for(var index = 0; index < lengths.length; index++)
                 {
-                    tooltipText += catalog.i18nc("@label Print estimates: m for meters, g for grams, %4 is currency and %3 is print cost", "<tr><td>Extruder %0:&nbsp;&nbsp;</td><td>%1m&nbsp;&nbsp;</td><td>%2g&nbsp;&nbsp;</td><td>%4 %3</td></tr>").arg(index + 1).arg(lengths[index])
-                            .arg(weights[index]).arg(costs[index]).arg(UM.Preferences.getValue("cura/currency"));
+                    var item_strings = [
+                        catalog.i18nc("@label", "Extruder %1:").arg(index + 1),
+                        catalog.i18nc("@label m for meter", "%1m").arg(lengths[index]),
+                        catalog.i18nc("@label g for grams", "%1g").arg(weights[index]),
+                        "%1 %2".arg(UM.Preferences.getValue("cura/currency")).arg(costs[index]),
+                    ];
+                    tooltip_html += "<tr>";
+                    for(var item = 0; item < item_strings.length; item++) {
+                        tooltip_html += "<td>%1&nbsp;&nbsp;</td>".arg(item_strings[item]);
+                    }
                 }
-                tooltipText += catalog.i18nc("@label Print totals: m for meters, g for grams, %4 is currency and %3 is print cost", "<tr><td>Total:&nbsp;&nbsp;</td><td>%1m&nbsp;&nbsp;</td><td>%2g&nbsp;&nbsp;</td><td>%4 %3</td></tr>").arg(total_length.toFixed(2))
-                            .arg(Math.round(total_weight)).arg(total_cost.toFixed(2)).arg(UM.Preferences.getValue("cura/currency"));
-                tooltipText += "</table>";
+                var item_strings = [
+                    catalog.i18nc("@label", "Total:"),
+                    catalog.i18nc("@label m for meter", "%1m").arg(total_length.toFixed(2)),
+                    catalog.i18nc("@label g for grams", "%1g").arg(Math.round(total_weight)),
+                    "%1 %2".arg(UM.Preferences.getValue("cura/currency")).arg(total_cost.toFixed(2)),
+                ];
+                tooltip_html += "<tr>";
+                for(var item = 0; item < item_strings.length; item++) {
+                    tooltip_html += "<td>%1&nbsp;&nbsp;</td>".arg(item_strings[item]);
+                }
+                tooltip_html += "</tr></table>";
+                tooltipText = tooltip_html;
 
                 if(some_costs_known)
                 {

--- a/resources/qml/SidebarTooltip.qml
+++ b/resources/qml/SidebarTooltip.qml
@@ -54,6 +54,7 @@ UM.PointingRectangle {
             rightMargin: UM.Theme.getSize("tooltip_margins").width;
         }
         wrapMode: Text.Wrap;
+        textFormat: Text.RichText
         font: UM.Theme.getFont("default");
         color: UM.Theme.getColor("tooltip_text");
     }


### PR DESCRIPTION
This PR rearranges the time & cost specs in the save button area, and puts some more information in the tooltips for these elements

![image](https://user-images.githubusercontent.com/143551/32143816-d1f86e1c-bcaf-11e7-9986-122f0d94d9c4.png)

* Time specification has better formatting and now adds percentages
* Cost item has elide, shows only total cost and weight
* Cost item has a tooltip that shows further specification

This PR fixes https://github.com/Ultimaker/Cura/issues/2662 and https://github.com/Ultimaker/Cura/issues/2643 (CURA-4478)

Currently a WIP, because there are still a couple of QML binding loops that need fixing.