### PR TITLE
Add definition for Printrbot Simple Maker's Kit 1405

### DIFF
--- a/resources/definitions/printrbot_simple_makers_kit.def.json
+++ b/resources/definitions/printrbot_simple_makers_kit.def.json
@@ -1,0 +1,39 @@
+{
+    "version": 2,
+    "name": "Printrbot Simple Maker's Kit (1405)",
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": true,
+        "author": "Timur Tabi",
+        "manufacturer": "Printrbot",
+        "file_formats": "text/x-gcode",
+        "preferred_material": "*pla*"
+    },
+
+    "overrides": {
+        "machine_name": { "default_value": "Printrbot Simple Maker's Kit (1405)" },
+        "machine_heated_bed": { "default_value": false },
+        "machine_width": { "default_value": 100 },
+        "machine_depth": { "default_value": 100 },
+        "machine_height": { "default_value": 115 },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_nozzle_size": { "default_value": 0.4 },
+        "machine_head_with_fans_polygon": {
+            "default_value": [
+                [-40, 1000],
+                [-40, -10],
+                [60, 1000],
+                [60, -10]
+            ]
+        },
+        "gantry_height": { "default_value": 1000 },
+        "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
+
+        "machine_start_gcode": {
+            "default_value": "G21       ;metric values\nG90       ;absolute positioning\nM82       ;set extruder to absolute mode\nM107      ;start with the fan off\nG28 X0 Y0 ;home X/Y\nG28 Z0    ;home Z\nG92 E0    ;zero the extruded length\nG29       ;initiate auto bed leveling sequence"
+        },
+        "machine_end_gcode": {
+            "default_value": "M104 S0     ;extruder heater off\nM140 S0     ;heated bed heater off (if you have it)\nM106 S0     ;fan off\nG91         ;relative positioning\nG1 E-1 F300 ;retract the filament a bit\nG1 Z+1 E-5 F9000 ;move Z up a bit and retract even more\nG28 X0 Y0   ;home X/Y, so the head is out of the way\nM84         ;steppers off\nG90         ;absolute positioning"
+        }
+    }
+}


### PR DESCRIPTION
The Printrbot Simple Maker's Kit, model 1405, was a low-cost FDM printer
without a heated bed and a 10x10cm print area.

The print area can be extended to 185x100mm with the "Printrbot Simple XL
Upgrade with Spool Rack for Maker's Kit 1405".