### PR TITLE
Retraction minimum travel update

### DIFF
--- a/resources/variants/ultimaker3_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker3_aa0.8.inst.cfg
@@ -46,6 +46,7 @@ retraction_count_max = 25
 retraction_extrusion_window = 1
 retraction_hop = 2
 retraction_hop_only_when_collides = True
+retraction_min_travel = =line_width * 2
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = 20

--- a/resources/variants/ultimaker3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_bb0.8.inst.cfg
@@ -58,7 +58,7 @@ retraction_extrusion_window = =retraction_amount
 retraction_hop = 2
 retraction_hop_enabled = True
 retraction_hop_only_when_collides = True
-retraction_min_travel = 5
+retraction_min_travel = =line_width * 3
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_layer_0 = 20

--- a/resources/variants/ultimaker3_extended_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa0.8.inst.cfg
@@ -46,6 +46,7 @@ retraction_count_max = 25
 retraction_extrusion_window = 1
 retraction_hop = 2
 retraction_hop_only_when_collides = True
+retraction_min_travel = =line_width * 2
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = 20

--- a/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
@@ -57,7 +57,7 @@ retraction_count_max = 15
 retraction_extrusion_window = =retraction_amount
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 5
+retraction_min_travel = =line_width * 3
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_layer_0 = 20


### PR DESCRIPTION
Changed  it to 2 or 3 times line width, similar as with the 0.4mm profiles.  Was 5mm standard for all profiles with the 0.8mm printcore, except TPU.