### PR TITLE
Limit flicking the Toolbox scrollviews to vertical only

### DIFF
--- a/plugins/Toolbox/resources/qml/ToolboxDetailList.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxDetailList.qml
@@ -14,6 +14,7 @@ Item
         frameVisible: false
         anchors.fill: detailList
         style: UM.Theme.styles.scrollview
+        flickableItem.flickableDirection: Flickable.VerticalFlick
         Column
         {
             anchors

--- a/plugins/Toolbox/resources/qml/ToolboxDownloadsPage.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxDownloadsPage.qml
@@ -12,6 +12,7 @@ ScrollView
     width: parent.width
     height: parent.height
     style: UM.Theme.styles.scrollview
+    flickableItem.flickableDirection: Flickable.VerticalFlick
     Column
     {
         width: parent.width - 2 * padding

--- a/plugins/Toolbox/resources/qml/ToolboxInstalledPage.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxInstalledPage.qml
@@ -15,6 +15,7 @@ ScrollView
     width: parent.width
     height: parent.height
     style: UM.Theme.styles.scrollview
+    flickableItem.flickableDirection: Flickable.VerticalFlick
     Column
     {
         spacing: UM.Theme.getSize("default_margin").height


### PR DESCRIPTION
This PR fixes the scrolling panes in the Toolbox window so they can only be "flicked" vertically, like other scrollviews in Cura. "Flicking" is where, instead of dragging the scrollbar or using mousewheel/multitouch scrolling, you just click and drag around the contents of the scrolling pane. Before this PR, the toolbox scrolling panes could be dragged horizontally as well as vertically, which looks weird.