### PR TITLE
[3.5][regression]Fix opening port after baudrate detection

### DIFF
--- a/plugins/USBPrinting/AutoDetectBaudJob.py
+++ b/plugins/USBPrinting/AutoDetectBaudJob.py
@@ -77,6 +77,7 @@ class AutoDetectBaudJob(Job):
                             self.setResult(baud_rate)
                             Logger.log("d", "Detected baud rate {baud_rate} on serial {serial} on retry {retry} with after {time_elapsed:0.2f} seconds.".format(
                                 serial = self._serial_port, baud_rate = baud_rate, retry = retry, time_elapsed = time() - start_timeout_time))
+                            serial.close() # close serial port so it can be opened by the USBPrinterOutputDevice
                             return
 
                     serial.write(b"M105\n")


### PR DESCRIPTION
This PR fixes opening the serial port after baud rate detection.

After detecting the baudrate, closing the serial port used for detection is left to garbage collection. This has worked for Cura for a long time, but while fixing #4369 I noticed Cura could no longer connect to the serial port, giving an Access Denied error. It looks like there's a race condition between the garbage collector doing its thing destroying the serial port object and the USBPrinterOutputDevice trying to open the same serial port again. By actively closing the serial port in the AutoDetectBaudRateJob, this race condition goes away.

I have created this PR against the 3.5 branch, because for me the 3.5 branch consistently fails to open the USB serial port, while the 3.4 branch has no such problem. I have not tested this extensively with different printers and as race-conditions go this issue could be very timing-dependent, but it feels like a pretty big regression if all USB printing is broken.