### PR TITLE
setting to disable omitting retractions in support

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2169,6 +2169,16 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
+                "limit_support_retractions":
+                {
+                    "label": "Limit Support Retractions",
+                    "description": "Omit retraction when moving from support to support in a straight line. Enabling this setting saves print time, but can lead to excesive stringing within the support structure.",
+                    "type": "bool",
+                    "default_value": true,
+                    "enabled": "retraction_enable and support_enable",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
                 "material_standby_temperature":
                 {
                     "label": "Standby Temperature",


### PR DESCRIPTION
Some users report that omitting the retractions causes print failures.
It might be machine/material dependant, so we need a user setting for this.

Omitting retractions was implemented somewhere in 2.5 or something, but it was never a setting.
We've since gotten some critique on this.