### PR TITLE
Addding printer profile for the popular Anycubic i3 Mega

### DIFF
--- a/resources/definitions/anycubic_i3_mega.def.json
+++ b/resources/definitions/anycubic_i3_mega.def.json
@@ -1,0 +1,71 @@
+{
+	"version":2,
+    "name":"Anycubic i3 Mega",
+    "inherits":"fdmprinter",
+    "metadata":{
+        "visible":true,
+        "author":"TheTobby",
+        "manufacturer":"Anycubic",
+        "file_formats":"text/x-gcode",
+        "icon":"icon_ultimaker2",
+        "platform":"prusai3_platform.stl"
+    },
+    "overrides":{
+        "machine_name":{
+            "default_value":"Anycubic i3 Mega"
+        },
+        "machine_heated_bed":{
+            "default_value":true
+        },
+        "machine_width":{
+            "default_value":210
+        },
+        "machine_height":{
+            "default_value":205
+        },
+        "machine_depth":{
+            "default_value":210
+        },
+        "machine_center_is_zero":{
+            "default_value":false
+        },
+        "machine_nozzle_size":{
+            "default_value":0.4
+        },
+        "material_diameter":{
+            "default_value":1.75
+        },
+        "machine_head_polygon":{
+            "default_value":[
+                [
+                    0,
+                    0
+                ],
+                [
+                    0,
+                    0
+                ],
+                [
+                    0,
+                    0
+                ],
+                [
+                    0,
+                    0
+                ]
+            ]
+        },
+        "gantry_height":{
+            "default_value":0
+        },
+        "machine_gcode_flavor":{
+            "default_value":"RepRap (Marlin/Sprinter)"
+        },
+        "machine_start_gcode":{
+            "default_value":"G21 ;metric values\nG90 ;absolute positioning\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG28 X0 Y0 ;move X/Y to min endstops\nG28 Z0 ;move Z to min endstops\nG1 Z15.0 F{travel_speed} ;move the platform down 15mm\nG92 E0 ;zero the extruded length\nG1 F200 E3 ;extrude 3mm of feed stock\nG92 E0 ;zero the extruded length again\nG1 F{travel_speed}\nM117 Printing...\nG5"
+        },
+        "machine_end_gcode":{
+            "default_value":"M104 S0 ; turn off extruder\nM140 S0 ; turn off bed\nM84 ; disable motors\nM107\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle\nto release some of the pressure\nG1 Z+0.5 E-5 ;X-20 Y-20 F{travel_speed} ;move Z up a bit and retract filament even more\nG28 X0 ;Y0 ;move X/Y to min endstops\nso the head is out of the way\nG1 Y180 F2000\nM84 ;steppers off\nG90\nM300 P300 S4000"
+        }
+    }
+}


### PR DESCRIPTION
Added definition for the very popular Anycubic i3 Mega according to manual provided by the factory.

JSON RFC 7159 validated.
As with other RepRap printers, it shows up as Marlin in Cura 3.1.0, bug?

Source for settings, not tested: http://12899463.s21d-12.faiusrd.com/0/ABUIABA9GAAgkdKqzAUoioTwnQM?f=ANYCUBIC_Mega_Manual_V2.3_English.pdf&v=1502259473