### PR TITLE
Use _engine_ready to detect if there is a QML engine

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -294,7 +294,7 @@ class BuildVolume(SceneNode):
         if not self._width or not self._height or not self._depth:
             return
 
-        if not self._application._qml_engine:
+        if not self._engine_ready:
             return
 
         if not self._volume_outline_color:


### PR DESCRIPTION
We already have this variable. Let's not use a private variable from another class.