### PR TITLE
Fix type error in NetworkedPrinterOutputDevice.post

### DIFF
--- a/cura/PrinterOutput/NetworkedPrinterOutputDevice.py
+++ b/cura/PrinterOutput/NetworkedPrinterOutputDevice.py
@@ -213,7 +213,7 @@ class NetworkedPrinterOutputDevice(PrinterOutputDevice):
         request = self._createEmptyRequest(target)
         self._last_request_time = time()
         if self._manager is not None:
-            reply = self._manager.post(request, data)
+            reply = self._manager.post(request, data.encode())
             if on_progress is not None:
                 reply.uploadProgress.connect(on_progress)
             self._registerOnFinishedCallback(reply, on_finished)

--- a/plugins/UM3NetworkPrinting/src/LegacyUM3OutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/LegacyUM3OutputDevice.py
@@ -499,8 +499,8 @@ class LegacyUM3OutputDevice(NetworkedPrinterOutputDevice):
         self._authentication_id = None
 
         self.post("auth/request",
-                  json.dumps({"application":  "Cura-" + CuraApplication.getInstance().getVersion(),
-                                               "user": self._getUserName()}).encode(),
+                  json.dumps({"application": "Cura-" + CuraApplication.getInstance().getVersion(),
+                              "user": self._getUserName()}),
                   on_finished=self._onRequestAuthenticationFinished)
 
         self.setAuthenticationState(AuthState.AuthenticationRequested)


### PR DESCRIPTION
This PR fixes a type error in NetworkedPrinterOutputDevice.post: NetworkedPrinterOutputDevice.post takes data as a Python string, and passes that to QNetworkManager.post(), which does not handle strings.

Strictly speaking the QNetworkManager.post() method takes a QByteArray instead of Python bytes, but according to the PyQt documentation, PyQt handles that conversion transparently:
http://pyqt.sourceforge.net/Docs/PyQt5/gotchas.html#python-strings-qt-strings-and-unicode

The type mismatch only came up recently when I added typing to OctoPrintPlugin:
https://github.com/fieldOfView/OctoPrintPlugin/issues/88#issuecomment-433621940
Only that plugin and the LegacyUM3OutputDevice use the NetworkedPrinterOutputDevice.post method. It would cause a crash when using the manual printer controls. I don't think LegacyUM3OutputDevice gets tested much, which is why this error was not spotted before.

From a product hygiene standpoint, I would argue that this needs to be fixed in Cura 3.6, though I can work around it for OctoPrintPlugin.