### PR TITLE
Use preferred material instead of generic PLA when creating a new material

### DIFF
--- a/cura/Machines/MaterialManager.py
+++ b/cura/Machines/MaterialManager.py
@@ -622,8 +622,11 @@ class MaterialManager(QObject):
         machine_manager = self._application.getMachineManager()
         extruder_stack = machine_manager.activeStack
 
+        machine_definition = self._application.getGlobalContainerStack().definition
+        preferred_material = machine_definition.getMetaDataEntry("preferred_material")
+
         approximate_diameter = str(extruder_stack.approximateMaterialDiameter)
-        root_material_id = "generic_pla"
+        root_material_id = preferred_material if preferred_material else "generic_pla"
         root_material_id = self.getRootMaterialIDForDiameter(root_material_id, approximate_diameter)
         material_group = self.getMaterialGroup(root_material_id)
 


### PR DESCRIPTION
This PR changes how the "Create" button on the Materials pane of the Preferences creates a new material. Since Cura 2.3, a new material is created by duplicating the Generic PLA material. This is done because *most of the time* creating a duplicate of PLA creates a material that is sure to be available for the current printer. However, for some printers, (generic) PLA may not be available or applicable (eg a printer that is specifically not compatible with the generic materials and only shows the materials that are offered/tested by a specific vendor).

Generic PLA is still used for printers that do not specify a preferred material.