### PR TITLE
Only open USB ports if the printer understands gcode.

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
+++ b/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
@@ -65,10 +65,11 @@ class USBPrinterOutputDeviceManager(QObject, OutputDevicePlugin):
             if container_stack is None:
                 time.sleep(5)
                 continue
+            port_list = []  # Just an empty list; all USB devices will be removed.
             if container_stack.getMetaDataEntry("supports_usb_connection"):
-                port_list = self.getSerialPortList(only_list_usb=True)
-            else:
-                port_list = []  # Just use an empty list; all USB devices will be removed.
+                machine_file_formats = [file_type.strip() for file_type in container_stack.getMetaDataEntry("file_formats").split(";")]
+                if "text/x-gcode" in machine_file_formats:
+                    port_list = self.getSerialPortList(only_list_usb=True)
             self._addRemovePorts(port_list)
             time.sleep(5)
 


### PR DESCRIPTION
Hi!

This fix prevents the USB print manager from needlessly tying up the serial port on printers that do not support gcode.

The current behavior with extended baud rate probing is harmless (at least on the ZYYX Agile) but annoying. I don't know your policy on which bugs are severe enough to go into the release, feel free to put this on master if that is more appropriate.