### PR TITLE
Extra machine settings

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -606,6 +606,73 @@
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false
                 },
+                "machine_steps_per_mm_x":
+                {
+                    "label": "Steps per Millimeter (X)",
+                    "description": "How many steps of the stepper motor will result in one millimeter of movement in the X direction.",
+                    "type": "int",
+                    "default_value": 50,
+                    "minimum_value": "0.0000001",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
+                "machine_steps_per_mm_y":
+                {
+                    "label": "Steps per Millimeter (Y)",
+                    "description": "How many steps of the stepper motor will result in one millimeter of movement in the Y direction.",
+                    "type": "int",
+                    "default_value": 50,
+                    "minimum_value": "0.0000001",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
+                "machine_steps_per_mm_z":
+                {
+                    "label": "Steps per Millimeter (Z)",
+                    "description": "How many steps of the stepper motor will result in one millimeter of movement in the Z direction.",
+                    "type": "int",
+                    "default_value": 50,
+                    "minimum_value": "0.0000001",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
+                "machine_steps_per_mm_e":
+                {
+                    "label": "Steps per Millimeter (E)",
+                    "description": "How many steps of the stepper motors will result in one millimeter of extrusion.",
+                    "type": "int",
+                    "default_value": 1600,
+                    "minimum_value": "0.0000001",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
+                "machine_endstop_positive_direction_x":
+                {
+                    "label": "X Endstop in Positive Direction",
+                    "description": "Whether the endstop of the X axis is in the positive direction (high X coordinate) or negative (low X coordinate).",
+                    "type": "bool",
+                    "default_value": false,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
+                "machine_endstop_positive_direction_y":
+                {
+                    "label": "Y Endstop in Positive Direction",
+                    "description": "Whether the endstop of the Y axis is in the positive direction (high Y coordinate) or negative (low Y coordinate).",
+                    "type": "bool",
+                    "default_value": false,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
+                "machine_endstop_positive_direction_z":
+                {
+                    "label": "Z Endstop in Positive Direction",
+                    "description": "Whether the endstop of the Z axis is in the positive direction (high Z coordinate) or negative (low Z coordinate).",
+                    "type": "bool",
+                    "default_value": true,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
                 "machine_minimum_feedrate":
                 {
                     "label": "Minimum Feedrate",
@@ -616,6 +683,16 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false
+                },
+                "machine_feeder_wheel_diameter":
+                {
+                    "label": "Feeder Wheel Diameter",
+                    "description": "The diameter of the wheel that drives the material in the feeder.",
+                    "unit": "mm",
+                    "type": "float",
+                    "default_value": 10.0,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
                 }
             }
         },

--- a/resources/definitions/m180.def.json
+++ b/resources/definitions/m180.def.json
@@ -25,8 +25,7 @@
             "default_value": true
         },
         "machine_nozzle_size": {
-            "default_value": 0.4,
-            "minimum_value": "0.001"
+            "default_value": 0.4
         },
         "machine_head_with_fans_polygon": {
             "default_value": [
@@ -35,6 +34,21 @@
                 [ 18, -18 ],
                 [ 18, 35 ]
             ]
+        },
+        "machine_max_feedrate_z": {
+            "default_value": 400
+        },
+        "steps_per_mm_x": {
+            "default_value": 93
+        },
+        "steps_per_mm_y": {
+            "default_value": 93
+        },
+        "steps_per_mm_z": {
+            "default_value": 1600
+        },
+        "steps_per_mm_e": {
+            "default_value": 92
         },
         "gantry_height": {
             "default_value": 55


### PR DESCRIPTION
This adds a few extra machine settings in order to be able to store more information about machines. These settings are primarily used by X3GWriter in order to output correct X3G. However I took care to select only settings that could feasibly be used for slicing in general. For instance, the steps per MM can be used to align g-code output to the step grid, which would improve quality and speed while reducing g-code size.

The settings are correctly configured for Malyan M180 as well. If we're going to use them for actual slicing we should set them correct for the Ultimaker printers too.