### PR TITLE
Fixes for preference pages

### DIFF
--- a/resources/qml/Preferences/MaterialsPage.qml
+++ b/resources/qml/Preferences/MaterialsPage.qml
@@ -404,6 +404,8 @@ Item
                         anchors.leftMargin: UM.Theme.getSize("default_margin").width
                         anchors.right: parent.right
 
+                        property bool isCurrentItem: parent.ListView.isCurrentItem
+
                         property bool isItemActivated:
                         {
                             const extruder_position = Cura.ExtruderManager.activeExtruderIndex;
@@ -416,7 +418,7 @@ Item
                             width: Math.floor(parent.height * 0.8)
                             height: Math.floor(parent.height * 0.8)
                             color: model.color_code
-                            border.color: parent.ListView.isCurrentItem ? palette.highlightedText : palette.text;
+                            border.color: materialRow.isCurrentItem ? palette.highlightedText : palette.text;
                             anchors.verticalCenter: parent.verticalCenter
                         }
                         Label
@@ -425,14 +427,14 @@ Item
                             text: model.material
                             elide: Text.ElideRight
                             font.italic: materialRow.isItemActivated
-                            color: parent.ListView.isCurrentItem ? palette.highlightedText : palette.text;
+                            color: materialRow.isCurrentItem ? palette.highlightedText : palette.text;
                         }
                         Label
                         {
                             text: (model.name != model.material) ? model.name : ""
                             elide: Text.ElideRight
                             font.italic: materialRow.isItemActivated
-                            color: parent.ListView.isCurrentItem ? palette.highlightedText : palette.text;
+                            color: materialRow.isCurrentItem ? palette.highlightedText : palette.text;
                         }
                     }
 

--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -377,6 +377,20 @@ Item
 
                 model: qualitiesModel
 
+                Component.onCompleted:
+                {
+                    var selectedItemName = Cura.MachineManager.activeQualityOrQualityChangesName;
+
+                    // Select the required quality name if given
+                    for (var idx = 0; idx < qualitiesModel.rowCount(); idx++) {
+                        var item = qualitiesModel.getItem(idx);
+                        if (item.name == selectedItemName) {
+                            currentIndex = idx;
+                            break;
+                        }
+                    }
+                }
+
                 section.property: "is_read_only"
                 section.delegate: Rectangle
                 {

--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -395,22 +395,20 @@ Item
                 {
                     width: profileScrollView.width
                     height: childrenRect.height
-                    color: ListView.isCurrentItem ? palette.highlight : (model.index % 2) ? palette.base : palette.alternateBase
 
-                    Row
+                    property bool isCurrentItem: ListView.isCurrentItem
+                    color: isCurrentItem ? palette.highlight : (model.index % 2) ? palette.base : palette.alternateBase
+
+                    Label
                     {
-                        spacing: (UM.Theme.getSize("default_margin").width / 2) | 0
                         anchors.left: parent.left
                         anchors.leftMargin: UM.Theme.getSize("default_margin").width
                         anchors.right: parent.right
-                        Label
-                        {
-                            width: Math.floor((parent.width * 0.8))
-                            text: model.name
-                            elide: Text.ElideRight
-                            font.italic: model.name == Cura.MachineManager.activeQualityOrQualityChangesName
-                            color: parent.ListView.isCurrentItem ? palette.highlightedText : palette.text
-                        }
+                        width: Math.floor((parent.width * 0.8))
+                        text: model.name
+                        elide: Text.ElideRight
+                        font.italic: model.name == Cura.MachineManager.activeQualityOrQualityChangesName
+                        color: parent.isCurrentItem ? palette.highlightedText : palette.text
                     }
 
                     MouseArea


### PR DESCRIPTION
This PR fixes two issues in the Profiles and Materials pages:

The profiles page now opens with the currently active profile selected. Not only is this consistent with the other preference pages (printers, materials), but it is also important for the usability of pressing the "star" icon next to the profile name in the sidebar. This should show the changed settings, otherwise the functionality of that button is moot.

Additionally the coloring of the currently selected items was not working correctly in the Materials and Profiles pages. In fixing this, I also slightly simplified the structure of the Profiles page QML.