### PR TITLE
Tweak layout and alignment of print time and cost estimation

### DIFF
--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -350,21 +350,20 @@ Rectangle
                         var total_seconds = parseInt(base.printDuration.getDisplayString(UM.DurationFormat.Seconds))
 
                         // A message is created and displayed when the user hover the time label
-                        var content = catalog.i18nc("@tooltip", "<b>Time specification</b><br/><table>");
+                        var tooltip_html = "<b>%1</b><br/><table>".arg(catalog.i18nc("@tooltip", "Time specification"));
                         for(var feature in print_time)
                         {
                             if(!print_time[feature].isTotalDurationZero)
                             {
-                                content += "<tr><td colspan='2'>" + feature + "</td></tr>" +
-                                    "<tr>" +
-                                    "<td width='60%'>" + print_time[feature].getDisplayString(UM.DurationFormat.Short) + "</td>" +
-                                    "<td width='40%'>&nbsp;&nbsp;" + Math.round(100 * parseInt(print_time[feature].getDisplayString(UM.DurationFormat.Seconds)) / total_seconds) + "%" +
+                                tooltip_html += "<tr><td>" + feature + " (in a more verbose language):</td>" +
+                                    "<td align=\"right\" valign=\"bottom\">&nbsp;&nbsp;%1</td>".arg(print_time[feature].getDisplayString(UM.DurationFormat.ISO8601).slice(0,-3)) +
+                                    "<td align=\"right\" valign=\"bottom\">&nbsp;&nbsp;%1%</td>".arg(Math.round(100 * parseInt(print_time[feature].getDisplayString(UM.DurationFormat.Seconds)) / total_seconds)) +
                                     "</td></tr>";
                             }
                         }
-                        content += "</table>";
+                        tooltip_html += "</table>";
 
-                        base.showTooltip(parent, Qt.point(-UM.Theme.getSize("sidebar_margin").width, 0), content);
+                        base.showTooltip(parent, Qt.point(-UM.Theme.getSize("sidebar_margin").width, 0), tooltip_html);
                     }
                 }
                 onExited:
@@ -376,9 +375,26 @@ Rectangle
 
         Label
         {
+            function formatRow(items)
+            {
+                var row_html = "<tr>";
+                for(var item = 0; item < items.length; item++)
+                {
+                    if (item == 0)
+                    {
+                        row_html += "<td valign=\"bottom\">%1</td>".arg(items[item]);
+                    }
+                    else
+                    {
+                        row_html += "<td align=\"right\" valign=\"bottom\">&nbsp;&nbsp;%1</td>".arg(items[item]);
+                    }
+                }
+                row_html += "</tr>";
+                return row_html;
+            }
 
-            function getSpecsData(){
-
+            function getSpecsData()
+            {
                 var lengths = [];
                 var total_length = 0;
                 var weights = [];
@@ -387,7 +403,8 @@ Rectangle
                 var total_cost = 0;
                 var some_costs_known = false;
                 var names = [];
-                if(base.printMaterialLengths) {
+                if(base.printMaterialLengths)
+                {
                     for(var index = 0; index < base.printMaterialLengths.length; index++)
                     {
                         if(base.printMaterialLengths[index] > 0)
@@ -415,33 +432,27 @@ Rectangle
                     costs = ["0.00"];
                 }
 
-                var tooltip_html = "<b>%1</b><br/><table>".arg(catalog.i18nc("@label", "Cost specification"));
+                var tooltip_html = "<b>%1</b><br/><table width=\"100%\">".arg(catalog.i18nc("@label", "Cost specification"));
                 for(var index = 0; index < lengths.length; index++)
                 {
-                    var item_strings = [
+                    tooltip_html += formatRow([
                         "%1:".arg(names[index]),
                         catalog.i18nc("@label m for meter", "%1m").arg(lengths[index]),
                         catalog.i18nc("@label g for grams", "%1g").arg(weights[index]),
-                        "%1 %2".arg(UM.Preferences.getValue("cura/currency")).arg(costs[index]),
-                    ];
-                    tooltip_html += "<tr>";
-                    for(var item = 0; item < item_strings.length; item++) {
-                        tooltip_html += "<td>%1&nbsp;&nbsp;</td>".arg(item_strings[item]);
-                    }
+                        "%1&nbsp;%2".arg(UM.Preferences.getValue("cura/currency")).arg(costs[index]),
+                    ]);
                 }
-                var item_strings = [
-                    catalog.i18nc("@label", "Total:"),
-                    catalog.i18nc("@label m for meter", "%1m").arg(total_length.toFixed(2)),
-                    catalog.i18nc("@label g for grams", "%1g").arg(Math.round(total_weight)),
-                    "%1 %2".arg(UM.Preferences.getValue("cura/currency")).arg(total_cost.toFixed(2)),
-                ];
-                tooltip_html += "<tr>";
-                for(var item = 0; item < item_strings.length; item++) {
-                    tooltip_html += "<td>%1&nbsp;&nbsp;</td>".arg(item_strings[item]);
+                if(lengths.length > 1)
+                {
+                    tooltip_html += formatRow([
+                        catalog.i18nc("@label", "Total:"),
+                        catalog.i18nc("@label m for meter", "%1m").arg(total_length.toFixed(2)),
+                        catalog.i18nc("@label g for grams", "%1g").arg(Math.round(total_weight)),
+                        "%1 %2".arg(UM.Preferences.getValue("cura/currency")).arg(total_cost.toFixed(2)),
+                    ]);
                 }
-                tooltip_html += "</tr></table>";
+                tooltip_html += "</table>";
                 tooltipText = tooltip_html;
-
 
                 return tooltipText
             }

--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -350,12 +350,12 @@ Rectangle
                         var total_seconds = parseInt(base.printDuration.getDisplayString(UM.DurationFormat.Seconds))
 
                         // A message is created and displayed when the user hover the time label
-                        var tooltip_html = "<b>%1</b><br/><table>".arg(catalog.i18nc("@tooltip", "Time specification"));
+                        var tooltip_html = "<b>%1</b><br/><table width=\"100%\">".arg(catalog.i18nc("@tooltip", "Time specification"));
                         for(var feature in print_time)
                         {
                             if(!print_time[feature].isTotalDurationZero)
                             {
-                                tooltip_html += "<tr><td>" + feature + " (in a more verbose language):</td>" +
+                                tooltip_html += "<tr><td>" + feature + ":</td>" +
                                     "<td align=\"right\" valign=\"bottom\">&nbsp;&nbsp;%1</td>".arg(print_time[feature].getDisplayString(UM.DurationFormat.ISO8601).slice(0,-3)) +
                                     "<td align=\"right\" valign=\"bottom\">&nbsp;&nbsp;%1%</td>".arg(Math.round(100 * parseInt(print_time[feature].getDisplayString(UM.DurationFormat.Seconds)) / total_seconds)) +
                                     "</td></tr>";


### PR DESCRIPTION
This PR tweaks the layout and alignment of print time and cost estimation tooltips, improving readability.

* table takes the full width and values are right-aligned
* time estimates are shortened
* values are right aligned
* feature/time/percentage are on a single line again
* handle long feature & material names gracefully
* totals are only shown when there are multiple extruders

Discussion:
In the current design it is fairly hard to associate the data with the label. Because there is a line of text between each datum, it is also harder to get an overview at a glance. Finally, this design is "punishing" wellbehaved (compact) languages for the chance that there may be a more verbose language.
![image](https://user-images.githubusercontent.com/143551/33424090-0b12fc84-d5bb-11e7-9903-8dc8b672bb15.png)

 It would be better if the layout adapted itself (as a HTML table can). Here is the counter offer (this PR):

For languages that are nice and compact:
![image](https://user-images.githubusercontent.com/143551/33422450-0a5d4cd6-d5b6-11e7-9b79-c8f9f9ad12da.png)

For languages that are fairly verbose (the exception, not the rule):
![image](https://user-images.githubusercontent.com/143551/33422523-43e57de8-d5b6-11e7-8ae3-7ba933236428.png)

Note how in this design, the table uses the full width, and the times and percentages are actually right-aligned for better readability. In the verbose version, the data still align vertically with the colon of the feature name. I made the time display a bit more compact (based on the ISO8601 duration-format instead of the short format).

This PR also amends the cost specification tooltip, removing the totals when there is nothing to add up:
![image](https://user-images.githubusercontent.com/143551/33424271-9c0b6abe-d5bb-11e7-9b3c-faafb1a63b82.png)
Same tooltip with multi-extrusion and long material names:
![image](https://user-images.githubusercontent.com/143551/33424363-e9716128-d5bb-11e7-9380-6e5a90cf759f.png)


Fixes #2712
