### PR TITLE
[3.3] Fix getting multiple extruder temperatures from USB printer

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -299,7 +299,21 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
             if b"ok T:" in line or line.startswith(b"T:") or b"ok B:" in line or line.startswith(b"B:"):  # Temperature message. 'T:' for extruder and 'B:' for bed
                 extruder_temperature_matches = re.findall(b"T(\d*): ?([\d\.]+) ?\/?([\d\.]+)?", line)
                 # Update all temperature values
-                for match, extruder in zip(extruder_temperature_matches, self._printers[0].extruders):
+                matched_extruder_nrs = []
+                for match in extruder_temperature_matches:
+                    extruder_nr = 0
+                    if match[0] != b"":
+                        extruder_nr = int(match[0])
+
+                    if extruder_nr in matched_extruder_nrs:
+                        continue
+                    matched_extruder_nrs.append(extruder_nr)
+
+                    if extruder_nr >= len(self._printers[0].extruders)
+                        Logger.log("w", "Printer reports more temperatures than the number of configured extruders")
+                        continue
+
+                    extruder = self._printers[0].extruders[extruder_nr]
                     if match[1]:
                         extruder.updateHotendTemperature(float(match[1]))
                     if match[2]:


### PR DESCRIPTION
This PR fixes the USB Printing plugin incorrectly handling multiple extruder temperatures. Zipping the extruders with the matches puts the temperature of the first extruder in both extruders, because the temperatures for the first extruder are returned twice for the M105 request; once without the tool number, and once with.

Could fix https://github.com/Ultimaker/Cura/issues/3563