### PR TITLE
SidebarHeader: Adding missing comment about "extruder row"

### DIFF
--- a/resources/qml/SidebarHeader.qml
+++ b/resources/qml/SidebarHeader.qml
@@ -34,6 +34,7 @@ Column
         width: height
     }
 
+    // Extruder Row
     Item
     {
         id: extruderSelectionRow


### PR DESCRIPTION
Just read the code and noticed that.