### PR TITLE
Added infill_enable_travel_optimization setting.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1853,6 +1853,14 @@
                             "settable_per_mesh": true
                         }
                     }
+                },
+                "infill_enable_travel_optimization":
+                {
+                    "label": "Enable Travel Optimization",
+                    "description": "When enabled, the order in which the infill lines are printed is optimized to reduce the distance travelled. The reduction in travel time achieved very much depends on the model being sliced, infill pattern, density, etc. Note that, for some models that have many small areas of infill, the time to slice the model may be greatly increased.",
+                    "type": "bool",
+                    "default_value": false,
+                    "settable_per_mesh": true
                 }
             }
         },


### PR DESCRIPTION
Enabling this can greatly reduce the travel time during the printing of infill but it can
be expensive to compute so now the user can decide whether to use it or not.