### PR TITLE
CURA-5578 Change the Cartesio variants to use the new ones

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade34to40/VersionUpgrade34to40.py
+++ b/plugins/VersionUpgrade/VersionUpgrade34to40/VersionUpgrade34to40.py
@@ -8,6 +8,54 @@ from UM.VersionUpgrade import VersionUpgrade
 
 deleted_settings = {"prime_tower_wall_thickness", "dual_pre_wipe", "prime_tower_purge_volume"}
 
+_RENAMED_MATERIAL_PROFILES = {
+    "dsm_arnitel2045_175_cartesio_0.25_mm": "dsm_arnitel2045_175_cartesio_0.25mm_thermoplastic_extruder",
+    "dsm_arnitel2045_175_cartesio_0.4_mm": "dsm_arnitel2045_175_cartesio_0.4mm_thermoplastic_extruder",
+    "dsm_arnitel2045_175_cartesio_0.8_mm": "dsm_arnitel2045_175_cartesio_0.8mm_thermoplastic_extruder",
+    "dsm_novamid1070_175_cartesio_0.25_mm": "dsm_novamid1070_175_cartesio_0.25mm_thermoplastic_extruder",
+    "dsm_novamid1070_175_cartesio_0.4_mm": "dsm_novamid1070_175_cartesio_0.4mm_thermoplastic_extruder",
+    "dsm_novamid1070_175_cartesio_0.8_mm": "dsm_novamid1070_175_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_abs_175_cartesio_0.25_mm": "generic_abs_175_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_abs_175_cartesio_0.4_mm": "generic_abs_175_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_abs_175_cartesio_0.8_mm": "generic_abs_175_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_hips_175_cartesio_0.25_mm": "generic_hips_175_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_hips_175_cartesio_0.4_mm": "generic_hips_175_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_hips_175_cartesio_0.8_mm": "generic_hips_175_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_nylon_175_cartesio_0.25_mm": "generic_nylon_175_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_nylon_175_cartesio_0.4_mm": "generic_nylon_175_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_nylon_175_cartesio_0.8_mm": "generic_nylon_175_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_pc_cartesio_0.25_mm": "generic_pc_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_pc_cartesio_0.4_mm": "generic_pc_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_pc_cartesio_0.8_mm": "generic_pc_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_pc_175_cartesio_0.25_mm": "generic_pc_175_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_pc_175_cartesio_0.4_mm": "generic_pc_175_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_pc_175_cartesio_0.8_mm": "generic_pc_175_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_petg_175_cartesio_0.25_mm": "generic_petg_175_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_petg_175_cartesio_0.4_mm": "generic_petg_175_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_petg_175_cartesio_0.8_mm": "generic_petg_175_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_pla_175_cartesio_0.25_mm": "generic_pla_175_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_pla_175_cartesio_0.4_mm": "generic_pla_175_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_pla_175_cartesio_0.8_mm": "generic_pla_175_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_pva_cartesio_0.25_mm": "generic_pva_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_pva_cartesio_0.4_mm": "generic_pva_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_pva_cartesio_0.8_mm": "generic_pva_cartesio_0.8mm_thermoplastic_extruder",
+    "generic_pva_175_cartesio_0.25_mm": "generic_pva_175_cartesio_0.25mm_thermoplastic_extruder",
+    "generic_pva_175_cartesio_0.4_mm": "generic_pva_175_cartesio_0.4mm_thermoplastic_extruder",
+    "generic_pva_175_cartesio_0.8_mm": "generic_pva_175_cartesio_0.8mm_thermoplastic_extruder",
+    "ultimaker_pc_black_cartesio_0.25_mm": "ultimaker_pc_black_cartesio_0.25mm_thermoplastic_extruder",
+    "ultimaker_pc_black_cartesio_0.4_mm": "ultimaker_pc_black_cartesio_0.4mm_thermoplastic_extruder",
+    "ultimaker_pc_black_cartesio_0.8_mm": "ultimaker_pc_black_cartesio_0.8mm_thermoplastic_extruder",
+    "ultimaker_pc_transparent_cartesio_0.25_mm": "ultimaker_pc_transparent_cartesio_0.25mm_thermoplastic_extruder",
+    "ultimaker_pc_transparent_cartesio_0.4_mm": "ultimaker_pc_transparent_cartesio_0.4mm_thermoplastic_extruder",
+    "ultimaker_pc_transparent_cartesio_0.8_mm": "ultimaker_pc_transparent_cartesio_0.8mm_thermoplastic_extruder",
+    "ultimaker_pc_white_cartesio_0.25_mm": "ultimaker_pc_white_cartesio_0.25mm_thermoplastic_extruder",
+    "ultimaker_pc_white_cartesio_0.4_mm": "ultimaker_pc_white_cartesio_0.4mm_thermoplastic_extruder",
+    "ultimaker_pc_white_cartesio_0.8_mm": "ultimaker_pc_white_cartesio_0.8mm_thermoplastic_extruder",
+    "ultimaker_pva_cartesio_0.25_mm": "ultimaker_pva_cartesio_0.25mm_thermoplastic_extruder",
+    "ultimaker_pva_cartesio_0.4_mm": "ultimaker_pva_cartesio_0.4mm_thermoplastic_extruder",
+    "ultimaker_pva_cartesio_0.8_mm": "ultimaker_pva_cartesio_0.8mm_thermoplastic_extruder"
+}
+
 ##  Upgrades configurations from the state they were in at version 3.4 to the
 #   state they should be in at version 4.0.
 class VersionUpgrade34to40(VersionUpgrade):
@@ -53,6 +101,10 @@ class VersionUpgrade34to40(VersionUpgrade):
         # Update version number.
         parser["general"]["version"] = "4"
         parser["metadata"]["setting_version"] = "5"
+
+        #Update the name of the quality profile.
+        if parser["containers"]["3"] in _RENAMED_MATERIAL_PROFILES:
+            parser["containers"]["3"] = _RENAMED_MATERIAL_PROFILES[parser["containers"]["3"]]
 
         result = io.StringIO()
         parser.write(result)

--- a/resources/definitions/cartesio.def.json
+++ b/resources/definitions/cartesio.def.json
@@ -15,7 +15,7 @@
         "has_variants": true,
 
         "variants_name": "Tool",
-        "preferred_variant_name": "0.8 mm",
+        "preferred_variant_name": "0.8mm thermoplastic extruder",
         "preferred_material": "generic_pla",
         "preferred_quality_type": "normal",
 

--- a/resources/quality/cartesio/abs/cartesio_0.25_abs_high.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.25_abs_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_abs
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/abs/cartesio_0.25_abs_normal.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.25_abs_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_abs
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/abs/cartesio_0.4_abs_high.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.4_abs_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_abs
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/abs/cartesio_0.4_abs_normal.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.4_abs_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_abs
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/abs/cartesio_0.8_abs_coarse.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.8_abs_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = coarse
 weight = 3
 material = generic_abs
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/abs/cartesio_0.8_abs_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.8_abs_extra_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = extra coarse
 weight = 4
 material = generic_abs
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/abs/cartesio_0.8_abs_high.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.8_abs_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_abs
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/abs/cartesio_0.8_abs_normal.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.8_abs_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_abs
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/arnitel/cartesio_0.4_arnitel2045_high.inst.cfg
+++ b/resources/quality/cartesio/arnitel/cartesio_0.4_arnitel2045_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = dsm_arnitel2045_175
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/arnitel/cartesio_0.4_arnitel2045_normal.inst.cfg
+++ b/resources/quality/cartesio/arnitel/cartesio_0.4_arnitel2045_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = dsm_arnitel2045_175
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/hips/cartesio_0.25_hips_high.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.25_hips_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_hips
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/hips/cartesio_0.25_hips_normal.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.25_hips_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_hips
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/hips/cartesio_0.4_hips_high.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.4_hips_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_hips
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/hips/cartesio_0.4_hips_normal.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.4_hips_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_hips
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/hips/cartesio_0.8_hips_coarse.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.8_hips_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = coarse
 weight = 3
 material = generic_hips
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/hips/cartesio_0.8_hips_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.8_hips_extra_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = extra coarse
 weight = 4
 material = generic_hips
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/hips/cartesio_0.8_hips_high.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.8_hips_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_hips
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/hips/cartesio_0.8_hips_normal.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.8_hips_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_hips
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/nylon/cartesio_0.25_nylon_high.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.25_nylon_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_nylon
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/nylon/cartesio_0.25_nylon_normal.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.25_nylon_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_nylon
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/nylon/cartesio_0.4_nylon_high.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.4_nylon_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_nylon
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/nylon/cartesio_0.4_nylon_normal.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.4_nylon_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_nylon
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/nylon/cartesio_0.8_nylon_coarse.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.8_nylon_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = coarse
 weight = 3
 material = generic_nylon
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/nylon/cartesio_0.8_nylon_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.8_nylon_extra_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = extra coarse
 weight = 4
 material = generic_nylon
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/nylon/cartesio_0.8_nylon_high.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.8_nylon_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_nylon
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/nylon/cartesio_0.8_nylon_normal.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.8_nylon_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_nylon
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pc/cartesio_0.25_pc_high.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.25_pc_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pc
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/pc/cartesio_0.25_pc_normal.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.25_pc_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_pc
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/pc/cartesio_0.4_pc_high.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.4_pc_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pc
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/pc/cartesio_0.4_pc_normal.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.4_pc_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_pc
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/pc/cartesio_0.8_pc_coarse.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.8_pc_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = coarse
 weight = 3
 material = generic_pc
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pc/cartesio_0.8_pc_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.8_pc_extra_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = extra coarse
 weight = 4
 material = generic_pc
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pc/cartesio_0.8_pc_high.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.8_pc_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pc
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pc/cartesio_0.8_pc_normal.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.8_pc_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_pc
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/petg/cartesio_0.25_petg_high.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.25_petg_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_petg
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/petg/cartesio_0.25_petg_normal.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.25_petg_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_petg
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/petg/cartesio_0.4_petg_high.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.4_petg_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_petg
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/petg/cartesio_0.4_petg_normal.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.4_petg_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_petg
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/petg/cartesio_0.8_petg_coarse.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.8_petg_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = coarse
 weight = 3
 material = generic_petg
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/petg/cartesio_0.8_petg_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.8_petg_extra_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = extra coarse
 weight = 4
 material = generic_petg
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/petg/cartesio_0.8_petg_high.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.8_petg_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_petg
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/petg/cartesio_0.8_petg_normal.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.8_petg_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_petg
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pla/cartesio_0.25_pla_high.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.25_pla_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pla
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/pla/cartesio_0.25_pla_normal.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.25_pla_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 0
 material = generic_pla
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/pla/cartesio_0.4_pla_high.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.4_pla_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pla
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/pla/cartesio_0.4_pla_normal.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.4_pla_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 0
 material = generic_pla
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/pla/cartesio_0.8_pla_coarse.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.8_pla_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = coarse
 weight = -3
 material = generic_pla
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pla/cartesio_0.8_pla_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.8_pla_extra_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = extra coarse
 weight = -4
 material = generic_pla
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pla/cartesio_0.8_pla_high.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.8_pla_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pla
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pla/cartesio_0.8_pla_normal.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.8_pla_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 0
 material = generic_pla
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pva/cartesio_0.25_pva_high.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.25_pva_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pva
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/pva/cartesio_0.25_pva_normal.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.25_pva_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_pva
-variant = 0.25 mm
+variant = 0.25mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.3

--- a/resources/quality/cartesio/pva/cartesio_0.4_pva_high.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.4_pva_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pva
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/pva/cartesio_0.4_pva_normal.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.4_pva_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_pva
-variant = 0.4 mm
+variant = 0.4mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.5

--- a/resources/quality/cartesio/pva/cartesio_0.8_pva_coarse.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.8_pva_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = coarse
 weight = 3
 material = generic_pva
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pva/cartesio_0.8_pva_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.8_pva_extra_coarse.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = extra coarse
 weight = 4
 material = generic_pva
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pva/cartesio_0.8_pva_high.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.8_pva_high.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = high
 weight = 1
 material = generic_pva
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/quality/cartesio/pva/cartesio_0.8_pva_normal.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.8_pva_normal.inst.cfg
@@ -9,7 +9,7 @@ type = quality
 quality_type = normal
 weight = 2
 material = generic_pva
-variant = 0.8 mm
+variant = 0.8mm thermoplastic extruder
 
 [values]
 infill_line_width = 0.9

--- a/resources/variants/cartesio_0.25.inst.cfg
+++ b/resources/variants/cartesio_0.25.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-name = 0.25 mm
+name = 0.25mm thermoplastic extruder
 version = 4
 definition = cartesio
 

--- a/resources/variants/cartesio_0.4.inst.cfg
+++ b/resources/variants/cartesio_0.4.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-name = 0.4 mm
+name = 0.4mm thermoplastic extruder
 version = 4
 definition = cartesio
 

--- a/resources/variants/cartesio_0.8.inst.cfg
+++ b/resources/variants/cartesio_0.8.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-name = 0.8 mm
+name = 0.8mm thermoplastic extruder
 version = 4
 definition = cartesio
 


### PR DESCRIPTION
Change all the quality profiles and the default variant for Cartesio printers. The VersionUpgrade is also adapted to change the old names to the new ones.

This PR goes together with https://github.com/Ultimaker/fdm_materials/pull/38