### PR TITLE
WORKAROUND: Don't preload libGL anymore

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -42,16 +42,6 @@ if not known_args["debug"]:
 import platform
 import faulthandler
 
-#WORKAROUND: GITHUB-88 GITHUB-385 GITHUB-612
-if Platform.isLinux(): # Needed for platform.linux_distribution, which is not available on Windows and OSX
-    # For Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826
-    linux_distro_name = platform.linux_distribution()[0].lower()
-    # TODO: Needs a "if X11_GFX == 'nvidia'" here. The workaround is only needed on Ubuntu+NVidia drivers. Other drivers are not affected, but fine with this fix.
-    import ctypes
-    from ctypes.util import find_library
-    libGL = find_library("GL")
-    ctypes.CDLL(libGL, ctypes.RTLD_GLOBAL)
-
 # When frozen, i.e. installer version, don't let PYTHONPATH mess up the search path for DLLs.
 if Platform.isWindows() and hasattr(sys, "frozen"):
     try:


### PR DESCRIPTION
The workaround is in my point of view not needed after two years anymore.
In the meantime distributions managed to fix the issue themselves.
Additionally, to be sure this old workaround does not conflict with future technologies and rendering methods, I would suggest to remove it again.
The workaround just gave the Linux distributions enough time to fix the issue we had properly