### PR TITLE
Gracefully handle missing libCharon

### DIFF
--- a/plugins/UFPWriter/__init__.py
+++ b/plugins/UFPWriter/__init__.py
@@ -1,13 +1,23 @@
 #Copyright (c) 2018 Ultimaker B.V.
 #Cura is released under the terms of the LGPLv3 or higher.
 
-from . import UFPWriter
+import sys
+
+from UM.Logger import Logger
+try:
+    from . import UFPWriter
+except ImportError:
+    Logger.log("w", "Could not import UFPWriter; libCharon may be missing")
+
 from UM.i18n import i18nCatalog #To translate the file format description.
 from UM.Mesh.MeshWriter import MeshWriter #For the binary mode flag.
 
 i18n_catalog = i18nCatalog("cura")
 
 def getMetaData():
+    if "UFPWriter.UFPWriter" not in sys.modules:
+        return {}
+
     return {
         "mesh_writer": {
             "output": [
@@ -22,4 +32,7 @@ def getMetaData():
     }
 
 def register(app):
+    if "UFPWriter.UFPWriter" not in sys.modules:
+        return {}
+
     return { "mesh_writer": UFPWriter.UFPWriter() }


### PR DESCRIPTION
This PR gracefully handles missing libCharon when importing the UFPWriter plugin, in the same way 3MFWriter handles a missing libSavitar. 

Please?