### PR TITLE
Fix the scrolling when the cursor is hovering the combobox settings

### DIFF
--- a/resources/qml/Settings/SettingComboBox.qml
+++ b/resources/qml/Settings/SettingComboBox.qml
@@ -20,13 +20,6 @@ SettingItem
 
         anchors.fill: parent
 
-        MouseArea
-        {
-            anchors.fill: parent
-            acceptedButtons: Qt.NoButton
-            onWheel: wheel.accepted = true
-        }
-
         background: Rectangle
         {
             color:

--- a/resources/qml/Settings/SettingExtruder.qml
+++ b/resources/qml/Settings/SettingExtruder.qml
@@ -71,13 +71,6 @@ SettingItem
 
         currentIndex: propertyProvider.properties.value
 
-        MouseArea
-        {
-            anchors.fill: parent
-            acceptedButtons: Qt.NoButton
-            onWheel: wheel.accepted = true;
-        }
-
         property string color: "#fff"
 
         Binding

--- a/resources/qml/Settings/SettingOptionalExtruder.qml
+++ b/resources/qml/Settings/SettingOptionalExtruder.qml
@@ -76,13 +76,6 @@ SettingItem
             when: control.model.items.length > 0
         }
 
-        MouseArea
-        {
-            anchors.fill: parent
-            acceptedButtons: Qt.NoButton
-            onWheel: wheel.accepted = true;
-        }
-
         property string color: "#fff"
 
         Binding


### PR DESCRIPTION
Previously, when I hover a combobox setting (e.g. Build Plate Adhesion Type) the scrolling doesn't work.