### PR TITLE
[3.5] CURA-5095 Reset send slice info and show privacy dialog

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade34to35/VersionUpgrade34to35.py
+++ b/plugins/VersionUpgrade/VersionUpgrade34to35/VersionUpgrade34to35.py
@@ -86,16 +86,17 @@ class VersionUpgrade34to35(VersionUpgrade):
         parser = configparser.ConfigParser(interpolation = None)
         parser.read_string(serialized)
 
+        # Need to show the data collection agreement again because the data Cura collects has been changed.
+        if parser.has_option("info", "asked_send_slice_info"):
+            parser.remove_option("info", "asked_send_slice_info")
+        if parser.has_option("info", "send_slice_info"):
+            parser.remove_option("info", "send_slice_info")
+
         # Update version number.
         parser["general"]["version"] = "6"
         if "metadata" not in parser:
             parser["metadata"] = {}
         parser["metadata"]["setting_version"] = "5"
-
-        # Need to show the data collection agreement again because the data Cura collects has been changed.
-        if parser.has_option("info", "asked_send_slice_info"):
-            parser.remove_option("info", "asked_send_slice_info")
-            parser.remove_option("info", "send_slice_info")
 
         result = io.StringIO()
         parser.write(result)

--- a/plugins/VersionUpgrade/VersionUpgrade34to35/VersionUpgrade34to35.py
+++ b/plugins/VersionUpgrade/VersionUpgrade34to35/VersionUpgrade34to35.py
@@ -92,6 +92,11 @@ class VersionUpgrade34to35(VersionUpgrade):
             parser["metadata"] = {}
         parser["metadata"]["setting_version"] = "5"
 
+        # Need to show the data collection agreement again because the data Cura collects has been changed.
+        if parser.has_option("info", "asked_send_slice_info"):
+            parser.remove_option("info", "asked_send_slice_info")
+            parser.remove_option("info", "send_slice_info")
+
         result = io.StringIO()
         parser.write(result)
         return [filename], [result.getvalue()]

--- a/plugins/VersionUpgrade/VersionUpgrade34to35/tests/TestVersionUpgrade34to35.py
+++ b/plugins/VersionUpgrade/VersionUpgrade34to35/tests/TestVersionUpgrade34to35.py
@@ -17,6 +17,10 @@ test_upgrade_version_nr_data = [
     version = 5
     [metadata]
     setting_version = 4
+
+    [info]
+    asked_send_slice_info = True
+    send_slice_info = True
 """
     )
 ]
@@ -33,3 +37,7 @@ def test_upgradeVersionNr(test_name, file_data, upgrader):
     #Check the new version.
     assert parser["general"]["version"] == "6"
     assert parser["metadata"]["setting_version"] == "5"
+
+    # Check if the data collection values have been removed
+    assert not parser.has_option("info", "asked_send_slice_info")
+    assert not parser.has_option("info", "send_slice_info")


### PR DESCRIPTION
Because the data Cura collects has been changed.