### PR TITLE
Fix QML errors building the material and nozzle menus

### DIFF
--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -44,14 +44,14 @@ Menu
         id: automaticMaterial
         text:
         {
-            if(printerConnected && Cura.MachineManager.printerOutputDevices[0].materialNames.length > extruderIndex && !isClusterPrinter)
+            if(visible)
             {
                 var materialName = Cura.MachineManager.printerOutputDevices[0].materialNames[extruderIndex];
                 return catalog.i18nc("@title:menuitem %1 is the automatically selected material", "Automatic: %1").arg(materialName);
             }
             return "";
         }
-        visible: printerConnected && Cura.MachineManager.printerOutputDevices[0].materialNames.length > extruderIndex && !isClusterPrinter
+        visible: printerConnected && Cura.MachineManager.printerOutputDevices[0].materialNames != undefined && Cura.MachineManager.printerOutputDevices[0].materialNames.length > extruderIndex && !isClusterPrinter
         onTriggered:
         {
             var materialId = Cura.MachineManager.printerOutputDevices[0].materialIds[extruderIndex];

--- a/resources/qml/Menus/NozzleMenu.qml
+++ b/resources/qml/Menus/NozzleMenu.qml
@@ -34,14 +34,14 @@ Menu
         id: automaticNozzle
         text:
         {
-            if(printerConnected && Cura.MachineManager.printerOutputDevices[0].hotendIds.length > extruderIndex && !isClusterPrinter)
+            if(visible)
             {
                 var nozzleName = Cura.MachineManager.printerOutputDevices[0].hotendIds[extruderIndex];
                 return catalog.i18nc("@title:menuitem %1 is the nozzle currently loaded in the printer", "Automatic: %1").arg(nozzleName);
             }
             return "";
         }
-        visible: printerConnected && Cura.MachineManager.printerOutputDevices[0].hotendIds.length > extruderIndex && !isClusterPrinter
+        visible: printerConnected && Cura.MachineManager.printerOutputDevices[0].hotendIds != undefined && Cura.MachineManager.printerOutputDevices[0].hotendIds.length > extruderIndex && !isClusterPrinter
         onTriggered:
         {
             var activeExtruderIndex = Cura.ExtruderManager.activeExtruderIndex;


### PR DESCRIPTION
This PR fixes a series of QML errors when when activating a printer. Since the network rewrite, outputdevices no longer have hotends and materials. This functionality may return, but until that time this does a better job at checking if the properties exist, preventing QML errors.