### PR TITLE
Add Fedora to test for nvidia driver work around.

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -12,7 +12,7 @@ from UM.Platform import Platform
 #WORKAROUND: GITHUB-88 GITHUB-385 GITHUB-612
 if Platform.isLinux(): # Needed for platform.linux_distribution, which is not available on Windows and OSX
     # For Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
-    if platform.linux_distribution()[0] in ("debian", "Ubuntu", "LinuxMint"): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
+    if platform.linux_distribution()[0] in ("debian", "Ubuntu", "LinuxMint", "Fedora"): # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
         import ctypes
         from ctypes.util import find_library
         libGL = find_library("GL")


### PR DESCRIPTION
As of 12/3/2017 Cura as provided with Fedora 27 does not work when the nvidia driver is installed.

The test in the top level script to decide to apply the Linux nvidia work around lists some Linux distributions:
"debian", "Ubuntu", "LinuxMint"
this patch adds "Fedora" to that test.

Tested on Fedora 27 with nvidia driver. Also submitted to Fedora bugzilla
https://bugzilla.redhat.com/show_bug.cgi?id=1520138
they additionally requested that this patch be proposed upstream.
