### PR TITLE
Allow postprocessing before sending data to the printer

### DIFF
--- a/plugins/UM3NetworkPrinting/NetworkClusterPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/NetworkClusterPrinterOutputDevice.py
@@ -263,6 +263,8 @@ class NetworkClusterPrinterOutputDevice(NetworkPrinterOutputDevice.NetworkPrinte
             self._error_message.show()
             return
 
+        self.writeStarted.emit(self) # Allow postprocessing before sending data to the printer
+
         if len(self._printers) > 1:
             self.spawnPrintView()  # Ask user how to print it.
         elif len(self._printers) == 1:


### PR DESCRIPTION
This PR fixes PostProcessing plugins and possibly other actions on the gcode when printing to a print cluster (Cura Connect). See OutputDevice.py: "output device subclasses are completely free to implement writing however they want, though you should emit writeStarted and related signals whenever certain events happen related to the write process."

This PR fixes https://github.com/Ultimaker/Cura/issues/2855
Also see https://github.com/Ultimaker/Cura/commit/91e8ac6868762595a73363230234d223c1270753

You'll probably want to cherry-pick this to 3.1 as well.