### PR TITLE
Feat: support brim

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4538,6 +4538,17 @@
                         }
                     }
                 },
+                "brim_replaces_support":
+                {
+                    "label": "Brim Replaces Support",
+                    "description": "Enforce brim to be printed around the model even if that space would otherwise be occupied by support. This replaces some regions fo the first layer of supprot by brim regions.",
+                    "type": "bool",
+                    "default_value": true,
+                    "enabled": "resolveOrValue('adhesion_type') == 'brim' and support_enable",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true,
+                    "limit_to_extruder": "adhesion_extruder_nr"
+                },
                 "brim_outside_only":
                 {
                     "label": "Brim Only on Outside",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -3888,6 +3888,48 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
+                "support_brim_enable":
+                {
+                    "label": "Enable Support Brim",
+                    "description": "Generate a brim within the support infill regions of the first layer. This brim is printed underneath the support, not around it. Enabling this setting increases the adhesion of support to the build plate.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": "support_enable or support_tree_enable",
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
+                "support_brim_width":
+                {
+                    "label": "Support Brim Width",
+                    "description": "The width of the brim to print underneath the support. A larger brim enhances adhesion to the build plate, at the cost of some extra material.",
+                    "type": "float",
+                    "unit": "mm",
+                    "default_value": 8.0,
+                    "minimum_value": "0.0",
+                    "maximum_value_warning": "50.0",
+                    "enabled": "support_enable",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true,
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "children":
+                    {
+                        "support_brim_line_count":
+                        {
+                            "label": "Support Brim Line Count",
+                            "description": "The number of lines used for the support brim. More brim lines enhance adhesion to the build plate, at the cost of some extra material.",
+                            "type": "int",
+                            "default_value": 20,
+                            "minimum_value": "0",
+                            "maximum_value_warning": "50 / skirt_brim_line_width",
+                            "value": "math.ceil(support_brim_width / (skirt_brim_line_width * initial_layer_line_width_factor / 100.0))",
+                            "enabled": "support_enable",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true,
+                            "limit_to_extruder": "support_infill_extruder_nr"
+                        }
+                    }
+                },
                 "support_z_distance":
                 {
                     "label": "Support Z Distance",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8895761/45488211-faf67780-b760-11e8-8f17-12f01decdeae.png)
![image](https://user-images.githubusercontent.com/8895761/45488273-2e390680-b761-11e8-928b-996e336cbaed.png)

I had some issues with my print, so I decided to fix the issues with a sweat and cool little pull request.

1) control the interaction between brim and support

2) generate a brim under support with the support extruder

new settings:
Enable Support Brim
Support Brim Width
Support Brim Line Count
and
Brim Replaces Support

This PR are the frontend settings for: https://github.com/Ultimaker/CuraEngine/pull/849