### PR TITLE
Post stretch algorithm fixes

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/Stretch.py
+++ b/plugins/PostProcessingPlugin/scripts/Stretch.py
@@ -12,6 +12,7 @@ import numpy as np
 from UM.Logger import Logger
 from UM.Application import Application
 import re
+from cura.Settings.ExtruderManager import ExtruderManager
 
 def _getValue(line, key, default=None):
     """
@@ -90,9 +91,9 @@ class Stretcher():
         """
         Computes the new X and Y coordinates of all g-code steps
         """
-        Logger.log("d", "Post stretch with line width = " + str(self.line_width)
-                   + "mm wide circle stretch = " + str(self.wc_stretch)+ "mm"
-                   + "and push wall stretch = " + str(self.pw_stretch) + "mm")
+        Logger.log("d", "Post stretch with line width " + str(self.line_width)
+                   + "mm wide circle stretch " + str(self.wc_stretch)+ "mm"
+                   + " and push wall stretch " + str(self.pw_stretch) + "mm")
         retdata = []
         layer_steps = []
         current = GCodeStep(0)
@@ -282,7 +283,7 @@ class Stretcher():
         dmin_tri is the minimum distance between two consecutive points
         of an acceptable triangle
         """
-        dmin_tri = self.line_width / 2.0
+        dmin_tri = 0.5
         iextra_base = np.floor_divide(len(orig_seq), 3) # Nb of extra points
         ibeg = 0 # Index of first point of the triangle
         iend = 0 # Index of the third point of the triangle
@@ -325,9 +326,10 @@ class Stretcher():
                 relpos = 0.5 # To avoid division by zero or precision loss
             projection = (pos_before[ibeg] + relpos * (pos_after[iend] - pos_before[ibeg]))
             dist_from_proj = np.sqrt(((projection - step) ** 2).sum(0))
-            if dist_from_proj > 0.001: # Move central point only if points are not aligned
+            if dist_from_proj > 0.0003: # Move central point only if points are not aligned
                 modif_seq[i] = (step - (self.wc_stretch / dist_from_proj)
                                 * (projection - step))
+
         return
 
     def wideTurn(self, orig_seq, modif_seq):
@@ -411,8 +413,6 @@ class Stretcher():
                 modif_seq[ibeg] = modif_seq[ibeg] + xperp * self.pw_stretch
             elif not materialleft and materialright:
                 modif_seq[ibeg] = modif_seq[ibeg] - xperp * self.pw_stretch
-            if materialleft and materialright:
-                modif_seq[ibeg] = orig_seq[ibeg] # Surrounded by walls, don't move
 
 # Setup part of the stretch plugin
 class Stretch(Script):
@@ -437,7 +437,7 @@ class Stretch(Script):
                     "description": "Distance by which the points are moved by the correction effect in corners. The higher this value, the higher the effect",
                     "unit": "mm",
                     "type": "float",
-                    "default_value": 0.08,
+                    "default_value": 0.1,
                     "minimum_value": 0,
                     "minimum_value_warning": 0,
                     "maximum_value_warning": 0.2
@@ -448,7 +448,7 @@ class Stretch(Script):
                     "description": "Distance by which the points are moved by the correction effect when two lines are nearby. The higher this value, the higher the effect",
                     "unit": "mm",
                     "type": "float",
-                    "default_value": 0.08,
+                    "default_value": 0.1,
                     "minimum_value": 0,
                     "minimum_value_warning": 0,
                     "maximum_value_warning": 0.2
@@ -463,7 +463,7 @@ class Stretch(Script):
         the returned string is the list of modified g-code instructions
         """
         stretcher = Stretcher(
-            Application.getInstance().getGlobalContainerStack().getProperty("line_width", "value")
+            ExtruderManager.getInstance().getActiveExtruderStack().getProperty("machine_nozzle_size", "value")
             , self.getSettingValueByKey("wc_stretch"), self.getSettingValueByKey("pw_stretch"))
         return stretcher.execute(data)
 


### PR DESCRIPTION
Extract line width from current extruder nozzle size
Change default values of stretch parameters from 0.08 to 0.1

Using the Cura version 3.2.1, the old global "line_width" parameter is not valid anymore (it reports 0.35 instead of 0.53 in my case). To fix this issue, I use the nozzle size of the current extruder.
By the way, I pushed small refinements...