### PR TITLE
Cura-5296 Make bundled resources visible to CuraPackageManager

### DIFF
--- a/cura/CuraPackageManager.py
+++ b/cura/CuraPackageManager.py
@@ -35,8 +35,10 @@ class CuraPackageManager(QObject):
             "resources",
             "packages.json"
         )
-        self._user_package_management_file_path = os.path.join(os.path.abspath(Resources.getDataStoragePath()), "packages.json")
-
+        self._user_package_management_file_path = os.path.join(
+            os.path.abspath(Resources.getDataStoragePath()),
+            "packages.json"
+        )
 
         self._bundled_package_dict = {}     # A dict of all bundled packages
         self._installed_package_dict = {}   # A dict of all installed packages
@@ -100,6 +102,8 @@ class CuraPackageManager(QObject):
     def _installAllScheduledPackages(self) -> None:
         for package_id, installation_package_data in self._to_install_package_dict.items():
             self._installPackage(installation_package_data)
+            self._installed_package_dict[package_id] = self._to_install_package_dict[package_id]
+            self._saveManagementData()
         self._to_install_package_dict.clear()
         self._saveManagementData()
 

--- a/cura/CuraPackageManager.py
+++ b/cura/CuraPackageManager.py
@@ -100,12 +100,13 @@ class CuraPackageManager(QObject):
 
     # (for initialize) Installs all packages that have been scheduled to be installed.
     def _installAllScheduledPackages(self) -> None:
-        for package_id, installation_package_data in self._to_install_package_dict.items():
-            self._installPackage(installation_package_data)
+
+        while self._to_install_package_dict:
+            package_id, package_info = list(self._to_install_package_dict.items())[0]
+            self._installPackage(package_info)
             self._installed_package_dict[package_id] = self._to_install_package_dict[package_id]
+            del self._to_install_package_dict[package_id]
             self._saveManagementData()
-        self._to_install_package_dict.clear()
-        self._saveManagementData()
 
     # Checks the given package is installed. If so, return a dictionary that contains the package's information.
     def getInstalledPackageInfo(self, package_id: str) -> Optional[dict]:

--- a/cura/CuraPackageManager.py
+++ b/cura/CuraPackageManager.py
@@ -30,8 +30,8 @@ class CuraPackageManager(QObject):
 
         # JSON file that keeps track of all installed packages.
         self._bundled_package_management_file_path = os.path.join(
-            Application.getInstallPrefix(),
-            Application.getInstance().getApplicationName(),
+            os.path.dirname(os.path.abspath(__file__)),
+            "..",
             "resources",
             "packages.json"
         )

--- a/plugins/MachineSettingsAction/plugin.json
+++ b/plugins/MachineSettingsAction/plugin.json
@@ -2,7 +2,7 @@
     "name": "Machine Settings action",
     "author": "fieldOfView",
     "version": "1.0.0",
-    "description": "Provides a way to change machine settings (such as build volume, nozzle size, etc)",
+    "description": "Provides a way to change machine settings (such as build volume, nozzle size, etc.).",
     "api": 4,
     "i18n-catalog": "cura"
 }

--- a/plugins/Toolbox/resources/qml/ToolboxActionButtonStyle.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxActionButtonStyle.qml
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 Ultimaker B.V.
+// Toolbox is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.2
+import QtQuick.Controls 1.4
+import QtQuick.Controls.Styles 1.4
+import UM 1.1 as UM
+
+ButtonStyle
+{
+    background: Rectangle
+    {
+        implicitWidth: UM.Theme.getSize("toolbox_action_button").width
+        implicitHeight: UM.Theme.getSize("toolbox_action_button").height
+        color: "transparent"
+        border
+        {
+            width: UM.Theme.getSize("default_lining").width
+            color: UM.Theme.getColor("lining")
+        }
+    }
+    label: Label
+    {
+        text: control.text
+        color: UM.Theme.getColor("text")
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignHCenter
+    }
+}

--- a/plugins/Toolbox/resources/qml/ToolboxInstalledTile.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxInstalledTile.qml
@@ -26,7 +26,7 @@ Item
     Column
     {
         id: pluginInfo
-        property var color: isEnabled ? UM.Theme.getColor("text") : UM.Theme.getColor("lining")
+        property var color: model.package_type === "plugin" && !isEnabled ? UM.Theme.getColor("lining") : UM.Theme.getColor("text")
         height: parent.height
         anchors
         {
@@ -49,12 +49,11 @@ Item
         Text
         {
             text: model.description
+            maximumLineCount: 3
+            elide: Text.ElideRight
             width: parent.width
-            height: UM.Theme.getSize("toolbox_property_label").height
-            clip: true
             wrapMode: Text.WordWrap
             color: pluginInfo.color
-            elide: Text.ElideRight
         }
     }
     Column
@@ -104,19 +103,11 @@ Item
             right: parent.right
             topMargin: UM.Theme.getSize("default_margin").height
         }
-        Button {
-            id: removeButton
-            text:
-            {
-                if (model.is_bundled)
-                {
-                    return isEnabled ? catalog.i18nc("@action:button", "Disable") : catalog.i18nc("@action:button", "Enable")
-                }
-                else
-                {
-                    return catalog.i18nc("@action:button", "Uninstall")
-                }
-            }
+        Button
+        {
+            id: disableButton
+            text: isEnabled ? catalog.i18nc("@action:button", "Disable") : catalog.i18nc("@action:button", "Enable")
+            visible: model.type == "plugin"
             enabled: !toolbox.isDownloading
             style: ButtonStyle
             {
@@ -139,24 +130,36 @@ Item
                     horizontalAlignment: Text.AlignHCenter
                 }
             }
-            onClicked:
+            onClicked: toolbox.isEnabled(model.id) ? toolbox.disable(model.id) : toolbox.enable(model.id)
+        }
+        Button
+        {
+            id: removeButton
+            text: catalog.i18nc("@action:button", "Uninstall")
+            visible: !model.is_bundled
+            enabled: !toolbox.isDownloading
+            style: ButtonStyle
             {
-                if (model.is_bundled)
+                background: Rectangle
                 {
-                    if (toolbox.isEnabled(model.id))
+                    implicitWidth: UM.Theme.getSize("toolbox_action_button").width
+                    implicitHeight: UM.Theme.getSize("toolbox_action_button").height
+                    color: "transparent"
+                    border
                     {
-                        toolbox.disable(model.id)
-                    }
-                    else
-                    {
-                        toolbox.enable(model.id)
+                        width: UM.Theme.getSize("default_lining").width
+                        color: UM.Theme.getColor("lining")
                     }
                 }
-                else
+                label: Label
                 {
-                    toolbox.uninstall(model.id)
+                    text: control.text
+                    color: UM.Theme.getColor("text")
+                    verticalAlignment: Text.AlignVCenter
+                    horizontalAlignment: Text.AlignHCenter
                 }
             }
+            onClicked: toolbox.uninstall(model.id)
         }
         Button
         {
@@ -180,10 +183,7 @@ Item
                     font: UM.Theme.getFont("default_bold")
                 }
             }
-            onClicked:
-            {
-                toolbox.update(model.id);
-            }
+            onClicked: toolbox.update(model.id)
         }
         ProgressBar
         {

--- a/plugins/Toolbox/src/PackagesModel.py
+++ b/plugins/Toolbox/src/PackagesModel.py
@@ -28,8 +28,9 @@ class PackagesModel(ListModel):
         self.addRoleName(Qt.UserRole + 11, "download_url")
         self.addRoleName(Qt.UserRole + 12, "last_updated")
         self.addRoleName(Qt.UserRole + 13, "is_bundled")
-        self.addRoleName(Qt.UserRole + 14, "has_configs")
-        self.addRoleName(Qt.UserRole + 15, "supported_configs")
+        self.addRoleName(Qt.UserRole + 14, "is_enabled")
+        self.addRoleName(Qt.UserRole + 15, "has_configs")
+        self.addRoleName(Qt.UserRole + 16, "supported_configs")
 
         # List of filters for queries. The result is the union of the each list of results.
         self._filter = {}  # type: Dict[str, str]
@@ -52,20 +53,26 @@ class PackagesModel(ListModel):
                         configs_model = ConfigsModel()
                         configs_model.setConfigs(package["data"]["supported_configs"])
 
+            if "author_id" not in package["author"] or "display_name" not in package["author"]:
+                package["author"]["author_id"] = ""
+                package["author"]["display_name"] = ""
+                # raise Exception("Detected a package with malformed author data.")
+
             items.append({
                 "id":                package["package_id"],
                 "type":              package["package_type"],
                 "name":              package["display_name"],
                 "version":           package["package_version"],
-                "author_id":         package["author"]["author_id"] if "author_id" in package["author"] else package["author"]["name"],
-                "author_name":       package["author"]["display_name"] if "display_name" in package["author"] else package["author"]["name"],
+                "author_id":         package["author"]["author_id"],
+                "author_name":       package["author"]["display_name"],
                 "author_email":      package["author"]["email"] if "email" in package["author"] else None,
-                "description":       package["description"],
+                "description":       package["description"] if "description" in package else None,
                 "icon_url":          package["icon_url"] if "icon_url" in package else None,
                 "image_urls":        package["image_urls"] if "image_urls" in package else None,
                 "download_url":      package["download_url"] if "download_url" in package else None,
                 "last_updated":      package["last_updated"] if "last_updated" in package else None,
                 "is_bundled":        package["is_bundled"] if "is_bundled" in package else False,
+                "is_enabled":        package["is_enabled"] if "is_enabled" in package else False,
                 "has_configs":       has_configs,
                 "supported_configs": configs_model
             })

--- a/plugins/Toolbox/src/Toolbox.py
+++ b/plugins/Toolbox/src/Toolbox.py
@@ -18,6 +18,7 @@ from UM.Extension import Extension
 from UM.i18n import i18nCatalog
 from UM.Version import Version
 
+import cura.CuraVersion
 from cura.CuraApplication import CuraApplication
 from .AuthorsModel import AuthorsModel
 from .PackagesModel import PackagesModel
@@ -34,7 +35,7 @@ class Toolbox(QObject, Extension):
         self._application = Application.getInstance()
         self._package_manager = None
         self._plugin_registry = Application.getInstance().getPluginRegistry()
-        self._packages_version = self._plugin_registry.APIVersion
+        self._packages_version = cura.CuraVersion.CuraPackagesVersion if hasattr(cura.CuraVersion, "CuraPackagesVersion") else self._plugin_registry.APIVersion # type:ignore
         self._api_version = 1
         self._api_url = "https://api-staging.ultimaker.com/cura-packages/v{api_version}/cura/v{package_version}".format( api_version = self._api_version, package_version = self._packages_version)
 

--- a/plugins/UM3NetworkPrinting/plugin.json
+++ b/plugins/UM3NetworkPrinting/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "UM3 Network Connection",
     "author": "Ultimaker B.V.",
-    "description": "Manages network connections to Ultimaker 3 printers",
+    "description": "Manages network connections to Ultimaker 3 printers.",
     "version": "1.0.0",
     "api": 4,
     "i18n-catalog": "cura"

--- a/plugins/UltimakerMachineActions/plugin.json
+++ b/plugins/UltimakerMachineActions/plugin.json
@@ -2,7 +2,7 @@
     "name": "Ultimaker machine actions",
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
-    "description": "Provides machine actions for Ultimaker machines (such as bed leveling wizard, selecting upgrades, etc)",
+    "description": "Provides machine actions for Ultimaker machines (such as bed leveling wizard, selecting upgrades, etc.).",
     "api": 4,
     "i18n-catalog": "cura"
 }

--- a/plugins/UserAgreement/plugin.json
+++ b/plugins/UserAgreement/plugin.json
@@ -2,7 +2,7 @@
     "name": "UserAgreement",
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
-    "description": "Ask the user once if he/she agrees with our license",
+    "description": "Ask the user once if he/she agrees with our license.",
     "api": 4,
     "i18n-catalog": "cura"
 }

--- a/resources/packages.json
+++ b/resources/packages.json
@@ -731,7 +731,6 @@
         }
     },
     "DagomaChromatikPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/DagomaChromatikPLA.curapackage",
         "package_info": {
             "package_id": "DagomaChromatikPLA",
             "package_type": "material",
@@ -749,7 +748,6 @@
         }
     },
     "FABtotumABS": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FABtotumABS.curapackage",
         "package_info": {
             "package_id": "FABtotumABS",
             "package_type": "material",
@@ -767,7 +765,6 @@
         }
     },
     "FABtotumNylon": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FABtotumNylon.curapackage",
         "package_info": {
             "package_id": "FABtotumNylon",
             "package_type": "material",
@@ -785,7 +782,6 @@
         }
     },
     "FABtotumPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FABtotumPLA.curapackage",
         "package_info": {
             "package_id": "FABtotumPLA",
             "package_type": "material",
@@ -803,7 +799,6 @@
         }
     },
     "FABtotumTPU": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FABtotumTPU.curapackage",
         "package_info": {
             "package_id": "FABtotumTPU",
             "package_type": "material",
@@ -821,7 +816,6 @@
         }
     },
     "FiberlogyHDPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FiberlogyHDPLA.curapackage",
         "package_info": {
             "package_id": "FiberlogyHDPLA",
             "package_type": "material",
@@ -839,7 +833,6 @@
         }
     },
     "Filo3DPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/Filo3DPLA.curapackage",
         "package_info": {
             "package_id": "Filo3DPLA",
             "package_type": "material",
@@ -857,7 +850,6 @@
         }
     },
     "IMADE3DJellyBOXPETG": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/IMADE3DJellyBOXPETG.curapackage",
         "package_info": {
             "package_id": "IMADE3DJellyBOXPETG",
             "package_type": "material",
@@ -875,7 +867,6 @@
         }
     },
     "IMADE3DJellyBOXPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/IMADE3DJellyBOXPLA.curapackage",
         "package_info": {
             "package_id": "IMADE3DJellyBOXPLA",
             "package_type": "material",
@@ -893,7 +884,6 @@
         }
     },
     "OctofiberPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/OctoFiberPLA.curapackage",
         "package_info": {
             "package_id": "OctofiberPLA",
             "package_type": "material",
@@ -911,7 +901,6 @@
         }
     },
     "PolyFlexPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/PolyFlexPLA.curapackage",
         "package_info": {
             "package_id": "PolyFlexPLA",
             "package_type": "material",
@@ -929,7 +918,6 @@
         }
     },
     "PolyMaxPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/PolyMaxPLA.curapackage",
         "package_info": {
             "package_id": "PolyMaxPLA",
             "package_type": "material",
@@ -947,7 +935,6 @@
         }
     },
     "PolyPlusPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/PolyPlusPLA.curapackage",
         "package_info": {
             "package_id": "PolyPlusPLA",
             "package_type": "material",
@@ -965,7 +952,6 @@
         }
     },
     "PolyWoodPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/PolyWoodPLA.curapackage",
         "package_info": {
             "package_id": "PolyWoodPLA",
             "package_type": "material",
@@ -983,7 +969,6 @@
         }
     },
     "UltimakerABS": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerABS.curapackage",
         "package_info": {
             "package_id": "UltimakerABS",
             "package_type": "material",
@@ -1003,7 +988,6 @@
         }
     },
     "UltimakerCPE": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerCPE.curapackage",
         "package_info": {
             "package_id": "UltimakerCPE",
             "package_type": "material",
@@ -1023,7 +1007,6 @@
         }
     },
     "UltimakerNylon": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerNylon.curapackage",
         "package_info": {
             "package_id": "UltimakerNylon",
             "package_type": "material",
@@ -1043,7 +1026,6 @@
         }
     },
     "UltimakerPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerPLA.curapackage",
         "package_info": {
             "package_id": "UltimakerPLA",
             "package_type": "material",
@@ -1063,7 +1045,6 @@
         }
     },
     "UltimakerPVA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerPVA.curapackage",
         "package_info": {
             "package_id": "UltimakerPVA",
             "package_type": "material",
@@ -1083,7 +1064,6 @@
         }
     },
     "VertexDeltaABS": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/VertexDeltaABS.curapackage",
         "package_info": {
             "package_id": "VertexDeltaABS",
             "package_type": "material",
@@ -1101,7 +1081,6 @@
         }
     },
     "VertexDeltaPET": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/VertexDeltaPET.curapackage",
         "package_info": {
             "package_id": "VertexDeltaPET",
             "package_type": "material",
@@ -1119,7 +1098,6 @@
         }
     },
     "VertexDeltaPLA": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/VertexDeltaPLA.curapackage",
         "package_info": {
             "package_id": "VertexDeltaPLA",
             "package_type": "material",
@@ -1137,7 +1115,6 @@
         }
     },
     "VertexDeltaTPU": {
-        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/VertexDeltaTPU.curapackage",
         "package_info": {
             "package_id": "VertexDeltaTPU",
             "package_type": "material",

--- a/resources/packages.json
+++ b/resources/packages.json
@@ -1,0 +1,1157 @@
+{
+    "3MFReader": {
+        "package_info": {
+            "package_id": "3MFReader",
+            "package_type": "plugin",
+            "display_name": "3MF Reader",
+            "description": "Provides support for reading 3MF files.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "3MFWriter": {
+        "package_info": {
+            "package_id": "3MFWriter",
+            "package_type": "plugin",
+            "display_name": "3MF Writer",
+            "description": "Provides support for writing 3MF files.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "AutoSave": {
+        "package_info": {
+            "package_id": "AutoSave",
+            "package_type": "plugin",
+            "display_name": "Auto-Save",
+            "description": "Automatically saves Preferences, Machines and Profiles after changes.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "ChangeLogPlugin": {
+        "package_info": {
+            "package_id": "ChangeLogPlugin",
+            "package_type": "plugin",
+            "display_name": "Change Log",
+            "description": "Shows changes since latest checked version.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "CuraEngineBackend": {
+        "package_info": {
+            "package_id": "CuraEngineBackend",
+            "package_type": "plugin",
+            "display_name": "CuraEngine Backend",
+            "description": "Provides the link to the CuraEngine slicing backend.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "CuraProfileReader": {
+        "package_info": {
+            "package_id": "CuraProfileReader",
+            "package_type": "plugin",
+            "display_name": "Cura Profile Reader",
+            "description": "Provides support for importing Cura profiles.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "CuraProfileWriter": {
+        "package_info": {
+            "package_id": "CuraProfileWriter",
+            "package_type": "plugin",
+            "display_name": "Cura Profile Writer",
+            "description": "Provides support for exporting Cura profiles.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "FirmwareUpdateChecker": {
+        "package_info": {
+            "package_id": "FirmwareUpdateChecker",
+            "package_type": "plugin",
+            "display_name": "Firmware Update Checker",
+            "description": "Checks for firmware updates.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "GCodeGzReader": {
+        "package_info": {
+            "package_id": "GCodeGzReader",
+            "package_type": "plugin",
+            "display_name": "Compressed G-code Reader",
+            "description": "Reads g-code from a compressed archive.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "GCodeGzWriter": {
+        "package_info": {
+            "package_id": "GCodeGzWriter",
+            "package_type": "plugin",
+            "display_name": "Compressed G-code Writer",
+            "description": "Writes g-code to a compressed archive.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "GCodeProfileReader": {
+        "package_info": {
+            "package_id": "GCodeProfileReader",
+            "package_type": "plugin",
+            "display_name": "G-Code Profile Reader",
+            "description": "Provides support for importing profiles from g-code files.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "GCodeReader": {
+        "package_info": {
+            "package_id": "GCodeReader",
+            "package_type": "plugin",
+            "display_name": "G-Code Reader",
+            "description": "Allows loading and displaying G-code files.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "VictorLarchenko",
+                "display_name": "Victor Larchenko",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "GCodeWriter": {
+        "package_info": {
+            "package_id": "GCodeWriter",
+            "package_type": "plugin",
+            "display_name": "G-Code Writer",
+            "description": "Writes g-code to a file.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "ImageReader": {
+        "package_info": {
+            "package_id": "ImageReader",
+            "package_type": "plugin",
+            "display_name": "Image Reader",
+            "description": "Enables ability to generate printable geometry from 2D image files.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "LegacyProfileReader": {
+        "package_info": {
+            "package_id": "LegacyProfileReader",
+            "package_type": "plugin",
+            "display_name": "Legacy Cura Profile Reader",
+            "description": "Provides support for importing profiles from legacy Cura versions.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "MachineSettingsAction": {
+        "package_info": {
+            "package_id": "MachineSettingsAction",
+            "package_type": "plugin",
+            "display_name": "Machine Settings Action",
+            "description": "Provides a way to change machine settings (such as build volume, nozzle size, etc.).",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "fieldOfView",
+                "display_name": "fieldOfView",
+                "email": null,
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "ModelChecker": {
+        "package_info": {
+            "package_id": "ModelChecker",
+            "package_type": "plugin",
+            "display_name": "Model Checker",
+            "description": "Checks models and print configuration for possible printing issues and give suggestions.",
+            "package_version": "0.1.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "MonitorStage": {
+        "package_info": {
+            "package_id": "MonitorStage",
+            "package_type": "plugin",
+            "display_name": "Monitor Stage",
+            "description": "Provides a monitor stage in Cura.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "PerObjectSettingsTool": {
+        "package_info": {
+            "package_id": "PerObjectSettingsTool",
+            "package_type": "plugin",
+            "display_name": "Per-Object Settings Tool",
+            "description": "Provides the per-model settings.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "PostProcessingPlugin": {
+        "package_info": {
+            "package_id": "PostProcessingPlugin",
+            "package_type": "plugin",
+            "display_name": "Post Processing",
+            "description": "Extension that allows for user created scripts for post processing.",
+            "package_version": "2.2.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "PrepareStage": {
+        "package_info": {
+            "package_id": "PrepareStage",
+            "package_type": "plugin",
+            "display_name": "Prepare Stage",
+            "description": "Provides a prepare stage in Cura.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "RemovableDriveOutputDevice": {
+        "package_info": {
+            "package_id": "RemovableDriveOutputDevice",
+            "package_type": "plugin",
+            "display_name": "Removable Drive Output Device",
+            "description": "Provides removable drive hotplugging and writing support.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "SimulationView": {
+        "package_info": {
+            "package_id": "SimulationView",
+            "package_type": "plugin",
+            "display_name": "Simulation View",
+            "description": "Provides the Simulation view.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "SliceInfoPlugin": {
+        "package_info": {
+            "package_id": "SliceInfoPlugin",
+            "package_type": "plugin",
+            "display_name": "Slice Info",
+            "description": "Submits anonymous slice info. Can be disabled through preferences.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "SolidView": {
+        "package_info": {
+            "package_id": "SolidView",
+            "package_type": "plugin",
+            "display_name": "Solid View",
+            "description": "Provides a normal solid mesh view.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "SupportEraser": {
+        "package_info": {
+            "package_id": "SupportEraser",
+            "package_type": "plugin",
+            "display_name": "Support Eraser Tool",
+            "description": "Creates an eraser mesh to block the printing of support in certain places.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "Toolbox": {
+        "package_info": {
+            "package_id": "Toolbox",
+            "package_type": "plugin",
+            "display_name": "Toolbox",
+            "description": "Find, manage and install new Cura packages.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "UFPWriter": {
+        "package_info": {
+            "package_id": "UFPWriter",
+            "package_type": "plugin",
+            "display_name": "UFP Writer",
+            "description": "Provides support for writing Ultimaker Format Packages.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "UltimakerMachineActions": {
+        "package_info": {
+            "package_id": "UltimakerMachineActions",
+            "package_type": "plugin",
+            "display_name": "Ultimaker Machine Actions",
+            "description": "Provides machine actions for Ultimaker machines (such as bed leveling wizard, selecting upgrades, etc.).",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "UM3NetworkPrinting": {
+        "package_info": {
+            "package_id": "UM3NetworkPrinting",
+            "package_type": "plugin",
+            "display_name": "UM3 Network Printing",
+            "description": "Manages network connections to Ultimaker 3 printers.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "USBPrinting": {
+        "package_info": {
+            "package_id": "USBPrinting",
+            "package_type": "plugin",
+            "display_name": "USB Printing",
+            "description": "Accepts G-Code and sends them to a printer. Plugin can also update firmware.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "UserAgreement": {
+        "package_info": {
+            "package_id": "UserAgreement",
+            "package_type": "plugin",
+            "display_name": "User Agreement",
+            "description": "Ask the user once if he/she agrees with our license.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "VersionUpgrade21to22": {
+        "package_info": {
+            "package_id": "VersionUpgrade",
+            "package_type": "plugin",
+            "display_name": "Version Upgrade 2.1 to 2.2",
+            "description": "Upgrades configurations from Cura 2.1 to Cura 2.2.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "VersionUpgrade22to24": {
+        "package_info": {
+            "package_id": "VersionUpgrade",
+            "package_type": "plugin",
+            "display_name": "Version Upgrade 2.2 to 2.4",
+            "description": "Upgrades configurations from Cura 2.2 to Cura 2.4.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "VersionUpgrade25to26": {
+        "package_info": {
+            "package_id": "VersionUpgrade",
+            "package_type": "plugin",
+            "display_name": "Version Upgrade 2.5 to 2.6",
+            "description": "Upgrades configurations from Cura 2.5 to Cura 2.6.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "VersionUpgrade26to27": {
+        "package_info": {
+            "package_id": "VersionUpgrade",
+            "package_type": "plugin",
+            "display_name": "Version Upgrade 2.6 to 2.7",
+            "description": "Upgrades configurations from Cura 2.6 to Cura 2.7.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "VersionUpgrade27to30": {
+        "package_info": {
+            "package_id": "VersionUpgrade",
+            "package_type": "plugin",
+            "display_name": "Version Upgrade 2.7 to 3.0",
+            "description": "Upgrades configurations from Cura 2.7 to Cura 3.0.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "VersionUpgrade30to31": {
+        "package_info": {
+            "package_id": "VersionUpgrade",
+            "package_type": "plugin",
+            "display_name": "Version Upgrade 3.0 to 3.1",
+            "description": "Upgrades configurations from Cura 3.0 to Cura 3.1.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "VersionUpgrade32to33": {
+        "package_info": {
+            "package_id": "VersionUpgrade",
+            "package_type": "plugin",
+            "display_name": "Version Upgrade 3.2 to 3.3",
+            "description": "Upgrades configurations from Cura 3.2 to Cura 3.3.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "VersionUpgrade33to34": {
+        "package_info": {
+            "package_id": "VersionUpgrade",
+            "package_type": "plugin",
+            "display_name": "Version Upgrade 3.3 to 3.4",
+            "description": "Upgrades configurations from Cura 3.3 to Cura 3.4.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "X3DReader": {
+        "package_info": {
+            "package_id": "X3DReader",
+            "package_type": "plugin",
+            "display_name": "X3D Reader",
+            "description": "Provides support for reading X3D files.",
+            "package_version": "0.5.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "SevaAlekseyev",
+                "display_name": "Seva Alekseyev",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "XmlMaterialProfile": {
+        "package_info": {
+            "package_id": "XMLMaterialProfile",
+            "package_type": "plugin",
+            "display_name": "XML Material Profiles",
+            "description": "Provides capabilities to read and write XML-based material profiles.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "XRayView": {
+        "package_info": {
+            "package_id": "XRayView",
+            "package_type": "plugin",
+            "display_name": "X-Ray View",
+            "description": "Provides the X-Ray view.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "DagomaChromatikPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/DagomaChromatikPLA.curapackage",
+        "package_info": {
+            "package_id": "DagomaChromatikPLA",
+            "package_type": "material",
+            "display_name": "Dagoma Chromatik PLA",
+            "description": "Filament testé et approuvé pour les imprimantes 3D Dagoma. Chromatik est l'idéal pour débuter et suivre les tutoriels premiers pas. Il vous offre qualité et résistance pour chacune de vos impressions.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://dagoma.fr/boutique/filaments.html",
+            "author": {
+                "author_id": "Dagoma",
+                "display_name": "Dagoma",
+                "email": null,
+                "website": "https://dagoma.fr"
+            }
+        }
+    },
+    "FABtotumABS": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FABtotumABS.curapackage",
+        "package_info": {
+            "package_id": "FABtotumABS",
+            "package_type": "material",
+            "display_name": "FABtotum ABS",
+            "description": "This material is easy to be extruded but it is not the simplest to use. It is one of the most used in 3D printing to get very well finished objects. It is not sustainable and its smoke can be dangerous if inhaled. The reason to prefer this filament to PLA is mainly because of its precision and mechanical specs. ABS (for plastic) stands for Acrylonitrile Butadiene Styrene and it is a thermoplastic which is widely used in everyday objects. It can be printed with any FFF 3D printer which can get to high temperatures as it must be extruded in a range between 220° and 245°, so it’s compatible with all versions of the FABtotum Personal fabricator.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://store.fabtotum.com/eu/products/filaments.html?filament_type=40",
+            "author": {
+                "author_id": "FABtotum",
+                "display_name": "FABtotum S.R.L.",
+                "email": "info@fabtotum.com",
+                "website": "https://www.fabtotum.com"
+            }
+        }
+    },
+    "FABtotumNylon": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FABtotumNylon.curapackage",
+        "package_info": {
+            "package_id": "FABtotumNylon",
+            "package_type": "material",
+            "display_name": "FABtotum Nylon",
+            "description": "When 3D printing started this material was not listed among the extrudable filaments. It is flexible as well as resistant to tractions. It is well known for its uses in textile but also in industries which require a strong and flexible material. There are different kinds of Nylon: 3D printing mostly uses Nylon 6 and Nylon 6.6, which are the most common. It requires higher temperatures to be printed, so a 3D printer must be able to reach them (around 240°C): the FABtotum, of course, can.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://store.fabtotum.com/eu/products/filaments.html?filament_type=53",
+            "author": {
+                "author_id": "FABtotum",
+                "display_name": "FABtotum S.R.L.",
+                "email": "info@fabtotum.com",
+                "website": "https://www.fabtotum.com"
+            }
+        }
+    },
+    "FABtotumPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FABtotumPLA.curapackage",
+        "package_info": {
+            "package_id": "FABtotumPLA",
+            "package_type": "material",
+            "display_name": "FABtotum PLA",
+            "description": "It is the most common filament used for 3D printing. It is studied to be bio-degradable as it comes from corn starch’s sugar mainly. It is completely made of renewable sources and has no footprint on polluting. PLA stands for PolyLactic Acid and it is a thermoplastic that today is still considered the easiest material to be 3D printed. It can be extruded at lower temperatures: the standard range of FABtotum’s one is between 185° and 195°.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://store.fabtotum.com/eu/products/filaments.html?filament_type=39",
+            "author": {
+                "author_id": "FABtotum",
+                "display_name": "FABtotum S.R.L.",
+                "email": "info@fabtotum.com",
+                "website": "https://www.fabtotum.com"
+            }
+        }
+    },
+    "FABtotumTPU": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FABtotumTPU.curapackage",
+        "package_info": {
+            "package_id": "FABtotumTPU",
+            "package_type": "material",
+            "display_name": "FABtotum TPU Shore 98A",
+            "description": "",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://store.fabtotum.com/eu/products/filaments.html?filament_type=66",
+            "author": {
+                "author_id": "FABtotum",
+                "display_name": "FABtotum S.R.L.",
+                "email": "info@fabtotum.com",
+                "website": "https://www.fabtotum.com"
+            }
+        }
+    },
+    "FiberlogyHDPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/FiberlogyHDPLA.curapackage",
+        "package_info": {
+            "package_id": "FiberlogyHDPLA",
+            "package_type": "material",
+            "display_name": "Fiberlogy HD PLA",
+            "description": "With our HD PLA you have many more options. You can use this material in two ways. Choose the one you like best. You can use it as a normal PLA and get prints characterized by a very good adhesion between the layers and high precision. You can also make your prints acquire similar properties to that of ABS – better impact resistance and high temperature resistance. All you need is an oven. Yes, an oven! By annealing our HD PLA in an oven, in accordance with the manual, you will avoid all the inconveniences of printing with ABS, such as unpleasant odour or hazardous fumes.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "http://fiberlogy.com/en/fiberlogy-filaments/filament-hd-pla/",
+            "author": {
+                "author_id": "Fiberlogy",
+                "diplay_name": "Fiberlogy S.A.",
+                "email": "grzegorz.h@fiberlogy.com",
+                "website": "http://fiberlogy.com"
+            }
+        }
+    },
+    "Filo3DPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/Filo3DPLA.curapackage",
+        "package_info": {
+            "package_id": "Filo3DPLA",
+            "package_type": "material",
+            "display_name": "Filo3D PLA",
+            "description": "Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://dagoma.fr",
+            "author": {
+                "author_id": "Dagoma",
+                "display_name": "Dagoma",
+                "email": null,
+                "website": "https://dagoma.fr"
+            }
+        }
+    },
+    "IMADE3DJellyBOXPETG": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/IMADE3DJellyBOXPETG.curapackage",
+        "package_info": {
+            "package_id": "IMADE3DJellyBOXPETG",
+            "package_type": "material",
+            "display_name": "IMADE3D JellyBOX PETG",
+            "description": "",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "http://shop.imade3d.com/filament.html",
+            "author": {
+                "author_id": "IMADE3D",
+                "display_name": "IMADE3D",
+                "email": "info@imade3d.com",
+                "website": "https://www.imade3d.com"
+            }
+        }
+    },
+    "IMADE3DJellyBOXPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/IMADE3DJellyBOXPLA.curapackage",
+        "package_info": {
+            "package_id": "IMADE3DJellyBOXPLA",
+            "package_type": "material",
+            "display_name": "IMADE3D JellyBOX PLA",
+            "description": "",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "http://shop.imade3d.com/filament.html",
+            "author": {
+                "author_id": "IMADE3D",
+                "display_name": "IMADE3D",
+                "email": "info@imade3d.com",
+                "website": "https://www.imade3d.com"
+            }
+        }
+    },
+    "OctofiberPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/OctoFiberPLA.curapackage",
+        "package_info": {
+            "package_id": "OctofiberPLA",
+            "package_type": "material",
+            "display_name": "Octofiber PLA",
+            "description": "PLA material from Octofiber.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://nl.octofiber.com/3d-printing-filament/pla.html",
+            "author": {
+                "author_id": "Octofiber",
+                "display_name": "Octofiber",
+                "email": "info@octofiber.com",
+                "website": "https://nl.octofiber.com"
+            }
+        }
+    },
+    "PolyFlexPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/PolyFlexPLA.curapackage",
+        "package_info": {
+            "package_id": "PolyFlexPLA",
+            "package_type": "material",
+            "display_name": "PolyFlex™ PLA",
+            "description": "PolyFlex™ is a highly flexible yet easy to print 3D printing material. Featuring good elasticity and a large strain-to- failure, PolyFlex™ opens up a completely new realm of applications.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "http://www.polymaker.com/shop/polyflex/",
+            "author": {
+                "author_id": "Polymaker",
+                "display_name": "Polymaker L.L.C.",
+                "email": "inquiry@polymaker.com",
+                "website": "https://www.polymaker.com"
+            }
+        }
+    },
+    "PolyMaxPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/PolyMaxPLA.curapackage",
+        "package_info": {
+            "package_id": "PolyMaxPLA",
+            "package_type": "material",
+            "display_name": "PolyMax™ PLA",
+            "description": "PolyMax™ PLA is a 3D printing material with excellent mechanical properties and printing quality. PolyMax™ PLA has an impact resistance of up to nine times that of regular PLA, and better overall mechanical properties than ABS.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "http://www.polymaker.com/shop/polymax/",
+            "author": {
+                "author_id": "Polymaker",
+                "display_name": "Polymaker L.L.C.",
+                "email": "inquiry@polymaker.com",
+                "website": "https://www.polymaker.com"
+            }
+        }
+    },
+    "PolyPlusPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/PolyPlusPLA.curapackage",
+        "package_info": {
+            "package_id": "PolyPlusPLA",
+            "package_type": "material",
+            "display_name": "PolyPlus™ PLA True Colour",
+            "description": "PolyPlus™ PLA is a premium PLA designed for all desktop FDM/FFF 3D printers. It is produced with our patented Jam-Free™ technology that ensures consistent extrusion and prevents jams.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "http://www.polymaker.com/shop/polyplus-true-colour/",
+            "author": {
+                "author_id": "Polymaker",
+                "display_name": "Polymaker L.L.C.",
+                "email": "inquiry@polymaker.com",
+                "website": "https://www.polymaker.com"
+            }
+        }
+    },
+    "PolyWoodPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/PolyWoodPLA.curapackage",
+        "package_info": {
+            "package_id": "PolyWoodPLA",
+            "package_type": "material",
+            "display_name": "PolyWood™ PLA",
+            "description": "PolyWood™ is a wood mimic printing material that contains no actual wood ensuring a clean Jam-Free™ printing experience.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "http://www.polymaker.com/shop/polywood/",
+            "author": {
+                "author_id": "Polymaker",
+                "display_name": "Polymaker L.L.C.",
+                "email": "inquiry@polymaker.com",
+                "website": "https://www.polymaker.com"
+            }
+        }
+    },
+    "UltimakerABS": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerABS.curapackage",
+        "package_info": {
+            "package_id": "UltimakerABS",
+            "package_type": "material",
+            "display_name": "Ultimaker ABS",
+            "description": "Example package for material and quality profiles for Ultimaker materials.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com/products/materials/abs",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "materials@ultimaker.com",
+                "website": "https://ultimaker.com",
+                "description": "Professional 3D printing made accessible.",
+                "support_website": "https://ultimaker.com/en/resources/troubleshooting/materials"
+            }
+        }
+    },
+    "UltimakerCPE": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerCPE.curapackage",
+        "package_info": {
+            "package_id": "UltimakerCPE",
+            "package_type": "material",
+            "display_name": "Ultimaker CPE",
+            "description": "Example package for material and quality profiles for Ultimaker materials.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com/products/materials/abs",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "materials@ultimaker.com",
+                "website": "https://ultimaker.com",
+                "description": "Professional 3D printing made accessible.",
+                "support_website": "https://ultimaker.com/en/resources/troubleshooting/materials"
+            }
+        }
+    },
+    "UltimakerNylon": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerNylon.curapackage",
+        "package_info": {
+            "package_id": "UltimakerNylon",
+            "package_type": "material",
+            "display_name": "Ultimaker Nylon",
+            "description": "Example package for material and quality profiles for Ultimaker materials.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com/products/materials/abs",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "materials@ultimaker.com",
+                "website": "https://ultimaker.com",
+                "description": "Professional 3D printing made accessible.",
+                "support_website": "https://ultimaker.com/en/resources/troubleshooting/materials"
+            }
+        }
+    },
+    "UltimakerPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerPLA.curapackage",
+        "package_info": {
+            "package_id": "UltimakerPLA",
+            "package_type": "material",
+            "display_name": "Ultimaker PLA",
+            "description": "Example package for material and quality profiles for Ultimaker materials.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com/products/materials/abs",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "materials@ultimaker.com",
+                "website": "https://ultimaker.com",
+                "description": "Professional 3D printing made accessible.",
+                "support_website": "https://ultimaker.com/en/resources/troubleshooting/materials"
+            }
+        }
+    },
+    "UltimakerPVA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/UltimakerPVA.curapackage",
+        "package_info": {
+            "package_id": "UltimakerPVA",
+            "package_type": "material",
+            "display_name": "Ultimaker PVA",
+            "description": "Example package for material and quality profiles for Ultimaker materials.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://ultimaker.com/products/materials/abs",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "materials@ultimaker.com",
+                "website": "https://ultimaker.com",
+                "description": "Professional 3D printing made accessible.",
+                "support_website": "https://ultimaker.com/en/resources/troubleshooting/materials"
+            }
+        }
+    },
+    "VertexDeltaABS": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/VertexDeltaABS.curapackage",
+        "package_info": {
+            "package_id": "VertexDeltaABS",
+            "package_type": "material",
+            "display_name": "Vertex Delta ABS",
+            "description": "ABS material and quality files for the Delta Vertex K8800.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://vertex3dprinter.eu",
+            "author": {
+                "author_id": "Velleman",
+                "display_name": "Velleman N.V.",
+                "email": "info@velleman.eu",
+                "website": "https://www.vellemanprojects.eu"
+            }
+        }
+    },
+    "VertexDeltaPET": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/VertexDeltaPET.curapackage",
+        "package_info": {
+            "package_id": "VertexDeltaPET",
+            "package_type": "material",
+            "display_name": "Vertex Delta PET",
+            "description": "ABS material and quality files for the Delta Vertex K8800.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://vertex3dprinter.eu",
+            "author": {
+                "author_id": "Velleman",
+                "display_name": "Velleman N.V.",
+                "email": "info@velleman.eu",
+                "website": "https://www.vellemanprojects.eu"
+            }
+        }
+    },
+    "VertexDeltaPLA": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/VertexDeltaPLA.curapackage",
+        "package_info": {
+            "package_id": "VertexDeltaPLA",
+            "package_type": "material",
+            "display_name": "Vertex Delta PLA",
+            "description": "ABS material and quality files for the Delta Vertex K8800.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://vertex3dprinter.eu",
+            "author": {
+                "author_id": "Velleman",
+                "display_name": "Velleman N.V.",
+                "email": "info@velleman.eu",
+                "website": "https://www.vellemanprojects.eu"
+            }
+        }
+    },
+    "VertexDeltaTPU": {
+        "filename": "/Users/i.paschal/Library/Application Support/cura/3.2/cache/cura_packages/VertexDeltaTPU.curapackage",
+        "package_info": {
+            "package_id": "VertexDeltaTPU",
+            "package_type": "material",
+            "display_name": "Vertex Delta TPU",
+            "description": "ABS material and quality files for the Delta Vertex K8800.",
+            "package_version": "1.0.0",
+            "cura_version": 4,
+            "website": "https://vertex3dprinter.eu",
+            "author": {
+                "author_id": "Velleman",
+                "display_name": "Velleman N.V.",
+                "email": "info@velleman.eu",
+                "website": "https://www.vellemanprojects.eu"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR makes bundled packages (that is to say: the packages which Cura ships with), visible to the package manager as such. Now, you will see bundled materials in the Installed tab and will not be able to install them a second time unless a higher version is present on the server. 