### PR TITLE
[3.6] CL-1117 Hotfix: Show printer selection

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml
@@ -8,9 +8,6 @@ import UM 1.1 as UM
 
 UM.Dialog {
     id: base;
-    property var printersModel: {
-        return ListModel{};
-    }
     height: minimumHeight;
     leftButtons: [
         Button {
@@ -87,7 +84,9 @@ UM.Dialog {
             id: printerSelectionCombobox;
             Behavior on height { NumberAnimation { duration: 100 } }
             height: 40 * screenScaleFactor;
-            model: base.printersModel;
+            model: ListModel {
+                id: printersModel;
+            }
             textRole: "name";
             width: parent.width;
         }


### PR DESCRIPTION
Small fix in QML to make sure the printer selection pops up for clusters when sending print jobs.