### PR TITLE
Fix updating icon in the top bar

### DIFF
--- a/plugins/MonitorStage/MonitorStage.py
+++ b/plugins/MonitorStage/MonitorStage.py
@@ -77,6 +77,7 @@ class MonitorStage(CuraStage):
     def _onEngineCreated(self):
         # We can only connect now, as we need to be sure that everything is loaded (plugins get created quite early)
         Application.getInstance().getMachineManager().outputDevicesChanged.connect(self._onOutputDevicesChanged)
+        self._onOutputDevicesChanged()
         self._updateMainOverlay()
         self._updateSidebar()
         self._updateIconSource()


### PR DESCRIPTION
This PR makes sure events such as onAcceptsCommandsChanges get connected if an outputdevice has been added before the monitorstage is initialized. Without these connections, an outputdevice that uses eg setAcceptCommands to change its state will not show an updated icon in the topbar. 

This PR applies to #2974
  