### PR TITLE
Select models after loading

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1572,6 +1572,8 @@ class CuraApplication(QtApplication):
             self.callLater(self.openProjectFile.emit, file)
             return
 
+        Selection.clear()
+
         f = file.toLocalFile()
         extension = os.path.splitext(f)[1]
         filename = os.path.basename(f)
@@ -1695,6 +1697,8 @@ class CuraApplication(QtApplication):
 
             node.callDecoration("setActiveExtruder", default_extruder_id)
             scene.sceneChanged.emit(node)
+
+            Selection.add(node)
 
         self.fileCompleted.emit(filename)
 

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -377,6 +377,7 @@ class CuraApplication(QtApplication):
 
         preferences.addPreference("cura/categories_expanded", "")
         preferences.addPreference("cura/jobname_prefix", True)
+        preferences.addPreference("cura/select_models_on_load", False)
         preferences.addPreference("view/center_on_select", False)
         preferences.addPreference("mesh/scale_to_fit", False)
         preferences.addPreference("mesh/scale_tiny_meshes", True)
@@ -1572,7 +1573,8 @@ class CuraApplication(QtApplication):
             self.callLater(self.openProjectFile.emit, file)
             return
 
-        Selection.clear()
+        if Preferences.getInstance().getValue("cura/select_models_on_load"):
+            Selection.clear()
 
         f = file.toLocalFile()
         extension = os.path.splitext(f)[1]
@@ -1698,7 +1700,8 @@ class CuraApplication(QtApplication):
             node.callDecoration("setActiveExtruder", default_extruder_id)
             scene.sceneChanged.emit(node)
 
-            Selection.add(node)
+            if Preferences.getInstance().getValue("cura/select_models_on_load"):
+                Selection.add(node)
 
         self.fileCompleted.emit(filename)
 

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1627,6 +1627,8 @@ class CuraApplication(QtApplication):
         default_extruder_position = self.getMachineManager().defaultExtruderPosition
         default_extruder_id = self._global_container_stack.extruders[default_extruder_position].getId()
 
+        select_models_on_load = Preferences.getInstance().getValue("cura/select_models_on_load")
+
         for original_node in nodes:
 
             # Create a CuraSceneNode just if the original node is not that type
@@ -1700,7 +1702,7 @@ class CuraApplication(QtApplication):
             node.callDecoration("setActiveExtruder", default_extruder_id)
             scene.sceneChanged.emit(node)
 
-            if Preferences.getInstance().getValue("cura/select_models_on_load"):
+            if select_models_on_load:
                 Selection.add(node)
 
         self.fileCompleted.emit(filename)

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -79,6 +79,8 @@ UM.PreferencesPage
         scaleToFitCheckbox.checked = boolCheck(UM.Preferences.getValue("mesh/scale_to_fit"))
         UM.Preferences.resetPreference("mesh/scale_tiny_meshes")
         scaleTinyCheckbox.checked = boolCheck(UM.Preferences.getValue("mesh/scale_tiny_meshes"))
+        UM.Preferences.resetPreference("cura/select_models_on_load")
+        selectModelsOnLoadCheckbox.checked = boolCheck(UM.Preferences.getValue("cura/select_models_on_load"))
         UM.Preferences.resetPreference("cura/jobname_prefix")
         prefixJobNameCheckbox.checked = boolCheck(UM.Preferences.getValue("cura/jobname_prefix"))
         UM.Preferences.resetPreference("view/show_overhang");
@@ -495,6 +497,21 @@ UM.PreferencesPage
                     text: catalog.i18nc("@option:check","Scale extremely small models")
                     checked: boolCheck(UM.Preferences.getValue("mesh/scale_tiny_meshes"))
                     onCheckedChanged: UM.Preferences.setValue("mesh/scale_tiny_meshes", checked)
+                }
+            }
+
+            UM.TooltipArea
+            {
+                width: childrenRect.width
+                height: childrenRect.height
+                text: catalog.i18nc("@info:tooltip","Should models be selected after they are loaded?")
+
+                CheckBox
+                {
+                    id: selectModelsOnLoadCheckbox
+                    text: catalog.i18nc("@option:check","Select models when loaded")
+                    checked: boolCheck(UM.Preferences.getValue("cura/select_models_on_load"))
+                    onCheckedChanged: UM.Preferences.setValue("cura/select_models_on_load", checked)
                 }
             }
 


### PR DESCRIPTION
This PR selects models after loading them into Cura. This makes Cura behave like other applications, including legacy Cura.

Fixes #356