### PR TITLE
Fix rendering support eraser cubes

### DIFF
--- a/plugins/SupportEraser/SupportEraser.py
+++ b/plugins/SupportEraser/SupportEraser.py
@@ -25,6 +25,8 @@ from cura.Scene.BuildPlateDecorator import BuildPlateDecorator
 
 from UM.Settings.SettingInstance import SettingInstance
 
+import numpy
+
 class SupportEraser(Tool):
     def __init__(self):
         super().__init__()
@@ -96,8 +98,7 @@ class SupportEraser(Tool):
 
         node.setName("Eraser")
         node.setSelectable(True)
-        mesh = MeshBuilder()
-        mesh.addCube(10,10,10)
+        mesh = self._createCube(10)
         node.setMeshData(mesh.build())
 
         active_build_plate = CuraApplication.getInstance().getMultiBuildPlateModel().activeBuildPlate
@@ -160,3 +161,28 @@ class SupportEraser(Tool):
             self._skip_press = False
 
         self._had_selection = has_selection
+
+    def _createCube(self, size):
+        mesh = MeshBuilder()
+
+        # Can't use MeshBuilder.addCube() because that does not get per-vertex normals
+        # Per-vertex normals require duplication of vertices
+        s = size / 2
+        verts = [ # 6 faces with 4 corners each
+            [-s, -s,  s], [-s,  s,  s], [ s,  s,  s], [ s, -s,  s],
+            [-s,  s, -s], [-s, -s, -s], [ s, -s, -s], [ s,  s, -s],
+            [ s, -s, -s], [-s, -s, -s], [-s, -s,  s], [ s, -s,  s],
+            [-s,  s, -s], [ s,  s, -s], [ s,  s,  s], [-s,  s,  s],
+            [-s, -s,  s], [-s, -s, -s], [-s,  s, -s], [-s,  s,  s],
+            [ s, -s, -s], [ s, -s,  s], [ s,  s,  s], [ s,  s, -s]
+        ]
+        mesh.setVertices(numpy.asarray(verts, dtype=numpy.float32))
+
+        indices = []
+        for i in range(0, 24, 4): # All 6 quads (12 triangles)
+            indices.append([i, i+2, i+1])
+            indices.append([i, i+3, i+2])
+        mesh.setIndices(numpy.asarray(indices, dtype=numpy.int32))
+
+        mesh.calculateNormals()
+        return mesh


### PR DESCRIPTION
This PR fixes rendering support eraser/blocker cubes by creating meshes that have per-vertex normals.

MeshBuilder.addCube creates cubes that don't have per-vertex normals. Geometry like that does not render properly in most shaders used in Cura. This becomes obvious when a user changes the "Mesh Type" using Per Model Settings.

Contributes to https://github.com/Ultimaker/Cura/issues/3959 by making the effect of changing a support blocker mesh to another type more visible and predictable.