### PR TITLE
bq Hephestos2: Getting a rid of custom g-code

### DIFF
--- a/resources/definitions/bq_hephestos_2.def.json
+++ b/resources/definitions/bq_hephestos_2.def.json
@@ -17,8 +17,8 @@
 
     "overrides": {
         "machine_name": { "default_value": "BQ Hephestos 2" },
-        "machine_start_gcode": { "default_value": "; -- START GCODE --\nM104 S{material_print_temperature} ; Heat up extruder while leveling\nM800 ; Custom GCODE to fire start print procedure\nM109 S{material_print_temperature} ; Makes sure the temperature is correct before printing\n; -- end of START GCODE --" },
-        "machine_end_gcode": { "default_value": "; -- END GCODE --\nM801        ; Custom GCODE to fire end print procedure\n; -- end of END GCODE --" },
+        "machine_start_gcode": { "default_value": "; -- START GCODE --\nM104 S{material_print_temperature}\nG28 ; Zero-ing position\nG29 ; Auto bed-leveling\nG0 X4 Y297 Z15 F4000 ; Fast move to BQ's start position\nG90 ; Set to Absolute Positioning\nG92 E0 ; Reset extruder 0\nG1 F1800 ; Set default feedrate\nM109 S{material_print_temperature} ; Makes sure the temperature is correct before printing\n; -- end of START GCODE --" },
+        "machine_end_gcode": { "default_value": "; -- END GCODE --\nM801        ; Marlin G-CODE to fire end print procedure\n; -- end of END GCODE --" },
         "machine_width": { "default_value": 210 },
         "machine_depth": { "default_value": 297 },
         "machine_height": { "default_value": 220 },


### PR DESCRIPTION
* Getting a rid of M800:
This removes M800 completely. The problem is basically that M800 sets the temperature to 200deg.
As a result we tell the firmware to heat up to e.g. 205deg, then M800 kicks in and sets the temperature to 200deg and then we heat up to 205deg again.
Therefore I looked into the firmware and extracted all g-code lines except the one which tells to go to 200deg.

* Getting independent of bq's fork and therefore adding compatibility to Marlin
We use standard g-code, which is safe to be used with both firmware.

Note: This change might be also interesting for other bq products, but can't test on them. Therefore it is up to bq and/or the owners of these products to contribute and correct this here, as I did.