### PR TITLE
Modify the compatibility message to only use glue

### DIFF
--- a/resources/qml/SidebarHeader.qml
+++ b/resources/qml/SidebarHeader.qml
@@ -535,7 +535,7 @@ Column
             y: -Math.round(UM.Theme.getSize("sidebar_margin").height / 3)
             anchors.left: parent.left
             width: parent.width - materialCompatibilityLink.width
-            text: catalog.i18nc("@label", "Use adhesion sheet or glue with this material combination")
+            text: catalog.i18nc("@label", "Use glue with this material combination")
             font: UM.Theme.getFont("very_small")
             color: UM.Theme.getColor("text")
             visible: buildplateCompatibilityError || buildplateCompatibilityWarning


### PR DESCRIPTION
When a material is not compatible with the buildplate, Cura shows a message that now needs to change.

FYI @Kristel88.