### PR TITLE
Fix firmware upload on Windows

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -15,7 +15,7 @@ from cura.PrinterOutput.GenericOutputController import GenericOutputController
 from .AutoDetectBaudJob import AutoDetectBaudJob
 from .avr_isp import stk500v2, intelHex
 
-from PyQt5.QtCore import pyqtSlot, pyqtSignal, pyqtProperty
+from PyQt5.QtCore import pyqtSlot, pyqtSignal, pyqtProperty, QUrl
 
 from serial import Serial, SerialException, SerialTimeoutException
 from threading import Thread, Event
@@ -128,7 +128,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
     @pyqtSlot(str)
     def updateFirmware(self, file):
         # the file path is qurl encoded.
-        self._firmware_location = file.replace("file://", "")
+        self._firmware_location = QUrl(file).toLocalFile()
         self.showFirmwareInterface()
         self.setFirmwareUpdateState(FirmwareUpdateState.updating)
         self._update_firmware_thread.start()

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -127,8 +127,8 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
 
     @pyqtSlot(str)
     def updateFirmware(self, file):
-        # the file path could be qurl encoded.
-        if file[:7] == "file://":
+        # the file path could be url-encoded.
+        if file.startswith("file://"):
             self._firmware_location = QUrl(file).toLocalFile()
         else:
             self._firmware_location = file

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -127,8 +127,11 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
 
     @pyqtSlot(str)
     def updateFirmware(self, file):
-        # the file path is qurl encoded.
-        self._firmware_location = QUrl(file).toLocalFile()
+        # the file path could be qurl encoded.
+        if file[:7] == "file://":
+            self._firmware_location = QUrl(file).toLocalFile()
+        else:
+            self._firmware_location = file
         self.showFirmwareInterface()
         self.setFirmwareUpdateState(FirmwareUpdateState.updating)
         self._update_firmware_thread.start()


### PR DESCRIPTION
This PR fixes firmware uploading on Windows by correctly creating a local path from a url-encoded path. 

On Windows, local file URLs start with file:/// (three forwards slashes). Instead of hardcoding a fix for Windows only, this PR uses QUrl to handle this properly.

Fixes #3731 and #3987