### PR TITLE
CURA-5672 Fix S5 extruder start and end locations

### DIFF
--- a/resources/extruders/ultimaker_s5_extruder_left.def.json
+++ b/resources/extruders/ultimaker_s5_extruder_left.def.json
@@ -17,10 +17,10 @@
         "machine_nozzle_offset_y": { "default_value": 0 },
 
         "machine_extruder_start_pos_abs": { "default_value": true },
-        "machine_extruder_start_pos_x": { "default_value": 310 },
+        "machine_extruder_start_pos_x": { "default_value": 330 },
         "machine_extruder_start_pos_y": { "default_value": 237 },
         "machine_extruder_end_pos_abs": { "default_value": true },
-        "machine_extruder_end_pos_x": { "default_value": 310 },
+        "machine_extruder_end_pos_x": { "default_value": 330 },
         "machine_extruder_end_pos_y": { "default_value": 237 },
         "machine_nozzle_head_distance": { "default_value": 2.7 },
         "extruder_prime_pos_x": { "default_value": -3 },

--- a/resources/extruders/ultimaker_s5_extruder_right.def.json
+++ b/resources/extruders/ultimaker_s5_extruder_right.def.json
@@ -17,10 +17,10 @@
         "machine_nozzle_offset_y": { "default_value": 0 },
 
         "machine_extruder_start_pos_abs": { "default_value": true },
-        "machine_extruder_start_pos_x": { "default_value": 310 },
+        "machine_extruder_start_pos_x": { "default_value": 330 },
         "machine_extruder_start_pos_y": { "default_value": 219 },
         "machine_extruder_end_pos_abs": { "default_value": true },
-        "machine_extruder_end_pos_x": { "default_value": 310 },
+        "machine_extruder_end_pos_x": { "default_value": 330 },
         "machine_extruder_end_pos_y": { "default_value": 219 },
         "machine_nozzle_head_distance": { "default_value": 4.2 },
         "extruder_prime_pos_x": { "default_value": 333 },


### PR DESCRIPTION
The X coordinate 310 is not at the rightmost position, and this causes the prime tower to start printing from somewhere in the middle.