### PR TITLE
Prevent Cura from messing with serial ports of other devices

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
+++ b/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
@@ -5,6 +5,8 @@ import threading
 import platform
 import time
 import serial.tools.list_ports
+from os import environ
+from re import search
 
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtProperty, pyqtSignal
 
@@ -175,6 +177,27 @@ class USBPrinterOutputDeviceManager(QObject, OutputDevicePlugin):
                 port = (port.device, port.description, port.hwid)
             if only_list_usb and not port[2].startswith("USB"):
                 continue
+
+            # To prevent cura from messing with serial ports of other devices,
+            # filter by regular expressions passed in as environment variables.
+            # Get possible patterns with python3 -m serial.tools.list_ports -v
+
+            # set CURA_DEVICENAMES=USB[1-9] -> e.g. not matching /dev/ttyUSB0
+            pattern = environ.get('CURA_DEVICENAMES')
+            if pattern and not search(pattern, port[0]):
+                continue
+
+            # set CURA_DEVICETYPES=CP2102 -> match a type of serial converter
+            pattern = environ.get('CURA_DEVICETYPES')
+            if pattern and not search(pattern, port[1]):
+                continue
+
+            # set CURA_DEVICEINFOS=LOCATION=2-1.4 -> match a physical port
+            # set CURA_DEVICEINFOS=VID:PID=10C4:EA60 -> match a vendor:product
+            pattern = environ.get('CURA_DEVICEINFOS')
+            if pattern and not search(pattern, port[2]):
+                continue
+
             base_list += [port[0]]
 
         return list(base_list)


### PR DESCRIPTION
…by filtering ports with regular expressions passed in as environment variables.

## The problem
Cura scans all USB serial ports for printers. To do this it reads (steals) data from the ports, writes data and changes settings of those ports. 
Due to this you cannot use USB serial ports for other things while using Cura.

## Not a solution here
Cura could check for lock files and leave associated ports alone. Not all other software uses those lock files, so this would not be a universal solution.
On linux you can prevent unwanted access to the devices by authorization. E.g. make the device file owned by a group and make only the services or users that should access the device a member of that group. This does not help here, since the Cura user and the user of the other devices can easily be the same. Also it would need an administrator to set this up.

## Solution
This patch allows an enduser to set environment variables with regular expression patterns describing ports Cura is allowed to use, based on device name, device type or physical port.

## Example usage 
Call this to find a unique pattern for your 3d printer port:
```
python3 -m serial.tools.list_ports -v

/dev/ttyUSB0        
    desc: CP2102 USB to UART Bridge Controller
    hwid: USB VID:PID=10C4:EA60 SER=0001 LOCATION=2-1.1
/dev/ttyUSB1        
    desc: USB2.0-Serial
    hwid: USB VID:PID=1A86:7523 LOCATION=1-1.1
/dev/ttyUSB2        
    desc: Qualcomm Gobi 2000
    hwid: USB VID:PID=05C6:9204 LOCATION=2-1.4
/dev/ttyUSB3        
    desc: CP2102 USB to UART Bridge Controller
    hwid: USB VID:PID=10C4:EA60 SER=0001 LOCATION=1-1.2
4 ports found
```
Then set an environment variable according to your needs, e.g.:

 CURA_DEVICETYPES=CP2102 -> match a desc type of serial converter
 CURA_DEVICEINFOS=LOCATION=2-1.4 -> match a specific physical port
 CURA_DEVICEINFOS=VID:PID=10C4:EA60 -> match a vendor:product id
 CURA_DEVICENAMES=USB[1-9] -> not matching /dev/ttyUSB0. 

The last example is not recommended though, since device names are volatile outside of the users control.
