### PR TITLE
Support Mesh enhancements

### DIFF
--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -42,6 +42,13 @@ Item {
                 verticalAlignment: Text.AlignVCenter
             }
 
+            UM.SettingPropertyProvider
+            {
+                id: meshTypePropertyProvider
+                containerStackId: Cura.MachineManager.activeMachineId
+                watchedProperties: [ "enabled" ]
+            }
+
             ComboBox
             {
                 id: meshTypeSelection
@@ -52,36 +59,55 @@ Item {
                 model: ListModel
                 {
                     id: meshTypeModel
-                    Component.onCompleted:
+                    Component.onCompleted: meshTypeSelection.populateModel()
+                }
+
+                function populateModel()
+                {
+                    meshTypeModel.append({
+                        type:  "",
+                        text: catalog.i18nc("@label", "Normal model")
+                    });
+                    meshTypePropertyProvider.key = "support_mesh";
+                    if(meshTypePropertyProvider.properties.enabled == "True")
                     {
-                        meshTypeModel.append({
-                            type:  "",
-                            text: catalog.i18nc("@label", "Normal model")
-                        });
                         meshTypeModel.append({
                             type:  "support_mesh",
                             text: catalog.i18nc("@label", "Print as support")
                         });
+                    }
+                    meshTypePropertyProvider.key = "anti_overhang_mesh";
+                    if(meshTypePropertyProvider.properties.enabled == "True")
+                    {
                         meshTypeModel.append({
                             type:  "anti_overhang_mesh",
                             text: catalog.i18nc("@label", "Don't support overlap with other models")
                         });
+                    }
+                    meshTypePropertyProvider.key = "cutting_mesh";
+                    if(meshTypePropertyProvider.properties.enabled == "True")
+                    {
                         meshTypeModel.append({
                             type:  "cutting_mesh",
                             text: catalog.i18nc("@label", "Modify settings for overlap with other models")
                         });
+                    }
+                    meshTypePropertyProvider.key = "infill_mesh";
+                    if(meshTypePropertyProvider.properties.enabled == "True")
+                    {
                         meshTypeModel.append({
                             type:  "infill_mesh",
                             text: catalog.i18nc("@label", "Modify settings for infill of other models")
                         });
-
-                        meshTypeSelection.updateCurrentIndex();
                     }
+
+                    meshTypeSelection.updateCurrentIndex();
                 }
 
                 function updateCurrentIndex()
                 {
                     var mesh_type = UM.ActiveTool.properties.getValue("MeshType");
+                    meshTypeSelection.currentIndex = -1;
                     for(var index=0; index < meshTypeSelection.model.count; index++)
                     {
                         if(meshTypeSelection.model.get(index).type == mesh_type)
@@ -91,6 +117,16 @@ Item {
                         }
                     }
                     meshTypeSelection.currentIndex = 0;
+                }
+            }
+
+            Connections
+            {
+                target: Cura.MachineManager
+                onGlobalContainerChanged:
+                {
+                    meshTypeSelection.model.clear();
+                    meshTypeSelection.populateModel();
                 }
             }
 

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4233,6 +4233,18 @@
                     "limit_to_extruder": "support_infill_extruder_nr",
                     "enabled": "support_enable and support_use_towers",
                     "settable_per_mesh": true
+                },
+                "support_mesh_drop_down":
+                {
+                    "label": "Drop Down Support Mesh",
+                    "description": "Make support everywhere below the support mesh, so that there's no overhang in the support mesh.",
+                    "type": "bool",
+                    "default_value": true,
+                    "enabled": "support_mesh",
+                    "settable_per_mesh": true,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false,
+                    "settable_globally": false
                 }
             }
         },
@@ -5256,18 +5268,6 @@
                     "description": "Use this mesh to specify support areas. This can be used to generate support structure.",
                     "type": "bool",
                     "default_value": false,
-                    "settable_per_mesh": true,
-                    "settable_per_extruder": false,
-                    "settable_per_meshgroup": false,
-                    "settable_globally": false
-                },
-                "support_mesh_drop_down":
-                {
-                    "label": "Drop Down Support Mesh",
-                    "description": "Make support everywhere below the support mesh, so that there's no overhang in the support mesh.",
-                    "type": "bool",
-                    "default_value": true,
-                    "enabled": "support_mesh",
                     "settable_per_mesh": true,
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false,

--- a/resources/shaders/striped.shader
+++ b/resources/shaders/striped.shader
@@ -32,6 +32,7 @@ fragment =
     uniform highp vec3 u_viewPosition;
 
     uniform mediump float u_width;
+    uniform mediump bool u_vertical_stripes;
 
     varying highp vec3 v_position;
     varying highp vec3 v_vertex;
@@ -40,7 +41,9 @@ fragment =
     void main()
     {
         mediump vec4 finalColor = vec4(0.0);
-        mediump vec4 diffuseColor = (mod((-v_position.x + v_position.y), u_width) < (u_width / 2.)) ? u_diffuseColor1 : u_diffuseColor2;
+        mediump vec4 diffuseColor = u_vertical_stripes ?
+            (((mod(v_vertex.x, u_width) < (u_width / 2.)) ^^ (mod(v_vertex.z, u_width) < (u_width / 2.))) ? u_diffuseColor1 : u_diffuseColor2) :
+            ((mod((-v_position.x + v_position.y), u_width) < (u_width / 2.)) ? u_diffuseColor1 : u_diffuseColor2);
 
         /* Ambient Component */
         finalColor += u_ambientColor;
@@ -98,6 +101,7 @@ fragment41core =
     uniform highp vec3 u_viewPosition;
 
     uniform mediump float u_width;
+    uniform mediump bool u_vertical_stripes;
 
     in highp vec3 v_position;
     in highp vec3 v_vertex;
@@ -108,7 +112,9 @@ fragment41core =
     void main()
     {
         mediump vec4 finalColor = vec4(0.0);
-        mediump vec4 diffuseColor = (mod((-v_position.x + v_position.y), u_width) < (u_width / 2.)) ? u_diffuseColor1 : u_diffuseColor2;
+        mediump vec4 diffuseColor = u_vertical_stripes ?
+            (((mod(v_vertex.x, u_width) < (u_width / 2.)) ^^ (mod(v_vertex.z, u_width) < (u_width / 2.))) ? u_diffuseColor1 : u_diffuseColor2) :
+            ((mod((-v_position.x + v_position.y), u_width) < (u_width / 2.)) ? u_diffuseColor1 : u_diffuseColor2);
 
         /* Ambient Component */
         finalColor += u_ambientColor;
@@ -138,6 +144,7 @@ u_diffuseColor2 = [0.5, 0.5, 0.5, 1.0]
 u_specularColor = [0.4, 0.4, 0.4, 1.0]
 u_shininess = 20.0
 u_width = 5.0
+u_vertical_stripes = 0
 
 [bindings]
 u_modelMatrix = model_matrix
@@ -145,7 +152,8 @@ u_viewProjectionMatrix = view_projection_matrix
 u_normalMatrix = normal_matrix
 u_viewPosition = view_position
 u_lightPosition = light_0_position
-u_diffuseColor = diffuse_color
+u_diffuseColor1 = diffuse_color
+u_diffuseColor2 = diffuse_color_2
 
 [attributes]
 a_vertex = vertex


### PR DESCRIPTION
This PR provides the following enhancements to support meshes:
* Allow adding (only) support-specific settings for support meshes in Per Model Settings
* Render support meshes with a vertical stripe to tell them apart from normal meshes
* Hide the Support Mesh/Anti overhang mesh/... option if the machine definition disables the settings

This PR is a continuation of #2758
  