### PR TITLE
Fix gcode reader bug that can create a gap at the start of a spiralized layer

### DIFF
--- a/plugins/GCodeReader/FlavorParser.py
+++ b/plugins/GCodeReader/FlavorParser.py
@@ -368,6 +368,7 @@ class FlavorParser:
                     layer_number = int(line[len(self._layer_keyword):])
                     self._createPolygon(self._current_layer_thickness, current_path, self._extruder_offsets.get(self._extruder_number, [0, 0]))
                     current_path.clear()
+                    # start the new layer at the end position of the last layer
                     current_path.append([current_position.x, current_position.y, current_position.z, current_position.f, current_position.e[self._extruder_number], LayerPolygon.MoveCombingType])
 
                     # When using a raft, the raft layers are stored as layers < 0, it mimics the same behavior

--- a/plugins/GCodeReader/FlavorParser.py
+++ b/plugins/GCodeReader/FlavorParser.py
@@ -368,6 +368,7 @@ class FlavorParser:
                     layer_number = int(line[len(self._layer_keyword):])
                     self._createPolygon(self._current_layer_thickness, current_path, self._extruder_offsets.get(self._extruder_number, [0, 0]))
                     current_path.clear()
+                    current_path.append([current_position.x, current_position.y, current_position.z, current_position.f, current_position.e[self._extruder_number], LayerPolygon.MoveCombingType])
 
                     # When using a raft, the raft layers are stored as layers < 0, it mimics the same behavior
                     # as in ProcessSlicedLayersJob


### PR DESCRIPTION
The gcode reader assumed that each layer starts with a move to the initial position but
for spiralized code that isn't true because the previous layer always ends up in the right
location. So we now start each layer with a fake move to the end position of the previous layer.
This won't actually cause a real move to occur but it ensures that the first line segment
in the new layer has the correct initial point.

Without this PR:

![screenshot_2018-04-11_08-15-55](https://user-images.githubusercontent.com/585618/38602452-ac04a89a-3d62-11e8-81b1-2258c147c02f.png)

With this PR:

![screenshot_2018-04-11_08-18-10](https://user-images.githubusercontent.com/585618/38602460-b529a614-3d62-11e8-872f-dcb14c3a8105.png)

I admit that this PR hasn't received extensive testing.
