### PR TITLE
Set renderType to Text.NativeRendering for qtquick controls 2 Labels

### DIFF
--- a/resources/qml/Settings/SettingCategory.qml
+++ b/resources/qml/Settings/SettingCategory.qml
@@ -78,6 +78,7 @@ Button
                 verticalCenter: parent.verticalCenter;
             }
             text: definition.label
+            renderType: Text.NativeRendering
             font: UM.Theme.getFont("setting_category")
             color:
             {

--- a/resources/qml/Settings/SettingComboBox.qml
+++ b/resources/qml/Settings/SettingComboBox.qml
@@ -80,6 +80,7 @@ SettingItem
             anchors.right: downArrow.left
 
             text: control.currentText
+            renderType: Text.NativeRendering
             font: UM.Theme.getFont("default")
             color: !enabled ? UM.Theme.getColor("setting_control_disabled_text") : UM.Theme.getColor("setting_control_text")
             elide: Text.ElideRight
@@ -116,6 +117,7 @@ SettingItem
             contentItem: Label
             {
                 text: modelData.value
+                renderType: Text.NativeRendering
                 color: control.contentItem.color
                 font: UM.Theme.getFont("default")
                 elide: Text.ElideRight

--- a/resources/qml/Settings/SettingExtruder.qml
+++ b/resources/qml/Settings/SettingExtruder.qml
@@ -117,6 +117,7 @@ SettingItem
             rightPadding: swatch.width + UM.Theme.getSize("setting_unit_margin").width
 
             text: control.currentText
+            renderType: Text.NativeRendering
             font: UM.Theme.getFont("default")
             color: enabled ? UM.Theme.getColor("setting_control_text") : UM.Theme.getColor("setting_control_disabled_text")
 
@@ -171,6 +172,7 @@ SettingItem
             contentItem: Label
             {
                 text: model.name
+                renderType: Text.NativeRendering
                 color: UM.Theme.getColor("setting_control_text")
                 font: UM.Theme.getFont("default")
                 elide: Text.ElideRight

--- a/resources/qml/Settings/SettingItem.qml
+++ b/resources/qml/Settings/SettingItem.qml
@@ -112,11 +112,9 @@ Item {
             anchors.right: settingControls.left;
             anchors.verticalCenter: parent.verticalCenter
 
-            height: UM.Theme.getSize("section").height;
-            verticalAlignment: Text.AlignVCenter;
-
             text: definition.label
             elide: Text.ElideMiddle;
+            renderType: Text.NativeRendering
 
             color: UM.Theme.getColor("setting_control_text");
             opacity: (definition.visible) ? 1 : 0.5

--- a/resources/qml/Settings/SettingOptionalExtruder.qml
+++ b/resources/qml/Settings/SettingOptionalExtruder.qml
@@ -136,6 +136,7 @@ SettingItem
             rightPadding: swatch.width + UM.Theme.getSize("setting_unit_margin").width
 
             text: control.currentText
+            renderType: Text.NativeRendering
             font: UM.Theme.getFont("default")
             color: enabled ? UM.Theme.getColor("setting_control_text") : UM.Theme.getColor("setting_control_disabled_text")
 
@@ -190,6 +191,7 @@ SettingItem
             contentItem: Label
             {
                 text: model.name
+                renderType: Text.NativeRendering
                 color: UM.Theme.getColor("setting_control_text")
                 font: UM.Theme.getFont("default")
                 elide: Text.ElideRight

--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -83,11 +83,12 @@ SettingItem
 
         Label
         {
-            anchors.right: parent.right;
+            anchors.right: parent.right
             anchors.rightMargin: Math.round(UM.Theme.getSize("setting_unit_margin").width)
-            anchors.verticalCenter: parent.verticalCenter;
+            anchors.verticalCenter: parent.verticalCenter
 
-            text: definition.unit;
+            text: definition.unit
+            renderType: Text.NativeRendering
             color: UM.Theme.getColor("setting_unit")
             font: UM.Theme.getFont("default")
         }

--- a/resources/qml/Sidebar.qml
+++ b/resources/qml/Sidebar.qml
@@ -207,12 +207,13 @@ Rectangle
                     color: (control.checked || control.pressed) ? UM.Theme.getColor("action_button_active") : control.hovered ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("action_button")
                 }
 
-                contentItem: Text
+                contentItem: Label
                 {
                     text: model.text
                     font: UM.Theme.getFont("default")
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
+                    renderType: Text.NativeRendering
                     elide: Text.ElideRight
                     color:
                     {
@@ -352,6 +353,7 @@ Rectangle
             font: UM.Theme.getFont("large")
             color: UM.Theme.getColor("text_subtext")
             text: (!base.printDuration || !base.printDuration.valid) ? catalog.i18nc("@label Hours and minutes", "00h 00min") : base.printDuration.getDisplayString(UM.DurationFormat.Short)
+            renderType: Text.NativeRendering
 
             MouseArea
             {
@@ -479,6 +481,7 @@ Rectangle
             anchors.left: parent.left
             anchors.bottom: parent.bottom
             font: UM.Theme.getFont("very_small")
+            renderType: Text.NativeRendering
             color: UM.Theme.getColor("text_subtext")
             elide: Text.ElideMiddle
             width: parent.width


### PR DESCRIPTION
This PR fixes font rendering of setting labels in the sidebar on affected OS X installations. Apparently, the qtquickcontrols 2 Label no longer defaults to using renderType: Text.NativeRendering
This causes text to render with QtRendering which looks subtly different on Windows and succinctly broken on some OSX installations.

With this PR the sidebar is now rendered with a single renderer again, making for a more consistent look on all systems and avoiding the broken QtRendering on OS X alltogether.