### PR TITLE
[3.3] Prevent preheat timeout from occurring during a print

### DIFF
--- a/cura/PrinterOutput/GenericOutputController.py
+++ b/cura/PrinterOutput/GenericOutputController.py
@@ -152,3 +152,17 @@ class GenericOutputController(PrinterOutputController):
         for extruder in self._preheat_hotends:
             self.setTargetHotendTemperature(extruder.getPrinter(), extruder.getPosition(), 0)
         self._preheat_hotends = set()
+
+    # Cancel any ongoing preheating timers, without setting back the temperature to 0
+    # This can be used eg at the start of a print
+    def stopPreheatTimers(self):
+        if self._preheat_hotends_timer.isActive():
+            for extruder in self._preheat_hotends:
+                extruder.updateIsPreheating(False)
+            self._preheat_hotends = set()
+
+            self._preheat_hotends_timer.stop()
+
+        if self._preheat_bed_timer.isActive():
+            self._active_printer.updateIsPreheating(False)
+            self._preheat_bed_timer.stop()

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -96,6 +96,9 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
         if self._is_printing:
             return  # Aleady printing
 
+        # cancel any ongoing preheat timer before starting a print
+        self._printers[0].stopPreheatTimers()
+
         Application.getInstance().getController().setActiveStage("MonitorStage")
 
         # find the G-code for the active build plate to print


### PR DESCRIPTION
This PR prevents preheat timers (bed, extruder) resetting the temperature to 0 after a print has started. Starting a print should stop all preheat timers, without setting the temperatures back to 0.

Steps to reproduce the issue:
* Use printer connected with USB
* Preheat bed
* Start print

After a couple of minutes of printing, the bed temperature will be set back to 0, and the print will detach from the buildplate.