### PR TITLE
CURA-5370 Small refactor for Arranger: 

### DIFF
--- a/cura/Arranging/Arrange.py
+++ b/cura/Arranging/Arrange.py
@@ -18,17 +18,20 @@ LocationSuggestion = namedtuple("LocationSuggestion", ["x", "y", "penalty_points
 #   good locations for objects that you try to put on a build place.
 #   Different priority schemes can be defined so it alters the behavior while using
 #   the same logic.
+#
+#   Note: Make sure the scale is the same between ShapeArray objects and the Arrange instance.
 class Arrange:
     build_volume = None
 
-    def __init__(self, x, y, offset_x, offset_y, scale= 1.0):
-        self.shape = (y, x)
-        self._priority = numpy.zeros((x, y), dtype=numpy.int32)
-        self._priority_unique_values = []
-        self._occupied = numpy.zeros((x, y), dtype=numpy.int32)
+    def __init__(self, x, y, offset_x, offset_y, scale= 0.5):
         self._scale = scale  # convert input coordinates to arrange coordinates
-        self._offset_x = offset_x
-        self._offset_y = offset_y
+        world_x, world_y = int(x * self._scale), int(y * self._scale)
+        self._shape = (world_y, world_x)
+        self._priority = numpy.zeros((world_y, world_x), dtype=numpy.int32)  # beware: these are indexed (y, x)
+        self._priority_unique_values = []
+        self._occupied = numpy.zeros((world_y, world_x), dtype=numpy.int32)  # beware: these are indexed (y, x)
+        self._offset_x = int(offset_x * self._scale)
+        self._offset_y = int(offset_y * self._scale)
         self._last_priority = 0
         self._is_empty = True
 
@@ -39,7 +42,7 @@ class Arrange:
     #   \param scene_root   Root for finding all scene nodes
     #   \param fixed_nodes  Scene nodes to be placed
     @classmethod
-    def create(cls, scene_root = None, fixed_nodes = None, scale = 0.5, x = 220, y = 220):
+    def create(cls, scene_root = None, fixed_nodes = None, scale = 0.5, x = 350, y = 250):
         arranger = Arrange(x, y, x // 2, y // 2, scale = scale)
         arranger.centerFirst()
 
@@ -61,12 +64,16 @@ class Arrange:
 
         # If a build volume was set, add the disallowed areas
         if Arrange.build_volume:
-            disallowed_areas = Arrange.build_volume.getDisallowedAreas()
+            disallowed_areas = Arrange.build_volume.getDisallowedAreasNoBrim()
             for area in disallowed_areas:
                 points = copy.deepcopy(area._points)
                 shape_arr = ShapeArray.fromPolygon(points, scale = scale)
                 arranger.place(0, 0, shape_arr, update_empty = False)
         return arranger
+
+    ##  This resets the optimization for finding location based on size
+    def resetLastPriority(self):
+        self._last_priority = 0
 
     ##  Find placement for a node (using offset shape) and place it (using hull shape)
     #   return the nodes that should be placed
@@ -104,7 +111,7 @@ class Arrange:
     def centerFirst(self):
         # Square distance: creates a more round shape
         self._priority = numpy.fromfunction(
-            lambda i, j: (self._offset_x - i) ** 2 + (self._offset_y - j) ** 2, self.shape, dtype=numpy.int32)
+            lambda j, i: (self._offset_x - i) ** 2 + (self._offset_y - j) ** 2, self._shape, dtype=numpy.int32)
         self._priority_unique_values = numpy.unique(self._priority)
         self._priority_unique_values.sort()
 
@@ -112,7 +119,7 @@ class Arrange:
     #   This is a strategy for the arranger.
     def backFirst(self):
         self._priority = numpy.fromfunction(
-            lambda i, j: 10 * j + abs(self._offset_x - i), self.shape, dtype=numpy.int32)
+            lambda j, i: 10 * j + abs(self._offset_x - i), self._shape, dtype=numpy.int32)
         self._priority_unique_values = numpy.unique(self._priority)
         self._priority_unique_values.sort()
 
@@ -126,9 +133,15 @@ class Arrange:
         y = int(self._scale * y)
         offset_x = x + self._offset_x + shape_arr.offset_x
         offset_y = y + self._offset_y + shape_arr.offset_y
+        if offset_x < 0 or offset_y < 0:
+            return None  # out of bounds in self._occupied
+        occupied_x_max = offset_x + shape_arr.arr.shape[1]
+        occupied_y_max = offset_y + shape_arr.arr.shape[0]
+        if occupied_x_max > self._occupied.shape[1] + 1 or occupied_y_max > self._occupied.shape[0] + 1:
+            return None  # out of bounds in self._occupied
         occupied_slice = self._occupied[
-            offset_y:offset_y + shape_arr.arr.shape[0],
-            offset_x:offset_x + shape_arr.arr.shape[1]]
+            offset_y:occupied_y_max,
+            offset_x:occupied_x_max]
         try:
             if numpy.any(occupied_slice[numpy.where(shape_arr.arr == 1)]):
                 return None
@@ -140,7 +153,7 @@ class Arrange:
         return numpy.sum(prio_slice[numpy.where(shape_arr.arr == 1)])
 
     ##  Find "best" spot for ShapeArray
-    #   Return namedtuple with properties x, y, penalty_points, priority
+    #   Return namedtuple with properties x, y, penalty_points, priority.
     #   \param shape_arr ShapeArray
     #   \param start_prio Start with this priority value (and skip the ones before)
     #   \param step Slicing value, higher = more skips = faster but less accurate
@@ -153,12 +166,11 @@ class Arrange:
         for priority in self._priority_unique_values[start_idx::step]:
             tryout_idx = numpy.where(self._priority == priority)
             for idx in range(len(tryout_idx[0])):
-                x = tryout_idx[0][idx]
-                y = tryout_idx[1][idx]
-                projected_x = x - self._offset_x
-                projected_y = y - self._offset_y
+                x = tryout_idx[1][idx]
+                y = tryout_idx[0][idx]
+                projected_x = int((x - self._offset_x) / self._scale)
+                projected_y = int((y - self._offset_y) / self._scale)
 
-                # array to "world" coordinates
                 penalty_points = self.checkShape(projected_x, projected_y, shape_arr)
                 if penalty_points is not None:
                     return LocationSuggestion(x = projected_x, y = projected_y, penalty_points = penalty_points, priority = priority)
@@ -191,8 +203,12 @@ class Arrange:
 
         # Set priority to low (= high number), so it won't get picked at trying out.
         prio_slice = self._priority[min_y:max_y, min_x:max_x]
-        prio_slice[numpy.where(shape_arr.arr[
-            min_y - offset_y:max_y - offset_y, min_x - offset_x:max_x - offset_x] == 1)] = 999
+        prio_slice[new_occupied] = 999
+
+        # If you want to see how the rasterized arranger build plate looks like, uncomment this code
+        # numpy.set_printoptions(linewidth=500, edgeitems=200)
+        # print(self._occupied.shape)
+        # print(self._occupied)
 
     @property
     def isEmpty(self):

--- a/cura/Arranging/Arrange.py
+++ b/cura/Arranging/Arrange.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2018 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
 from UM.Scene.Iterator.DepthFirstIterator import DepthFirstIterator
 from UM.Logger import Logger
 from UM.Math.Vector import Vector

--- a/cura/Arranging/ArrangeObjectsAllBuildPlatesJob.py
+++ b/cura/Arranging/ArrangeObjectsAllBuildPlatesJob.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Ultimaker B.V.
+# Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 from UM.Application import Application
@@ -18,7 +18,7 @@ from cura.Arranging.ShapeArray import ShapeArray
 from typing import List
 
 
-##  Do an arrangements on a bunch of build plates
+##  Do arrangements on multiple build plates (aka builtiplexer)
 class ArrangeArray:
     def __init__(self, x: int, y: int, fixed_nodes: List[SceneNode]):
         self._x = x

--- a/cura/Arranging/ArrangeObjectsAllBuildPlatesJob.py
+++ b/cura/Arranging/ArrangeObjectsAllBuildPlatesJob.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
+from UM.Application import Application
 from UM.Job import Job
 from UM.Scene.SceneNode import SceneNode
 from UM.Math.Vector import Vector
@@ -17,6 +18,7 @@ from cura.Arranging.ShapeArray import ShapeArray
 from typing import List
 
 
+##  Do an arrangements on a bunch of build plates
 class ArrangeArray:
     def __init__(self, x: int, y: int, fixed_nodes: List[SceneNode]):
         self._x = x
@@ -79,7 +81,11 @@ class ArrangeObjectsAllBuildPlatesJob(Job):
         nodes_arr.sort(key=lambda item: item[0])
         nodes_arr.reverse()
 
-        x, y = 200, 200
+        global_container_stack = Application.getInstance().getGlobalContainerStack()
+        machine_width = global_container_stack.getProperty("machine_width", "value")
+        machine_depth = global_container_stack.getProperty("machine_depth", "value")
+
+        x, y = machine_width, machine_depth
 
         arrange_array = ArrangeArray(x = x, y = y, fixed_nodes = [])
         arrange_array.add()
@@ -93,19 +99,10 @@ class ArrangeObjectsAllBuildPlatesJob(Job):
         for idx, (size, node, offset_shape_arr, hull_shape_arr) in enumerate(nodes_arr):
             # For performance reasons, we assume that when a location does not fit,
             # it will also not fit for the next object (while what can be untrue).
-            # We also skip possibilities by slicing through the possibilities (step = 10)
 
             try_placement = True
 
             current_build_plate_number = 0  # always start with the first one
-
-            # # Only for first build plate
-            # if last_size == size and last_build_plate_number == current_build_plate_number:
-            #     # This optimization works if many of the objects have the same size
-            #     # Continue with same build plate number
-            #     start_priority = last_priority
-            # else:
-            #     start_priority = 0
 
             while try_placement:
                 # make sure that current_build_plate_number is not going crazy or you'll have a lot of arrange objects
@@ -113,7 +110,7 @@ class ArrangeObjectsAllBuildPlatesJob(Job):
                     arrange_array.add()
                 arranger = arrange_array.get(current_build_plate_number)
 
-                best_spot = arranger.bestSpot(offset_shape_arr, start_prio=start_priority, step=10)
+                best_spot = arranger.bestSpot(offset_shape_arr, start_prio=start_priority)
                 x, y = best_spot.x, best_spot.y
                 node.removeDecorator(ZOffsetDecorator)
                 if node.getBoundingBox():

--- a/cura/Arranging/ArrangeObjectsJob.py
+++ b/cura/Arranging/ArrangeObjectsJob.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2017 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
+from UM.Application import Application
 from UM.Job import Job
 from UM.Scene.SceneNode import SceneNode
 from UM.Math.Vector import Vector
@@ -32,7 +33,11 @@ class ArrangeObjectsJob(Job):
                                  progress = 0,
                                  title = i18n_catalog.i18nc("@info:title", "Finding Location"))
         status_message.show()
-        arranger = Arrange.create(fixed_nodes = self._fixed_nodes)
+        global_container_stack = Application.getInstance().getGlobalContainerStack()
+        machine_width = global_container_stack.getProperty("machine_width", "value")
+        machine_depth = global_container_stack.getProperty("machine_depth", "value")
+
+        arranger = Arrange.create(x = machine_width, y = machine_depth, fixed_nodes = self._fixed_nodes)
 
         # Collect nodes to be placed
         nodes_arr = []  # fill with (size, node, offset_shape_arr, hull_shape_arr)
@@ -50,15 +55,15 @@ class ArrangeObjectsJob(Job):
         last_size = None
         grouped_operation = GroupedOperation()
         found_solution_for_all = True
+        not_fit_count = 0
         for idx, (size, node, offset_shape_arr, hull_shape_arr) in enumerate(nodes_arr):
             # For performance reasons, we assume that when a location does not fit,
             # it will also not fit for the next object (while what can be untrue).
-            # We also skip possibilities by slicing through the possibilities (step = 10)
             if last_size == size:  # This optimization works if many of the objects have the same size
                 start_priority = last_priority
             else:
                 start_priority = 0
-            best_spot = arranger.bestSpot(offset_shape_arr, start_prio=start_priority, step=10)
+            best_spot = arranger.bestSpot(offset_shape_arr, start_prio=start_priority)
             x, y = best_spot.x, best_spot.y
             node.removeDecorator(ZOffsetDecorator)
             if node.getBoundingBox():
@@ -70,12 +75,12 @@ class ArrangeObjectsJob(Job):
                 last_priority = best_spot.priority
 
                 arranger.place(x, y, hull_shape_arr)  # take place before the next one
-
                 grouped_operation.addOperation(TranslateOperation(node, Vector(x, center_y, y), set_position = True))
             else:
                 Logger.log("d", "Arrange all: could not find spot!")
                 found_solution_for_all = False
-                grouped_operation.addOperation(TranslateOperation(node, Vector(200, center_y, - idx * 20), set_position = True))
+                grouped_operation.addOperation(TranslateOperation(node, Vector(200, center_y, -not_fit_count * 20), set_position = True))
+                not_fit_count += 1
 
             status_message.setProgress((idx + 1) / len(nodes_arr) * 100)
             Job.yieldThread()

--- a/cura/Arranging/ShapeArray.py
+++ b/cura/Arranging/ShapeArray.py
@@ -74,7 +74,7 @@ class ShapeArray:
     #   \param vertices
     @classmethod
     def arrayFromPolygon(cls, shape, vertices):
-        base_array = numpy.zeros(shape, dtype=float)  # Initialize your array of zeros
+        base_array = numpy.zeros(shape, dtype = numpy.int32)  # Initialize your array of zeros
 
         fill = numpy.ones(base_array.shape) * True  # Initialize boolean array defining shape fill
 

--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -460,7 +460,7 @@ class BuildVolume(SceneNode):
             minimum = Vector(min_w, min_h - 1.0, min_d),
             maximum = Vector(max_w, max_h - self._raft_thickness - self._extra_z_clearance, max_d))
 
-        bed_adhesion_size = self._getEdgeDisallowedSize()
+        bed_adhesion_size = self.getEdgeDisallowedSize()
 
         # As this works better for UM machines, we only add the disallowed_area_size for the z direction.
         # This is probably wrong in all other cases. TODO!
@@ -652,7 +652,7 @@ class BuildVolume(SceneNode):
 
         extruder_manager = ExtruderManager.getInstance()
         used_extruders = extruder_manager.getUsedExtruderStacks()
-        disallowed_border_size = self._getEdgeDisallowedSize()
+        disallowed_border_size = self.getEdgeDisallowedSize()
 
         if not used_extruders:
             # If no extruder is used, assume that the active extruder is used (else nothing is drawn)
@@ -962,12 +962,12 @@ class BuildVolume(SceneNode):
                 all_values[i] = 0
         return all_values
 
-    ##  Convenience function to calculate the disallowed radius around the edge.
+    ##  Calculate the disallowed radius around the edge.
     #
     #   This disallowed radius is to allow for space around the models that is
     #   not part of the collision radius, such as bed adhesion (skirt/brim/raft)
     #   and travel avoid distance.
-    def _getEdgeDisallowedSize(self):
+    def getEdgeDisallowedSize(self):
         if not self._global_container_stack or not self._global_container_stack.extruders:
             return 0
 

--- a/cura/CuraActions.py
+++ b/cura/CuraActions.py
@@ -73,7 +73,8 @@ class CuraActions(QObject):
     #   \param count The number of times to multiply the selection.
     @pyqtSlot(int)
     def multiplySelection(self, count: int) -> None:
-        job = MultiplyObjectsJob(Selection.getAllSelectedObjects(), count, min_offset = 8)
+        min_offset = Application.getInstance().getBuildVolume().getEdgeDisallowedSize() + 2  # Allow for some rounding errors
+        job = MultiplyObjectsJob(Selection.getAllSelectedObjects(), count, min_offset = max(min_offset, 8))
         job.start()
 
     ##  Delete all selected objects.

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1264,7 +1264,8 @@ class CuraApplication(QtApplication):
     #   \param nodes nodes that we have to place
     #   \param fixed_nodes nodes that are placed in the arranger before finding spots for nodes
     def arrange(self, nodes, fixed_nodes):
-        job = ArrangeObjectsJob(nodes, fixed_nodes)
+        min_offset = self.getBuildVolume().getEdgeDisallowedSize() + 2  # Allow for some rounding errors
+        job = ArrangeObjectsJob(nodes, fixed_nodes, min_offset = max(min_offset, 8))
         job.start()
 
     ##  Reload all mesh data on the screen from file.
@@ -1612,7 +1613,6 @@ class CuraApplication(QtApplication):
                 #Setting meshdata does not apply scaling.
                 if(original_node.getScale() != Vector(1.0, 1.0, 1.0)):
                     node.scale(original_node.getScale())
-
 
             node.setSelectable(True)
             node.setName(os.path.basename(filename))

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1260,29 +1260,6 @@ class CuraApplication(QtApplication):
                     nodes.append(node)
         self.arrange(nodes, fixed_nodes = [])
 
-    ##  Arrange Selection
-    @pyqtSlot()
-    def arrangeSelection(self):
-        nodes = Selection.getAllSelectedObjects()
-
-        # What nodes are on the build plate and are not being moved
-        fixed_nodes = []
-        for node in DepthFirstIterator(self.getController().getScene().getRoot()):
-            if not isinstance(node, SceneNode):
-                continue
-            if not node.getMeshData() and not node.callDecoration("isGroup"):
-                continue  # Node that doesnt have a mesh and is not a group.
-            if node.getParent() and node.getParent().callDecoration("isGroup"):
-                continue  # Grouped nodes don't need resetting as their parent (the group) is resetted)
-            if not node.isSelectable():
-                continue  # i.e. node with layer data
-            if not node.callDecoration("isSliceable") and not node.callDecoration("isGroup"):
-                continue  # i.e. node with layer data
-            if node in nodes:  # exclude selected node from fixed_nodes
-                continue
-            fixed_nodes.append(node)
-        self.arrange(nodes, fixed_nodes)
-
     ##  Arrange a set of nodes given a set of fixed nodes
     #   \param nodes nodes that we have to place
     #   \param fixed_nodes nodes that are placed in the arranger before finding spots for nodes


### PR DESCRIPTION
Fixed CURA-5370 bug: arranger didn't find a location while it fits fine. This was caused by brims taken into account double. The arranger used an offset convex hull, but the disallowed areas already had a "brim"* in.
- arranger uses disallowed areas without brim* 
- faster, 
- better results when "Arrange all"
- cleanup, 
- more unit tests, 
- take actual build plate size in Arranger instances
- make x and y consistent (numpy arrays start with y first in general), they were used mixed but it wasn't seen because previously the build size was always a square
- use *brim to determine minimum offset between objects

*brim = brim / skirt / other