### PR TITLE
Feature: "Nozzle Switch Extra Prime Distance"

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2466,6 +2466,19 @@
                             "settable_per_extruder": true
                         }
                     }
+                },
+                "switch_extruder_extra_prime_distance": 
+                {
+                    "label": "Nozzle Switch Extra Prime Distance",
+                    "description": "Extra material to prime after nozzle switching.",
+                    "type": "float",
+                    "unit": "mm",
+                    "default_value": 0,
+                    "minimum_value_warning": "0",
+                    "maximum_value_warning": "100",
+                    "enabled": "retraction_enable",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2467,12 +2467,12 @@
                         }
                     }
                 },
-                "switch_extruder_extra_prime_distance": 
+                "switch_extruder_extra_prime_amount": 
                 {
-                    "label": "Nozzle Switch Extra Prime Distance",
+                    "label": "Nozzle Switch Extra Prime Amount",
                     "description": "Extra material to prime after nozzle switching.",
                     "type": "float",
-                    "unit": "mm",
+                    "unit": "mm³",
                     "default_value": 0,
                     "minimum_value_warning": "0",
                     "maximum_value_warning": "100",


### PR DESCRIPTION
Feature: "Nozzle Switch Extra Prime Distance"
This feature allows to set the extra material to prime after nozzle switching.
New Setting:
"Nozzle Switch Extra Prime Distance"
This PR is frontend settings for backend implementation: https://github.com/Ultimaker/CuraEngine/pull/882