### PR TITLE
Fix initial start-up when providing model parameter

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1580,6 +1580,11 @@ class CuraApplication(QtApplication):
         job.start()
 
     def _readMeshFinished(self, job):
+        global_container_stack = self.getGlobalContainerStack()
+        if not global_container_stack:
+            Logger.log("w", "Can't load meshes before a printer is added.")
+            return
+
         nodes = job.getResult()
         file_name = job.getFileName()
         file_name_lower = file_name.lower()
@@ -1594,7 +1599,6 @@ class CuraApplication(QtApplication):
         for node_ in DepthFirstIterator(root):
             if node_.callDecoration("isSliceable") and node_.callDecoration("getBuildPlateNumber") == target_build_plate:
                 fixed_nodes.append(node_)
-        global_container_stack = self.getGlobalContainerStack()
         machine_width = global_container_stack.getProperty("machine_width", "value")
         machine_depth = global_container_stack.getProperty("machine_depth", "value")
         arranger = Arrange.create(x = machine_width, y = machine_depth, fixed_nodes = fixed_nodes)


### PR DESCRIPTION
If you're adding a model file as command line argument to Cura, it should auto-load this file upon start-up. However when adding this command line argument upon first launch of Cura, there is no printer yet so Cura would crash because it tries to load a model before there is a build volume. This prevents that crash and instead doesn't load the model at all.