### PR TITLE
Fix duplicated generic materials

### DIFF
--- a/plugins/Toolbox/src/Toolbox.py
+++ b/plugins/Toolbox/src/Toolbox.py
@@ -845,6 +845,7 @@ class Toolbox(QObject, Extension):
     def buildMaterialsModels(self) -> None:
         self._metadata["materials_showcase"] = []
         self._metadata["materials_available"] = []
+        self._metadata["materials_generic"] = []
 
         processed_authors = [] # type: List[str]
 


### PR DESCRIPTION
Reset the list of generic materials to emtpy when creating the models.

Contributes to CURA-5873.