### PR TITLE
Add experimental settings for adaptive layer heights - CURA-4524

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5983,6 +5983,49 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false
+                },
+                "adaptive_layer_height_enabled":
+                {
+                    "label": "Use adaptive layers",
+                    "description": "Adaptive layers computes the layer heights depending on the shape of the model.",
+                    "type": "bool",
+                    "default_value": false,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false
+                },
+                "adaptive_layer_height_variation":
+                {
+                    "label": "Adaptive layers maximum variation",
+                    "description": "The maximum allowed height different from the base layer height in mm.",
+                    "type": "float",
+                    "enabled": "adaptive_layer_height_enabled",
+                    "default_value": 0.1,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false
+                },
+                "adaptive_layer_height_variation_step":
+                {
+                    "label": "Adaptive layers variation step size",
+                    "description": "The difference in height of the next layer height compared to the previous one.",
+                    "type": "float",
+                    "enabled": "adaptive_layer_height_enabled",
+                    "default_value": 0.01,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false
+                },
+                "adaptive_layer_height_threshold":
+                {
+                    "label": "Adaptive layers threshold",
+                    "description": "Threshold whether to use a smaller layer or not. This number is compared to the tan of the steepest slope in a layer.",
+                    "type": "float",
+                    "enabled": "adaptive_layer_height_enabled",
+                    "default_value": 200.0,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false
                 }
             }
         },


### PR DESCRIPTION
New experimental settings for adaptive layer heights in the engine. See https://github.com/Ultimaker/CuraEngine/pull/649 for details of this feature. Note that the default values might change depending on results from materials & processing.