### PR TITLE
Fix support blocker on older (legacy) opengl

### DIFF
--- a/resources/shaders/camera_distance.shader
+++ b/resources/shaders/camera_distance.shader
@@ -25,9 +25,9 @@ fragment =
         highp float distance_to_camera = distance(v_vertex, u_viewPosition) * 1000.; // distance in micron
 
         vec3 encoded; // encode float into 3 8-bit channels; this gives a precision of a micron at a range of up to ~16 meter
-        encoded.b = floor(distance_to_camera / 65536.0);
-        encoded.g = floor((distance_to_camera - encoded.b * 65536.0) / 256.0);
-        encoded.r = floor(distance_to_camera - encoded.b * 65536.0 - encoded.g * 256.0);
+        encoded.r = floor(distance_to_camera / 65536.0);
+        encoded.g = floor((distance_to_camera - encoded.r * 65536.0) / 256.0);
+        encoded.b = floor(distance_to_camera - encoded.r * 65536.0 - encoded.g * 256.0);
 
         gl_FragColor.rgb = encoded / 255.;
         gl_FragColor.a = 1.0;


### PR DESCRIPTION
This PR fixes depth picking on older GPUs that do not support the 4.1 shading model. This causes the Support Blocker to put its cubes in totally unexpected locations.

Fixes #3747 