### PR TITLE
Fix location of post processing scripts on Linux

### DIFF
--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.py
@@ -173,7 +173,7 @@ class PostProcessingPlugin(QObject, Extension):
         Logger.log("d", "Creating post processing plugin view.")
 
         ## Load all scripts in the scripts folders
-        for root in [PluginRegistry.getInstance().getPluginPath("PostProcessingPlugin"), Resources.getStoragePath(Resources.Preferences)]:
+        for root in [PluginRegistry.getInstance().getPluginPath("PostProcessingPlugin"), Resources.getStoragePath(Resources.Resources)]:
             path = os.path.join(root, "scripts")
             if not os.path.isdir(path):
                 try:


### PR DESCRIPTION
This PR fixes the location of post processing scripts on Linux.

On Windows and OSX, resources and preferences are stored in the same folder. On Linux, preferences are in ~/.config, resources are in ~/.local/shared. Postprocessing scripts belong in the latter, along with all the other resources (definitions, plugins, themes).

Fixes #3356