### PR TITLE
Fix setting jobname before saving

### DIFF
--- a/resources/qml/SaveButton.qml
+++ b/resources/qml/SaveButton.qml
@@ -256,7 +256,8 @@ Item {
             text: UM.OutputDeviceManager.activeDeviceShortDescription
             onClicked:
             {
-                UM.OutputDeviceManager.requestWriteToDevice(UM.OutputDeviceManager.activeDevice, PrintInformation.jobName, { "filter_by_machine": true, "preferred_mimetype":Printer.preferredOutputMimetype })
+                forceActiveFocus();
+                UM.OutputDeviceManager.requestWriteToDevice(UM.OutputDeviceManager.activeDevice, PrintInformation.jobName, { "filter_by_machine": true, "preferred_mimetype":Printer.preferredOutputMimetype });
             }
 
             style: ButtonStyle {


### PR DESCRIPTION
This PR enforces focus on the save button to ensure edits to jobname happen before saving.

Fixes #4007