### PR TITLE
Fix-up Dagoma3d dagoma profiles

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -335,6 +335,7 @@ class MachineManager(QObject):
                            global_stack.getName(), new_quality_changes_group.name)
         else:
             new_quality_group = quality_groups.get(quality_type)
+            print(quality_groups)
             if new_quality_group is not None:
                 self._setQualityGroup(new_quality_group, empty_quality_changes = True)
                 same_quality_found = True
@@ -1107,6 +1108,7 @@ class MachineManager(QObject):
         # Set quality and quality_changes for each ExtruderStack
         for position, node in quality_group.nodes_for_extruders.items():
             self._global_container_stack.extruders[str(position)].quality = node.getContainer()
+            print("#######", node.getContainer().getName())
             if empty_quality_changes:
                 self._global_container_stack.extruders[str(position)].qualityChanges = self._empty_quality_changes_container
 

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -335,7 +335,6 @@ class MachineManager(QObject):
                            global_stack.getName(), new_quality_changes_group.name)
         else:
             new_quality_group = quality_groups.get(quality_type)
-            print(quality_groups)
             if new_quality_group is not None:
                 self._setQualityGroup(new_quality_group, empty_quality_changes = True)
                 same_quality_found = True
@@ -1108,7 +1107,6 @@ class MachineManager(QObject):
         # Set quality and quality_changes for each ExtruderStack
         for position, node in quality_group.nodes_for_extruders.items():
             self._global_container_stack.extruders[str(position)].quality = node.getContainer()
-            print("#######", node.getContainer().getName())
             if empty_quality_changes:
                 self._global_container_stack.extruders[str(position)].qualityChanges = self._empty_quality_changes_container
 

--- a/resources/definitions/dagoma_discoeasy200.def.json
+++ b/resources/definitions/dagoma_discoeasy200.def.json
@@ -44,9 +44,6 @@
         "machine_end_gcode": {
             "default_value": "\nM104 S0\nM106 S255\nM140 S0\nG91\nG1 E-1 F300\nG1 Z+3 F3000\nG90\nG28 X Y\nM107\nM84\n"
         },
-        "material_diameter": {
-            "default_value": 1.75
-        },
         "default_material_print_temperature": {
             "default_value": 205
         },

--- a/resources/definitions/dagoma_discoeasy200.def.json
+++ b/resources/definitions/dagoma_discoeasy200.def.json
@@ -9,6 +9,8 @@
         "file_formats": "text/x-gcode",
         "platform": "discoeasy200.stl",
         "platform_offset": [ 105, -59, 280],
+        "has_machine_quality": true,
+        "has_materials": true,
         "machine_extruder_trains":
         {
             "0": "dagoma_discoeasy200_extruder_0"

--- a/resources/definitions/dagoma_neva.def.json
+++ b/resources/definitions/dagoma_neva.def.json
@@ -9,6 +9,8 @@
         "file_formats": "text/x-gcode",
         "platform": "neva.stl",
         "platform_offset": [ 0, 0, 0],
+        "has_machine_quality": true,
+        "has_materials": true,
         "machine_extruder_trains":
         {
             "0": "dagoma_neva_extruder_0"

--- a/resources/definitions/dagoma_neva.def.json
+++ b/resources/definitions/dagoma_neva.def.json
@@ -1,5 +1,4 @@
 {
-    "id": "dagoma_neva",
     "name": "Dagoma NEVA",
     "version": 2,
     "inherits": "fdmprinter",
@@ -50,9 +49,6 @@
         },
         "machine_end_gcode": {
             "default_value": "\nM104 S0\nM106 S255\nM140 S0\nG91\nG1 E-1 F300\nG1 Z+3 E-2 F9000\nG90\nG28\n"
-        },
-        "material_diameter": {
-            "default_value": 1.75
         },
         "default_material_print_temperature": {
             "default_value": 205

--- a/resources/definitions/dagoma_neva_magis.def.json
+++ b/resources/definitions/dagoma_neva_magis.def.json
@@ -13,7 +13,7 @@
         "has_materials": true,
         "machine_extruder_trains":
         {
-            "0": "dagoma_neva_extruder_0"
+            "0": "dagoma_neva_magis_extruder_0"
         }
     },
     "overrides": {

--- a/resources/definitions/dagoma_neva_magis.def.json
+++ b/resources/definitions/dagoma_neva_magis.def.json
@@ -1,5 +1,4 @@
 {
-    "id": "dagoma_neva_magis",
     "name": "Dagoma NEVA Magis",
     "version": 2,
     "inherits": "fdmprinter",
@@ -46,9 +45,6 @@
         },
         "machine_end_gcode": {
             "default_value": "\nM104 S0\nM106 S255\nM140 S0\nG91\nG1 E-1 F300\nG1 Z+3 E-2 F9000\nG90\nG28\n"
-        },
-        "material_diameter": {
-            "default_value": 1.75
         },
         "default_material_print_temperature": {
             "default_value": 205

--- a/resources/definitions/dagoma_neva_magis.def.json
+++ b/resources/definitions/dagoma_neva_magis.def.json
@@ -24,9 +24,6 @@
         "machine_center_is_zero": {
             "default_value": true
         },
-        "machine_nozzle_size": {
-            "default_value": 0.4
-        },
         "machine_head_with_fans_polygon": {
             "default_value": [
                 [-36, -42],

--- a/resources/definitions/dagoma_neva_magis.def.json
+++ b/resources/definitions/dagoma_neva_magis.def.json
@@ -8,7 +8,13 @@
         "manufacturer": "Dagoma",
         "file_formats": "text/x-gcode",
         "platform": "neva.stl",
-        "platform_offset": [ 0, 0, 0]
+        "platform_offset": [ 0, 0, 0],
+        "has_machine_quality": true,
+        "has_materials": true,
+        "machine_extruder_trains":
+        {
+            "0": "dagoma_neva_extruder_0"
+        }
     },
     "overrides": {
         "machine_width": {

--- a/resources/extruders/dagoma_discoeasy200_extruder_0.def.json
+++ b/resources/extruders/dagoma_discoeasy200_extruder_0.def.json
@@ -1,5 +1,4 @@
 {
-    "id": "dagoma_discoeasy200_extruder_0",
     "version": 2,
     "name": "Extruder 1",
     "inherits": "fdmextruder",
@@ -14,6 +13,9 @@
         },
         "machine_nozzle_size": {
             "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
         }
     }
 }

--- a/resources/extruders/dagoma_neva_extruder_0.def.json
+++ b/resources/extruders/dagoma_neva_extruder_0.def.json
@@ -1,5 +1,4 @@
 {
-    "id": "dagoma_neva_extruder_0",
     "version": 2,
     "name": "Extruder 1",
     "inherits": "fdmextruder",
@@ -14,6 +13,9 @@
         },
         "machine_nozzle_size": {
             "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
         }
     }
 }

--- a/resources/extruders/dagoma_neva_extruder_0.def.json
+++ b/resources/extruders/dagoma_neva_extruder_0.def.json
@@ -9,8 +9,11 @@
     },
 
     "overrides": {
-        "extruder_nr": { "default_value": 0 },
-        "machine_nozzle_size": { "default_value": 0.4 },
-        "material_diameter": { "default_value": 1.75 }
+        "extruder_nr": {
+            "default_value": 0
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        }
     }
 }

--- a/resources/extruders/dagoma_neva_magis_extruder_0.def.json
+++ b/resources/extruders/dagoma_neva_magis_extruder_0.def.json
@@ -1,5 +1,4 @@
 {
-    "id": "dagoma_neva_magis_extruder_0",
     "version": 2,
     "name": "Extruder 1",
     "inherits": "fdmextruder",
@@ -14,6 +13,9 @@
         },
         "machine_nozzle_size": {
             "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
         }
     }
 }

--- a/resources/extruders/dagoma_neva_magis_extruder_0.def.json
+++ b/resources/extruders/dagoma_neva_magis_extruder_0.def.json
@@ -1,10 +1,10 @@
 {
-    "id": "dagoma_discoeasy200_extruder_0",
+    "id": "dagoma_neva_magis_extruder_0",
     "version": 2,
     "name": "Extruder 1",
     "inherits": "fdmextruder",
     "metadata": {
-        "machine": "dagoma_discoeasy200",
+        "machine": "dagoma_neva_magis",
         "position": "0"
     },
 

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = dagoma_discoeasy200
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Fast
 definition = dagoma_discoeasy200
 

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
@@ -11,7 +11,5 @@ weight = -2
 material = generic_pla
 
 [values]
-layer_height = 0.2
-
 material_print_temperature = =default_material_print_temperature + 10
 material_bed_temperature_layer_0 = =default_material_bed_temperature + 10

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
@@ -14,4 +14,4 @@ material = generic_pla
 layer_height = 0.2
 
 material_print_temperature = =default_material_print_temperature + 10
-material_bed_temperature_layer_0 = =default_material_print_temperature + 10
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 10

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_fine.inst.cfg
@@ -4,9 +4,9 @@ name = Fine
 definition = dagoma_discoeasy200
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
-quality_type = high
+quality_type = normal
 weight = 0
 material = generic_pla
 

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_fine.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Fine
 definition = dagoma_discoeasy200
 

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_standard.inst.cfg
@@ -4,9 +4,9 @@ name = Standard
 definition = dagoma_discoeasy200
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
-quality_type = normal
+quality_type = fast
 weight = -1
 material = generic_pla
 

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_standard.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Standard
 definition = dagoma_discoeasy200
 
@@ -14,4 +14,4 @@ material = generic_pla
 layer_height = 0.15
 
 material_print_temperature = =default_material_print_temperature + 5
-material_bed_temperature_layer_0 = =default_material_print_temperature + 5
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 5

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_standard.inst.cfg
@@ -11,7 +11,5 @@ weight = -1
 material = generic_pla
 
 [values]
-layer_height = 0.15
-
 material_print_temperature = =default_material_print_temperature + 5
 material_bed_temperature_layer_0 = =default_material_bed_temperature + 5

--- a/resources/quality/dagoma/dagoma_global_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_global_fast.inst.cfg
@@ -1,13 +1,14 @@
 [general]
 version = 4
-name = Fine
+name = Fast
 definition = dagoma_discoeasy200
 
 [metadata]
 setting_version = 5
 type = quality
-quality_type = normal
-weight = 0
-material = generic_pla
+quality_type = draft
+weight = -2
+global_quality = True
 
 [values]
+layer_height = 0.2

--- a/resources/quality/dagoma/dagoma_global_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_global_fine.inst.cfg
@@ -1,13 +1,14 @@
 [general]
 version = 4
 name = Fine
-definition = dagoma_neva
+definition = dagoma_discoeasy200
 
 [metadata]
 setting_version = 5
 type = quality
 quality_type = normal
 weight = 0
-material = generic_pla
+global_quality = True
 
 [values]
+layer_height = 0.1

--- a/resources/quality/dagoma/dagoma_global_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_global_standard.inst.cfg
@@ -1,13 +1,14 @@
 [general]
 version = 4
-name = Fine
+name = Standard
 definition = dagoma_discoeasy200
 
 [metadata]
 setting_version = 5
 type = quality
-quality_type = normal
-weight = 0
-material = generic_pla
+quality_type = fast
+weight = -1
+global_quality = True
 
 [values]
+layer_height = 0.15

--- a/resources/quality/dagoma/dagoma_neva_magis_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_magis_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = dagoma_neva
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/dagoma/dagoma_neva_magis_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_magis_pla_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Fast
 definition = dagoma_neva
 
@@ -14,4 +14,4 @@ material = generic_pla
 layer_height = 0.2
 
 material_print_temperature = =default_material_print_temperature + 10
-material_bed_temperature_layer_0 = =default_material_print_temperature + 10
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 10

--- a/resources/quality/dagoma/dagoma_neva_magis_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_magis_pla_fast.inst.cfg
@@ -11,7 +11,5 @@ weight = -2
 material = generic_pla
 
 [values]
-layer_height = 0.2
-
 material_print_temperature = =default_material_print_temperature + 10
 material_bed_temperature_layer_0 = =default_material_bed_temperature + 10

--- a/resources/quality/dagoma/dagoma_neva_magis_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_magis_pla_fine.inst.cfg
@@ -4,9 +4,9 @@ name = Fine
 definition = dagoma_neva
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
-quality_type = high
+quality_type = normal
 weight = 0
 material = generic_pla
 

--- a/resources/quality/dagoma/dagoma_neva_magis_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_magis_pla_fine.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Fine
 definition = dagoma_neva
 

--- a/resources/quality/dagoma/dagoma_neva_magis_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_magis_pla_standard.inst.cfg
@@ -4,9 +4,9 @@ name = Standard
 definition = dagoma_neva
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
-quality_type = normal
+quality_type = fast
 weight = -1
 material = generic_pla
 

--- a/resources/quality/dagoma/dagoma_neva_magis_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_magis_pla_standard.inst.cfg
@@ -11,7 +11,5 @@ weight = -1
 material = generic_pla
 
 [values]
-layer_height = 0.15
-
 material_print_temperature = =default_material_print_temperature + 5
 material_bed_temperature_layer_0 = =default_material_bed_temperature + 5

--- a/resources/quality/dagoma/dagoma_neva_magis_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_magis_pla_standard.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Standard
 definition = dagoma_neva
 
@@ -14,4 +14,4 @@ material = generic_pla
 layer_height = 0.15
 
 material_print_temperature = =default_material_print_temperature + 5
-material_bed_temperature_layer_0 = =default_material_print_temperature + 5
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 5

--- a/resources/quality/dagoma/dagoma_neva_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = dagoma_neva
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/dagoma/dagoma_neva_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_fast.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Fast
 definition = dagoma_neva
 
@@ -14,4 +14,4 @@ material = generic_pla
 layer_height = 0.2
 
 material_print_temperature = =default_material_print_temperature + 10
-material_bed_temperature_layer_0 = =default_material_print_temperature + 10
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 10

--- a/resources/quality/dagoma/dagoma_neva_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_fast.inst.cfg
@@ -11,7 +11,5 @@ weight = -2
 material = generic_pla
 
 [values]
-layer_height = 0.2
-
 material_print_temperature = =default_material_print_temperature + 10
 material_bed_temperature_layer_0 = =default_material_bed_temperature + 10

--- a/resources/quality/dagoma/dagoma_neva_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_fine.inst.cfg
@@ -4,9 +4,9 @@ name = Fine
 definition = dagoma_neva
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
-quality_type = high
+quality_type = normal
 weight = 0
 material = generic_pla
 

--- a/resources/quality/dagoma/dagoma_neva_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_fine.inst.cfg
@@ -11,4 +11,3 @@ weight = 0
 material = generic_pla
 
 [values]
-layer_height = 0.1

--- a/resources/quality/dagoma/dagoma_neva_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_fine.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Fine
 definition = dagoma_neva
 

--- a/resources/quality/dagoma/dagoma_neva_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_standard.inst.cfg
@@ -4,9 +4,9 @@ name = Standard
 definition = dagoma_neva
 
 [metadata]
-setting_version = 4
+setting_version = 5
 type = quality
-quality_type = normal
+quality_type = fast
 weight = -1
 material = generic_pla
 

--- a/resources/quality/dagoma/dagoma_neva_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_standard.inst.cfg
@@ -11,7 +11,5 @@ weight = -1
 material = generic_pla
 
 [values]
-layer_height = 0.15
-
 material_print_temperature = =default_material_print_temperature + 5
 material_bed_temperature_layer_0 = =default_material_bed_temperature + 5

--- a/resources/quality/dagoma/dagoma_neva_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_standard.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-version = 3
+version = 4
 name = Standard
 definition = dagoma_neva
 
@@ -14,4 +14,4 @@ material = generic_pla
 layer_height = 0.15
 
 material_print_temperature = =default_material_print_temperature + 5
-material_bed_temperature_layer_0 = =default_material_print_temperature + 5
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 5


### PR DESCRIPTION
- Removed nozzle size in magis def because it's in the extruder def on other machines
- Removed material diam from disco extruder def because its in the disco machine
- Removed material diam from neva extruder def because its in the neva machine
- Added extruder def for magis machine
- Fixed unused id field in disco machine
- Fixed duplicate name between Neva and Neva magis

Contributes to CURA-5499