### PR TITLE
CL-1119 Use shorter machine name for skeleton and longer for text (Fix for 3.6)

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/PrinterCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrinterCard.qml
@@ -118,7 +118,10 @@ Item {
                     Item {
                         id: machineNameLabel;
                         height: UM.Theme.getSize("monitor_text_line").height;
-                        width: Math.round(parent.width * 0.3);
+                        width: {
+                            var percent = printer ? 0.75 : 0.3;
+                            return Math.round(parent.width * percent);
+                        }
 
                         // Skeleton
                         Rectangle {


### PR DESCRIPTION
Contributes to CL-1119

Fixes this issue:

![image](https://user-images.githubusercontent.com/1137232/47509341-37e07e80-d876-11e8-9073-3f7178e46451.png)
