### PR TITLE
Now divides line width by 2 as this gives a visually better result.

### DIFF
--- a/plugins/GCodeReader/FlavorParser.py
+++ b/plugins/GCodeReader/FlavorParser.py
@@ -160,7 +160,8 @@ class FlavorParser:
         # Area of the printed line. This area is a rectangle
         Ae = dVe / dX
         # This area is a rectangle with area equal to layer_thickness * layer_width
-        line_width = Ae / layer_thickness
+        # 11/04/2018 - added divide by 2 to obtain visually correct line widths
+        line_width = Ae / layer_thickness / 2
 
         # A threshold is set to avoid weird paths in the GCode
         if line_width > 1.2:


### PR DESCRIPTION
Without this PR:

![screenshot_2018-04-11_15-40-25](https://user-images.githubusercontent.com/585618/38623898-b9a465bc-3d9e-11e8-8289-22995a9ac212.png)

With this PR:

![screenshot_2018-04-11_15-34-36](https://user-images.githubusercontent.com/585618/38623791-7862eb82-3d9e-11e8-8628-51dccfea2cb2.png)
