### PR TITLE
CURA-5613 Set the focus in the upper handle in the layer view

### DIFF
--- a/plugins/SimulationView/LayerSlider.qml
+++ b/plugins/SimulationView/LayerSlider.qml
@@ -67,6 +67,10 @@ Item {
         activeHandle = handle
     }
 
+    // make sure the upper handle is focussed when pressing the parent handle
+    // needed to connect the key bindings when switching active handle
+    onVisibleChanged: if (visible) upperHandleLabel.forceActiveFocus()
+
     // slider track
     Rectangle {
         id: track

--- a/plugins/SimulationView/LayerSlider.qml
+++ b/plugins/SimulationView/LayerSlider.qml
@@ -67,10 +67,6 @@ Item {
         activeHandle = handle
     }
 
-    // make sure the upper handle is focussed when pressing the parent handle
-    // needed to connect the key bindings when switching active handle
-    onVisibleChanged: if (visible) upperHandleLabel.forceActiveFocus()
-
     // slider track
     Rectangle {
         id: track

--- a/plugins/SimulationView/SimulationSliderLabel.qml
+++ b/plugins/SimulationView/SimulationSliderLabel.qml
@@ -25,10 +25,6 @@ UM.PointingRectangle {
     width: valueLabel.width + UM.Theme.getSize("default_margin").width
     visible: false
 
-    // make sure the text field is focussed when pressing the parent handle
-    // needed to connect the key bindings when switching active handle
-    onVisibleChanged: if (visible) valueLabel.forceActiveFocus()
-
     color: UM.Theme.getColor("tool_panel_background")
     borderColor: UM.Theme.getColor("lining")
     borderWidth: UM.Theme.getSize("default_lining").width


### PR DESCRIPTION
Previously it was set to the text field. That makes it easier to release the focus by clicking in the main view and use the arrow keys to rotate the view.