### PR TITLE
Maximum mesh resolution

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4827,6 +4827,18 @@
                     "default_value": false,
                     "settable_per_mesh": true
                 },
+                "meshfix_maximum_resolution":
+                {
+                    "label": "Maximum Resolution",
+                    "description": "The minimum size of a line segment after slicing. If you increase this, the mesh will have a lower resolution. This may allow the printer to keep up with the speed it has to process g-code and will increase slice speed by removing details of the mesh that it can't process anyway.",
+                    "type": "float",
+                    "unit": "mm",
+                    "default_value": 0.01,
+                    "minimum_value": "0.001",
+                    "minimum_value_warning": "0.005",
+                    "maximum_value_warning": "0.1",
+                    "settable_per_mesh": true
+                },
                 "multiple_mesh_overlap":
                 {
                     "label": "Merged Meshes Overlap",


### PR DESCRIPTION
A mesh fix setting that reduces the resolution of mesh polygons. This is already happening by default to a resolution of 10 micrometres, but now it's a setting that can be edited.

Implements issue CURA-4590.

See also https://github.com/Ultimaker/CuraEngine/pull/657 for the actual implementation.