### PR TITLE
Fix postprocessing persistence of setting names with uppercase characters

### DIFF
--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.py
@@ -210,6 +210,7 @@ class PostProcessingPlugin(QObject, Extension):
                 continue
             script_str = script_str.replace("\\n", "\n").replace("\\\\", "\\") #Unescape escape sequences.
             script_parser = configparser.ConfigParser(interpolation = None)
+            script_parser.optionxform = str #Don't transform the setting keys as they are case-sensitive.
             script_parser.read_string(script_str)
             for script_name, settings in script_parser.items(): #There should only be one, really! Otherwise we can't guarantee the order or allow multiple uses of the same script.
                 if script_name == "DEFAULT": #ConfigParser always has a DEFAULT section, but we don't fill it. Ignore this one.
@@ -230,6 +231,7 @@ class PostProcessingPlugin(QObject, Extension):
         script_list_strs = []
         for script in self._script_list:
             parser = configparser.ConfigParser(interpolation = None) #We'll encode the script as a config with one section. The section header is the key and its values are the settings.
+            parser.optionxform = str #Don't transform the setting keys as they are case-sensitive.
             script_name = script.getSettingData()["key"]
             parser.add_section(script_name)
             for key in script.getSettingData()["settings"]:


### PR DESCRIPTION
There was a bug in the persistent post-processing scripts. Actually, this is a bug in all of our cfg files but it comes to fruition here.

Python's ConfigParser by default always outputs lowercase keys. Some of our post-processing scripts have setting keys with uppercase characters though. So when we saved these settings in a cfg document it would transform them to lowercase and when loading them back in we couldn't recognise any more which setting that value belonged to. The setting value was then lost (and a warning was put in our log about that).

Setting ConfigParser's transform function to `str()` when saving and loading prevents casting to lowercase.