### PR TITLE
Hide material diameter when the machine has no materials

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -283,6 +283,7 @@ Cura.MachineAction
                             Loader
                             {
                                 id: materialDiameterField
+                                visible: Cura.MachineManager.hasMaterials
                                 sourceComponent: numericTextFieldWithUnit
                                 property string settingKey: "material_diameter"
                                 property string unit: catalog.i18nc("@label", "mm")


### PR DESCRIPTION
This PR hides the material diameter field from Machine Settings when the current machine does not have materials (eg Ultimaker 2 when using UltiGcode)

Contributes to https://github.com/Ultimaker/Cura/issues/1273