### PR TITLE
Make the "Add Printer" dialog less spartan

### DIFF
--- a/resources/definitions/3dator.def.json
+++ b/resources/definitions/3dator.def.json
@@ -7,7 +7,6 @@
         "author": "3Dator GmbH",
         "manufacturer": "3Dator GmbH",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "supports_usb_connection": true,
         "platform": "3dator_platform.stl",
         "machine_extruder_trains":

--- a/resources/definitions/anycubic_i3_mega.def.json
+++ b/resources/definitions/anycubic_i3_mega.def.json
@@ -8,7 +8,6 @@
         "author": "TheTobby",
         "manufacturer": "Anycubic",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "anycubic_i3_mega_platform.stl",
         "has_materials": false,
         "has_machine_quality": true,

--- a/resources/definitions/deltacomb.def.json
+++ b/resources/definitions/deltacomb.def.json
@@ -8,7 +8,6 @@
         "manufacturer": "Deltacomb 3D",
         "category": "Other",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "deltacomb.stl",
         "has_machine_quality": true,
         "machine_extruder_trains":

--- a/resources/definitions/fabtotum.def.json
+++ b/resources/definitions/fabtotum.def.json
@@ -9,7 +9,6 @@
         "category": "Other",
         "file_formats": "text/x-gcode",
         "platform": "fabtotum_platform.stl",
-        "icon": "fabtotum_platform.png",
         "has_machine_quality": true,
         "has_variants": true,
         "variants_name": "Head",

--- a/resources/definitions/grr_neo.def.json
+++ b/resources/definitions/grr_neo.def.json
@@ -7,7 +7,6 @@
         "author": "Simon Cor",
         "manufacturer": "German RepRap",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker.png",
         "platform": "grr_neo_platform.stl",
         "machine_extruder_trains":
         {

--- a/resources/definitions/kossel_mini.def.json
+++ b/resources/definitions/kossel_mini.def.json
@@ -7,7 +7,6 @@
         "author": "Claudio Sampaio (Patola)",
         "manufacturer": "Other",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "kossel_platform.stl",
         "platform_offset": [0, -0.25, 0],
         "machine_extruder_trains":

--- a/resources/definitions/kossel_pro.def.json
+++ b/resources/definitions/kossel_pro.def.json
@@ -7,7 +7,6 @@
         "author": "Chris Petersen",
         "manufacturer": "OpenBeam",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "kossel_pro_build_platform.stl",
         "platform_offset": [0, -0.25, 0],
         "machine_extruder_trains":

--- a/resources/definitions/makeR_pegasus.def.json
+++ b/resources/definitions/makeR_pegasus.def.json
@@ -7,7 +7,6 @@
         "author": "makeR",
         "manufacturer": "makeR",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "makeR_pegasus_platform.stl",
         "platform_offset": [-200, -10, 200],
         "machine_extruder_trains":

--- a/resources/definitions/makeR_prusa_tairona_i3.def.json
+++ b/resources/definitions/makeR_prusa_tairona_i3.def.json
@@ -7,7 +7,6 @@
         "author": "makeR",
         "manufacturer": "makeR",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "makeR_prusa_tairona_i3_platform.stl",
         "platform_offset": [-2, 0, 0],
         "machine_extruder_trains":

--- a/resources/definitions/maker_starter.def.json
+++ b/resources/definitions/maker_starter.def.json
@@ -7,7 +7,6 @@
         "author": "tvlgiao",
         "manufacturer": "3DMaker",
         "file_formats": "text/x-gcode;application/x-stl-ascii;application/x-stl-binary;application/x-wavefront-obj",
-        "icon": "icon_ultimaker2.png",
         "platform": "makerstarter_platform.stl",
         "preferred_quality_type": "draft",
         "machine_extruder_trains":

--- a/resources/definitions/prusa_i3.def.json
+++ b/resources/definitions/prusa_i3.def.json
@@ -7,7 +7,6 @@
         "author": "Quillford",
         "manufacturer": "Prusajr",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "prusai3_platform.stl",
         "machine_extruder_trains":
         {

--- a/resources/definitions/prusa_i3_mk2.def.json
+++ b/resources/definitions/prusa_i3_mk2.def.json
@@ -7,7 +7,6 @@
         "author": "Apsu, Nounours2099",
         "manufacturer": "Prusa Research",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "prusai3_platform.stl",
         "has_materials": true,
         "machine_extruder_trains":

--- a/resources/definitions/prusa_i3_xl.def.json
+++ b/resources/definitions/prusa_i3_xl.def.json
@@ -7,7 +7,6 @@
         "author": "guigashm",
         "manufacturer": "Prusajr",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2.png",
         "platform": "prusai3_xl_platform.stl",
         "machine_extruder_trains":
         {

--- a/resources/definitions/seemecnc_artemis.def.json
+++ b/resources/definitions/seemecnc_artemis.def.json
@@ -7,7 +7,6 @@
         "author": "PouncingIguana, JJ",
         "manufacturer": "SeeMeCNC",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "artemis_platform.stl",
         "has_materials": true,
         "machine_extruder_trains":

--- a/resources/definitions/seemecnc_v32.def.json
+++ b/resources/definitions/seemecnc_v32.def.json
@@ -7,7 +7,6 @@
         "author": "PouncingIguana, JJ",
         "manufacturer": "SeeMeCNC",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "rostock_platform.stl",
         "has_materials": true,
         "machine_extruder_trains":

--- a/resources/definitions/tevo_blackwidow.def.json
+++ b/resources/definitions/tevo_blackwidow.def.json
@@ -7,7 +7,6 @@
         "author": "TheTobby",
         "manufacturer": "Tevo",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "has_materials": false,
         "has_machine_quality": true,
         "platform": "tevo_blackwidow.stl",

--- a/resources/definitions/tevo_tarantula.def.json
+++ b/resources/definitions/tevo_tarantula.def.json
@@ -8,7 +8,6 @@
         "author": "TheAssassin",
         "manufacturer": "Tevo",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "prusai3_platform.stl",
         "machine_extruder_trains":
         {

--- a/resources/definitions/tevo_tornado.def.json
+++ b/resources/definitions/tevo_tornado.def.json
@@ -7,7 +7,6 @@
         "author": "nean",
         "manufacturer": "Tevo",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2.png",
         "has_materials": true,
         "machine_extruder_trains": {
             "0": "tevo_tornado_extruder_0"

--- a/resources/definitions/ubuild-3d_mr_bot_280.def.json
+++ b/resources/definitions/ubuild-3d_mr_bot_280.def.json
@@ -9,7 +9,6 @@
         "manufacturer": "uBuild-3D",
         "category": "Other",
         "file_formats": "text/x-gcode",
-        "icon": "icon_uBuild-3D",
         "platform": "mr_bot_280_platform.stl",
         "has_materials": true,
         "preferred_quality_type": "draft",

--- a/resources/definitions/ultimaker2.def.json
+++ b/resources/definitions/ultimaker2.def.json
@@ -8,7 +8,6 @@
         "manufacturer": "Ultimaker B.V.",
         "weight": 3,
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2.png",
         "platform": "ultimaker2_platform.obj",
         "platform_texture": "Ultimaker2backplate.png",
         "platform_offset": [9, 0, 0],

--- a/resources/definitions/ultimaker2_extended.def.json
+++ b/resources/definitions/ultimaker2_extended.def.json
@@ -8,7 +8,6 @@
         "quality_definition": "ultimaker2",
         "weight": 3,
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2.png",
         "platform": "ultimaker2_platform.obj",
         "platform_texture": "Ultimaker2Extendedbackplate.png",
         "machine_extruder_trains":

--- a/resources/definitions/ultimaker2_go.def.json
+++ b/resources/definitions/ultimaker2_go.def.json
@@ -8,7 +8,6 @@
         "quality_definition": "ultimaker2",
         "weight": 3,
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2.png",
         "platform": "ultimaker2go_platform.obj",
         "platform_texture": "Ultimaker2Gobackplate.png",
         "platform_offset": [0, 0, 0],

--- a/resources/definitions/ultimaker_original.def.json
+++ b/resources/definitions/ultimaker_original.def.json
@@ -8,7 +8,6 @@
         "manufacturer": "Ultimaker B.V.",
         "weight": 4,
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker.png",
         "platform": "ultimaker_platform.stl",
         "has_materials": true,
         "has_machine_quality": true,

--- a/resources/definitions/ultimaker_original_dual.def.json
+++ b/resources/definitions/ultimaker_original_dual.def.json
@@ -8,7 +8,6 @@
         "manufacturer": "Ultimaker B.V.",
         "weight": 4,
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker.png",
         "platform": "ultimaker_platform.stl",
         "has_materials": true,
         "has_machine_quality": true,

--- a/resources/definitions/ultimaker_original_plus.def.json
+++ b/resources/definitions/ultimaker_original_plus.def.json
@@ -7,7 +7,6 @@
         "manufacturer": "Ultimaker B.V.",
         "weight": 4,
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker.png",
         "platform": "ultimaker2_platform.obj",
         "platform_texture": "UltimakerPlusbackplate.png",
         "quality_definition": "ultimaker_original",

--- a/resources/definitions/uniqbot_one.def.json
+++ b/resources/definitions/uniqbot_one.def.json
@@ -6,7 +6,6 @@
         "author": "Unimatech",
         "manufacturer": "Unimatech",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2.png",
         "machine_extruder_trains":
         {
             "0": "uniqbot_one_extruder_0"

--- a/resources/definitions/vertex_k8400.def.json
+++ b/resources/definitions/vertex_k8400.def.json
@@ -6,7 +6,6 @@
         "visible": true,
         "manufacturer": "Velleman",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "Vertex_build_panel.stl",
         "platform_offset": [0, -3, 0],
         "supports_usb_connection": true,

--- a/resources/definitions/vertex_k8400_dual.def.json
+++ b/resources/definitions/vertex_k8400_dual.def.json
@@ -6,7 +6,6 @@
         "visible": true,
         "manufacturer": "Velleman",
         "file_formats": "text/x-gcode",
-        "icon": "icon_ultimaker2",
         "platform": "Vertex_build_panel.stl",
         "platform_offset": [0, -3, 0],
         "machine_extruder_trains": {

--- a/resources/definitions/wanhao_d4s.def.json
+++ b/resources/definitions/wanhao_d4s.def.json
@@ -7,7 +7,6 @@
     "author": "Ricardo Snoek",
     "manufacturer": "Wanhao",
     "file_formats": "text/x-gcode",
-    "icon": "wanhao-icon.png",
     "has_materials": true,
     "platform": "wanhao_225_145_platform.obj",
     "platform_texture": "Wanhaobackplate.png",

--- a/resources/definitions/wanhao_d6.def.json
+++ b/resources/definitions/wanhao_d6.def.json
@@ -7,7 +7,6 @@
     "author": "Ricardo Snoek",
     "manufacturer": "Wanhao",
     "file_formats": "text/x-gcode",
-    "icon": "wanhao-icon.png",
     "has_materials": true,
     "platform": "wanhao_200_200_platform.obj",
     "platform_texture": "Wanhaobackplate.png",

--- a/resources/definitions/wanhao_d6_plus.def.json
+++ b/resources/definitions/wanhao_d6_plus.def.json
@@ -7,7 +7,6 @@
     "author": "Ricardo Snoek",
     "manufacturer": "Wanhao",
     "file_formats": "text/x-gcode",
-    "icon": "wanhao-icon.png",
     "has_materials": true,
     "platform": "wanhao_200_200_platform.obj",
     "platform_texture": "Wanhaobackplate.png",

--- a/resources/definitions/wanhao_duplicator5S.def.json
+++ b/resources/definitions/wanhao_duplicator5S.def.json
@@ -7,7 +7,6 @@
     "author": "Ricardo Snoek",
     "manufacturer": "Wanhao",
     "file_formats": "text/x-gcode",
-    "icon": "wanhao-icon.png",
     "has_materials": true,
     "platform": "wanhao_300_200_platform.obj",
     "platform_texture": "Wanhaobackplate.png",

--- a/resources/definitions/wanhao_duplicator5Smini.def.json
+++ b/resources/definitions/wanhao_duplicator5Smini.def.json
@@ -7,7 +7,6 @@
     "author": "Ricardo Snoek",
     "manufacturer": "Wanhao",
     "file_formats": "text/x-gcode",
-    "icon": "wanhao-icon.png",
     "has_materials": true,
     "platform": "wanhao_300_200_platform.obj",
     "platform_texture": "Wanhaobackplate.png",

--- a/resources/definitions/wanhao_i3.def.json
+++ b/resources/definitions/wanhao_i3.def.json
@@ -7,7 +7,6 @@
     "author": "Ricardo Snoek",
     "manufacturer": "Wanhao",
     "file_formats": "text/x-gcode",
-    "icon": "wanhao-icon.png",
     "has_materials": true,
     "platform": "wanhao_200_200_platform.obj",
     "platform_texture": "Wanhaobackplate.png",

--- a/resources/definitions/wanhao_i3mini.def.json
+++ b/resources/definitions/wanhao_i3mini.def.json
@@ -7,7 +7,6 @@
     "author": "Ricardo Snoek",
     "manufacturer": "Wanhao",
     "file_formats": "text/x-gcode",
-    "icon": "wanhao-icon.png",
     "has_materials": true,
     "platform": "wanhao_110_110_platform.obj",
     "platform_texture": "Wanhaobackplate.png",

--- a/resources/definitions/wanhao_i3plus.def.json
+++ b/resources/definitions/wanhao_i3plus.def.json
@@ -7,7 +7,6 @@
     "author": "Ricardo Snoek",
     "manufacturer": "Wanhao",
     "file_formats": "text/x-gcode",
-    "icon": "wanhao-icon.png",
     "has_materials": true,
     "platform": "wanhao_200_200_platform.obj",
     "platform_texture": "Wanhaobackplate.png",

--- a/resources/qml/AddMachineDialog.qml
+++ b/resources/qml/AddMachineDialog.qml
@@ -45,10 +45,46 @@ UM.Dialog
     }
 
     signal machineAdded(string id)
+
     function getMachineName()
     {
-        var name = machineList.model.getItem(machineList.currentIndex) != undefined ? machineList.model.getItem(machineList.currentIndex).name : ""
-        return name
+        return machineList.model.getItem(machineList.currentIndex) != undefined ? machineList.model.getItem(machineList.currentIndex).name : "";
+    }
+
+    function getMachineMetaDataEntry(key)
+    {
+        var metadata = machineList.model.getItem(machineList.currentIndex) != undefined ? machineList.model.getItem(machineList.currentIndex).metadata : undefined;
+        if (metadata)
+        {
+            return metadata[key];
+        }
+        return undefined;
+    }
+    Label {
+        id: titleLabel
+
+        anchors {
+            top: parent.top
+            left: parent.left
+            topMargin: UM.Theme.getSize("default_margin")
+        }
+        text: catalog.i18nc("@title:tab", "Add a printer to Cura")
+
+        font.pointSize: 18
+    }
+
+    Label
+    {
+        id: captionLabel
+        anchors
+        {
+            left: parent.left
+            top: titleLabel.bottom
+            topMargin: UM.Theme.getSize("default_margin")
+        }
+        text: catalog.i18nc("@title:tab", "Select the printer you want to use from the list below.\n\nIf your printer is not in the list, use the \"Custom FFF Printer\" from the \"Custom\" category and match adjust the settings to match your printer in the next dialog.")
+        width: parent.width
+        wrapMode: Text.WordWrap
     }
 
     ScrollView
@@ -57,11 +93,19 @@ UM.Dialog
 
         anchors
         {
-            left: parent.left;
-            top: parent.top;
-            right: parent.right;
-            bottom: machineNameRow.top;
+            top: captionLabel.visible ? captionLabel.bottom : parent.top;
+            topMargin: captionLabel.visible ? UM.Theme.getSize("default_margin").height : 0;
+            bottom: addPrinterButton.top;
             bottomMargin: UM.Theme.getSize("default_margin").height
+        }
+
+        width: Math.round(parent.width * 0.45)
+
+        frameVisible: true;
+        Rectangle {
+            parent: viewport
+            anchors.fill: parent
+            color: palette.light
         }
 
         ListView
@@ -184,32 +228,76 @@ UM.Dialog
         }
     }
 
-    Row
+    Column
     {
-        id: machineNameRow
-        anchors.bottom:parent.bottom
-        spacing: UM.Theme.getSize("default_margin").width
-
-        Label
+        anchors
         {
-            text: catalog.i18nc("@label", "Printer Name:")
-            anchors.verticalCenter: machineName.verticalCenter
+            top: machinesHolder.top
+            left: machinesHolder.right
+            right: parent.right
+            leftMargin: UM.Theme.getSize("default_margin").width
         }
 
-        TextField
+        spacing: UM.Theme.getSize("default_margin").height
+        Label
         {
-            id: machineName
+            width: parent.width
+            wrapMode: Text.WordWrap
             text: getMachineName()
-            implicitWidth: UM.Theme.getSize("standard_list_input").width
-            maximumLength: 40
-            //validator: Cura.MachineNameValidator { } //TODO: Gives a segfault in PyQt5.6. For now, we must use a signal on text changed.
-            validator: RegExpValidator
+            font.pointSize: 16
+            elide: Text.ElideRight
+        }
+        Grid
+        {
+            width: parent.width
+            columns: 2
+            rowSpacing: UM.Theme.getSize("default_lining").height
+            columnSpacing: UM.Theme.getSize("default_margin").width
+            verticalItemAlignment: Grid.AlignVCenter
+
+            Label
             {
-                regExp: {
-                    machineName.machine_name_validator.machineNameRegex
-                }
+                wrapMode: Text.WordWrap
+                text: catalog.i18nc("@label", "Manufacturer")
             }
-            property var machine_name_validator: Cura.MachineNameValidator { }
+            Label
+            {
+                width: Math.floor(parent.width * 0.65)
+                wrapMode: Text.WordWrap
+                text: getMachineMetaDataEntry("manufacturer")
+            }
+            Label
+            {
+                wrapMode: Text.WordWrap
+                text: catalog.i18nc("@label", "Author")
+            }
+            Label
+            {
+                width: Math.floor(parent.width * 0.75)
+                wrapMode: Text.WordWrap
+                text: getMachineMetaDataEntry("author")
+            }
+            Label
+            {
+                wrapMode: Text.WordWrap
+                text: catalog.i18nc("@label", "Printer Name")
+            }
+            TextField
+            {
+                id: machineName
+                text: getMachineName()
+                width: Math.floor(parent.width * 0.75)
+                implicitWidth: UM.Theme.getSize("standard_list_input").width
+                maximumLength: 40
+                //validator: Cura.MachineNameValidator { } //TODO: Gives a segfault in PyQt5.6. For now, we must use a signal on text changed.
+                validator: RegExpValidator
+                {
+                    regExp: {
+                        machineName.machine_name_validator.machineNameRegex
+                    }
+                }
+                property var machine_name_validator: Cura.MachineNameValidator { }
+            }
         }
     }
 


### PR DESCRIPTION
This PR applies some TLC to one of the first dialogs a new user of Cura is presented with. The layout is loosely modeled on the layout of the UM3/UMS5 "Connect to Network" dialog, and adds some instructions/intention to the dialog.

![image](https://user-images.githubusercontent.com/143551/46556854-3ca1ba80-c8e8-11e8-9dc5-6ebee4919f2c.png)


