### PR TITLE
Fix for detecting USB connection to Malyan M200 and Monoprice Mini

### DIFF
--- a/plugins/USBPrinting/AutoDetectBaudJob.py
+++ b/plugins/USBPrinting/AutoDetectBaudJob.py
@@ -58,7 +58,7 @@ class AutoDetectBaudJob(Job):
 
                 while timeout_time > time():
                     line = serial.readline()
-                    if b"ok T:" in line:
+                    if b"ok " in line and b"T:" in line:
                         successful_responses += 1
                         if successful_responses >= 3:
                             self.setResult(baud_rate)

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -305,7 +305,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
                 if self._firmware_name is None:
                     self.sendCommand("M115")
 
-            if b"ok T:" in line or line.startswith(b"T:") or b"ok B:" in line or line.startswith(b"B:"):  # Temperature message. 'T:' for extruder and 'B:' for bed
+            if (b"ok " in line and b"T:" in line) or b"ok T:" in line or line.startswith(b"T:") or b"ok B:" in line or line.startswith(b"B:"):  # Temperature message. 'T:' for extruder and 'B:' for bed
                 extruder_temperature_matches = re.findall(b"T(\d*): ?([\d\.]+) ?\/?([\d\.]+)?", line)
                 # Update all temperature values
                 matched_extruder_nrs = []


### PR DESCRIPTION
Hello, just installed Ultimate Cura 3.3.1 and wasn't able to connect my Malyan M200 via USB. Debugging the problem I found that the answer from the printer during the `AutoDetectBaudJob` was:

`b'ok N0 P15 B15 T:28.8 /0.0 B:24.8 /0.0 T0:28.8 /0.0 @:0 B@:0\n'`

So it didn't pass the check. Changing the check to `if b"ok " in line and b"T:" in line` fixed it.

I don't have any other printers to test if the fix breaks the check for them, but I think they will be fine

Jorge.