### PR TITLE
Fix toolbox download

### DIFF
--- a/plugins/Toolbox/resources/qml/ToolboxAuthorPage.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxAuthorPage.qml
@@ -15,7 +15,7 @@ Item
     {
         id: sidebar
     }
-    Rectangle
+    Item
     {
         id: header
         anchors

--- a/plugins/Toolbox/resources/qml/ToolboxBackColumn.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxBackColumn.qml
@@ -23,6 +23,7 @@ Item
     {
         id: button
         text: catalog.i18nc("@action:button", "Back")
+        enabled: !toolbox.isDownloading
         UM.RecolorImage
         {
             id: backArrow
@@ -39,7 +40,7 @@ Item
                 width: width
                 height: height
             }
-            color: button.hovered ? UM.Theme.getColor("primary") : UM.Theme.getColor("text")
+            color: button.enabled ? (button.hovered ? UM.Theme.getColor("primary") : UM.Theme.getColor("text")) : UM.Theme.getColor("text_inactive")
             source: UM.Theme.getIcon("arrow_left")
         }
         width: UM.Theme.getSize("toolbox_back_button").width
@@ -59,7 +60,7 @@ Item
             {
                 id: labelStyle
                 text: control.text
-                color: control.hovered ? UM.Theme.getColor("primary") : UM.Theme.getColor("text")
+                color: control.enabled ? (control.hovered ? UM.Theme.getColor("primary") : UM.Theme.getColor("text")) : UM.Theme.getColor("text_inactive")
                 font: UM.Theme.getFont("default_bold")
                 horizontalAlignment: Text.AlignRight
                 width: control.width

--- a/plugins/Toolbox/resources/qml/ToolboxDetailPage.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxDetailPage.qml
@@ -9,9 +9,8 @@ import UM 1.1 as UM
 Item
 {
     id: page
-    property var details: base.selection
+    property var details: base.selection || {}
     anchors.fill: parent
-    width: parent.width
     ToolboxBackColumn
     {
         id: sidebar

--- a/plugins/Toolbox/resources/qml/ToolboxHeader.qml
+++ b/plugins/Toolbox/resources/qml/ToolboxHeader.qml
@@ -25,7 +25,7 @@ Item
         {
             text: catalog.i18nc("@title:tab", "Plugins")
             active: toolbox.viewCategory == "plugin" && enabled
-            enabled: toolbox.viewPage != "loading" && toolbox.viewPage != "errored"
+            enabled: !toolbox.isDownloading && toolbox.viewPage != "loading" && toolbox.viewPage != "errored"
             onClicked:
             {
                 toolbox.filterModelByProp("packages", "type", "plugin")
@@ -39,7 +39,7 @@ Item
         {
             text: catalog.i18nc("@title:tab", "Materials")
             active: toolbox.viewCategory == "material" && enabled
-            enabled: toolbox.viewPage != "loading" && toolbox.viewPage != "errored"
+            enabled: !toolbox.isDownloading && toolbox.viewPage != "loading" && toolbox.viewPage != "errored"
             onClicked:
             {
                 toolbox.filterModelByProp("authors", "package_types", "material")
@@ -53,6 +53,7 @@ Item
     {
         text: catalog.i18nc("@title:tab", "Installed")
         active: toolbox.viewCategory == "installed"
+        enabled: !toolbox.isDownloading
         anchors
         {
             right: parent.right

--- a/plugins/Toolbox/src/Toolbox.py
+++ b/plugins/Toolbox/src/Toolbox.py
@@ -603,7 +603,7 @@ class Toolbox(QObject, Extension):
 
     @pyqtSlot()
     def cancelDownload(self) -> None:
-        Logger.log("i", "Toolbox: User cancelled the download of a plugin.")
+        Logger.log("i", "Toolbox: User cancelled the download of a package.")
         self.resetDownload()
 
     def resetDownload(self) -> None:
@@ -755,6 +755,7 @@ class Toolbox(QObject, Extension):
         self._active_package = package
         self.activePackageChanged.emit()
 
+    ##  The active package is the package that is currently being downloaded
     @pyqtProperty(QObject, fset = setActivePackage, notify = activePackageChanged)
     def activePackage(self) -> Optional[Dict[str, Any]]:
         return self._active_package


### PR DESCRIPTION
This fixes an issue that makes Cura crashing when clicking on the "Back" button while downloading a package. I did it this way to avoid risks since we are close to the 3.5 release.