### PR TITLE
Add AppImageKit to credits

### DIFF
--- a/resources/i18n/cura.pot
+++ b/resources/i18n/cura.pot
@@ -3598,6 +3598,11 @@ msgctxt "@label"
 msgid "SVG icons"
 msgstr ""
 
+#: /home/ruben/Projects/Cura/resources/qml/AboutDialog.qml:139
+msgctxt "@label"
+msgid "Linux cross-distribution application deployment"
+msgstr ""
+
 #: /home/ruben/Projects/Cura/resources/qml/Settings/SettingView.qml:41
 msgctxt "@label"
 msgid "Profile:"

--- a/resources/i18n/de_DE/cura.po
+++ b/resources/i18n/de_DE/cura.po
@@ -3485,6 +3485,11 @@ msgctxt "@label"
 msgid "SVG icons"
 msgstr "SVG-Symbole"
 
+#: /home/ruben/Projects/Cura/resources/qml/AboutDialog.qml:139
+msgctxt "@label"
+msgid "Linux cross-distribution application deployment"
+msgstr "Distributionsunabhängiges Format für Linux-Anwendungen"
+
 #: /home/ruben/Projects/Cura/resources/qml/Settings/SettingView.qml:41
 msgctxt "@label"
 msgid "Profile:"

--- a/resources/qml/AboutDialog.qml
+++ b/resources/qml/AboutDialog.qml
@@ -136,7 +136,7 @@ UM.Dialog
 
                 projectsModel.append({ name:"Noto Sans", description: catalog.i18nc("@label", "Font"), license: "Apache 2.0", url: "https://www.google.com/get/noto/" });
                 projectsModel.append({ name:"Font-Awesome-SVG-PNG", description: catalog.i18nc("@label", "SVG icons"), license: "SIL OFL 1.1", url: "https://github.com/encharm/Font-Awesome-SVG-PNG" });
-                projectsModel.append({ name:"AppImageKit", description: catalog.i18nc("@label", "AppImageKit"), license: "MIT", url: "https://github.com/AppImage/AppImageKit" });
+                projectsModel.append({ name:"AppImageKit", description: catalog.i18nc("@label", "Linux cross-distribution application deployment"), license: "MIT", url: "https://github.com/AppImage/AppImageKit" });
             }
         }
     }

--- a/resources/qml/AboutDialog.qml
+++ b/resources/qml/AboutDialog.qml
@@ -136,6 +136,7 @@ UM.Dialog
 
                 projectsModel.append({ name:"Noto Sans", description: catalog.i18nc("@label", "Font"), license: "Apache 2.0", url: "https://www.google.com/get/noto/" });
                 projectsModel.append({ name:"Font-Awesome-SVG-PNG", description: catalog.i18nc("@label", "SVG icons"), license: "SIL OFL 1.1", url: "https://github.com/encharm/Font-Awesome-SVG-PNG" });
+                projectsModel.append({ name:"AppImageKit", description: catalog.i18nc("@label", "AppImageKit"), license: "MIT", url: "https://github.com/AppImage/AppImageKit" });
             }
         }
     }


### PR DESCRIPTION
Add AppImageKit to credits. AppImageKit has been used to distribute Cura to Linux users running various Linux distributions for a while now.