### PR TITLE
Add confirmation dialogues before making destructive changes in UM3/S5 monitor

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/ClusterControlItem.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/ClusterControlItem.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.3
+import QtQuick.Dialogs 1.1
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.3
 import QtGraphicalEffects 1.0
@@ -443,8 +444,8 @@ Component
                                             text: catalog.i18nc("@label", "Abort")
                                             onClicked:
                                             {
-                                                modelData.activePrintJob.setState("abort")
-                                                popup.close()
+                                                abortConfirmationDialog.visible = true;
+                                                popup.close();
                                             }
                                             width: parent.width
                                             anchors.top: pauseButton.bottom
@@ -455,6 +456,17 @@ Component
                                                 opacity: abortButton.down || abortButton.hovered ? 1 : 0
                                                 color: UM.Theme.getColor("viewport_background")
                                             }
+                                        }
+
+                                        MessageDialog
+                                        {
+                                            id: abortConfirmationDialog
+                                            title: catalog.i18nc("@window:title", "Abort print")
+                                            icon: StandardIcon.Warning
+                                            text: catalog.i18nc("@label %1 is the name of a print job.", "Are you sure you want to abort %1?").arg(modelData.activePrintJob.name)
+                                            standardButtons: StandardButton.Yes | StandardButton.No
+                                            Component.onCompleted: visible = false
+                                            onYes: modelData.activePrintJob.setState("abort")
                                         }
                                     }
 

--- a/plugins/UM3NetworkPrinting/resources/qml/PrintJobInfoBlock.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrintJobInfoBlock.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.2
+import QtQuick.Dialogs 1.1
 import QtQuick.Controls 2.0
 import QtQuick.Controls.Styles 1.4
 import QtGraphicalEffects 1.0
@@ -212,8 +213,8 @@ Item
                         text: catalog.i18nc("@label", "Move to top")
                         onClicked:
                         {
-                            OutputDevice.sendJobToTop(printJob.key)
-                            popup.close()
+                            sendToTopConfirmationDialog.visible = true;
+                            popup.close();
                         }
                         width: parent.width
                         enabled: OutputDevice.queuedPrintJobs[0].key != printJob.key
@@ -225,6 +226,17 @@ Item
                             opacity: sendToTopButton.down || sendToTopButton.hovered ? 1 : 0
                             color: UM.Theme.getColor("viewport_background")
                         }
+                    }
+
+                    MessageDialog
+                    {
+                        id: sendToTopConfirmationDialog
+                        title: catalog.i18nc("@window:title", "Move print job to top")
+                        icon: StandardIcon.Warning
+                        text: catalog.i18nc("@label %1 is the name of a print job.", "Are you sure you want to move %1 to the top of the queue?").arg(printJob.name)
+                        standardButtons: StandardButton.Yes | StandardButton.No
+                        Component.onCompleted: visible = false
+                        onYes: OutputDevice.sendJobToTop(printJob.key)
                     }
 
                     Button

--- a/plugins/UM3NetworkPrinting/resources/qml/PrintJobInfoBlock.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrintJobInfoBlock.qml
@@ -245,8 +245,8 @@ Item
                         text: catalog.i18nc("@label", "Delete")
                         onClicked:
                         {
-                            OutputDevice.deleteJobFromQueue(printJob.key)
-                            popup.close()
+                            deleteConfirmationDialog.visible = true;
+                            popup.close();
                         }
                         width: parent.width
                         anchors.top: sendToTopButton.bottom
@@ -256,6 +256,17 @@ Item
                             opacity: deleteButton.down || deleteButton.hovered ? 1 : 0
                             color: UM.Theme.getColor("viewport_background")
                         }
+                    }
+
+                    MessageDialog
+                    {
+                        id: deleteConfirmationDialog
+                        title: catalog.i18nc("@window:title", "Delete print job")
+                        icon: StandardIcon.Warning
+                        text: catalog.i18nc("@label %1 is the name of a print job.", "Are you sure you want to delete %1?").arg(printJob.name)
+                        standardButtons: StandardButton.Yes | StandardButton.No
+                        Component.onCompleted: visible = false
+                        onYes: OutputDevice.deleteJobFromQueue(printJob.key)
                     }
                 }
 

--- a/resources/qml/MonitorButton.qml
+++ b/resources/qml/MonitorButton.qml
@@ -1,5 +1,5 @@
-// Copyright (c) 2017 Ultimaker B.V.
-// Cura is released under the terms of the LGPLv3 or higher.
+//Copyright (c) 2018 Ultimaker B.V.
+//Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.2
 import QtQuick.Controls 1.1
@@ -281,16 +281,16 @@ Item
             text: {
                 if (!printerConnected || activePrintJob == null)
                 {
-                   return catalog.i18nc("@label:", "Pause");
+                   return catalog.i18nc("@label", "Pause");
                 }
 
                 if (activePrintJob.state == "paused")
                 {
-                    return catalog.i18nc("@label:", "Resume");
+                    return catalog.i18nc("@label", "Resume");
                 }
                 else
                 {
-                    return catalog.i18nc("@label:", "Pause");
+                    return catalog.i18nc("@label", "Pause");
                 }
             }
             onClicked:
@@ -322,7 +322,7 @@ Item
 
             height: UM.Theme.getSize("save_button_save_to_button").height
 
-            text: catalog.i18nc("@label:", "Abort Print")
+            text: catalog.i18nc("@label", "Abort Print")
             onClicked: confirmationDialog.visible = true
 
             style: UM.Theme.styles.sidebar_action_button


### PR DESCRIPTION
Whenever you make a destructive change in the monitor for UM3/UMS5 connectivity (such as deleting a print job), you should now get a confirmation dialogue first to ask whether you're certain about this.

Implements CL-1053 and CURA-5729.