### PR TITLE
Updating Inner Wall Speed calculation for Custom FDM Printer profile

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2471,7 +2471,7 @@
                                     "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                                     "maximum_value_warning": "150",
                                     "default_value": 60,
-                                    "value": "speed_wall * 2", //Let's think about how to better calculate inner wall speed and limit it to print speed
+                                    "value": "(speed_wall + speed_infil) / 2", 
                                     "limit_to_extruder": "wall_x_extruder_nr",
                                     "settable_per_mesh": true
                                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2471,7 +2471,7 @@
                                     "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                                     "maximum_value_warning": "150",
                                     "default_value": 60,
-                                    "value": "(speed_wall + speed_infill) / 2", 
+                                    "value": "(speed_wall_0 + speed_infill) / 2", 
                                     "limit_to_extruder": "wall_x_extruder_nr",
                                     "settable_per_mesh": true
                                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2471,7 +2471,7 @@
                                     "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                                     "maximum_value_warning": "150",
                                     "default_value": 60,
-                                    "value": "speed_wall * 2",
+                                    "value": "speed_wall * 2", //Let's think about how to better calculate inner wall speed and limit it to print speed
                                     "limit_to_extruder": "wall_x_extruder_nr",
                                     "settable_per_mesh": true
                                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2471,7 +2471,7 @@
                                     "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                                     "maximum_value_warning": "150",
                                     "default_value": 60,
-                                    "value": "(speed_wall + speed_infil) / 2", 
+                                    "value": "(speed_wall + speed_infill) / 2", 
                                     "limit_to_extruder": "wall_x_extruder_nr",
                                     "settable_per_mesh": true
                                 }


### PR DESCRIPTION
Value was previously calculated by multiplying Outer Wall Speed by two. This works when the Wall speed is the default of 30 with a print speed of 60, but can cause unexpectedly high print speeds if the user manually raises Wall Speed, especially if the Inner Wall Speed setting is hidden. For example, if Wall Speed is set to 50, Inner Wall Speed would become 100.


I've updated the formula to reflect the definition. This has been working well in my testing. 