### PR TITLE
Fix showing info about SliceInfo in general preferences

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -112,8 +112,7 @@ from cura.ObjectsModel import ObjectsModel
 from UM.FlameProfiler import pyqtSlot
 
 
-if TYPE_CHECKING:
-    from plugins.SliceInfoPlugin.SliceInfo import SliceInfo
+from plugins.SliceInfoPlugin.SliceInfo import SliceInfo
 
 
 numpy.seterr(all = "ignore")


### PR DESCRIPTION
This PR fixes a crash in the Cura general preferences, when the user wants to learn more about the information that is sent to Ultimaker when slicing.

See https://community.ultimaker.com/topic/24494-introducing-ultimaker-cura-35-beta/?page=2&tab=comments#comment-219744

Since this is a regression in Cura 3.5 and the patch is very small, this PR is against that branch. Let me know if you prefer it against master.
