### PR TITLE
Added Support Eraser Plugin

### DIFF
--- a/plugins/SupportEraser/SupportEraser.py
+++ b/plugins/SupportEraser/SupportEraser.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2018 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
 from UM.Tool import Tool
 from PyQt5.QtCore import Qt, QUrl
 from UM.Application import Application

--- a/plugins/SupportEraser/SupportEraser.py
+++ b/plugins/SupportEraser/SupportEraser.py
@@ -1,0 +1,68 @@
+from UM.Tool import Tool
+from PyQt5.QtCore import Qt, QUrl
+from UM.Application import Application
+from UM.Event import Event
+from UM.Mesh.MeshBuilder import MeshBuilder
+from UM.Operations.AddSceneNodeOperation import AddSceneNodeOperation
+from UM.Settings.SettingInstance import SettingInstance
+from cura.Scene.CuraSceneNode import CuraSceneNode
+from cura.Scene.SliceableObjectDecorator import SliceableObjectDecorator
+from cura.Scene.BuildPlateDecorator import BuildPlateDecorator
+from cura.Settings.SettingOverrideDecorator import SettingOverrideDecorator
+
+import os
+import os.path
+
+class SupportEraser(Tool):
+    def __init__(self):
+        super().__init__()
+        self._shortcut_key = Qt.Key_G
+        self._controller = Application.getInstance().getController()
+
+    def event(self, event):
+        super().event(event)
+
+        if event.type == Event.ToolActivateEvent:
+
+            # Load the remover mesh:
+            self._createEraserMesh()
+
+            # After we load the mesh, deactivate the tool again:
+            self.getController().setActiveTool(None)
+
+    def _createEraserMesh(self):
+        # Selection.clear()
+
+        node = CuraSceneNode()
+
+        node.setName("Eraser")
+        node.setSelectable(True)
+        mesh = MeshBuilder()
+        mesh.addCube(10,10,10)
+        node.setMeshData(mesh.build())
+
+        active_build_plate = Application.getInstance().getBuildPlateModel().activeBuildPlate
+
+        node.addDecorator(SettingOverrideDecorator())
+        node.addDecorator(BuildPlateDecorator(active_build_plate))
+        node.addDecorator(SliceableObjectDecorator())
+
+        stack = node.callDecoration("getStack") #Don't try to get the active extruder since it may be None anyway.
+        if not stack:
+            node.addDecorator(SettingOverrideDecorator())
+            stack = node.callDecoration("getStack")
+
+        print(stack)
+        settings = stack.getTop()
+
+        if not (settings.getInstance("anti_overhang_mesh") and settings.getProperty("anti_overhang_mesh", "value")):
+            definition = stack.getSettingDefinition("anti_overhang_mesh")
+            new_instance = SettingInstance(definition, settings)
+            new_instance.setProperty("value", True)
+            new_instance.resetState()  # Ensure that the state is not seen as a user state.
+            settings.addInstance(new_instance)
+
+        scene = self._controller.getScene()
+        op = AddSceneNodeOperation(node, scene.getRoot())
+        op.push()
+        Application.getInstance().getController().getScene().sceneChanged.emit(node)

--- a/plugins/SupportEraser/__init__.py
+++ b/plugins/SupportEraser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Ultimaker B.V.
+# Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 from . import SupportEraser

--- a/plugins/SupportEraser/__init__.py
+++ b/plugins/SupportEraser/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2015 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
+from . import SupportEraser
+
+from UM.i18n import i18nCatalog
+i18n_catalog = i18nCatalog("uranium")
+
+def getMetaData():
+    return {
+        "tool": {
+            "name": i18n_catalog.i18nc("@label", "Support Blocker"),
+            "description": i18n_catalog.i18nc("@info:tooltip", "Create a volume in which supports are not printed."),
+            "icon": "tool_icon.svg",
+            "weight": 4
+        }
+    }
+
+def register(app):
+    return { "tool": SupportEraser.SupportEraser() }

--- a/plugins/SupportEraser/plugin.json
+++ b/plugins/SupportEraser/plugin.json
@@ -1,0 +1,8 @@
+{
+    "name": "Support Eraser",
+    "author": "Ultimaker B.V.",
+    "version": "1.0.0",
+    "description": "Creates an eraser mesh to block the printing of support in certain places",
+    "api": 4,
+    "i18n-catalog": "cura"
+}

--- a/plugins/SupportEraser/tool_icon.svg
+++ b/plugins/SupportEraser/tool_icon.svg
@@ -1,0 +1,11 @@
+<svg width="30px" height="30px" viewBox="0 0 30 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Cura-Icon" fill="#000000">
+            <path d="M19,27 L12,27 L3,27 L3,3 L12,3 L12,11 L19,11 L19,19 L27,19 L27,27 L19,27 Z M4,4 L4,26 L11,26 L11,4 L4,4 Z" id="Combined-Shape"></path>
+            <polygon id="Path" points="10 17.1441441 9.18918919 17.954955 7.52252252 16.3333333 5.85585586 18 5.04504505 17.1891892 6.66666667 15.4774775 5 13.8558559 5.81081081 13.045045 7.52252252 14.6666667 9.18918919 13 10 13.8108108 8.33333333 15.4774775"></polygon>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This is the first draft of the Support Eraser tool. The plugin creates a cube mesh which has the `anti_overhang_mesh` decorator causing it to block the creation of support material for overhangs within its volume. This distinction is necessary to avoid confusing this behavior from actually erasing a _portion_ of a support structure.

Some (non-necessary) improvements could be made such as:

- Better graphical style
- Discussion of whether the cube should be able to pass through the build plate or not
- Possible improvements to the tool's icon
- Placing the cube at a cursor click location