### PR TITLE
Fix sending commands in rapid succession over USB

### DIFF
--- a/cura/PrinterOutput/GenericOutputController.py
+++ b/cura/PrinterOutput/GenericOutputController.py
@@ -58,9 +58,7 @@ class GenericOutputController(PrinterOutputController):
         self._output_device.sendCommand("G90")
 
     def homeHead(self, printer):
-        self._output_device.sendCommand("G28 X")
-        self._output_device.sendCommand("G28 Y")
-        self._output_device.sendCommand("G28 Z")
+        self._output_device.sendCommand("G28 XY")
 
     def homeBed(self, printer):
         self._output_device.sendCommand("G28 Z")


### PR DESCRIPTION
This PR fixes sending commands in rapid succession over USB. When sending multiple commands using sendCommand(), it can happen that a command is sent before a previous command is fully received.

Probably contributes to #3050