### PR TITLE
Only select all text when tabbing to fields, not when clicking a field

### DIFF
--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -13,11 +13,17 @@ SettingItem
 
     property string textBeforeEdit
     property bool textHasChanged
+    property bool focusGainedByClick: false
     onFocusReceived:
     {
         textHasChanged = false;
         textBeforeEdit = focusItem.text;
-        focusItem.selectAll();
+
+        if(!focusGainedByClick)
+        {
+            // select all text when tabbing through fields (but not when selecting a field with the mouse)
+            focusItem.selectAll();
+        }
     }
 
     contents: Rectangle
@@ -92,14 +98,6 @@ SettingItem
             font: UM.Theme.getFont("default")
         }
 
-        MouseArea
-        {
-            id: mouseArea
-            anchors.fill: parent;
-            //hoverEnabled: true;
-            cursorShape: Qt.IBeamCursor
-        }
-
         TextInput
         {
             id: input
@@ -141,6 +139,7 @@ SettingItem
                 {
                     base.focusReceived();
                 }
+                base.focusGainedByClick = false;
             }
 
             color: !enabled ? UM.Theme.getColor("setting_control_disabled_text") : UM.Theme.getColor("setting_control_text")
@@ -176,6 +175,22 @@ SettingItem
                     }
                 }
                 when: !input.activeFocus
+            }
+
+            MouseArea
+            {
+                id: mouseArea
+                anchors.fill: parent;
+
+                cursorShape: Qt.IBeamCursor
+
+                onPressed: {
+                    if(!input.activeFocus) {
+                        base.focusGainedByClick = true;
+                        input.forceActiveFocus();
+                    }
+                    mouse.accepted = false;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR is a re-issue of #3196, against master.

This PR tweaks the behavior introduced in #3017, which intended to select all text when tabbing through text input fields. In #3017 text is also selected when the control is clicked. Some users have reported that the latter is unwanted.

This PR makes sure the text selection is not triggered when the input field gains the focus by pressing on the input field. I have made the PR against the 3.2 branch, since it fixes behavior introduced in 3.2; some would call the current behavior in 3.2 a regression.

See https://github.com/Ultimaker/Cura/issues/1969#issuecomment-352632035 for the original comment, and https://github.com/Ultimaker/Cura/pull/3017#issuecomment-358357664 and https://community.ultimaker.com/topic/21149-introducing-ultimaker-cura-32-beta/?tab=comments#comment-197552 for the complaints