### PR TITLE
CL-1118 Don't show the context menu for printed jobs

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/PrintJobContextMenu.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrintJobContextMenu.qml
@@ -33,6 +33,7 @@ Item {
         hoverEnabled: true;
         onClicked: parent.switchPopupState();
         text: "\u22EE"; //Unicode; Three stacked points.
+        visible: printJob.state == "queued" || running ? true : false;
         width: 35 * screenScaleFactor; // TODO: Theme!
     }
 
@@ -101,7 +102,7 @@ Item {
 
             PrintJobContextMenuItem {
                 enabled: {
-                    if (printJob && !running) {
+                    if (printJob && printJob.state == "queued") {
                         if (OutputDevice && OutputDevice.queuedPrintJobs[0]) {
                             return OutputDevice.queuedPrintJobs[0].key != printJob.key;
                         }
@@ -116,7 +117,7 @@ Item {
             }
 
             PrintJobContextMenuItem {
-                enabled: printJob && !running;
+                enabled: printJob && printJob.state == "queued";
                 onClicked: {
                     deleteConfirmationDialog.visible = true;
                     popup.close();


### PR DESCRIPTION
The context menu for queued jobs has "move to top" and "delete"

The context menu for running jobs has "pause" and "abort"

The context menu for paused jobs has "resume" and "abort"

All other print job states do not show the context menu