### PR TITLE
Add option to UM3NetworkPlugin to allow preventing print queue buildup

### DIFF
--- a/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py
@@ -865,6 +865,14 @@ class NetworkPrinterOutputDevice(PrinterOutputDevice):
             self._error_message.show()
             return
 
+        # Check if the printer is already printing, if user wants to prevent queuing, stop queuing.
+        if not self._print_finished and self._prevent_queue:
+            self._error_message = Message(
+                i18n_catalog.i18nc("@info:status",
+                                   "Sending new jobs blocked, a print job is currently in progress."))
+            self._error_message.show()
+            return
+
         # Indicate we're starting a new write action, is set back to True at the end of this method
         self._write_finished = False
 

--- a/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevicePlugin.py
+++ b/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevicePlugin.py
@@ -54,6 +54,8 @@ class NetworkPrinterOutputDevicePlugin(QObject, OutputDevicePlugin):
         self._preferences = Preferences.getInstance()
         self._preferences.addPreference("um3networkprinting/manual_instances", "") #  A comma-separated list of ip adresses or hostnames
         self._manual_instances = self._preferences.getValue("um3networkprinting/manual_instances").split(",")
+        self._preferences.addPreference("um3networkprinting/prevent_queue", False) # Whether to prevent queuing of prints over network
+        self._prevent_queue = self._preferences.getValue("um3networkprinting/prevent_queue")
 
         self._network_requests_buffer = {}  # store api responses until data is complete
 

--- a/resources/i18n/de_DE/cura.po
+++ b/resources/i18n/de_DE/cura.po
@@ -453,6 +453,12 @@ msgctxt "@info:status"
 msgid "Sending new jobs (temporarily) blocked, still sending the previous print job."
 msgstr "Das Senden neuer Aufträge ist (vorübergehend) blockiert; der vorherige Druckauftrag wird noch gesendet."
 
+#: /home/ruben/Projects/Cura/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py:872
+msgctxt "@info:status"
+msgid "Sending new jobs blocked, a print job is currently in progress."
+msgstr "Das Senden neuer Aufträge ist blockiert; ein Druckauftrag wird ausgeführt."
+
+
 #: /home/ruben/Projects/Cura/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py:873
 msgctxt "@info:status"
 msgid "Sending data to printer"

--- a/resources/i18n/fr_FR/cura.po
+++ b/resources/i18n/fr_FR/cura.po
@@ -453,6 +453,12 @@ msgctxt "@info:status"
 msgid "Sending new jobs (temporarily) blocked, still sending the previous print job."
 msgstr "Envoi de nouvelles tâches (temporairement) bloqué, envoi de la tâche d'impression précédente en cours."
 
+#: /home/ruben/Projects/Cura/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py:872
+msgctxt "@info:status"
+msgid "Sending new jobs blocked, a print job is currently in progress."
+msgstr "Envoi de nouvelles tâches bloqué, un travail d'impression est en cours."
+
+
 #: /home/ruben/Projects/Cura/plugins/UM3NetworkPrinting/NetworkPrinterOutputDevice.py:873
 msgctxt "@info:status"
 msgid "Sending data to printer"


### PR DESCRIPTION
## Use case
We have a problem in our print shop where users will accidentally send a print over network to a printer that's already printing. 

When we were using USBs, there was a physical barrier to sending prints. Now, because prints can be queued when sent over network, our users don't realize that they are queuing prints to a printer that's already printing. They think the print failed so they try to send it to another printer, which is problematic.

## What this PR does
Added an option in the cfg file to prevent queuing of network prints on Cura. It's set to False by default, so it will not affect normal usage.

When set to True, if the print is not finished, it will prevent the user from sending a print and tell them that  a print is already in progress. I did partial translation (German and French).