### PR TITLE
Feature: "First Layer Support Line Width"

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -973,6 +973,20 @@
                             "maximum_value_warning": "150",
                             "settable_per_mesh": false,
                             "settable_per_extruder": true
+                        },
+                        "first_layer_support_line_width": 
+                        {
+                            "label": "First Layer Support Line Width",
+                            "description": "Separate line width for the first layer of support structure that touches the raft or build plate. After this first layer, the support line width returns to normal.",
+                            "type": "float",
+                            "unit": "mm",
+                            "minimum_value": "0.001",
+                            "default_value": 0.4,
+                            "enabled": "support_enable",
+                            "value": "line_width",
+                            "limit_to_extruder": "support_infill_extruder_nr",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
                         }
                     }
                 }


### PR DESCRIPTION
This feature set separate line width for the first layer of support that touches the raft or build plate. After this first layer, the support line width returns to normal.
New setting: "First Layer Support Line Width"
Default value is 0.4 (in consistency with default value for support line width).
Additional info:
CuraEngine already has setting "Initial Layer Line Width"(initial_layer_line_width_factor) used for multiplying the line width on layers <= 0. The "First Layer Support Line Width" feature allows to set separate line width only for the support only on the very first layer (it could be the 0 layer, if adhesion type is not raft, or the very first support layer on the top of the raft – first of the filler layer – if adhesion type is raft).
This PR is frontend settings for backend implementation: https://github.com/Ultimaker/CuraEngine/pull/880