### PR TITLE
Add setting to try multiple line thicknesses

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6585,6 +6585,14 @@
                     "type": "float",
                     "enabled": "bridge_settings_enabled and bridge_enable_more_layers",
                     "settable_per_mesh": true
+                },
+                "wall_try_line_thickness":
+                {
+                    "label": "Try Multiple Line Thicknesses",
+                    "description": "When creating inner walls, try various line thicknesses to fit the wall lines better in narrow spaces. This reduces or increases the inner wall line width by up to 0.01mm.",
+                    "default_value": false,
+                    "type": "bool",
+                    "settable_per_mesh": true
                 }
             }
         },


### PR DESCRIPTION
Engine implementation is here: https://github.com/Ultimaker/CuraEngine/pull/739. This setting is intended for debugging problems with interrupted walls. It should probably not be published in a final release, but we're planning to merge it now to allow people to test.

Implements CURA-5189.