### PR TITLE
Fix a bright line/gap between the viewport and sidebar due to rounding

### DIFF
--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -20,6 +20,8 @@ UM.MainWindow
     viewportRect: Qt.rect(0, 0, (base.width - sidebar.width) / base.width, 1.0)
     property bool showPrintMonitor: false
 
+    backgroundColor: UM.Theme.getColor("viewport_background")
+
     // This connection is here to support legacy printer output devices that use the showPrintMonitor signal on Application to switch to the monitor stage
     // It should be phased out in newer plugin versions.
     Connections


### PR DESCRIPTION
This PR fixes a bright line/gap between the viewport and the sidebar that can appear due to rounding issues or when resizing the window when using a dark theme.