### PR TITLE
Stop simulation when dragging handles

### DIFF
--- a/plugins/SimulationView/LayerSlider.qml
+++ b/plugins/SimulationView/LayerSlider.qml
@@ -39,6 +39,7 @@ Item {
     property real lowerValue: minimumValue
 
     property bool layersVisible: true
+    property bool manuallyChanged: true     // Indicates whether the value was changed manually or during simulation
 
     function getUpperValueFromSliderHandle() {
         return upperHandle.getValue()
@@ -96,7 +97,8 @@ Item {
         visible: sliderRoot.layersVisible
 
         // set the new value when dragging
-        function onHandleDragged () {
+        function onHandleDragged() {
+            sliderRoot.manuallyChanged = true
 
             upperHandle.y = y - upperHandle.height
             lowerHandle.y = y + height
@@ -109,7 +111,7 @@ Item {
             UM.SimulationView.setMinimumLayer(lowerValue)
         }
 
-        function setValue (value) {
+        function setValue(value) {
             var range = sliderRoot.upperValue - sliderRoot.lowerValue
             value = Math.min(value, sliderRoot.maximumValue)
             value = Math.max(value, sliderRoot.minimumValue + range)
@@ -168,7 +170,8 @@ Item {
         color: upperHandleLabel.activeFocus ? sliderRoot.handleActiveColor : sliderRoot.upperHandleColor
         visible: sliderRoot.layersVisible
 
-        function onHandleDragged () {
+        function onHandleDragged() {
+            sliderRoot.manuallyChanged = true
 
             // don't allow the lower handle to be heigher than the upper handle
             if (lowerHandle.y - (y + height) < sliderRoot.minimumRangeHandleSize) {
@@ -183,7 +186,7 @@ Item {
         }
 
         // get the upper value based on the slider position
-        function getValue () {
+        function getValue() {
             var result = y / (sliderRoot.height - (2 * sliderRoot.handleSize + sliderRoot.minimumRangeHandleSize))
             result = sliderRoot.maximumValue + result * (sliderRoot.minimumValue - (sliderRoot.maximumValue - sliderRoot.minimumValue))
             result = sliderRoot.roundValues ? Math.round(result) : result
@@ -191,7 +194,7 @@ Item {
         }
 
         // set the slider position based on the upper value
-        function setValue (value) {
+        function setValue(value) {
             // Normalize values between range, since using arrow keys will create out-of-the-range values
             value = sliderRoot.normalizeValue(value)
 
@@ -205,8 +208,16 @@ Item {
             sliderRoot.updateRangeHandle()
         }
 
-        Keys.onUpPressed: upperHandleLabel.setValue(upperHandleLabel.value + ((event.modifiers & Qt.ShiftModifier) ? 10 : 1))
-        Keys.onDownPressed: upperHandleLabel.setValue(upperHandleLabel.value - ((event.modifiers & Qt.ShiftModifier) ? 10 : 1))
+        Keys.onUpPressed:
+        {
+            sliderRoot.manuallyChanged = true
+            upperHandleLabel.setValue(upperHandleLabel.value + ((event.modifiers & Qt.ShiftModifier) ? 10 : 1))
+        }
+        Keys.onDownPressed:
+        {
+            sliderRoot.manuallyChanged = true
+            upperHandleLabel.setValue(upperHandleLabel.value - ((event.modifiers & Qt.ShiftModifier) ? 10 : 1))
+        }
 
         // dragging
         MouseArea {
@@ -256,7 +267,8 @@ Item {
 
         visible: sliderRoot.layersVisible
 
-        function onHandleDragged () {
+        function onHandleDragged() {
+            sliderRoot.manuallyChanged = true
 
             // don't allow the upper handle to be lower than the lower handle
             if (y - (upperHandle.y + upperHandle.height) < sliderRoot.minimumRangeHandleSize) {
@@ -271,7 +283,7 @@ Item {
         }
 
         // get the lower value from the current slider position
-        function getValue () {
+        function getValue() {
             var result = (y - (sliderRoot.handleSize + sliderRoot.minimumRangeHandleSize)) / (sliderRoot.height - (2 * sliderRoot.handleSize + sliderRoot.minimumRangeHandleSize));
             result = sliderRoot.maximumValue - sliderRoot.minimumRange + result * (sliderRoot.minimumValue - (sliderRoot.maximumValue - sliderRoot.minimumRange))
             result = sliderRoot.roundValues ? Math.round(result) : result
@@ -279,7 +291,7 @@ Item {
         }
 
         // set the slider position based on the lower value
-        function setValue (value) {
+        function setValue(value) {
             // Normalize values between range, since using arrow keys will create out-of-the-range values
             value = sliderRoot.normalizeValue(value)
 

--- a/plugins/SimulationView/PathSlider.qml
+++ b/plugins/SimulationView/PathSlider.qml
@@ -34,6 +34,7 @@ Item {
     property real handleValue: maximumValue
 
     property bool pathsVisible: true
+    property bool manuallyChanged: true     // Indicates whether the value was changed manually or during simulation
 
     function getHandleValueFromSliderHandle () {
         return handle.getValue()
@@ -97,6 +98,7 @@ Item {
         visible: sliderRoot.pathsVisible
 
         function onHandleDragged () {
+            sliderRoot.manuallyChanged = true
 
             // update the range handle
             sliderRoot.updateRangeHandle()
@@ -128,8 +130,16 @@ Item {
             sliderRoot.updateRangeHandle()
         }
 
-        Keys.onRightPressed: handleLabel.setValue(handleLabel.value + ((event.modifiers & Qt.ShiftModifier) ? 10 : 1))
-        Keys.onLeftPressed: handleLabel.setValue(handleLabel.value - ((event.modifiers & Qt.ShiftModifier) ? 10 : 1))
+        Keys.onRightPressed:
+        {
+            sliderRoot.manuallyChanged = true
+            handleLabel.setValue(handleLabel.value + ((event.modifiers & Qt.ShiftModifier) ? 10 : 1))
+        }
+        Keys.onLeftPressed:
+        {
+            sliderRoot.manuallyChanged = true
+            handleLabel.setValue(handleLabel.value - ((event.modifiers & Qt.ShiftModifier) ? 10 : 1))
+        }
 
         // dragging
         MouseArea {

--- a/plugins/SimulationView/SimulationView.qml
+++ b/plugins/SimulationView/SimulationView.qml
@@ -623,7 +623,15 @@ Item
             {
                 target: UM.SimulationView
                 onMaxPathsChanged: pathSlider.setHandleValue(UM.SimulationView.currentPath)
-                onCurrentPathChanged: pathSlider.setHandleValue(UM.SimulationView.currentPath)
+                onCurrentPathChanged:
+                {
+                    // Only pause the simulation when the layer was changed manually, not when the simulation is running
+                    if (pathSlider.manuallyChanged)
+                    {
+                        playButton.pauseSimulation()
+                    }
+                    pathSlider.setHandleValue(UM.SimulationView.currentPath)
+                }
             }
 
             // make sure the slider handlers show the correct value after switching views
@@ -667,9 +675,14 @@ Item
             {
                 target: UM.SimulationView
                 onMaxLayersChanged: layerSlider.setUpperValue(UM.SimulationView.currentLayer)
+                onMinimumLayerChanged: layerSlider.setLowerValue(UM.SimulationView.minimumLayer)
                 onCurrentLayerChanged:
                 {
-                    playButton.pauseSimulation()
+                    // Only pause the simulation when the layer was changed manually, not when the simulation is running
+                    if (layerSlider.manuallyChanged)
+                    {
+                        playButton.pauseSimulation()
+                    }
                     layerSlider.setUpperValue(UM.SimulationView.currentLayer)
                 }
             }
@@ -719,6 +732,8 @@ Item
                 iconSource = "./resources/simulation_resume.svg"
                 simulationTimer.stop()
                 status = 0
+                layerSlider.manuallyChanged = true
+                pathSlider.manuallyChanged = true
             }
 
             function resumeSimulation()
@@ -726,7 +741,8 @@ Item
                 UM.SimulationView.setSimulationRunning(true)
                 iconSource = "./resources/simulation_pause.svg"
                 simulationTimer.start()
-                status = 1
+                layerSlider.manuallyChanged = false
+                pathSlider.manuallyChanged = false
             }
         }
 
@@ -770,7 +786,6 @@ Item
                         {
                             UM.SimulationView.setCurrentLayer(currentLayer+1)
                             UM.SimulationView.setCurrentPath(0)
-                            playButton.resumeSimulation()
                         }
                     }
                     else
@@ -778,6 +793,8 @@ Item
                         UM.SimulationView.setCurrentPath(currentPath+1)
                     }
                 }
+                // The status must be set here instead of in the resumeSimulation function otherwise it won't work
+                // correctly, because part of the logic is in this trigger function.
                 playButton.status = 1
             }
         }


### PR DESCRIPTION
Add a property that indicates when the layer or the path slider has changed manually.

With this we can differentiate when the layer changed automatically (during simulation) or manually (by user interaction). In case it was changed manually, the simulation will stop.