### PR TITLE
CuraApplication/UM.MeshBuilder: Removing _reloadMeshFinished

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1151,7 +1151,7 @@ class CuraApplication(QtApplication):
             if file_name:
                 job = ReadMeshJob(file_name)
                 job._node = node
-                job.finished.connect(self._reloadMeshFinished)
+                job.finished.connect(node._reloadJobFinished)
                 job.start()
             else:
                 Logger.log("w", "Unable to reload data because we don't have a filename.")
@@ -1277,14 +1277,6 @@ class CuraApplication(QtApplication):
         pass
 
     fileLoaded = pyqtSignal(str)
-
-    def _reloadMeshFinished(self, job):
-        # TODO; This needs to be fixed properly. We now make the assumption that we only load a single mesh!
-        mesh_data = job.getResult()[0].getMeshData()
-        if mesh_data:
-            job._node.setMeshData(mesh_data)
-        else:
-            Logger.log("w", "Could not find a mesh in reloaded node.")
 
     def _openFile(self, filename):
         self.readLocalFile(QUrl.fromLocalFile(filename))


### PR DESCRIPTION
If this commit gets merged into Uranium, then _reloadMeshFinished is not needed anymore.
https://github.com/Ultimaker/Uranium/commit/31bff5b9b9797fb5654ea8ed74a51fff42600e1d
The function has been moved, so reloading a mesh after a file has been modified is possible.