### PR TITLE
Add keyboard accessibility for Settings>Profiles>Manage Profile...

### DIFF
--- a/resources/i18n/cura.pot
+++ b/resources/i18n/cura.pot
@@ -3940,7 +3940,7 @@ msgstr ""
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr ""
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/de_DE/cura.po
+++ b/resources/i18n/de_DE/cura.po
@@ -3787,7 +3787,7 @@ msgstr "&Profil von aktuellen Einstellungen/Überschreibungen erstellen..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Profile verwalten..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/es_ES/cura.po
+++ b/resources/i18n/es_ES/cura.po
@@ -3799,7 +3799,7 @@ msgstr "&Crear perfil a partir de ajustes o sobrescrituras actuales..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Administrar perfiles..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/fi_FI/cura.po
+++ b/resources/i18n/fi_FI/cura.po
@@ -3806,7 +3806,7 @@ msgstr "&Luo profiili nykyisten asetusten tai ohitusten perusteella..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Profiilien hallinta..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/fr_FR/cura.po
+++ b/resources/i18n/fr_FR/cura.po
@@ -3787,7 +3787,7 @@ msgstr "&Créer un profil à partir des paramètres / forçages actuels..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Gérer les profils..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/it_IT/cura.po
+++ b/resources/i18n/it_IT/cura.po
@@ -3785,7 +3785,7 @@ msgstr "&Crea profilo dalle impostazioni/esclusioni correnti..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Gestione profili..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/ja_JP/cura.po
+++ b/resources/i18n/ja_JP/cura.po
@@ -3791,7 +3791,7 @@ msgstr "&今の設定/無効からプロファイルを作成する…"
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "プロファイルを管理する"
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/ko_KR/cura.po
+++ b/resources/i18n/ko_KR/cura.po
@@ -3783,7 +3783,7 @@ msgstr "현재 설정으로 프로파일 생성..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "프로파일 관리..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/nl_NL/cura.po
+++ b/resources/i18n/nl_NL/cura.po
@@ -3785,7 +3785,7 @@ msgstr "Profiel maken op basis van huidige instellingen/overs&chrijvingen..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Profielen Beheren..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/pl_PL/cura.po
+++ b/resources/i18n/pl_PL/cura.po
@@ -3821,7 +3821,7 @@ msgstr "&Utwórz profil z bieżących ustawień..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Zarządzaj profilami..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/pt_BR/cura.po
+++ b/resources/i18n/pt_BR/cura.po
@@ -3824,7 +3824,7 @@ msgstr "&Criar perfil a partir de ajustes atuais..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Administrar perfis..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/pt_PT/cura.po
+++ b/resources/i18n/pt_PT/cura.po
@@ -3903,7 +3903,7 @@ msgstr "&Criar perfil a partir das definições/substituições atuais..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Gerir Perfis..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/ru_RU/cura.po
+++ b/resources/i18n/ru_RU/cura.po
@@ -3791,7 +3791,7 @@ msgstr "Создать профиль из текущих параметров�
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Управление профилями..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/tr_TR/cura.po
+++ b/resources/i18n/tr_TR/cura.po
@@ -3785,7 +3785,7 @@ msgstr "&Geçerli ayarlardan/geçersiz kılmalardan profil oluştur..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "Profilleri Yönet..."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/zh_CN/cura.po
+++ b/resources/i18n/zh_CN/cura.po
@@ -3821,7 +3821,7 @@ msgstr "从当前设置 / 重写值创建配置文件（&C）…"
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "管理配置文件.."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/i18n/zh_TW/cura.po
+++ b/resources/i18n/zh_TW/cura.po
@@ -3822,7 +3822,7 @@ msgstr "從目前設定 / 覆寫值建立列印參數（&C）…"
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:202
 msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
+msgid "&Manage Profiles..."
 msgstr "管理列印參數.."
 
 #: /home/ruben/Projects/Cura/resources/qml/Actions.qml:209

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -199,7 +199,7 @@ Item
     Action
     {
         id: manageProfilesAction;
-        text: catalog.i18nc("@action:inmenu menubar:profile","Manage Profiles...");
+        text: catalog.i18nc("@action:inmenu menubar:profile","&Manage Profiles...");
         iconName: "configure";
     }
 


### PR DESCRIPTION
This menu item is missing a key shortcut, so let's add one.

Unfortunately I haven't been able to test this due to issues getting Cura to run with system versions of Uranium-git. Localization of some sort builds with cmake/make fine. Please tell me if I'm misunderstanding any part of the i18n system with these changes.