### PR TITLE
Do not sync only with read_only material groups

### DIFF
--- a/cura/Machines/MaterialManager.py
+++ b/cura/Machines/MaterialManager.py
@@ -378,9 +378,8 @@ class MaterialManager(QObject):
             # Look at the guid to material dictionary
             root_material_id = None
             for material_group in self._guid_material_groups_map[material_guid]:
-                if material_group.is_read_only:
-                    root_material_id = material_group.root_material_node.metadata["id"]
-                    break
+                root_material_id = material_group.root_material_node.metadata["id"]
+                break
 
             if not root_material_id:
                 Logger.log("i", "Cannot find materials with guid [%s] ", material_guid)


### PR DESCRIPTION
Fixes CURA-5548.

Requesting you, @diegopradogesto, since you know why you set it to only sync with `read_only` groups