### PR TITLE
Reduce the maximum precision of floats in SettingTextField inputs

### DIFF
--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -152,7 +152,7 @@ SettingItem
             maximumLength: (definition.type == "str" || definition.type == "[int]") ? -1 : 10;
             clip: true; //Hide any text that exceeds the width of the text box.
 
-            validator: RegExpValidator { regExp: (definition.type == "[int]") ? /^\[?(\s*-?[0-9]{0,9}\s*,)*(\s*-?[0-9]{0,9})\s*\]?$/ : (definition.type == "int") ? /^-?[0-9]{0,10}$/ : (definition.type == "float") ? /^-?[0-9]{0,9}[.,]?[0-9]{0,10}$/ : /^.*$/ } // definition.type property from parent loader used to disallow fractional number entry
+            validator: RegExpValidator { regExp: (definition.type == "[int]") ? /^\[?(\s*-?[0-9]{0,9}\s*,)*(\s*-?[0-9]{0,9})\s*\]?$/ : (definition.type == "int") ? /^-?[0-9]{0,10}$/ : (definition.type == "float") ? /^-?[0-9]{0,9}[.,]?[0-9]{0,3}$/ : /^.*$/ } // definition.type property from parent loader used to disallow fractional number entry
 
             Binding
             {


### PR DESCRIPTION
This PR reduces the maximum precision of floats in the sidebar to 3 digits. No settings in Cura require more than 3 digits of precision. Many settings are in mm, and CuraEngine does its calculations in while microns. Having more precision in the frontend than in the backend apparently thoroughly confuses some people. 

This PR fixes #4368