### PR TITLE
[3.5] Use 0.1 layer height as normal for Ender 3

### DIFF
--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -60,7 +60,7 @@
             "default_value": 20
         },
         "layer_height": {
-            "default_value": 0.15
+            "default_value": 0.10
         },
         "layer_height_0": {
             "default_value": 0.2


### PR DESCRIPTION
hi @stelgenhof, because the default layer height of Ender 3 is 0.15mm which is the same as "Draft" quality, you can see double qualities in the dropdown list:
![image](https://user-images.githubusercontent.com/2630468/46715881-27b78500-cc62-11e8-9ce1-1dd53670c0f7.png)

So, we propose to change the default layer height to 0.1mm. For Ender 3, you already have `"preferred_quality_type": "draft"`, so it will be draft by default which is 0.15mm