### PR TITLE
[CRITICAL] Prevent start & end gcode snippets being double encoded

### DIFF
--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -225,10 +225,10 @@ class StartSliceJob(Job):
         try:
             # any setting can be used as a token
             fmt = GcodeStartEndFormatter()
-            return str(fmt.format(value, **settings)).encode("utf-8")
+            return str(fmt.format(value, **settings))
         except:
             Logger.logException("w", "Unable to do token replacement on start/end gcode")
-            return str(value).encode("utf-8")
+            return str(value)
 
     ##  Create extruder message from stack
     def _buildExtruderMessage(self, stack):


### PR DESCRIPTION
This PR fixes a regression caused by https://github.com/Ultimaker/Cura/commit/1d6b7c71cbd3301915a0777404d0d6627373b979 which double encodes start/end gcode snippets, leading to non-valid start and end seuqences.

See https://github.com/Ultimaker/Cura/issues/2877#issuecomment-348113324 for discussion

Note: the issue does not manifest on UM2(+) or UM3 printers, because they don't use start/end gcode snippets. On all other printers, Cura outputs quite broken gcode at the moment.