### PR TITLE
CURA-5135 Easy version

### DIFF
--- a/plugins/PluginBrowser/PluginEntry.qml
+++ b/plugins/PluginBrowser/PluginEntry.qml
@@ -129,6 +129,28 @@ Component {
                         return catalog.i18nc("@action:button", "Install");
                     }
                 }
+                enabled:
+                {
+                    if ( manager.isDownloading )
+                    {
+                        return pluginList.activePlugin == model ? true : false
+                    }
+                    else
+                    {
+                        return true
+                    }
+                }
+                opacity:
+                {
+                    if ( pluginList.activePlugin == model )
+                    {
+                        return 1.0
+                    }
+                    else
+                    {
+                        manager.isDownloading ? 0.5 : 1.0
+                    }
+                }
                 visible: model.external && ((model.status !== "installed") || model.can_upgrade)
                 style: ButtonStyle {
                     background: Rectangle {


### PR DESCRIPTION
This is the easy fix. When a plugin is downloading, the other plugins' download buttons are not possible to be clicked. This avoids having to write any new logic. It does detract a bit from the user experience though.

The complicated version requires re-writing a big part of the plugin browser code to enable the queueing of downloads and stuff. That's sort of how it "should" be but is a lot more work.

It also requires a lot of new UI to cope with not only the multiple downloads but handling queued license pop-ups, timing of said pop-ups, etc.