### PR TITLE
Select text when gaining focus

### DIFF
--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -17,6 +17,7 @@ SettingItem
     {
         textHasChanged = false;
         textBeforeEdit = focusItem.text;
+        focusItem.selectAll();
     }
 
     contents: Rectangle


### PR DESCRIPTION
This PR changes the textfield to select its contents when gaining focus. This is especially usefull when tabbing through fields.

See https://github.com/Ultimaker/Cura/issues/1969#issuecomment-352632035