### PR TITLE
Cmake script patch so they depend on Python 3 instead of 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT ${URANIUM_SCRIPTS_DIR} STREQUAL "")
     CREATE_TRANSLATION_TARGETS()
 endif()
 
-find_package(PythonInterp 3.5.0 REQUIRED)
+find_package(PythonInterp 3 REQUIRED)
 
 install(DIRECTORY resources
         DESTINATION ${CMAKE_INSTALL_DATADIR}/cura)

--- a/cmake/CuraTests.cmake
+++ b/cmake/CuraTests.cmake
@@ -4,7 +4,7 @@
 enable_testing()
 include(CMakeParseArguments)
 
-find_package(PythonInterp 3.5.0 REQUIRED)
+find_package(PythonInterp 3 REQUIRED)
 
 function(cura_add_test)
     set(_single_args NAME DIRECTORY PYTHONPATH)


### PR DESCRIPTION
This is a fix for #2715 .