### PR TITLE
 Inner Wall Speed changed to be an average speed between Wall Speed and Infill Speed

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2471,7 +2471,7 @@
                                     "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                                     "maximum_value_warning": "150",
                                     "default_value": 60,
-                                    "value": "speed_wall * 2", //Let's think about how to better calculate inner wall speed and limit it to print speed
+                                    "value": "(speed_wall + speed_infil) / 2", 
                                     "limit_to_extruder": "wall_x_extruder_nr",
                                     "settable_per_mesh": true
                                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2471,7 +2471,7 @@
                                     "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                                     "maximum_value_warning": "150",
                                     "default_value": 60,
-                                    "value": "speed_wall * 2",
+                                    "value": "speed_wall * 2", //Let's think about how to better calculate inner wall speed and limit it to print speed
                                     "limit_to_extruder": "wall_x_extruder_nr",
                                     "settable_per_mesh": true
                                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2471,7 +2471,7 @@
                                     "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                                     "maximum_value_warning": "150",
                                     "default_value": 60,
-                                    "value": "(speed_wall + speed_infil) / 2", 
+                                    "value": "(speed_wall + speed_infill) / 2", 
                                     "limit_to_extruder": "wall_x_extruder_nr",
                                     "settable_per_mesh": true
                                 }


### PR DESCRIPTION
Previously speed_wall_x (Inner Wall Speed) was calculated by multiplying speed_wall (Wall Speed) by two. This meant that if a user raised their base Wall Speed, it could result in unexpectedly high Inner Wall Speed, especially if the Inner Wall Speed setting is not visible. The description says that inner walls are usually best between Outer Wall Speed and Infill Speed, so I've modified the definition to reflect this. 

This is my first time contributing to Cura, so I apologize if I'm overlooking something. This may need to be changed in multiple places, but I know this affects the Custom FDM Printer profile, which is the only one I use. I'm using this formula now and it seems to work well. Someone with more expertise may have room for improvement though.