### PR TITLE
CURA-5342 replace speed setting constants in profiles to formulas

### DIFF
--- a/resources/quality/abax_pri3/apri3_pla_fast.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_fast.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 80
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 80)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/abax_pri3/apri3_pla_high.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_high.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/abax_pri3/apri3_pla_normal.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_normal.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/abax_pri5/apri5_pla_fast.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_fast.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 80
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 80)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/abax_pri5/apri5_pla_high.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_high.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/abax_pri5/apri5_pla_normal.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_normal.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/abax_titan/atitan_pla_fast.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_fast.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 80
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 80)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/abax_titan/atitan_pla_high.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_high.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/abax_titan/atitan_pla_normal.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_normal.inst.cfg
@@ -17,6 +17,6 @@ top_bottom_thickness = 0.8
 infill_sparse_density = 20
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_draft.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_draft.inst.cfg
@@ -41,13 +41,13 @@ retraction_speed = 40
 skirt_brim_speed = 40
 skirt_gap = 5
 skirt_line_count = 3
-speed_infill = 60
+speed_infill = =speed_print
 speed_print = 60
 speed_support = 60
-speed_topbottom = 30
+speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_travel = 100
-speed_wall = 60
-speed_wall_x = 60
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 support_angle = 60
 support_enable = True
 support_interface_enable = True

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_high.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_high.inst.cfg
@@ -41,13 +41,13 @@ retraction_speed = 40
 skirt_brim_speed = 40
 skirt_gap = 5
 skirt_line_count = 3
-speed_infill = 50
+speed_infill = =speed_print
 speed_print = 50
 speed_support = 30
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 speed_travel = 50
-speed_wall = 50
-speed_wall_x = 50
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 support_angle = 60
 support_enable = True
 support_interface_enable = True

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_normal.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_normal.inst.cfg
@@ -41,13 +41,13 @@ retraction_speed = 40
 skirt_brim_speed = 40
 skirt_gap = 5
 skirt_line_count = 3
-speed_infill = 50
+speed_infill = =speed_print
 speed_print = 50
 speed_support = 30
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 speed_travel = 100
-speed_wall = 50
-speed_wall_x = 50
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 support_angle = 60
 support_enable = True
 support_interface_enable = True

--- a/resources/quality/deltacomb/deltacomb_nylon_fast.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_nylon_fast.inst.cfg
@@ -43,11 +43,11 @@ skirt_brim_minimal_length = 75
 skirt_gap = 1.5
 skirt_line_count = 5
 speed_infill = =speed_print
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 40
+speed_topbottom = =math.ceil(speed_print * 40 / 50)
 speed_travel = 200
-speed_wall_0 = 40
+speed_wall_0 = =math.ceil(speed_print * 40 / 50)
 speed_wall_x = =speed_print
 support_angle = 70
 support_type = buildplate

--- a/resources/quality/deltacomb/deltacomb_nylon_high.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_nylon_high.inst.cfg
@@ -43,11 +43,11 @@ skirt_brim_minimal_length = 75
 skirt_gap = 1.5
 skirt_line_count = 5
 speed_infill = =speed_print
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 40
+speed_topbottom = =math.ceil(speed_print * 40 / 50)
 speed_travel = 200
-speed_wall_0 = 40
+speed_wall_0 = =math.ceil(speed_print * 40 / 50)
 speed_wall_x = =speed_print
 support_angle = 70
 support_type = buildplate

--- a/resources/quality/deltacomb/deltacomb_nylon_normal.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_nylon_normal.inst.cfg
@@ -43,11 +43,11 @@ skirt_brim_minimal_length = 75
 skirt_gap = 1.5
 skirt_line_count = 5
 speed_infill = =speed_print
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 40
+speed_topbottom = =math.ceil(speed_print * 40 / 50)
 speed_travel = 200
-speed_wall_0 = 40
+speed_wall_0 = =math.ceil(speed_print * 40 / 50)
 speed_wall_x = =speed_print
 support_angle = 70
 support_type = buildplate

--- a/resources/quality/fabtotum/fabtotum_nylon_fast.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_nylon_fast.inst.cfg
@@ -43,11 +43,11 @@ skirt_brim_minimal_length = 75
 skirt_gap = 1.5
 skirt_line_count = 5
 speed_infill = =speed_print
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 30)
 speed_print = 30
-speed_topbottom = 40
+speed_topbottom = =math.ceil(speed_print * 40 / 30)
 speed_travel = 200
-speed_wall_0 = 40
+speed_wall_0 = =math.ceil(speed_print * 40 / 30)
 speed_wall_x = =speed_print
 support_angle = 70
 support_type = buildplate

--- a/resources/quality/fabtotum/fabtotum_nylon_high.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_nylon_high.inst.cfg
@@ -43,11 +43,11 @@ skirt_brim_minimal_length = 75
 skirt_gap = 1.5
 skirt_line_count = 5
 speed_infill = =speed_print
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 30)
 speed_print = 30
-speed_topbottom = 40
+speed_topbottom = =math.ceil(speed_print * 40 / 30)
 speed_travel = 200
-speed_wall_0 = 40
+speed_wall_0 = =math.ceil(speed_print * 40 / 30)
 speed_wall_x = =speed_print
 support_angle = 70
 support_type = buildplate

--- a/resources/quality/fabtotum/fabtotum_nylon_normal.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_nylon_normal.inst.cfg
@@ -43,11 +43,11 @@ skirt_brim_minimal_length = 75
 skirt_gap = 1.5
 skirt_line_count = 5
 speed_infill = =speed_print
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 30)
 speed_print = 30
-speed_topbottom = 40
+speed_topbottom = =math.ceil(speed_print * 40 / 30)
 speed_travel = 200
-speed_wall_0 = 40
+speed_wall_0 = =math.ceil(speed_print * 40 / 30)
 speed_wall_x = =speed_print
 support_angle = 70
 support_type = buildplate

--- a/resources/quality/fast.inst.cfg
+++ b/resources/quality/fast.inst.cfg
@@ -14,8 +14,8 @@ global_quality = True
 infill_sparse_density = 10
 layer_height = 0.15
 cool_min_layer_time = 3
-speed_wall_0 = 40
-speed_wall_x = 80
-speed_infill = 100
+speed_wall_0 = =math.ceil(speed_print * 40 / 60)
+speed_wall_x = =math.ceil(speed_print * 80 / 60)
+speed_infill = =math.ceil(speed_print * 100 / 60)
 wall_thickness = 1
-speed_topbottom = 30
+speed_topbottom = =math.ceil(speed_print * 30 / 60)

--- a/resources/quality/high.inst.cfg
+++ b/resources/quality/high.inst.cfg
@@ -12,5 +12,5 @@ global_quality = True
 
 [values]
 layer_height = 0.06
-speed_topbottom = 15
-speed_infill = 80
+speed_topbottom = =math.ceil(speed_print * 15 / 60)
+speed_infill = =math.ceil(speed_print * 80 / 60)

--- a/resources/quality/imade3d_jellybox/generic_petg_0.4_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_petg_0.4_coarse.inst.cfg
@@ -43,13 +43,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 25
 skirt_line_count = 2
-speed_layer_0 = 14
+speed_layer_0 = =math.ceil(speed_print * 14 / 40)
 speed_print = 40
 speed_slowdown_layers = 1
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 40)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 40)
+speed_wall_x = =math.ceil(speed_print * 35 / 40)
 top_thickness = =top_bottom_thickness
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_petg_0.4_coarse_2-fans.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_petg_0.4_coarse_2-fans.inst.cfg
@@ -43,13 +43,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 25
 skirt_line_count = 2
-speed_layer_0 = 14
+speed_layer_0 = =math.ceil(speed_print * 14 / 40)
 speed_print = 40
 speed_slowdown_layers = 1
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 40)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 40)
+speed_wall_x = =math.ceil(speed_print * 35 / 40)
 top_thickness = =top_bottom_thickness
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_petg_0.4_medium.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_petg_0.4_medium.inst.cfg
@@ -43,13 +43,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 25
 skirt_line_count = 2
-speed_layer_0 = 14
+speed_layer_0 = =math.ceil(speed_print * 14 / 40)
 speed_print = 40
 speed_slowdown_layers = 1
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 40)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 40)
+speed_wall_x = =math.ceil(speed_print * 35 / 40)
 top_thickness = =top_bottom_thickness
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_petg_0.4_medium_2-fans.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_petg_0.4_medium_2-fans.inst.cfg
@@ -43,13 +43,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 25
 skirt_line_count = 2
-speed_layer_0 = 14
+speed_layer_0 = =math.ceil(speed_print * 14 / 40)
 speed_print = 40
 speed_slowdown_layers = 1
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 40)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 40)
+speed_wall_x = =math.ceil(speed_print * 35 / 40)
 top_thickness = =top_bottom_thickness
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_pla_0.4_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_pla_0.4_coarse.inst.cfg
@@ -41,13 +41,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 20
 skirt_line_count = 3
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_slowdown_layers = 1
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 45)
+speed_wall_x = =math.ceil(speed_print * 35 / 45)
 top_thickness = 0.8
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_pla_0.4_coarse_2-fans.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_pla_0.4_coarse_2-fans.inst.cfg
@@ -41,13 +41,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 20
 skirt_line_count = 3
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_slowdown_layers = 1
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 45)
+speed_wall_x = =math.ceil(speed_print * 35 / 45)
 top_thickness = 0.8
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_pla_0.4_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_pla_0.4_fine.inst.cfg
@@ -42,13 +42,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 20
 skirt_line_count = 3
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_slowdown_layers = 1
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 45)
+speed_wall_x = =math.ceil(speed_print * 35 / 45)
 top_thickness = 0.8
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_pla_0.4_fine_2-fans.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_pla_0.4_fine_2-fans.inst.cfg
@@ -42,13 +42,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 20
 skirt_line_count = 3
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_slowdown_layers = 1
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 45)
+speed_wall_x = =math.ceil(speed_print * 35 / 45)
 top_thickness = 0.8
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_pla_0.4_medium.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_pla_0.4_medium.inst.cfg
@@ -41,13 +41,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 20
 skirt_line_count = 3
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_slowdown_layers = 1
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 45)
+speed_wall_x = =math.ceil(speed_print * 35 / 45)
 top_thickness = 0.8
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_pla_0.4_medium_2-fans.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_pla_0.4_medium_2-fans.inst.cfg
@@ -41,13 +41,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 20
 skirt_line_count = 3
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_slowdown_layers = 1
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 45)
+speed_wall_x = =math.ceil(speed_print * 35 / 45)
 top_thickness = 0.8
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_pla_0.4_ultrafine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_pla_0.4_ultrafine.inst.cfg
@@ -43,13 +43,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 20
 skirt_line_count = 3
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_slowdown_layers = 1
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 45)
+speed_wall_x = =math.ceil(speed_print * 35 / 45)
 top_thickness = 0.8
 wall_thickness = 0.8

--- a/resources/quality/imade3d_jellybox/generic_pla_0.4_ultrafine_2-fans.inst.cfg
+++ b/resources/quality/imade3d_jellybox/generic_pla_0.4_ultrafine_2-fans.inst.cfg
@@ -43,13 +43,13 @@ skin_no_small_gaps_heuristic = False
 skirt_brim_minimal_length = 100
 skirt_brim_speed = 20
 skirt_line_count = 3
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_slowdown_layers = 1
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
 speed_travel = 120
 speed_travel_layer_0 = 60
-speed_wall = 25
-speed_wall_x = 35
+speed_wall = =math.ceil(speed_print * 25 / 45)
+speed_wall_x = =math.ceil(speed_print * 35 / 45)
 top_thickness = 0.8
 wall_thickness = 0.8

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_draft.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_draft.inst.cfg
@@ -15,11 +15,11 @@ layer_height = 0.35
 layer_height_0 = 0.3
 
 speed_print = 70
-speed_infill = 60
-speed_layer_0 = 20
-speed_wall_0 = 30
-speed_wall_x = 50
-speed_topbottom = 30
+speed_infill = =math.ceil(speed_print * 60 / 70)
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
+speed_wall_0 = =math.ceil(speed_print * 30 / 70)
+speed_wall_x = =math.ceil(speed_print * 50 / 70)
+speed_topbottom = =math.ceil(speed_print * 30 / 70)
 speed_travel = 120
 
 material_print_temperature = 246

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_extra_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_extra_fine.inst.cfg
@@ -15,11 +15,11 @@ layer_height = 0.06
 layer_height_0 = 0.3
 
 speed_print = 40
-speed_infill = 50
-speed_layer_0 = 15
-speed_wall_0 = 20
-speed_wall_x = 40
-speed_topbottom = 20
+speed_infill = =math.ceil(speed_print * 50 / 40)
+speed_layer_0 = =math.ceil(speed_print * 15 / 40)
+speed_wall_0 = =math.ceil(speed_print * 20 / 40)
+speed_wall_x = =speed_print
+speed_topbottom = =math.ceil(speed_print * 20 / 40)
 speed_travel = 120
 
 material_print_temperature = 246

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_fine.inst.cfg
@@ -15,11 +15,11 @@ layer_height = 0.1
 layer_height_0 = 0.3
 
 speed_print = 50
-speed_infill = 60
-speed_layer_0 = 20
-speed_wall_0 = 25
-speed_wall_x = 45
-speed_topbottom = 30
+speed_infill = =math.ceil(speed_print * 60 / 50)
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
+speed_wall_0 = =math.ceil(speed_print * 25 / 50)
+speed_wall_x = =math.ceil(speed_print * 45 / 50)
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_travel = 120
 
 material_print_temperature = 246

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_low.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_low.inst.cfg
@@ -15,11 +15,11 @@ layer_height = 0.2
 layer_height_0 = 0.3
 
 speed_print = 70
-speed_infill = 60
-speed_layer_0 = 20
-speed_wall_0 = 30
-speed_wall_x = 50
-speed_topbottom = 30
+speed_infill = =math.ceil(speed_print * 60 / 70)
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
+speed_wall_0 = =math.ceil(speed_print * 30 / 70)
+speed_wall_x = =math.ceil(speed_print * 50 / 70)
+speed_topbottom = =math.ceil(speed_print * 30 / 70)
 speed_travel = 120
 
 material_print_temperature = 246

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_normal.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_normal.inst.cfg
@@ -15,11 +15,11 @@ layer_height = 0.15
 layer_height_0 = 0.3
 
 speed_print = 60
-speed_infill = 50
-speed_layer_0 = 15
-speed_wall_0 = 20
-speed_wall_x = 40
-speed_topbottom = 20
+speed_infill = =math.ceil(speed_print * 50 / 60)
+speed_layer_0 = =math.ceil(speed_print * 15 / 60)
+speed_wall_0 = =math.ceil(speed_print * 20 / 60)
+speed_wall_x = =math.ceil(speed_print * 40 / 60)
+speed_topbottom = =math.ceil(speed_print * 20 / 60)
 speed_travel = 120
 
 material_print_temperature = 246

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_extra_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_extra_fine.inst.cfg
@@ -15,11 +15,11 @@ layer_height = 0.06
 adhesion_type = skirt
 
 speed_print = 40
-speed_infill = 50
-speed_layer_0 = 15
-speed_wall_0 = 20
-speed_wall_x = 40
-speed_topbottom = 20
+speed_infill = =math.ceil(speed_print * 50 / 40)
+speed_layer_0 = =math.ceil(speed_print * 15 / 40)
+speed_wall_0 = =math.ceil(speed_print * 20 / 40)
+speed_wall_x = =speed_print
+speed_topbottom = =math.ceil(speed_print * 20 / 40)
 speed_travel = 120
 
 material_print_temperature = 214

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_fine.inst.cfg
@@ -15,11 +15,11 @@ layer_height = 0.1
 adhesion_type = skirt
 
 speed_print = 50
-speed_infill = 60
-speed_layer_0 = 20
-speed_wall_0 = 25
-speed_wall_x = 45
-speed_topbottom = 30
+speed_infill = =math.ceil(speed_print * 60 / 50)
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
+speed_wall_0 = =math.ceil(speed_print * 25 / 50)
+speed_wall_x = =math.ceil(speed_print * 45 / 50)
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_travel = 120
 
 material_print_temperature = 214

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_normal.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_normal.inst.cfg
@@ -15,11 +15,11 @@ layer_height = 0.15
 adhesion_type = skirt
 
 speed_print = 60
-speed_infill = 50
-speed_layer_0 = 15
-speed_wall_0 = 20
-speed_wall_x = 40
-speed_topbottom = 20
+speed_infill = =math.ceil(speed_print * 50 / 60)
+speed_layer_0 = =math.ceil(speed_print * 15 / 60)
+speed_wall_0 = =math.ceil(speed_print * 20 / 60)
+speed_wall_x = =math.ceil(speed_print * 40 / 60)
+speed_topbottom = =math.ceil(speed_print * 20 / 60)
 speed_travel = 120
 
 material_print_temperature = 214

--- a/resources/quality/malyan_m200/malyan_m200_global_Draft_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_Draft_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/malyan_m200/malyan_m200_global_Fast_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_Fast_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/malyan_m200/malyan_m200_global_High_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_High_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/malyan_m200/malyan_m200_global_Normal_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_Normal_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/malyan_m200/malyan_m200_global_SuperDraft_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_SuperDraft_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/malyan_m200/malyan_m200_global_ThickerDraft_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_ThickerDraft_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/malyan_m200/malyan_m200_global_Ultra_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_Ultra_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/malyan_m200/malyan_m200_global_VeryDraft_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_VeryDraft_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Draft_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Draft_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Fast_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Fast_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_High_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_High_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Normal_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Normal_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_SuperDraft_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_SuperDraft_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_ThickerDraft_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_ThickerDraft_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Ultra_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Ultra_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_VeryDraft_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_VeryDraft_Quality.inst.cfg
@@ -18,6 +18,6 @@ top_bottom_thickness = 0.72
 infill_sparse_density = 22
 speed_print = 50
 speed_layer_0 = =round(speed_print * 30 / 50)
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 cool_min_layer_time = 5
 cool_min_speed = 10

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_draft.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_draft.inst.cfg
@@ -14,13 +14,13 @@ brim_width = 4.0
 infill_pattern = zigzag
 layer_height = 0.3
 material_diameter = 1.75
-speed_infill = 50
+speed_infill = =speed_print
 speed_print = 50
 speed_support = 30
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 speed_travel = 100
-speed_wall = 50
-speed_wall_x = 50
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 support_angle = 60
 support_enable = True
 support_interface_enable = True

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_high.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_high.inst.cfg
@@ -14,13 +14,13 @@ brim_width = 4.0
 infill_pattern = zigzag
 layer_height = 0.1
 material_diameter = 1.75
-speed_infill = 50
+speed_infill = =speed_print
 speed_print = 50
 speed_support = 30
-speed_topbottom = 15
+speed_topbottom = =math.ceil(speed_print * 15 / 50)
 speed_travel = 100
-speed_wall = 50
-speed_wall_x = 50
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 support_angle = 60
 support_enable = True
 support_interface_enable = True

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_normal.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_normal.inst.cfg
@@ -14,13 +14,13 @@ brim_width = 4.0
 infill_pattern = zigzag
 layer_height = 0.2
 material_diameter = 1.75
-speed_infill = 60
+speed_infill = =math.ceil(speed_print * 60 / 50)
 speed_print = 50
 speed_support = 30
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 speed_travel = 100
-speed_wall = 50
-speed_wall_x = 50
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 support_angle = 60
 support_enable = True
 support_interface_enable = True

--- a/resources/quality/ultimaker2/um2_fast.inst.cfg
+++ b/resources/quality/ultimaker2/um2_fast.inst.cfg
@@ -14,8 +14,8 @@ global_quality = True
 infill_sparse_density = 10
 layer_height = 0.15
 cool_min_layer_time = 3
-speed_wall_0 = 40
-speed_wall_x = 80
-speed_infill = 100
+speed_wall_0 = =math.ceil(speed_print * 40 / 60)
+speed_wall_x = =math.ceil(speed_print * 80 / 60)
+speed_infill = =math.ceil(speed_print * 100 / 60)
 wall_thickness = 1
-speed_topbottom = 30
+speed_topbottom = =math.ceil(speed_print * 30 / 60)

--- a/resources/quality/ultimaker2/um2_high.inst.cfg
+++ b/resources/quality/ultimaker2/um2_high.inst.cfg
@@ -12,5 +12,5 @@ global_quality = True
 
 [values]
 layer_height = 0.06
-speed_topbottom = 15
-speed_infill = 80
+speed_topbottom = =math.ceil(speed_print * 15 / 60)
+speed_infill = =math.ceil(speed_print * 80 / 60)

--- a/resources/quality/ultimaker2_plus/pla_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_fast.inst.cfg
@@ -18,8 +18,8 @@ infill_sparse_density = 18
 layer_height = 0.15
 speed_layer_0 = =round(speed_print * 30 / 60)
 speed_print = 60
-speed_topbottom = 30
+speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_travel = 150
-speed_wall = 50
+speed_wall = =math.ceil(speed_print * 50 / 60)
 top_bottom_thickness = 0.75
 wall_thickness = 0.7

--- a/resources/quality/ultimaker2_plus/pla_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_high.inst.cfg
@@ -18,6 +18,6 @@ infill_sparse_density = 22
 layer_height = 0.06
 speed_layer_0 = =round(speed_print * 30 / 50)
 speed_print = 50
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 top_bottom_thickness = 0.72
 wall_thickness = 1.05

--- a/resources/quality/ultimaker2_plus/pla_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_normal.inst.cfg
@@ -18,6 +18,6 @@ infill_sparse_density = 20
 layer_height = 0.1
 speed_layer_0 = =round(speed_print * 30 / 50)
 speed_print = 50
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 50)
 top_bottom_thickness = 0.8
 wall_thickness = 1.05

--- a/resources/quality/ultimaker2_plus/pla_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.6_normal.inst.cfg
@@ -18,8 +18,8 @@ infill_sparse_density = 20
 layer_height = 0.15
 speed_layer_0 = =round(speed_print * 30 / 55)
 speed_print = 55
-speed_topbottom = 20
-speed_wall = 40
-speed_wall_0 = 25
+speed_topbottom = =math.ceil(speed_print * 20 / 55)
+speed_wall = =math.ceil(speed_print * 40 / 55)
+speed_wall_0 = =math.ceil(speed_print * 25 / 55)
 top_bottom_thickness = 1.2
 wall_thickness = 1.59

--- a/resources/quality/ultimaker2_plus/pla_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.8_normal.inst.cfg
@@ -18,6 +18,6 @@ infill_sparse_density = 20
 layer_height = 0.2
 speed_layer_0 = =round(speed_print * 30 / 40)
 speed_print = 40
-speed_wall_0 = 25
+speed_wall_0 = =math.ceil(speed_print * 25 / 40)
 top_bottom_thickness = 1.2
 wall_thickness = 2.1

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_fast.inst.cfg
@@ -20,8 +20,11 @@ infill_sparse_density = 18
 layer_height = 0.15
 speed_layer_0 = =round(speed_print * 30 / 55)
 speed_print = 55
-speed_topbottom = 30
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
 speed_travel = 150
-speed_wall = 40
+speed_wall = =math.ceil(speed_print * 40 / 55)
 top_bottom_thickness = 0.75
 wall_thickness = 0.7
+speed_wall_0 = =math.ceil(speed_print * 40 / 55)
+speed_wall_x = =math.ceil(speed_print * 80 / 55)
+speed_infill = =math.ceil(speed_print * 100 / 55)

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_high.inst.cfg
@@ -20,6 +20,8 @@ infill_sparse_density = 22
 layer_height = 0.06
 speed_layer_0 = =round(speed_print * 30 / 45)
 speed_print = 45
-speed_wall = 30
+speed_wall = =math.ceil(speed_print * 30 / 45)
 top_bottom_thickness = 0.72
 wall_thickness = 1.05
+speed_topbottom = =math.ceil(speed_print * 15 / 45)
+speed_infill = =math.ceil(speed_print * 80 / 45)

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_normal.inst.cfg
@@ -20,6 +20,6 @@ infill_sparse_density = 20
 layer_height = 0.1
 speed_layer_0 = =round(speed_print * 30 / 45)
 speed_print = 45
-speed_wall = 30
+speed_wall = =math.ceil(speed_print * 30 / 45)
 top_bottom_thickness = 0.8
 wall_thickness = 1.05

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.6_normal.inst.cfg
@@ -18,7 +18,7 @@ cool_min_layer_time_fan_speed_max = 20
 cool_min_speed = 20
 infill_sparse_density = 20
 layer_height = 0.15
-speed_infill = 55
+speed_infill = =math.ceil(speed_print * 55 / 40)
 speed_layer_0 = =round(speed_print * 30 / 40)
 speed_print = 40
 top_bottom_thickness = 1.2

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_fast.inst.cfg
@@ -21,6 +21,10 @@ layer_height = 0.15
 speed_layer_0 = =round(speed_print * 30 / 45)
 speed_print = 45
 speed_travel = 150
-speed_wall = 40
+speed_wall = =math.ceil(speed_print * 40 / 45)
 top_bottom_thickness = 0.75
 wall_thickness = 0.7
+speed_wall_0 = =math.ceil(speed_print * 40 / 45)
+speed_topbottom = =math.ceil(speed_print * 30 / 45)
+speed_wall_x = =math.ceil(speed_print * 80 / 45)
+speed_infill = =math.ceil(speed_print * 100 / 45)

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_high.inst.cfg
@@ -20,6 +20,8 @@ infill_sparse_density = 22
 layer_height = 0.06
 speed_layer_0 = =round(speed_print * 30 / 45)
 speed_print = 45
-speed_wall = 30
+speed_wall = =math.ceil(speed_print * 30 / 45)
 top_bottom_thickness = 0.72
 wall_thickness = 1.05
+speed_topbottom = =math.ceil(speed_print * 15 / 45)
+speed_infill = =math.ceil(speed_print * 80 / 45)

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_normal.inst.cfg
@@ -20,6 +20,6 @@ infill_sparse_density = 20
 layer_height = 0.1
 speed_layer_0 = =round(speed_print * 30 / 45)
 speed_print = 45
-speed_wall = 30
+speed_wall = =math.ceil(speed_print * 30 / 45)
 top_bottom_thickness = 0.8
 wall_thickness = 1.05

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.4_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.4_draft.inst.cfg
@@ -29,11 +29,11 @@ raft_interface_line_spacing = 1
 raft_interface_line_width = 0.8
 raft_margin = 15
 raft_surface_line_width = 0.38
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
-speed_topbottom = 20
-speed_wall_0 = 20
-speed_wall_x = 25
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
+speed_wall_0 = =math.ceil(speed_print * 20 / 25)
+speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
 support_infill_rate = 20

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.4_normal.inst.cfg
@@ -29,11 +29,11 @@ raft_interface_line_spacing = 1
 raft_interface_line_width = 0.8
 raft_margin = 15
 raft_surface_line_width = 0.38
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 35)
 speed_print = 35
-speed_topbottom = 20
-speed_wall_0 = 20
-speed_wall_x = 30
+speed_topbottom = =math.ceil(speed_print * 20 / 35)
+speed_wall_0 = =math.ceil(speed_print * 20 / 35)
+speed_wall_x = =math.ceil(speed_print * 30 / 35)
 support_angle = 45
 support_enable = True
 support_infill_rate = 20

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.6_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.6_draft.inst.cfg
@@ -32,10 +32,10 @@ raft_surface_line_width = 0.57
 raft_surface_thickness = 0.2
 speed_layer_0 = =round(speed_print * 30 / 50)
 speed_print = 25
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
 speed_travel = 150
-speed_wall_0 = 20
-speed_wall_x = 25
+speed_wall_0 = =math.ceil(speed_print * 20 / 25)
+speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
 support_infill_rate = 20

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.6_normal.inst.cfg
@@ -30,12 +30,12 @@ raft_interface_line_width = 1.2
 raft_margin = 15
 raft_surface_line_width = 0.57
 raft_surface_thickness = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 35)
 speed_print = 35
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 35)
 speed_travel = 150
-speed_wall_0 = 30
-speed_wall_x = 35
+speed_wall_0 = =math.ceil(speed_print * 30 / 35)
+speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
 support_infill_rate = 20

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.8_draft.inst.cfg
@@ -30,9 +30,9 @@ raft_surface_line_width = 0.7
 raft_surface_thickness = 0.2
 speed_layer_0 = =round(speed_print * 30 / 25)
 speed_print = 25
-speed_topbottom = 20
-speed_wall_0 = 20
-speed_wall_x = 25
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
+speed_wall_0 = =math.ceil(speed_print * 20 / 25)
+speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
 support_infill_rate = 20

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.8_normal.inst.cfg
@@ -30,9 +30,9 @@ raft_surface_line_width = 0.7
 raft_surface_thickness = 0.2
 speed_layer_0 = =round(speed_print * 30 / 30)
 speed_print = 30
-speed_topbottom = 20
-speed_wall_0 = 20
-speed_wall_x = 30
+speed_topbottom = =math.ceil(speed_print * 20 / 30)
+speed_wall_0 = =math.ceil(speed_print * 20 / 30)
+speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
 support_infill_rate = 20

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.25_high.inst.cfg
@@ -28,13 +28,13 @@ raft_interface_line_width = 0.5
 raft_margin = 15
 raft_surface_line_width = 0.2
 retraction_hop_enabled = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 40)
 speed_print = 40
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 40)
 speed_travel = 150
-speed_wall_0 = 20
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 20 / 40)
+speed_wall_x = =speed_print
 support_enable = True
 support_infill_rate = 20
 support_pattern = lines
@@ -42,3 +42,4 @@ support_xy_distance = 0.6
 support_z_distance = =layer_height * 2
 top_bottom_thickness = 1.2
 wall_thickness = 1
+speed_infill = =math.ceil(speed_print * 80 / 40)

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.25_normal.inst.cfg
@@ -28,13 +28,13 @@ raft_interface_line_width = 0.5
 raft_margin = 15
 raft_surface_line_width = 0.2
 retraction_hop_enabled = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 40)
 speed_print = 40
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 40)
 speed_travel = 150
-speed_wall_0 = 20
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 20 / 40)
+speed_wall_x = =speed_print
 support_enable = True
 support_infill_rate = 20
 support_pattern = lines

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.4_fast.inst.cfg
@@ -28,11 +28,11 @@ raft_interface_line_width = 0.8
 raft_margin = 15
 raft_surface_line_width = 0.5
 raft_surface_thickness = 0.15
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 45)
 speed_print = 45
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 45)
 speed_travel = 150
-speed_wall = 40
+speed_wall = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
 support_infill_rate = 25
@@ -41,3 +41,6 @@ support_xy_distance = 0.6
 support_z_distance = =layer_height * 2
 top_bottom_thickness = 0.75
 wall_thickness = 1.06
+speed_wall_0 = =math.ceil(speed_print * 40 / 45)
+speed_wall_x = =math.ceil(speed_print * 80 / 45)
+speed_infill = =math.ceil(speed_print * 100 / 45)

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.4_normal.inst.cfg
@@ -28,10 +28,10 @@ raft_interface_line_width = 0.8
 raft_margin = 15
 raft_surface_line_width = 0.5
 raft_surface_thickness = 0.15
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 45)
 speed_print = 45
 speed_travel = 150
-speed_wall = 40
+speed_wall = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
 support_infill_rate = 25

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.6_fast.inst.cfg
@@ -29,13 +29,13 @@ raft_margin = 15
 raft_surface_line_width = 0.6
 raft_surface_thickness = 0.15
 retraction_hop_enabled = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 55)
 speed_print = 55
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 55)
 speed_travel = 150
-speed_wall_0 = 15
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 15 / 55)
+speed_wall_x = =math.ceil(speed_print * 40 / 55)
 support_angle = 45
 support_bottom_distance = 0.55
 support_enable = True
@@ -46,3 +46,4 @@ support_xy_distance = 0.7
 support_z_distance = =layer_height * 2
 top_bottom_thickness = 1.2
 wall_thickness = 1.2
+speed_infill = =math.ceil(speed_print * 100 / 55)

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.6_normal.inst.cfg
@@ -29,13 +29,13 @@ raft_margin = 15
 raft_surface_line_width = 0.6
 raft_surface_thickness = 0.15
 retraction_hop_enabled = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 55)
 speed_print = 55
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 55)
 speed_travel = 150
-speed_wall_0 = 15
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 15 / 55)
+speed_wall_x = =math.ceil(speed_print * 40 / 55)
 support_angle = 45
 support_enable = True
 support_infill_rate = 25

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.8_draft.inst.cfg
@@ -28,13 +28,13 @@ raft_margin = 15
 raft_surface_line_width = 0.7
 raft_surface_thickness = 0.2
 retraction_hop_enabled = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 55)
 speed_print = 55
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 55)
 speed_travel = 150
-speed_wall_0 = 15
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 15 / 55)
+speed_wall_x = =math.ceil(speed_print * 40 / 55)
 support_angle = 45
 support_bottom_distance = 0.65
 support_enable = True

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.8_normal.inst.cfg
@@ -31,10 +31,10 @@ retraction_hop_enabled = 0.2
 speed_layer_0 = =round(speed_print * 30 / 55)
 speed_print = 55
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 55)
 speed_travel = 150
-speed_wall_0 = 15
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 15 / 55)
+speed_wall_x = =math.ceil(speed_print * 40 / 55)
 support_angle = 45
 support_bottom_distance = 0.65
 support_enable = True

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.25_high.inst.cfg
@@ -36,3 +36,5 @@ support_infill_rate = 20
 support_pattern = lines
 support_z_distance = 0.19
 wall_thickness = 0.88
+speed_topbottom = =math.ceil(speed_print * 15 / 30)
+speed_infill = =math.ceil(speed_print * 80 / 30)

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.4_fast.inst.cfg
@@ -29,11 +29,13 @@ raft_interface_line_width = 0.8
 raft_margin = 15
 speed_layer_0 = =round(speed_print * 30 / 45)
 speed_print = 45
-speed_wall_0 = 20
-speed_wall_x = 30
+speed_wall_0 = =math.ceil(speed_print * 20 / 45)
+speed_wall_x = =math.ceil(speed_print * 30 / 45)
 support_angle = 45
 support_enable = True
 support_infill_rate = 20
 support_pattern = lines
 support_z_distance = 0.19
 wall_thickness = 1.2
+speed_topbottom = =math.ceil(speed_print * 30 / 45)
+speed_infill = =math.ceil(speed_print * 100 / 45)

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.4_normal.inst.cfg
@@ -29,8 +29,8 @@ raft_interface_line_width = 0.8
 raft_margin = 15
 speed_layer_0 = =round(speed_print * 30 / 45)
 speed_print = 45
-speed_wall_0 = 20
-speed_wall_x = 30
+speed_wall_0 = =math.ceil(speed_print * 20 / 45)
+speed_wall_x = =math.ceil(speed_print * 30 / 45)
 support_angle = 45
 support_enable = True
 support_infill_rate = 20

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.6_fast.inst.cfg
@@ -29,12 +29,12 @@ raft_interface_line_width = 1.2
 raft_margin = 15
 raft_surface_line_width = 0.6
 raft_surface_thickness = 0.15
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 45)
 speed_print = 45
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 45)
 speed_travel = 150
-speed_wall_0 = 30
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 30 / 45)
+speed_wall_x = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
 support_infill_rate = 20
@@ -43,3 +43,4 @@ support_pattern = lines
 support_z_distance = 0.21
 top_bottom_thickness = 0.75
 wall_thickness = 1.06
+speed_infill = =math.ceil(speed_print * 100 / 45)

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.6_normal.inst.cfg
@@ -29,12 +29,12 @@ raft_interface_line_width = 1.2
 raft_margin = 15
 raft_surface_line_width = 0.6
 raft_surface_thickness = 0.15
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 45)
 speed_print = 45
-speed_topbottom = 20
+speed_topbottom = =math.ceil(speed_print * 20 / 45)
 speed_travel = 150
-speed_wall_0 = 30
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 30 / 45)
+speed_wall_x = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
 support_infill_rate = 20

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.4_fast.inst.cfg
@@ -50,7 +50,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.5
 retraction_prime_speed = 15
 skin_overlap = 10
-speed_layer_0 = 25
+speed_layer_0 = =speed_print
 speed_prime_tower = =speed_topbottom
 speed_print = 25
 speed_support_interface = =speed_topbottom
@@ -69,3 +69,5 @@ travel_avoid_distance = 3
 wall_0_inset = 0
 wall_line_width_x = =round(line_width * 0.38 / 0.38, 2)
 wall_thickness = 0.76
+speed_wall_x = =math.ceil(speed_print * 80 / 25)
+speed_infill = =math.ceil(speed_print * 100 / 25)

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.4_normal.inst.cfg
@@ -49,7 +49,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.5
 retraction_prime_speed = 15
 skin_overlap = 10
-speed_layer_0 = 25
+speed_layer_0 = =speed_print
 speed_prime_tower = =speed_topbottom
 speed_print = 25
 speed_support_interface = =speed_topbottom

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.6_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.6_draft.inst.cfg
@@ -50,7 +50,7 @@ retraction_hop_only_when_collides = True
 retraction_prime_speed = 15
 skin_overlap = 10
 skirt_brim_line_width = 0.6
-speed_layer_0 = 25
+speed_layer_0 = =speed_print
 speed_prime_tower = =speed_topbottom
 speed_print = 25
 speed_support_interface = =speed_topbottom

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.6_fast.inst.cfg
@@ -50,7 +50,7 @@ retraction_hop_only_when_collides = True
 retraction_prime_speed = 15
 skin_overlap = 10
 skirt_brim_line_width = 0.6
-speed_layer_0 = 25
+speed_layer_0 = =speed_print
 speed_prime_tower = =speed_topbottom
 speed_print = 25
 speed_support_interface = =speed_topbottom
@@ -70,3 +70,5 @@ travel_avoid_distance = 3
 wall_0_inset = 0
 wall_line_width_x = =round(line_width * 0.57 / 0.57, 2)
 wall_thickness = 1.14
+speed_wall_x = =math.ceil(speed_print * 80 / 25)
+speed_infill = =math.ceil(speed_print * 100 / 25)

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.8_draft.inst.cfg
@@ -50,7 +50,7 @@ retraction_hop_only_when_collides = True
 retraction_prime_speed = 15
 skin_overlap = 10
 skirt_brim_line_width = 0.8
-speed_layer_0 = 25
+speed_layer_0 = =speed_print
 speed_prime_tower = =speed_topbottom
 speed_print = 25
 speed_support_interface = =speed_topbottom

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.8_verydraft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.8_verydraft.inst.cfg
@@ -50,7 +50,7 @@ retraction_hop_only_when_collides = True
 retraction_prime_speed = 15
 skin_overlap = 10
 skirt_brim_line_width = 0.8
-speed_layer_0 = 25
+speed_layer_0 = =speed_print
 speed_prime_tower = =speed_topbottom
 speed_print = 25
 speed_support_interface = =speed_topbottom

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.25_high.inst.cfg
@@ -27,13 +27,13 @@ raft_interface_line_spacing = 1
 raft_interface_line_width = 0.2
 raft_surface_line_width = 0.2
 retraction_hop_enabled = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 40)
 speed_print = 40
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 40)
 speed_travel = 150
-speed_wall_0 = 15
-speed_wall_x = 38
+speed_wall_0 = =math.ceil(speed_print * 15 / 40)
+speed_wall_x = =math.ceil(speed_print * 38 / 40)
 support_angle = 45
 support_enable = True
 support_infill_rate = 25
@@ -41,3 +41,4 @@ support_xy_distance = 0.6
 support_z_distance = =layer_height * 2
 top_bottom_thickness = 1.2
 wall_thickness = 0.88
+speed_infill = =math.ceil(speed_print * 80 / 40)

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.4_normal.inst.cfg
@@ -24,13 +24,13 @@ raft_base_line_width = 0.8
 raft_interface_line_spacing = 1
 raft_margin = 12
 retraction_hop_enabled = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 40)
 speed_print = 40
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 40)
 speed_travel = 150
-speed_wall_0 = 20
-speed_wall_x = 35
+speed_wall_0 = =math.ceil(speed_print * 20 / 40)
+speed_wall_x = =math.ceil(speed_print * 35 / 40)
 support_angle = 45
 support_enable = True
 support_infill_rate = 25

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.6_fast.inst.cfg
@@ -29,13 +29,13 @@ raft_interface_line_width = 0.57
 raft_margin = 15
 raft_surface_line_width = 0.5
 retraction_hop_enabled = 0.2
-speed_layer_0 = 30
+speed_layer_0 = =math.ceil(speed_print * 30 / 45)
 speed_print = 45
 speed_support = 40
-speed_topbottom = 35
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
 speed_travel = 150
-speed_wall_0 = 15
-speed_wall_x = 40
+speed_wall_0 = =math.ceil(speed_print * 15 / 45)
+speed_wall_x = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
 support_infill_rate = 25
@@ -43,3 +43,4 @@ support_xy_distance = 0.7
 support_z_distance = =layer_height * 2
 top_bottom_thickness = 1.2
 wall_thickness = 1.14
+speed_infill = =math.ceil(speed_print * 100 / 45)

--- a/resources/quality/ultimaker3/um3_aa0.25_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_CPE_Normal_Quality.inst.cfg
@@ -16,7 +16,7 @@ prime_tower_purge_volume = 1
 prime_tower_size = 12
 prime_tower_wall_thickness = 0.9
 retraction_extrusion_window = 0.5
-speed_infill = 40
+speed_infill = =math.ceil(speed_print * 40 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 top_bottom_thickness = 0.8
 wall_thickness = 0.92

--- a/resources/quality/ultimaker3/um3_aa0.25_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_PC_Normal_Quality.inst.cfg
@@ -38,9 +38,9 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_travel = 250
 speed_wall = =math.ceil(speed_print * 40 / 50)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 40)

--- a/resources/quality/ultimaker3/um3_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -24,11 +24,11 @@ material_initial_print_temperature = =max(-273.15, material_print_temperature - 
 material_print_temperature = 190
 retraction_hop = 0.2
 skin_overlap = 5
-speed_layer_0 = 30
+speed_layer_0 = =speed_print
 speed_print = 30
 speed_travel_layer_0 = 120
-speed_wall = 25
-speed_wall_0 = 20
+speed_wall = =math.ceil(speed_print * 25 / 30)
+speed_wall_0 = =math.ceil(speed_print * 20 / 30)
 top_bottom_thickness = 0.72
 travel_avoid_distance = 0.4
 wall_0_inset = 0.015

--- a/resources/quality/ultimaker3/um3_aa0.25_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_PP_Normal_Quality.inst.cfg
@@ -42,7 +42,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 13
 speed_equalize_flow_enabled = True
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
 speed_travel = 300
 speed_travel_layer_0 = 50

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Draft_Print.inst.cfg
@@ -20,7 +20,7 @@ material_final_print_temperature = =material_print_temperature - 10
 prime_tower_enable = False
 skin_overlap = 20
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 35 / 60)
 speed_wall = =math.ceil(speed_print * 45 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 45)

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Fast_Print.inst.cfg
@@ -21,7 +21,7 @@ material_final_print_temperature = =material_print_temperature - 10
 material_standby_temperature = 100
 prime_tower_enable = False
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_wall = =math.ceil(speed_print * 40 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_High_Quality.inst.cfg
@@ -21,6 +21,6 @@ material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
 prime_tower_enable = False
 speed_print = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_wall = =math.ceil(speed_print * 30 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -19,6 +19,6 @@ material_final_print_temperature = =material_print_temperature - 10
 material_standby_temperature = 100
 prime_tower_enable = False
 speed_print = 55
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 speed_wall = =math.ceil(speed_print * 30 / 55)

--- a/resources/quality/ultimaker3/um3_aa0.4_BAM_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_BAM_Draft_Print.inst.cfg
@@ -20,7 +20,7 @@ material_print_temperature = =default_material_print_temperature + 5
 # prime_tower_enable: see CURA-4248
 prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 speed_topbottom = =math.ceil(speed_print * 35 / 70)
 speed_wall = =math.ceil(speed_print * 50 / 70)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.4_BAM_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_BAM_Fast_Print.inst.cfg
@@ -19,7 +19,7 @@ machine_nozzle_heat_up_speed = 1.6
 # prime_tower_enable: see CURA-4248
 prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
 speed_print = 80
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 80)
 speed_topbottom = =math.ceil(speed_print * 30 / 80)
 speed_wall = =math.ceil(speed_print * 40 / 80)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)

--- a/resources/quality/ultimaker3/um3_aa0.4_BAM_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_BAM_Normal_Quality.inst.cfg
@@ -20,7 +20,7 @@ machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 10
 prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
 skin_overlap = 10
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 support_interface_enable = True
 support_interface_density = =min(extruderValues('material_surface_energy'))
 support_interface_pattern = ='lines' if support_interface_density < 100 else 'concentric'

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Draft_Print.inst.cfg
@@ -38,7 +38,7 @@ retraction_hop = 0.2
 retraction_hop_enabled = False
 retraction_hop_only_when_collides = True
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 40 / 50)
 speed_travel = 250

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Fast_Print.inst.cfg
@@ -38,7 +38,7 @@ retraction_hop = 0.2
 retraction_hop_enabled = False
 retraction_hop_only_when_collides = True
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 35 / 45)
 speed_travel = 250

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_High_Quality.inst.cfg
@@ -40,7 +40,7 @@ retraction_hop = 0.2
 retraction_hop_enabled = False
 retraction_hop_only_when_collides = True
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 40)
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 30 / 35)
 speed_travel = 250

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Normal_Quality.inst.cfg
@@ -39,7 +39,7 @@ retraction_hop = 0.2
 retraction_hop_enabled = False
 retraction_hop_only_when_collides = True
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 40)
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 30 / 35)
 speed_travel = 250

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Draft_Print.inst.cfg
@@ -19,7 +19,7 @@ material_standby_temperature = 100
 prime_tower_purge_volume = 1
 skin_overlap = 20
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 35 / 60)
 speed_wall = =math.ceil(speed_print * 45 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 45)

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Fast_Print.inst.cfg
@@ -19,7 +19,7 @@ material_final_print_temperature = =material_print_temperature - 10
 material_standby_temperature = 100
 prime_tower_purge_volume = 1
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_wall = =math.ceil(speed_print * 40 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_High_Quality.inst.cfg
@@ -21,6 +21,6 @@ material_final_print_temperature = =material_print_temperature - 10
 material_standby_temperature = 100
 prime_tower_purge_volume = 1
 speed_print = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_wall = =math.ceil(speed_print * 30 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Normal_Quality.inst.cfg
@@ -19,6 +19,6 @@ material_final_print_temperature = =material_print_temperature - 10
 material_standby_temperature = 100
 prime_tower_purge_volume = 1
 speed_print = 55
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 speed_wall = =math.ceil(speed_print * 30 / 55)

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -29,7 +29,7 @@ raft_jerk = =jerk_layer_0
 raft_margin = 10
 raft_surface_thickness = =round(machine_nozzle_size * 0.2 / 0.4, 2)
 skin_overlap = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -29,7 +29,7 @@ raft_jerk = =jerk_layer_0
 raft_margin = 10
 raft_surface_thickness = =round(machine_nozzle_size * 0.2 / 0.4, 2)
 skin_overlap = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_High_Quality.inst.cfg
@@ -28,7 +28,7 @@ raft_jerk = =jerk_layer_0
 raft_margin = 10
 raft_surface_thickness = =round(machine_nozzle_size * 0.2 / 0.4, 2)
 skin_overlap = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -28,7 +28,7 @@ raft_jerk = =jerk_layer_0
 raft_margin = 10
 raft_surface_thickness = =round(machine_nozzle_size * 0.2 / 0.4, 2)
 skin_overlap = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Draft_Print.inst.cfg
@@ -48,7 +48,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_travel = 250

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Fast_Print.inst.cfg
@@ -47,7 +47,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_travel = 250

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_High_Quality.inst.cfg
@@ -48,7 +48,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_travel = 250

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Normal_Quality.inst.cfg
@@ -45,7 +45,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_travel = 250

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Draft_Print.inst.cfg
@@ -21,7 +21,7 @@ material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 speed_topbottom = =math.ceil(speed_print * 40 / 70)
 speed_wall = =math.ceil(speed_print * 55 / 70)
 speed_wall_0 = =math.ceil(speed_wall * 45 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Fast_Print.inst.cfg
@@ -20,7 +20,7 @@ machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
 prime_tower_enable = False
 speed_print = 80
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 80)
 speed_topbottom = =math.ceil(speed_print * 30 / 80)
 speed_wall = =math.ceil(speed_print * 40 / 80)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_High_Quality.inst.cfg
@@ -23,7 +23,7 @@ material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 10
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_wall = =math.ceil(speed_print * 30 / 60)
 top_bottom_thickness = 1

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -21,6 +21,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 10
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 top_bottom_thickness = 1
 wall_thickness = 1

--- a/resources/quality/ultimaker3/um3_aa0.4_PP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PP_Draft_Print.inst.cfg
@@ -49,7 +49,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 18
 speed_equalize_flow_enabled = True
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_travel = 300

--- a/resources/quality/ultimaker3/um3_aa0.4_PP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PP_Fast_Print.inst.cfg
@@ -48,7 +48,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 18
 speed_equalize_flow_enabled = True
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_travel = 300

--- a/resources/quality/ultimaker3/um3_aa0.4_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PP_Normal_Quality.inst.cfg
@@ -47,7 +47,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 18
 speed_equalize_flow_enabled = True
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_travel = 300

--- a/resources/quality/ultimaker3/um3_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -27,7 +27,7 @@ prime_tower_enable = False
 roofing_layer_count = 2
 skin_outline_count = 0
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_print = 50
 speed_roofing = =math.ceil(speed_wall * 20 / 24)
 speed_topbottom = =math.ceil(speed_print * 25 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -21,7 +21,7 @@ machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
 prime_tower_enable = False
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 35 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)

--- a/resources/quality/ultimaker3/um3_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -23,7 +23,7 @@ material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 10
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 35 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -48,7 +48,7 @@ retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True
-speed_layer_0 = 18
+speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_travel = 300

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -49,7 +49,7 @@ retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True
-speed_layer_0 = 18
+speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_travel = 300

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -46,7 +46,7 @@ retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True
-speed_layer_0 = 18
+speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_travel = 300

--- a/resources/quality/ultimaker3/um3_aa0.8_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPEP_Fast_Print.inst.cfg
@@ -26,7 +26,7 @@ retraction_combing = off
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 15
 speed_topbottom = =math.ceil(speed_print * 35 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.8_CPEP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPEP_Superdraft_Print.inst.cfg
@@ -27,7 +27,7 @@ retraction_combing = off
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 8
 speed_topbottom = =math.ceil(speed_print * 35 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.8_CPEP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPEP_Verydraft_Print.inst.cfg
@@ -27,7 +27,7 @@ retraction_combing = off
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 10
 speed_topbottom = =math.ceil(speed_print * 35 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.8_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PC_Fast_Print.inst.cfg
@@ -22,7 +22,7 @@ material_standby_temperature = 100
 raft_airgap = 0.5
 raft_margin = 15
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 15
 speed_topbottom = =math.ceil(speed_print * 25 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.8_PC_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PC_Superdraft_Print.inst.cfg
@@ -22,7 +22,7 @@ material_standby_temperature = 100
 raft_airgap = 0.5
 raft_margin = 15
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 8
 speed_topbottom = =math.ceil(speed_print * 25 / 50)

--- a/resources/quality/ultimaker3/um3_aa0.8_PC_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PC_Verydraft_Print.inst.cfg
@@ -23,7 +23,7 @@ material_standby_temperature = 100
 raft_airgap = 0.5
 raft_margin = 15
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 10
 speed_topbottom = =math.ceil(speed_print * 25 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_CPE_Normal_Quality.inst.cfg
@@ -15,7 +15,7 @@ variant = AA 0.25
 prime_tower_size = 12
 prime_tower_wall_thickness = 0.9
 retraction_extrusion_window = 0.5
-speed_infill = 40
+speed_infill = =math.ceil(speed_print * 40 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 top_bottom_thickness = 0.8
 wall_thickness = 0.92

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PC_Normal_Quality.inst.cfg
@@ -38,9 +38,9 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 40)
 support_bottom_distance = =support_z_distance

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -24,11 +24,11 @@ material_initial_print_temperature = =max(-273.15, material_print_temperature - 
 material_print_temperature = 190
 retraction_hop = 0.2
 skin_overlap = 5
-speed_layer_0 = 30
+speed_layer_0 = =speed_print
 speed_print = 30
 speed_travel_layer_0 = 120
-speed_wall = 25
-speed_wall_0 = 20
+speed_wall = =math.ceil(speed_print * 25 / 30)
+speed_wall_0 = =math.ceil(speed_print * 20 / 30)
 top_bottom_thickness = 0.72
 travel_avoid_distance = 0.4
 wall_0_inset = 0.015

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PP_Normal_Quality.inst.cfg
@@ -42,7 +42,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 13
 speed_equalize_flow_enabled = True
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
 speed_travel_layer_0 = 50
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Draft_Print.inst.cfg
@@ -20,7 +20,7 @@ material_final_print_temperature = =material_print_temperature - 20
 prime_tower_enable = False
 skin_overlap = 20
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 35 / 60)
 speed_wall = =math.ceil(speed_print * 45 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print.inst.cfg
@@ -20,7 +20,7 @@ material_initial_print_temperature = =material_print_temperature - 15
 material_final_print_temperature = =material_print_temperature - 20
 prime_tower_enable = False
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_wall = =math.ceil(speed_print * 40 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_High_Quality.inst.cfg
@@ -20,7 +20,7 @@ material_initial_print_temperature = =material_print_temperature - 15
 material_final_print_temperature = =material_print_temperature - 20
 prime_tower_enable = False
 speed_print = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_wall = =math.ceil(speed_print * 30 / 50)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -19,7 +19,7 @@ material_initial_print_temperature = =material_print_temperature - 15
 material_final_print_temperature = =material_print_temperature - 20
 prime_tower_enable = False
 speed_print = 55
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 speed_wall = =math.ceil(speed_print * 30 / 55)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Draft_Print.inst.cfg
@@ -20,7 +20,7 @@ material_print_temperature = =default_material_print_temperature + 5
 # prime_tower_enable: see CURA-4248
 prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 speed_topbottom = =math.ceil(speed_print * 35 / 70)
 speed_wall = =math.ceil(speed_print * 50 / 70)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Fast_Print.inst.cfg
@@ -19,7 +19,7 @@ machine_nozzle_heat_up_speed = 1.6
 # prime_tower_enable: see CURA-4248
 prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
 speed_print = 80
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 80)
 speed_topbottom = =math.ceil(speed_print * 30 / 80)
 speed_wall = =math.ceil(speed_print * 40 / 80)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Normal_Quality.inst.cfg
@@ -21,7 +21,7 @@ material_print_temperature = =default_material_print_temperature - 10
 # prime_tower_enable: see CURA-4248
 prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
 skin_overlap = 10
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 support_interface_enable = True
 support_interface_density = =min(extruderValues('material_surface_energy'))
 support_interface_pattern = ='lines' if support_interface_density < 100 else 'concentric'

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Draft_Print.inst.cfg
@@ -35,7 +35,7 @@ retraction_hop = 0.2
 retraction_hop_enabled = False
 retraction_hop_only_when_collides = True
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 40 / 50)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print.inst.cfg
@@ -35,7 +35,7 @@ retraction_hop = 0.2
 retraction_hop_enabled = False
 retraction_hop_only_when_collides = True
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 35 / 45)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_High_Quality.inst.cfg
@@ -37,7 +37,7 @@ retraction_hop = 0.2
 retraction_hop_enabled = False
 retraction_hop_only_when_collides = True
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 40)
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 30 / 35)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality.inst.cfg
@@ -37,7 +37,7 @@ retraction_hop = 0.2
 retraction_hop_enabled = False
 retraction_hop_only_when_collides = True
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 40)
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 30 / 35)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Draft_Print.inst.cfg
@@ -17,7 +17,7 @@ material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
 skin_overlap = 20
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 35 / 60)
 speed_wall = =math.ceil(speed_print * 45 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print.inst.cfg
@@ -17,7 +17,7 @@ material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
 speed_print = 60
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_wall = =math.ceil(speed_print * 40 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_High_Quality.inst.cfg
@@ -19,7 +19,7 @@ material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
 speed_print = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_wall = =math.ceil(speed_print * 30 / 50)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality.inst.cfg
@@ -17,7 +17,7 @@ machine_nozzle_heat_up_speed = 1.5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
 speed_print = 55
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 speed_wall = =math.ceil(speed_print * 30 / 55)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -29,7 +29,7 @@ raft_jerk = =jerk_layer_0
 raft_margin = 10
 raft_surface_thickness = =round(machine_nozzle_size * 0.2 / 0.4, 2)
 skin_overlap = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -29,7 +29,7 @@ raft_jerk = =jerk_layer_0
 raft_margin = 10
 raft_surface_thickness = =round(machine_nozzle_size * 0.2 / 0.4, 2)
 skin_overlap = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_High_Quality.inst.cfg
@@ -28,7 +28,7 @@ raft_jerk = =jerk_layer_0
 raft_margin = 10
 raft_surface_thickness = =round(machine_nozzle_size * 0.2 / 0.4, 2)
 skin_overlap = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -28,7 +28,7 @@ raft_jerk = =jerk_layer_0
 raft_margin = 10
 raft_surface_thickness = =round(machine_nozzle_size * 0.2 / 0.4, 2)
 skin_overlap = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Draft_Print.inst.cfg
@@ -47,9 +47,9 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 40)
 support_bottom_distance = =support_z_distance

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print.inst.cfg
@@ -46,9 +46,9 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
 
 speed_wall = =math.ceil(speed_print * 40 / 50)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_High_Quality.inst.cfg
@@ -47,9 +47,9 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
 
 speed_wall = =math.ceil(speed_print * 40 / 50)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality.inst.cfg
@@ -45,9 +45,9 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 15
 skin_overlap = 30
-speed_layer_0 = 25
+speed_layer_0 = =math.ceil(speed_print * 25 / 50)
 speed_print = 50
-speed_topbottom = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
 
 speed_wall = =math.ceil(speed_print * 40 / 50)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
@@ -20,7 +20,7 @@ material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 speed_topbottom = =math.ceil(speed_print * 40 / 70)
 speed_wall = =math.ceil(speed_print * 55 / 70)
 speed_wall_0 = =math.ceil(speed_wall * 45 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
@@ -19,7 +19,7 @@ machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
 prime_tower_enable = False
 speed_print = 70
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 speed_topbottom = =math.ceil(speed_print * 35 / 70)
 speed_wall = =math.ceil(speed_print * 45 / 70)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 70)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
@@ -22,7 +22,7 @@ material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 10
 speed_print = 50
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_topbottom = =math.ceil(speed_print * 35 / 50)
 speed_wall = =math.ceil(speed_print * 35 / 50)
 top_bottom_thickness = 1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -20,7 +20,7 @@ machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 10
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 70)
 top_bottom_thickness = 1
 wall_thickness = 1
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Draft_Print.inst.cfg
@@ -47,7 +47,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 18
 speed_equalize_flow_enabled = True
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_travel_layer_0 = 50

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Fast_Print.inst.cfg
@@ -47,7 +47,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 18
 speed_equalize_flow_enabled = True
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Normal_Quality.inst.cfg
@@ -47,7 +47,7 @@ retraction_hop_only_when_collides = True
 retraction_min_travel = 0.8
 retraction_prime_speed = 18
 speed_equalize_flow_enabled = True
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -27,7 +27,7 @@ prime_tower_enable = False
 roofing_layer_count = 2
 skin_outline_count = 0
 skin_overlap = 20
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_print = 50
 speed_roofing = =math.ceil(speed_wall * 20 / 24)
 speed_topbottom = =math.ceil(speed_print * 25 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -21,7 +21,7 @@ machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
 prime_tower_enable = False
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 35 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_High_Quality.inst.cfg
@@ -22,7 +22,7 @@ material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 10
 speed_print = 45
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_topbottom = =math.ceil(speed_print * 35 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -23,7 +23,7 @@ material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
 prime_tower_enable = False
 skin_overlap = 10
-speed_layer_0 = 20
+speed_layer_0 = =math.ceil(speed_print * 20 / 45)
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 35 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Draft_Print.inst.cfg
@@ -46,7 +46,7 @@ retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True
-speed_layer_0 = 18
+speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Fast_Print.inst.cfg
@@ -46,7 +46,7 @@ retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True
-speed_layer_0 = 18
+speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -45,7 +45,7 @@ retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 skin_overlap = 5
 speed_equalize_flow_enabled = True
-speed_layer_0 = 18
+speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Fast_Print.inst.cfg
@@ -26,7 +26,7 @@ retraction_combing = off
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 15
 speed_topbottom = =math.ceil(speed_print * 35 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Superdraft_Print.inst.cfg
@@ -26,7 +26,7 @@ retraction_combing = off
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 8
 speed_topbottom = =math.ceil(speed_print * 35 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Verydraft_Print.inst.cfg
@@ -26,7 +26,7 @@ retraction_combing = off
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 10
 speed_topbottom = =math.ceil(speed_print * 35 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Fast_Print.inst.cfg
@@ -22,7 +22,7 @@ material_standby_temperature = 100
 raft_airgap = 0.5
 raft_margin = 15
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 15
 speed_topbottom = =math.ceil(speed_print * 25 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Superdraft_Print.inst.cfg
@@ -21,7 +21,7 @@ material_standby_temperature = 100
 raft_airgap = 0.5
 raft_margin = 15
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 8
 speed_topbottom = =math.ceil(speed_print * 25 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Verydraft_Print.inst.cfg
@@ -22,7 +22,7 @@ material_standby_temperature = 100
 raft_airgap = 0.5
 raft_margin = 15
 skin_overlap = 0
-speed_layer_0 = 15
+speed_layer_0 = =math.ceil(speed_print * 15 / 50)
 speed_print = 50
 speed_slowdown_layers = 10
 speed_topbottom = =math.ceil(speed_print * 25 / 50)

--- a/resources/quality/zyyx/zyyx_agile_pro_flex_fast.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_flex_fast.inst.cfg
@@ -20,8 +20,8 @@ material_print_temperature_layer_0 = 235
 retraction_amount = 1.0
 retraction_speed = 15
 speed_print = 20
-speed_wall = 20
-speed_wall_x = 20
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 adhesion_type = brim
 material_flow = 105
 raft_airgap = 0.2

--- a/resources/quality/zyyx/zyyx_agile_pro_flex_fine.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_flex_fine.inst.cfg
@@ -20,8 +20,8 @@ material_print_temperature_layer_0 = 235
 retraction_amount = 0.2
 retraction_speed = 15
 speed_print = 15
-speed_wall = 15
-speed_wall_x = 15
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 adhesion_type = brim
 material_flow = 105
 raft_airgap = 0.1

--- a/resources/quality/zyyx/zyyx_agile_pro_flex_normal.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_flex_normal.inst.cfg
@@ -20,8 +20,8 @@ material_print_temperature_layer_0 = 235
 retraction_amount = 1.0
 retraction_speed = 15
 speed_print = 20
-speed_wall = 15
-speed_wall_x = 20
+speed_wall = =math.ceil(speed_print * 15 / 20)
+speed_wall_x = =speed_print
 adhesion_type = brim
 material_flow = 105
 raft_airgap = 0.2

--- a/resources/quality/zyyx/zyyx_agile_pro_pla_fast.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_pla_fast.inst.cfg
@@ -20,8 +20,8 @@ material_print_temperature_layer_0 = 225
 retraction_amount = 1.5
 retraction_speed = 20
 speed_print = 40
-speed_wall = 40
-speed_wall_x = 40
+speed_wall = =speed_print
+speed_wall_x = =speed_print
 adhesion_type = brim
 material_flow = 95
 raft_airgap = 0.15

--- a/resources/quality/zyyx/zyyx_agile_pro_pla_fine.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_pla_fine.inst.cfg
@@ -20,8 +20,8 @@ material_print_temperature_layer_0 = 225
 retraction_amount = 0.4
 retraction_speed = 20
 speed_print = 35
-speed_wall = 18
-speed_wall_x = 25
+speed_wall = =math.ceil(speed_print * 18 / 35)
+speed_wall_x = =math.ceil(speed_print * 25 / 35)
 adhesion_type = brim
 material_flow = 95
 raft_airgap = 0.08

--- a/resources/quality/zyyx/zyyx_agile_pro_pla_normal.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_pla_normal.inst.cfg
@@ -20,8 +20,8 @@ material_print_temperature_layer_0 = 225
 retraction_amount = 1.2
 retraction_speed = 20
 speed_print = 50
-speed_wall = 22
-speed_wall_x = 33
+speed_wall = =math.ceil(speed_print * 22 / 50)
+speed_wall_x = =math.ceil(speed_print * 33 / 50)
 adhesion_type = brim
 material_flow = 95
 raft_airgap = 0.15


### PR DESCRIPTION
also adds necessary settings for um2p if the setting is also defined in ultimaker2. 

i.e. in um2p_abs_0.4_fast you need to re-add all speed settings because the speed is then changed and thus the ratio between the intended value and speed is changed.

--> speed_infill = =math.ceil(speed_print * 100 / 55) instead of original speed_infill = =math.ceil(speed_print * 100 / 60)
