### PR TITLE
Fix configurationmenu text

### DIFF
--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml
@@ -92,6 +92,7 @@ Rectangle
                 anchors.verticalCenter: buildplateIcon.verticalCenter
                 anchors.leftMargin: Math.round(UM.Theme.getSize("default_margin").height / 2)
                 text: configuration.buildplateConfiguration
+                renderType: Text.NativeRendering
                 color: textColor
             }
         }

--- a/resources/qml/Menus/ConfigurationMenu/PrintCoreConfiguration.qml
+++ b/resources/qml/Menus/ConfigurationMenu/PrintCoreConfiguration.qml
@@ -26,6 +26,7 @@ Column
         {
             id: extruderLabel
             text: catalog.i18nc("@label:extruder label", "Extruder")
+            renderType: Text.NativeRendering
             elide: Text.ElideRight
             anchors.left: parent.left
             font: UM.Theme.getFont("default")
@@ -59,6 +60,7 @@ Column
                 id: extruderNumberText
                 anchors.centerIn: parent
                 text: printCoreConfiguration.position + 1
+                renderType: Text.NativeRendering
                 font: UM.Theme.getFont("default")
                 color: mainColor
             }
@@ -69,6 +71,7 @@ Column
     {
         id: materialLabel
         text: printCoreConfiguration.material.name
+        renderType: Text.NativeRendering
         elide: Text.ElideRight
         width: parent.width
         font: UM.Theme.getFont("default_bold")
@@ -79,6 +82,7 @@ Column
     {
         id: printCoreTypeLabel
         text: printCoreConfiguration.hotendID
+        renderType: Text.NativeRendering
         elide: Text.ElideRight
         width: parent.width
         font: UM.Theme.getFont("default")

--- a/resources/qml/Menus/ConfigurationMenu/SyncButton.qml
+++ b/resources/qml/Menus/ConfigurationMenu/SyncButton.qml
@@ -13,7 +13,7 @@ Button
     id: base
     property var outputDevice: null
     property var matched: updateOnSync()
-    text: matched == true ? "Yes" : "No"
+    text: matched == true ? catalog.i18nc("@label:extruder label", "Yes") : catalog.i18nc("@label:extruder label", "No")
     width: parent.width
     height: parent.height
 


### PR DESCRIPTION
This PR fixes some minor issues with the ConfigurationMenu ("sync button"):

* Fix text rendering on some OSX systems
* Fix untranslatable text