### PR TITLE
Fix updating temperature while preheating bed or extruder

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -313,6 +313,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
         while self._connection_state == ConnectionState.connected and self._serial is not None:
             try:
                 line = self._serial.readline()
+                print(line)
             except:
                 continue
 
@@ -326,8 +327,8 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
                 if self._firmware_name is None:
                     self.sendCommand("M115")
 
-            if (b"ok " in line and b"T:" in line) or line.startswith(b"T:") or b"ok B:" in line or line.startswith(b"B:"):  # Temperature message. 'T:' for extruder and 'B:' for bed
-                extruder_temperature_matches = re.findall(b"T(\d*): ?([\d\.]+) ?\/?([\d\.]+)?", line)
+            if re.search(b"[B|T\d*]: ?\d+\.?\d*", line):  # Temperature message. 'T:' for extruder and 'B:' for bed
+                extruder_temperature_matches = re.findall(b"T(\d*): ?(\d+\.?\d*) ?\/?(\d+\.?\d*)?", line)
                 # Update all temperature values
                 matched_extruder_nrs = []
                 for match in extruder_temperature_matches:
@@ -349,7 +350,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
                     if match[2]:
                         extruder.updateTargetHotendTemperature(float(match[2]))
 
-                bed_temperature_matches = re.findall(b"B: ?([\d\.]+) ?\/?([\d\.]+)?", line)
+                bed_temperature_matches = re.findall(b"B: ?(\d+\.?\d*)  ?\/?(\d+\.?\d*) ?", line)
                 if bed_temperature_matches:
                     match = bed_temperature_matches[0]
                     if match[0]:

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -313,7 +313,6 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
         while self._connection_state == ConnectionState.connected and self._serial is not None:
             try:
                 line = self._serial.readline()
-                print(line)
             except:
                 continue
 


### PR DESCRIPTION
This PR fixes updates to the print monitor temperatures while preheating.

While preheating the bed/extruder with M190 or M109, the firmware keeps outputting temperature lines, but these do not contain "ok" because no new command was acknowledged.

This PR is against master, but since it fixes a bug and the risk of regressions is low, it might be considered for cherry-picking to 3.5

Fixes #3741