### PR TITLE
Remove laggy transitions

### DIFF
--- a/resources/qml/AddMachineDialog.qml
+++ b/resources/qml/AddMachineDialog.qml
@@ -213,28 +213,6 @@ UM.Dialog
 
                     PropertyChanges { target: machineButton; opacity: 0; height: 0; }
                 }
-
-                transitions:
-                [
-                    Transition
-                    {
-                        to: "collapsed";
-                        SequentialAnimation
-                        {
-                            NumberAnimation { property: "opacity"; duration: 75; }
-                            NumberAnimation { property: "height"; duration: 75; }
-                        }
-                    },
-                    Transition
-                    {
-                        from: "collapsed";
-                        SequentialAnimation
-                        {
-                            NumberAnimation { property: "height"; duration: 75; }
-                            NumberAnimation { property: "opacity"; duration: 75; }
-                        }
-                    }
-                ]
             }
         }
     }


### PR DESCRIPTION
Remove transitions when collapsing/expanding the printer category in the add printer dialog. Due to these transitions, there is a weird behavior that Cura seems laggy when in fact is only the transition that make this feeling.