### PR TITLE
M&p setting optimization

### DIFF
--- a/resources/definitions/ultimaker3.def.json
+++ b/resources/definitions/ultimaker3.def.json
@@ -153,6 +153,7 @@
         "travel_avoid_distance": { "value": "3" },
         "wall_0_inset": { "value": "0" },
         "wall_line_width_x": { "value": "round(wall_line_width * 0.3 / 0.35, 2)" },
-        "wall_thickness": { "value": "1" }
+        "wall_thickness": { "value": "1" },
+        "zig_zaggify_infill": { "value": "True" }
     }
 }

--- a/resources/definitions/ultimaker3.def.json
+++ b/resources/definitions/ultimaker3.def.json
@@ -123,7 +123,6 @@
         "raft_margin": { "value": "10" },
         "raft_surface_layers": { "value": "1" },
         "retraction_amount": { "value": "2" },
-        "retraction_combing": { "default_value": "noskin" },		
         "retraction_count_max": { "value": "10" },
         "retraction_extrusion_window": { "value": "1" },
         "retraction_hop": { "value": "2" },

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -44,7 +44,7 @@ retraction_extrusion_window = 1
 retraction_hop = 1.5
 retraction_hop_enabled = True
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
+retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -45,7 +45,7 @@ retraction_extrusion_window = 1
 retraction_hop = 1.5
 retraction_hop_enabled = True
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
+retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -42,7 +42,7 @@ retraction_extrusion_window = 1
 retraction_hop = 1.5
 retraction_hop_enabled = True
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
+retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True

--- a/resources/quality/ultimaker3/um3_aa0.8_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPU_Draft_Print.inst.cfg
@@ -40,7 +40,7 @@ retraction_count_max = 12
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = 0.8
+retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_line_width = =round(line_width * 0.78 / 0.8, 2)
 speed_print = 30

--- a/resources/quality/ultimaker3/um3_aa0.8_TPU_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPU_Superdraft_Print.inst.cfg
@@ -41,7 +41,7 @@ retraction_count_max = 12
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = 0.8
+retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_line_width = =round(line_width * 0.78 / 0.8, 2)
 speed_print = 30

--- a/resources/quality/ultimaker3/um3_aa0.8_TPU_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPU_Verydraft_Print.inst.cfg
@@ -40,7 +40,7 @@ retraction_count_max = 12
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = 0.8
+retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_line_width = =round(line_width * 0.78 / 0.8, 2)
 speed_print = 30


### PR DESCRIPTION
Reverted combing settings (noskin lead to a lot of extra ooze), fixed the minimum travel for TPU and Connected our infill lines.