### PR TITLE
Correct the test to hide bed temperature when no heated bed is present.

### DIFF
--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -67,7 +67,7 @@ Column
     HeatedBedBox
     {
         visible: {
-            if(activePrinter != null && activePrinter.bed_temperature != -1)
+            if(activePrinter != null && activePrinter.bedTemperature != -1)
             {
                 return true
             }


### PR DESCRIPTION

When there is no heated bed, bed temperature stay to -1. The test for visibility was not made on the good property name.