### PR TITLE
Fix blank dropdown panel in the comboboxes

### DIFF
--- a/resources/qml/Settings/SettingComboBox.qml
+++ b/resources/qml/Settings/SettingComboBox.qml
@@ -90,7 +90,7 @@ SettingItem
         popup: Popup {
             y: control.height - UM.Theme.getSize("default_lining").height
             width: control.width
-            implicitHeight: contentItem.implicitHeight
+            implicitHeight: contentItem.implicitHeight + 2 * UM.Theme.getSize("default_lining").width
             padding: UM.Theme.getSize("default_lining").width
 
             contentItem: ListView {
@@ -117,8 +117,9 @@ SettingItem
             contentItem: Label
             {
                 // FIXME: Somehow the top/bottom anchoring is not correct on Linux and it results in invisible texts.
-                anchors.top: parent.top
-                anchors.bottom: parent.bottom
+                anchors.fill: parent
+                anchors.leftMargin: UM.Theme.getSize("setting_unit_margin").width
+                anchors.rightMargin: UM.Theme.getSize("setting_unit_margin").width
 
                 text: modelData.value
                 renderType: Text.NativeRendering

--- a/resources/qml/Settings/SettingExtruder.qml
+++ b/resources/qml/Settings/SettingExtruder.qml
@@ -180,7 +180,7 @@ SettingItem
         popup: Popup {
             y: control.height - UM.Theme.getSize("default_lining").height
             width: control.width
-            implicitHeight: contentItem.implicitHeight
+            implicitHeight: contentItem.implicitHeight + 2 * UM.Theme.getSize("default_lining").width
             padding: UM.Theme.getSize("default_lining").width
 
             contentItem: ListView {
@@ -206,6 +206,10 @@ SettingItem
 
             contentItem: Label
             {
+                anchors.fill: parent
+                anchors.leftMargin: UM.Theme.getSize("setting_unit_margin").width
+                anchors.rightMargin: UM.Theme.getSize("setting_unit_margin").width
+
                 text: model.name
                 renderType: Text.NativeRendering
                 color:

--- a/resources/qml/Settings/SettingOptionalExtruder.qml
+++ b/resources/qml/Settings/SettingOptionalExtruder.qml
@@ -175,7 +175,7 @@ SettingItem
         popup: Popup {
             y: control.height - UM.Theme.getSize("default_lining").height
             width: control.width
-            implicitHeight: contentItem.implicitHeight
+            implicitHeight: contentItem.implicitHeight + 2 * UM.Theme.getSize("default_lining").width
             padding: UM.Theme.getSize("default_lining").width
 
             contentItem: ListView {
@@ -201,6 +201,10 @@ SettingItem
 
             contentItem: Label
             {
+                anchors.fill: parent
+                anchors.leftMargin: UM.Theme.getSize("setting_unit_margin").width
+                anchors.rightMargin: UM.Theme.getSize("setting_unit_margin").width
+
                 text: model.name
                 renderType: Text.NativeRendering
                 color:


### PR DESCRIPTION
Align the dropdown panel in the combobox with the parent and get rid of binding loop messages. Fixes #4074.

I did the same fix for the Extruder selector and the Optional Extruder selector. Those were working but for sake of consistency. 

The height of the popups was adjusted so there is no more shakes when hovering the items.