### PR TITLE
Append a \n to each saved line of gcode otherwise the whole file ends up as one line!

### DIFF
--- a/plugins/GCodeReader/FlavorParser.py
+++ b/plugins/GCodeReader/FlavorParser.py
@@ -309,7 +309,7 @@ class FlavorParser:
         current_line = 0
         for line in stream.split("\n"):
             file_lines += 1
-            gcode_list.append(line)
+            gcode_list.append(line + "\n")
             if not self._is_layers_in_file and line[:len(self._layer_keyword)] == self._layer_keyword:
                 self._is_layers_in_file = True
         # stream.seek(0)


### PR DESCRIPTION
I tried saving a gcode file that was read by the gcode reader and it all came out in one very long line so this PR adds back a \n at the end of each gcode line.

With this PR, the saved file is identical to the original (on Linux, don't know about other systems)  except that it has the SETTINGS_3 block added to the end. The original settings block is still there so perhaps it would be good if the settings are not written when the gcode has been read (as opposed to having been created by slicing when you do want to write the settings block). Anyway, I won't be making that change so I just mention it in case someone else wants to do it.