### PR TITLE
Update OAuth2 scopes

### DIFF
--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -45,7 +45,7 @@ class Account(QObject):
             CALLBACK_PORT=self._callback_port,
             CALLBACK_URL="http://localhost:{}/callback".format(self._callback_port),
             CLIENT_ID="um---------------ultimaker_cura_drive_plugin",
-            CLIENT_SCOPES="user.read drive.backups.read drive.backups.write",
+            CLIENT_SCOPES="account.user.read drive.backup.read drive.backup.write packages.download packages.rating.read packages.rating.write",
             AUTH_DATA_PREFERENCE_KEY="general/ultimaker_auth_data",
             AUTH_SUCCESS_REDIRECT="{}/app/auth-success".format(self._oauth_root),
             AUTH_FAILED_REDIRECT="{}/app/auth-error".format(self._oauth_root)


### PR DESCRIPTION
Cloud team has updated the OAuth2 scopes format to be more uniform, while keeping compatibility with the old scopes) It is still advised though that all clients switch their requested scopes to the new format. This is currently deployed on staging as a test and will be deployed to production early next week, so this PR should be merged after that. Part of STAR-273.