### PR TITLE
Remove unnecessary import and declaration of i18n in plugins

### DIFF
--- a/plugins/3MFWriter/__init__.py
+++ b/plugins/3MFWriter/__init__.py
@@ -12,7 +12,7 @@ from . import ThreeMFWorkspaceWriter
 from UM.i18n import i18nCatalog
 from UM.Platform import Platform
 
-i18n_catalog = i18nCatalog("uranium")
+i18n_catalog = i18nCatalog("cura")
 
 def getMetaData():
     workspace_extension = "3mf"

--- a/plugins/ChangeLogPlugin/__init__.py
+++ b/plugins/ChangeLogPlugin/__init__.py
@@ -3,8 +3,6 @@
 
 from . import ChangeLog
 
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
 
 def getMetaData():
     return {}

--- a/plugins/FirmwareUpdateChecker/__init__.py
+++ b/plugins/FirmwareUpdateChecker/__init__.py
@@ -1,11 +1,7 @@
 # Copyright (c) 2017 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
-from UM.i18n import i18nCatalog
-
 from . import FirmwareUpdateChecker
-
-i18n_catalog = i18nCatalog("cura")
 
 
 def getMetaData():

--- a/plugins/MachineSettingsAction/__init__.py
+++ b/plugins/MachineSettingsAction/__init__.py
@@ -3,8 +3,6 @@
 
 from . import MachineSettingsAction
 
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
 
 def getMetaData():
     return {}

--- a/plugins/ModelChecker/__init__.py
+++ b/plugins/ModelChecker/__init__.py
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Ultimaker B.V.
-# This example is released under the terms of the AGPLv3 or higher.
+# Cura is released under the terms of the LGPLv3 or higher.
 
 from . import ModelChecker
-
-from UM.i18n import i18nCatalog
-i18n_catalog = i18nCatalog("cura")
 
 
 def getMetaData():

--- a/plugins/MonitorStage/__init__.py
+++ b/plugins/MonitorStage/__init__.py
@@ -3,6 +3,7 @@
 
 from . import MonitorStage
 
+
 from UM.i18n import i18nCatalog
 i18n_catalog = i18nCatalog("cura")
 

--- a/plugins/PostProcessingPlugin/__init__.py
+++ b/plugins/PostProcessingPlugin/__init__.py
@@ -2,10 +2,10 @@
 # The PostProcessingPlugin is released under the terms of the AGPLv3 or higher.
 
 from . import PostProcessingPlugin
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
+
+
 def getMetaData():
     return {}
-        
+
 def register(app):
     return {"extension": PostProcessingPlugin.PostProcessingPlugin()}

--- a/plugins/RemovableDriveOutputDevice/__init__.py
+++ b/plugins/RemovableDriveOutputDevice/__init__.py
@@ -3,12 +3,10 @@
 
 from UM.Platform import Platform
 from UM.Logger import Logger
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
+
 
 def getMetaData():
-    return {
-    }
+    return {}
 
 def register(app):
     if Platform.isWindows():

--- a/plugins/SliceInfoPlugin/__init__.py
+++ b/plugins/SliceInfoPlugin/__init__.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2015 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
+
 from . import SliceInfo
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
+
 
 def getMetaData():
-    return {
-    }
+    return {}
 
 def register(app):
     return { "extension": SliceInfo.SliceInfo()}

--- a/plugins/UM3NetworkPrinting/__init__.py
+++ b/plugins/UM3NetworkPrinting/__init__.py
@@ -2,9 +2,6 @@
 # Cura is released under the terms of the LGPLv3 or higher.
 
 from .src import DiscoverUM3Action
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
-
 from .src import UM3OutputDevicePlugin
 
 def getMetaData():

--- a/plugins/VersionUpgrade/VersionUpgrade21to22/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade21to22/__init__.py
@@ -3,9 +3,6 @@
 
 from . import VersionUpgrade21to22
 
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
-
 upgrade = VersionUpgrade21to22.VersionUpgrade21to22()
 
 def getMetaData():

--- a/plugins/VersionUpgrade/VersionUpgrade22to24/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade22to24/__init__.py
@@ -3,9 +3,6 @@
 
 from . import VersionUpgrade
 
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
-
 upgrade = VersionUpgrade.VersionUpgrade22to24()
 
 def getMetaData():

--- a/plugins/VersionUpgrade/VersionUpgrade25to26/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade25to26/__init__.py
@@ -3,9 +3,6 @@
 
 from . import VersionUpgrade25to26
 
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
-
 upgrade = VersionUpgrade25to26.VersionUpgrade25to26()
 
 def getMetaData():

--- a/plugins/VersionUpgrade/VersionUpgrade26to27/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade26to27/__init__.py
@@ -3,9 +3,6 @@
 
 from . import VersionUpgrade26to27
 
-from UM.i18n import i18nCatalog
-catalog = i18nCatalog("cura")
-
 upgrade = VersionUpgrade26to27.VersionUpgrade26to27()
 
 def getMetaData():

--- a/plugins/VersionUpgrade/VersionUpgrade33to34/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade33to34/__init__.py
@@ -5,7 +5,6 @@ from . import VersionUpgrade33to34
 
 upgrade = VersionUpgrade33to34.VersionUpgrade33to34()
 
-
 def getMetaData():
     return {
         "version_upgrade": {

--- a/plugins/VersionUpgrade/VersionUpgrade34to35/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade34to35/__init__.py
@@ -5,7 +5,6 @@ from . import VersionUpgrade34to35
 
 upgrade = VersionUpgrade34to35.VersionUpgrade34to35()
 
-
 def getMetaData():
     return {
         "version_upgrade": {

--- a/plugins/XmlMaterialProfile/__init__.py
+++ b/plugins/XmlMaterialProfile/__init__.py
@@ -5,10 +5,7 @@ from . import XmlMaterialProfile
 from . import XmlMaterialUpgrader
 
 from UM.MimeTypeDatabase import MimeType, MimeTypeDatabase
-from UM.i18n import i18nCatalog
 
-
-catalog = i18nCatalog("cura")
 upgrader = XmlMaterialUpgrader.XmlMaterialUpgrader()
 
 


### PR DESCRIPTION
This PR removes unused imports and declaration of i18n in plugins. There's also a PR for Uranium that does the same thing there.