### PR TITLE
Stop SettingTextField from setting values when getting/losing the focus

### DIFF
--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -11,6 +11,14 @@ SettingItem
     id: base
     property var focusItem: input
 
+    property string textBeforeEdit
+    property bool textHasChanged
+    onFocusReceived:
+    {
+        textHasChanged = false;
+        textBeforeEdit = focusItem.text;
+    }
+
     contents: Rectangle
     {
         id: control
@@ -115,12 +123,22 @@ SettingItem
 
             Keys.onReleased:
             {
-                propertyProvider.setPropertyValue("value", text)
+                if (text != textBeforeEdit)
+                {
+                    textHasChanged = true;
+                }
+                if (textHasChanged)
+                {
+                    propertyProvider.setPropertyValue("value", text)
+                }
             }
 
             onEditingFinished:
             {
-                propertyProvider.setPropertyValue("value", text)
+                if (textHasChanged)
+                {
+                    propertyProvider.setPropertyValue("value", text)
+                }
             }
 
             onActiveFocusChanged:


### PR DESCRIPTION
This PR stops SettingTextField from setting a new "literal" value when just tabbing in/out of focus by checking if the text has changed between receiving the focus and editingFinished.

Fixes #2694