### PR TITLE
Revert to use of RepRap (Marlin/Sprinter) in English GUI

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -302,7 +302,7 @@
                     "type": "enum",
                     "options":
                     {
-                        "RepRap (Marlin/Sprinter)": "Marlin",
+                        "RepRap (Marlin/Sprinter)": "RepRap (Marlin/Sprinter)",
                         "RepRap (Volumetric)": "Marlin (Volumetric)",
                         "RepRap (RepRap)": "RepRap",
                         "UltiGCode": "Ultimaker 2",

--- a/resources/i18n/fdmprinter.def.json.pot
+++ b/resources/i18n/fdmprinter.def.json.pot
@@ -334,7 +334,7 @@ msgstr ""
 
 #: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option RepRap (Marlin/Sprinter)"
-msgid "Marlin"
+msgid "RepRap (Marlin/Sprinter)"
 msgstr ""
 
 #: fdmprinter.def.json


### PR DESCRIPTION
Untill full changover from RepRap (Marlin/Sprinter) to Marlin is ready in #3058 
Much more userfriendly and the naming will be correct with most user manuals published