### PR TITLE
Switch to default extruder if disable the active one

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -985,6 +985,11 @@ class MachineManager(QObject):
         self.updateDefaultExtruder()
         self.updateNumberExtrudersEnabled()
         self.correctExtruderSettings()
+
+        # In case this extruder is being disabled and it's the currently selected one, switch to the default extruder
+        if not enabled and position == ExtruderManager.getInstance().activeExtruderIndex:
+            ExtruderManager.getInstance().setActiveExtruderIndex(int(self._default_extruder_position))
+
         # ensure that the quality profile is compatible with current combination, or choose a compatible one if available
         self._updateQualityWithMaterial()
         self.extruderChanged.emit()

--- a/resources/qml/SidebarHeader.qml
+++ b/resources/qml/SidebarHeader.qml
@@ -164,8 +164,12 @@ Column
                     onClicked: {
                         switch (mouse.button) {
                             case Qt.LeftButton:
-                                forceActiveFocus(); // Changing focus applies the currently-being-typed values so it can change the displayed setting values.
-                                Cura.ExtruderManager.setActiveExtruderIndex(index);
+                                extruder_enabled = Cura.MachineManager.getExtruder(model.index).isEnabled
+                                if (extruder_enabled)
+                                {
+                                    forceActiveFocus(); // Changing focus applies the currently-being-typed values so it can change the displayed setting values.
+                                    Cura.ExtruderManager.setActiveExtruderIndex(index);
+                                }
                                 break;
                             case Qt.RightButton:
                                 extruder_enabled = Cura.MachineManager.getExtruder(model.index).isEnabled


### PR DESCRIPTION
When the extruder is being disabled and it is the currently selected one, then switch to the default extruder. Also do not allow users to activate a disabled extruder, only allow right click to show the "Enable extruder" menu.