### PR TITLE
Only trigger settings filter on enter or after 500ms timeout

### DIFF
--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -179,6 +179,15 @@ Item
         height: visible ? UM.Theme.getSize("setting_control").height : 0
         Behavior on height { NumberAnimation { duration: 100 } }
 
+        Timer
+        {
+            id: settingsSearchTimer
+            onTriggered: filter.editingFinished()
+            interval: 500
+            running: false
+            repeat: false
+        }
+
         TextField
         {
             id: filter;
@@ -201,6 +210,11 @@ Item
             property bool lastFindingSettings: false
 
             onTextChanged:
+            {
+                settingsSearchTimer.restart()
+            }
+
+            onEditingFinished:
             {
                 definitionsModel.filter = {"i18n_label": "*" + text};
                 findingSettings = (text.length > 0);


### PR DESCRIPTION
This makes the settings filtering field way more bearable on slower machines. It now only triggers when you hit enter, leave the field or after you stop typing for 500ms.