### PR TITLE
Feature update old plugins

### DIFF
--- a/cura/CuraPackageManager.py
+++ b/cura/CuraPackageManager.py
@@ -134,7 +134,7 @@ class CuraPackageManager(QObject):
 
         return None
 
-    def getAllInstalledPackagesInfo(self) -> dict:
+    def getAllInstalledPackageIDs(self) -> set:
         # Add bundled, installed, and to-install packages to the set of installed package IDs
         all_installed_ids = set()
 
@@ -146,6 +146,12 @@ class CuraPackageManager(QObject):
         # If it's going to be installed and to be removed, then the package is being updated and it should be listed.
         if self._to_install_package_dict.keys():
             all_installed_ids = all_installed_ids.union(set(self._to_install_package_dict.keys()))
+
+        return all_installed_ids
+
+    def getAllInstalledPackagesInfo(self) -> dict:
+
+        all_installed_ids = self.getAllInstalledPackageIDs()
 
         # map of <package_type> -> <package_id> -> <package_info>
         installed_packages_dict = {}

--- a/plugins/Toolbox/resources/qml/ToolboxDetailTileActions.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxDetailTileActions.qml
@@ -34,6 +34,7 @@ Column
         // Don't allow installing while another download is running
         enabled: installed || !(toolbox.isDownloading && toolbox.activePackage != model)
         opacity: enabled ? 1.0 : 0.5
+        visible: !updateButton.visible // Don't show when the update button is visible
     }
 
     ToolboxProgressButton
@@ -55,7 +56,7 @@ Column
         // Don't allow installing while another download is running
         enabled: !(toolbox.isDownloading && toolbox.activePackage != model)
         opacity: enabled ? 1.0 : 0.5
-        visible: installed && canUpdate
+        visible: canUpdate
     }
     Connections
     {

--- a/plugins/Toolbox/src/Toolbox.py
+++ b/plugins/Toolbox/src/Toolbox.py
@@ -179,7 +179,7 @@ class Toolbox(QObject, Extension):
                    'cura-siemensnx-plugin']
 
     # check for plugins that were installed with the old plugin-browser
-    def _isOldPlugin(self, plugin_id) -> bool:
+    def _isOldPlugin(self, plugin_id: str) -> bool:
         if plugin_id in self.OLD_PLUGINS and plugin_id in self._plugin_registry.getInstalledPlugins():
             Logger.log('i', 'Found a plugin that was installed with the old plugin browser: %s', plugin_id)
             if not self._package_manager.isPackageInstalled(plugin_id):

--- a/resources/bundled_packages.json
+++ b/resources/bundled_packages.json
@@ -1132,5 +1132,277 @@
                 "website": "https://www.vellemanprojects.eu"
             }
         }
+    },
+    "ConsoleLogger": {
+        "package_info": {
+            "package_id": "ConsoleLogger",
+            "package_type": "plugin",
+            "display_name": "Console Logger",
+            "description": "Outputs log information to the console.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "OBJReader": {
+        "package_info": {
+            "package_id": "OBJReader",
+            "package_type": "plugin",
+            "display_name": "Wavefront OBJ Reader",
+            "description": "Makes it possible to read Wavefront OBJ files.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "OBJWriter": {
+        "package_info": {
+            "package_id": "OBJWriter",
+            "package_type": "plugin",
+            "display_name": "Wavefront OBJ Writer",
+            "description": "Makes it possible to write Wavefront OBJ files.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "STLReader": {
+        "package_info": {
+            "package_id": "STLReader",
+            "package_type": "plugin",
+            "display_name": "STL Reader",
+            "description": "Provides support for reading STL files.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "STLWriter": {
+        "package_info": {
+            "package_id": "STLWriter",
+            "package_type": "plugin",
+            "display_name": "STL Writer",
+            "description": "Provides support for writing STL files.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "FileLogger": {
+        "package_info": {
+            "package_id": "FileLogger",
+            "package_type": "plugin",
+            "display_name": "File Logger",
+            "description": "Outputs log information to a file in your settings folder.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "LocalContainerProvider": {
+        "package_info": {
+            "package_id": "LocalContainerProvider",
+            "package_type": "plugin",
+            "display_name": "Local Container Provider",
+            "description": "Provides built-in setting containers that come with the installation of the application.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "LocalFileOutputDevice": {
+        "package_info": {
+            "package_id": "LocalFileOutputDevice",
+            "package_type": "plugin",
+            "display_name": "Local File Output Device",
+            "description": "Enables saving to local files.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "CameraTool": {
+        "package_info": {
+            "package_id": "CameraTool",
+            "package_type": "plugin",
+            "display_name": "Camera Tool",
+            "description": "Provides the tool to manipulate the camera.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "MirrorTool": {
+        "package_info": {
+            "package_id": "MirrorTool",
+            "package_type": "plugin",
+            "display_name": "Mirror Tool",
+            "description": "Provides the Mirror tool.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "RotateTool": {
+        "package_info": {
+            "package_id": "RotateTool",
+            "package_type": "plugin",
+            "display_name": "Rotate Tool",
+            "description": "Provides the Rotate tool.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "ScaleTool": {
+        "package_info": {
+            "package_id": "ScaleTool",
+            "package_type": "plugin",
+            "display_name": "Scale Tool",
+            "description": "Provides the Scale tool.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "SelectionTool": {
+        "package_info": {
+            "package_id": "SelectionTool",
+            "package_type": "plugin",
+            "display_name": "Selection Tool",
+            "description": "Provides the Selection tool.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "TranslateTool": {
+        "package_info": {
+            "package_id": "TranslateTool",
+            "package_type": "plugin",
+            "display_name": "Move Tool",
+            "description": "Provides the Move tool.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "UpdateChecker": {
+        "package_info": {
+            "package_id": "UpdateChecker",
+            "package_type": "plugin",
+            "display_name": "Update Checker",
+            "description": "Checks for updates of the software.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
+    },
+    "SimpleView": {
+        "package_info": {
+            "package_id": "SimpleView",
+            "package_type": "plugin",
+            "display_name": "Simple View",
+            "description": "Provides a simple solid mesh view.",
+            "package_version": "1.0.0",
+            "sdk_version": 4,
+            "website": "https://ultimaker.com",
+            "author": {
+                "author_id": "Ultimaker",
+                "display_name": "Ultimaker B.V.",
+                "email": "plugins@ultimaker.com",
+                "website": "https://ultimaker.com"
+            }
+        }
     }
 }


### PR DESCRIPTION
Check if plugins are installed through the 'old' plugin browser and are not yet known in the package manager. If so, show them as installed and updatable.
Once a user updates them through the new Toolbox they are correctly known in the package manager.