### PR TITLE
Move "Exclude Materials" metadata to materials

### DIFF
--- a/cura/Machines/MaterialManager.py
+++ b/cura/Machines/MaterialManager.py
@@ -287,19 +287,10 @@ class MaterialManager(QObject):
         #  1. variant-specific material
         #  2. machine-specific material
         #  3. generic material (for fdmprinter)
-        machine_exclude_materials = machine_definition.getMetaDataEntry("exclude_materials", [])
-
         material_id_metadata_dict = dict() # type: Dict[str, MaterialNode]
         for node in nodes_to_check:
             if node is not None:
-                # Only exclude the materials that are explicitly specified in the "exclude_materials" field.
-                # Do not exclude other materials that are of the same type.
                 for material_id, node in node.material_map.items():
-                    if material_id in machine_exclude_materials:
-                        Logger.log("d", "Exclude material [%s] for machine [%s]",
-                                   material_id, machine_definition.getId())
-                        continue
-
                     if material_id not in material_id_metadata_dict:
                         material_id_metadata_dict[material_id] = node
 

--- a/cura/Machines/Models/BaseMaterialsModel.py
+++ b/cura/Machines/Models/BaseMaterialsModel.py
@@ -21,10 +21,11 @@ class BaseMaterialsModel(ListModel):
     MaterialRole = Qt.UserRole + 5
     ColorRole = Qt.UserRole + 6
     ContainerNodeRole = Qt.UserRole + 7
+    CompatibleRole = Qt.UserRole + 8
 
     extruderPositionChanged = pyqtSignal()
 
-    def __init__(self, parent = None):
+    def __init__(self, parent = None) -> None:
         super().__init__(parent)
         self._application = Application.getInstance()
         self._machine_manager = self._application.getMachineManager()
@@ -36,6 +37,7 @@ class BaseMaterialsModel(ListModel):
         self.addRoleName(self.MaterialRole, "material")
         self.addRoleName(self.ColorRole, "color_name")
         self.addRoleName(self.ContainerNodeRole, "container_node")
+        self.addRoleName(self.CompatibleRole, "compatible")
 
         self._extruder_position = 0
         self._extruder_stack = None

--- a/cura/Machines/Models/BaseMaterialsModel.py
+++ b/cura/Machines/Models/BaseMaterialsModel.py
@@ -3,7 +3,7 @@
 
 from PyQt5.QtCore import QObject, Qt, pyqtSignal, pyqtProperty
 
-from cura.CuraApplication import CuraApplication
+import cura.CuraApplication
 from UM.Qt.ListModel import ListModel
 
 
@@ -26,7 +26,7 @@ class BaseMaterialsModel(ListModel):
 
     def __init__(self, parent: QObject = None) -> None:
         super().__init__(parent)
-        self._application = CuraApplication.getInstance()
+        self._application = cura.CuraApplication.CuraApplication.getInstance()
         self._machine_manager = self._application.getMachineManager()
 
         self.addRoleName(self.RootMaterialIdRole, "root_material_id")

--- a/cura/Machines/Models/BaseMaterialsModel.py
+++ b/cura/Machines/Models/BaseMaterialsModel.py
@@ -21,7 +21,6 @@ class BaseMaterialsModel(ListModel):
     MaterialRole = Qt.UserRole + 5
     ColorRole = Qt.UserRole + 6
     ContainerNodeRole = Qt.UserRole + 7
-    CompatibleRole = Qt.UserRole + 8
 
     extruderPositionChanged = pyqtSignal()
 
@@ -37,7 +36,6 @@ class BaseMaterialsModel(ListModel):
         self.addRoleName(self.MaterialRole, "material")
         self.addRoleName(self.ColorRole, "color_name")
         self.addRoleName(self.ContainerNodeRole, "container_node")
-        self.addRoleName(self.CompatibleRole, "compatible")
 
         self._extruder_position = 0
         self._extruder_stack = None

--- a/cura/Machines/Models/BaseMaterialsModel.py
+++ b/cura/Machines/Models/BaseMaterialsModel.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
-from PyQt5.QtCore import Qt, pyqtSignal, pyqtProperty
+from PyQt5.QtCore import QObject, Qt, pyqtSignal, pyqtProperty
 
-from UM.Application import Application
+from cura.CuraApplication import CuraApplication
 from UM.Qt.ListModel import ListModel
 
 
@@ -24,9 +24,9 @@ class BaseMaterialsModel(ListModel):
 
     extruderPositionChanged = pyqtSignal()
 
-    def __init__(self, parent = None) -> None:
+    def __init__(self, parent: QObject = None) -> None:
         super().__init__(parent)
-        self._application = Application.getInstance()
+        self._application = CuraApplication.getInstance()
         self._machine_manager = self._application.getMachineManager()
 
         self.addRoleName(self.RootMaterialIdRole, "root_material_id")

--- a/cura/Machines/Models/BrandMaterialsModel.py
+++ b/cura/Machines/Models/BrandMaterialsModel.py
@@ -108,6 +108,8 @@ class BrandMaterialsModel(ListModel):
             # Only add results for generic materials
             if brand.lower() == "generic":
                 continue
+            if not metadata.get("compatible", True):
+                continue
 
             if brand not in brand_group_dict:
                 brand_group_dict[brand] = {}
@@ -123,7 +125,7 @@ class BrandMaterialsModel(ListModel):
                     "material": metadata["material"],
                     "color_name": metadata["color_name"],
                     "container_node": container_node,
-                    "compatible": metadata.get("compatible", "unknown")
+                    "compatible": metadata.get("compatible", True)
                     }
             brand_group_dict[brand][material_type].append(item)
 

--- a/cura/Machines/Models/BrandMaterialsModel.py
+++ b/cura/Machines/Models/BrandMaterialsModel.py
@@ -122,7 +122,8 @@ class BrandMaterialsModel(ListModel):
                     "brand": metadata["brand"],
                     "material": metadata["material"],
                     "color_name": metadata["color_name"],
-                    "container_node": container_node
+                    "container_node": container_node,
+                    "compatible": metadata.get("compatible", "unknown")
                     }
             brand_group_dict[brand][material_type].append(item)
 

--- a/cura/Machines/Models/BrandMaterialsModel.py
+++ b/cura/Machines/Models/BrandMaterialsModel.py
@@ -125,7 +125,6 @@ class BrandMaterialsModel(ListModel):
                     "material": metadata["material"],
                     "color_name": metadata["color_name"],
                     "container_node": container_node,
-                    "compatible": metadata.get("compatible", True)
                     }
             brand_group_dict[brand][material_type].append(item)
 

--- a/cura/Machines/Models/BrandMaterialsModel.py
+++ b/cura/Machines/Models/BrandMaterialsModel.py
@@ -124,7 +124,7 @@ class BrandMaterialsModel(ListModel):
                     "brand": metadata["brand"],
                     "material": metadata["material"],
                     "color_name": metadata["color_name"],
-                    "container_node": container_node,
+                    "container_node": container_node
                     }
             brand_group_dict[brand][material_type].append(item)
 

--- a/cura/Machines/Models/GenericMaterialsModel.py
+++ b/cura/Machines/Models/GenericMaterialsModel.py
@@ -19,7 +19,7 @@ class GenericMaterialsModel(BaseMaterialsModel):
         self._material_manager.materialsUpdated.connect(self._update) #Update when the list of materials changes.
         self._update()
 
-    def _update(self):
+    def _update(self) -> None:
         Logger.log("d", "Updating {model_class_name}.".format(model_class_name = self.__class__.__name__))
 
         global_stack = self._machine_manager.activeMachine
@@ -51,7 +51,8 @@ class GenericMaterialsModel(BaseMaterialsModel):
                     "brand": metadata["brand"],
                     "material": metadata["material"],
                     "color_name": metadata["color_name"],
-                    "container_node": container_node
+                    "container_node": container_node,
+                    "compatible": metadata.get("compatible", "unknown")
                     }
             item_list.append(item)
 

--- a/cura/Machines/Models/GenericMaterialsModel.py
+++ b/cura/Machines/Models/GenericMaterialsModel.py
@@ -44,6 +44,8 @@ class GenericMaterialsModel(BaseMaterialsModel):
             # Only add results for generic materials
             if metadata["brand"].lower() != "generic":
                 continue
+            if not metadata.get("compatible", True):
+                continue
 
             item = {"root_material_id": root_material_id,
                     "id": metadata["id"],
@@ -52,7 +54,7 @@ class GenericMaterialsModel(BaseMaterialsModel):
                     "material": metadata["material"],
                     "color_name": metadata["color_name"],
                     "container_node": container_node,
-                    "compatible": metadata.get("compatible", "unknown")
+                    "compatible": metadata.get("compatible", True)
                     }
             item_list.append(item)
 

--- a/cura/Machines/Models/GenericMaterialsModel.py
+++ b/cura/Machines/Models/GenericMaterialsModel.py
@@ -54,7 +54,6 @@ class GenericMaterialsModel(BaseMaterialsModel):
                     "material": metadata["material"],
                     "color_name": metadata["color_name"],
                     "container_node": container_node,
-                    "compatible": metadata.get("compatible", True)
                     }
             item_list.append(item)
 

--- a/cura/Machines/Models/GenericMaterialsModel.py
+++ b/cura/Machines/Models/GenericMaterialsModel.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
+from typing import Dict, List
+
 from UM.Logger import Logger
 from cura.Machines.Models.BaseMaterialsModel import BaseMaterialsModel
 
@@ -38,7 +40,7 @@ class GenericMaterialsModel(BaseMaterialsModel):
             self.setItems([])
             return
 
-        item_list = []
+        item_list = [] #type: List[Dict[str, str]]
         for root_material_id, container_node in available_material_dict.items():
             metadata = container_node.metadata
             # Only add results for generic materials

--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -6,8 +6,7 @@
         "author": "Ultimaker",
         "manufacturer": "Ultimaker B.V.",
         "category": "Ultimaker",
-        "visible": false,
-        "exclude_materials": [ "generic_hips", "generic_petg" ]
+        "visible": false
     },
     "overrides": {
         "machine_max_feedrate_e": {

--- a/resources/definitions/ultimaker2.def.json
+++ b/resources/definitions/ultimaker2.def.json
@@ -14,7 +14,6 @@
         "platform_offset": [9, 0, 0],
         "has_materials": false,
         "has_machine_quality": true,
-        "exclude_materials": ["generic_hips", "generic_petg", "generic_bam", "ultimaker_bam", "generic_pva", "ultimaker_pva", "generic_tough_pla", "ultimaker_tough_pla_black", "ultimaker_tough_pla_green", "ultimaker_tough_pla_red", "ultimaker_tough_pla_white"],
         "first_start_actions": ["UM2UpgradeSelection"],
         "supported_actions":["UM2UpgradeSelection", "UpgradeFirmware"],
         "machine_extruder_trains":

--- a/resources/definitions/ultimaker_original.def.json
+++ b/resources/definitions/ultimaker_original.def.json
@@ -12,7 +12,6 @@
         "platform": "ultimaker_platform.stl",
         "has_materials": true,
         "has_machine_quality": true,
-        "exclude_materials": ["generic_hips", "generic_petg", "generic_bam", "ultimaker_bam", "generic_pva", "ultimaker_pva", "generic_tough_pla", "ultimaker_tough_pla_black", "ultimaker_tough_pla_green", "ultimaker_tough_pla_red", "ultimaker_tough_pla_white"],
         "first_start_actions": ["UMOUpgradeSelection", "UMOCheckup", "BedLevel"],
         "supported_actions": ["UMOUpgradeSelection", "UMOCheckup", "BedLevel", "UpgradeFirmware"],
         "machine_extruder_trains":

--- a/resources/definitions/ultimaker_original_dual.def.json
+++ b/resources/definitions/ultimaker_original_dual.def.json
@@ -13,7 +13,6 @@
         "has_materials": true,
         "has_machine_quality": true,
         "quality_definition": "ultimaker_original",
-        "exclude_materials": ["generic_hips", "generic_petg", "generic_bam", "ultimaker_bam", "generic_pva", "ultimaker_pva", "generic_tough_pla", "ultimaker_tough_pla_black", "ultimaker_tough_pla_green", "ultimaker_tough_pla_red", "ultimaker_tough_pla_white"],
         "machine_extruder_trains":
         {
             "0": "ultimaker_original_dual_1st",

--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -22,7 +22,6 @@ Menu
             text: model.name
             checkable: true
             checked: model.root_material_id == Cura.MachineManager.currentRootMaterialId[extruderIndex]
-            enabled: model.compatible
             exclusiveGroup: group
             onTriggered:
             {

--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -22,6 +22,7 @@ Menu
             text: model.name
             checkable: true
             checked: model.root_material_id == Cura.MachineManager.currentRootMaterialId[extruderIndex]
+            enabled: model.compatible
             exclusiveGroup: group
             onTriggered:
             {

--- a/resources/qml/SidebarHeader.qml
+++ b/resources/qml/SidebarHeader.qml
@@ -1,5 +1,5 @@
-// Copyright (c) 2017 Ultimaker B.V.
-// Cura is released under the terms of the LGPLv3 or higher.
+//Copyright (c) 2018 Ultimaker B.V.
+//Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.7
 import QtQuick.Controls 1.1
@@ -402,7 +402,7 @@ Column
             property var valueError: !isMaterialSupported()
             property var valueWarning: ! Cura.MachineManager.isActiveQualitySupported
 
-            function isMaterialSupported ()
+            function isMaterialSupported()
             {
                 if (!hasActiveExtruder)
                 {


### PR DESCRIPTION
DO NOT MERGE THIS YET! This requires changes in the Ultimaker 3 and Ultimaker S5 firmware.

The Exclude Materials metadata property had the same functionality as the "hardware compatible" property in materials. We remove the data here in favour of the property in the material profiles.

Implements CURA-5460.