### PR TITLE
Prevent CrashHandler creating a QWidget before QApplication is created

### DIFF
--- a/cura/CrashHandler.py
+++ b/cura/CrashHandler.py
@@ -53,7 +53,7 @@ class CrashHandler:
         self.exception_type = exception_type
         self.value = value
         self.traceback = tb
-        self.dialog = QDialog()
+        self.dialog = None # Don't create a QDialog before there is a QApplication
 
         # While we create the GUI, the information will be stored for sending afterwards
         self.data = dict()
@@ -71,6 +71,7 @@ class CrashHandler:
         if not application:
             sys.exit(1)
 
+        self.dialog = QDialog()
         self._createDialog()
 
     ##  Creates a modal dialog.

--- a/cura/CrashHandler.py
+++ b/cura/CrashHandler.py
@@ -37,7 +37,7 @@ else:
 # List of exceptions that should be considered "fatal" and abort the program.
 # These are primarily some exception types that we simply cannot really recover from
 # (MemoryError and SystemError) and exceptions that indicate grave errors in the
-# code that cause the Python interpreter to fail (SyntaxError, ImportError). 
+# code that cause the Python interpreter to fail (SyntaxError, ImportError).
 fatal_exception_types = [
     MemoryError,
     SyntaxError,
@@ -289,4 +289,4 @@ class CrashHandler:
         # When the exception is not in the fatal_exception_types list, the dialog is not created, so we don't need to show it
         if self.dialog:
             self.dialog.exec_()
-            os._exit(1)
+        os._exit(1)


### PR DESCRIPTION
This PR prevents crashhandler from crashing (and hiding the actual exception) when it is invoked before the QApplication has been initialized (eg when there is an syntax error in a py file).

```
QWidget: Must construct a QApplication before a QWidget
Fatal Python error: Aborted

Current thread 0x000012c8 (most recent call first):
  File "...\UM\Cura\cura\CrashHandler.py", line 56 in __init__
  File "cura_app.py", line 47 in exceptHook
```