### PR TITLE
Make headers non-transparent

### DIFF
--- a/plugins/Toolbox/resources/qml/ToolboxCompatibilityChart.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxCompatibilityChart.qml
@@ -31,8 +31,9 @@ Item
         frameVisible: false
         selectionMode: 0
         model: packageData.supported_configs
-        headerDelegate: Item
+        headerDelegate: Rectangle
         {
+            color: UM.Theme.getColor("sidebar")
             height: UM.Theme.getSize("toolbox_chart_row").height
             Label
             {


### PR DESCRIPTION
This PR fixes a cosmetic issue in the Toolbox:
![image](https://user-images.githubusercontent.com/143551/40629249-31b193ea-62ca-11e8-8795-30cafb3928a3.png)
Notice how the items in the table shine through the header, which is not a great look.