### PR TITLE
Add Creality CR-10S machine definition

### DIFF
--- a/resources/definitions/creality_cr10s.def.json
+++ b/resources/definitions/creality_cr10s.def.json
@@ -1,0 +1,5 @@
+{
+    "name": "Creality CR-10S",
+    "version": 2,
+    "inherits": "creality_cr10"
+}


### PR DESCRIPTION
The CR-10S is functionally equivalent to the CR-10, but since the definitions support inheritance I figured I'd add it for completeness sake.

It's not entirely the same - The CR-10S has a different board and has dual Z-rods, but that shouldn't matter for this definition.