### PR TITLE
Fix the sliders that went out of range when using the arrow keys

### DIFF
--- a/plugins/SimulationView/LayerSlider.qml
+++ b/plugins/SimulationView/LayerSlider.qml
@@ -68,11 +68,7 @@ Item {
     }
 
     function normalizeValue(value) {
-        if (value > sliderRoot.maximumValue)
-            return sliderRoot.maximumValue
-        else if (value < sliderRoot.minimumValue)
-            return sliderRoot.minimumValue
-        return value
+        return Math.min(Math.max(value, sliderRoot.minimumValue), sliderRoot.maximumValue)
     }
 
     // slider track

--- a/plugins/SimulationView/LayerSlider.qml
+++ b/plugins/SimulationView/LayerSlider.qml
@@ -40,31 +40,39 @@ Item {
 
     property bool layersVisible: true
 
-    function getUpperValueFromSliderHandle () {
+    function getUpperValueFromSliderHandle() {
         return upperHandle.getValue()
     }
 
-    function setUpperValue (value) {
+    function setUpperValue(value) {
         upperHandle.setValue(value)
         updateRangeHandle()
     }
 
-    function getLowerValueFromSliderHandle () {
+    function getLowerValueFromSliderHandle() {
         return lowerHandle.getValue()
     }
 
-    function setLowerValue (value) {
+    function setLowerValue(value) {
         lowerHandle.setValue(value)
         updateRangeHandle()
     }
 
-    function updateRangeHandle () {
+    function updateRangeHandle() {
         rangeHandle.height = lowerHandle.y - (upperHandle.y + upperHandle.height)
     }
 
     // set the active handle to show only one label at a time
-    function setActiveHandle (handle) {
+    function setActiveHandle(handle) {
         activeHandle = handle
+    }
+
+    function normalizeValue(value) {
+        if (value > sliderRoot.maximumValue)
+            return sliderRoot.maximumValue
+        else if (value < sliderRoot.minimumValue)
+            return sliderRoot.minimumValue
+        return value
     }
 
     // slider track
@@ -188,6 +196,8 @@ Item {
 
         // set the slider position based on the upper value
         function setValue (value) {
+            // Normalize values between range, since using arrow keys will create out-of-the-range values
+            value = sliderRoot.normalizeValue(value)
 
             UM.SimulationView.setCurrentLayer(value)
 
@@ -274,6 +284,8 @@ Item {
 
         // set the slider position based on the lower value
         function setValue (value) {
+            // Normalize values between range, since using arrow keys will create out-of-the-range values
+            value = sliderRoot.normalizeValue(value)
 
             UM.SimulationView.setMinimumLayer(value)
 

--- a/plugins/SimulationView/PathSlider.qml
+++ b/plugins/SimulationView/PathSlider.qml
@@ -49,11 +49,7 @@ Item {
     }
 
     function normalizeValue(value) {
-        if (value > sliderRoot.maximumValue)
-            return sliderRoot.maximumValue
-        else if (value < sliderRoot.minimumValue)
-            return sliderRoot.minimumValue
-        return value
+        return Math.min(Math.max(value, sliderRoot.minimumValue), sliderRoot.maximumValue)
     }
 
     // slider track

--- a/plugins/SimulationView/PathSlider.qml
+++ b/plugins/SimulationView/PathSlider.qml
@@ -29,6 +29,7 @@ Item {
 
     // value properties
     property real maximumValue: 100
+    property real minimumValue: 0
     property bool roundValues: true
     property real handleValue: maximumValue
 
@@ -45,6 +46,14 @@ Item {
 
     function updateRangeHandle () {
         rangeHandle.width = handle.x - sliderRoot.handleSize
+    }
+
+    function normalizeValue(value) {
+        if (value > sliderRoot.maximumValue)
+            return sliderRoot.maximumValue
+        else if (value < sliderRoot.minimumValue)
+            return sliderRoot.minimumValue
+        return value
     }
 
     // slider track
@@ -110,6 +119,8 @@ Item {
 
         // set the slider position based on the value
         function setValue (value) {
+            // Normalize values between range, since using arrow keys will create out-of-the-range values
+            value = sliderRoot.normalizeValue(value)
 
             UM.SimulationView.setCurrentPath(value)
 


### PR DESCRIPTION
This PR tries to fix this problem:

- When using the arrow keys to move up/down the layers or left/right the paths, the slider went out of range, as you can see in this picture:
![image](https://user-images.githubusercontent.com/15830521/43580501-fb7172d6-9655-11e8-9341-0cdacc6f5e52.png)

It's more notifiable when there are just a few layers (or paths) and you use the SHIFT combination to move 10 by 10. 