### PR TITLE
MachineManager: Making totalNumberOfSettings more failsave

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -161,7 +161,10 @@ class MachineManager(QObject):
 
     @pyqtProperty(int, constant=True)
     def totalNumberOfSettings(self) -> int:
-        return len(ContainerRegistry.getInstance().findDefinitionContainers(id = "fdmprinter")[0].getAllKeys())
+        containers = ContainerRegistry.getInstance().findDefinitionContainers(id = "fdmprinter")
+        if len(containers) == 0:
+            return 0
+        return len(containers[0].getAllKeys())
 
     def _onHotendIdChanged(self, index: Union[str, int], hotend_id: str) -> None:
         if not self._global_container_stack:


### PR DESCRIPTION
This check should protect against early calls, like this:

```
2017-12-06 21:53:14,373 - ERROR - UM.Logger.logException [80]:   File "FooPlugin\Handler.py", line foo1, in __init__
2017-12-06 21:53:14,375 - ERROR - UM.Logger.logException [80]:     if not hasattr(self.__proxy_base, object_name):
2017-12-06 21:53:14,377 - ERROR - UM.Logger.logException [80]:   File "cura\Settings\MachineManager.py", line 150, in totalNumberOfSettings
2017-12-06 21:53:14,380 - ERROR - UM.Logger.logException [80]: IndexError: list index out of range
```