### PR TITLE
Fix legacy profile importer

### DIFF
--- a/cura/Machines/QualityManager.py
+++ b/cura/Machines/QualityManager.py
@@ -16,7 +16,7 @@ from .QualityGroup import QualityGroup
 from .QualityNode import QualityNode
 
 if TYPE_CHECKING:
-    from UM.Settings.DefinitionContainer import DefinitionContainer
+    from UM.Settings.Interfaces import DefinitionContainerInterface
     from cura.Settings.GlobalStack import GlobalStack
     from .QualityChangesGroup import QualityChangesGroup
     from cura.CuraApplication import CuraApplication
@@ -538,7 +538,7 @@ class QualityManager(QObject):
 #      Example: for an Ultimaker 3 Extended, it has "quality_definition = ultimaker3". This means Ultimaker 3 Extended
 #               shares the same set of qualities profiles as Ultimaker 3.
 #
-def getMachineDefinitionIDForQualitySearch(machine_definition: "DefinitionContainer",
+def getMachineDefinitionIDForQualitySearch(machine_definition: "DefinitionContainerInterface",
                                            default_definition_id: str = "fdmprinter") -> str:
     machine_definition_id = default_definition_id
     if parseBool(machine_definition.getMetaDataEntry("has_machine_quality", False)):

--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -419,13 +419,13 @@ class ContainerManager(QObject):
             self._container_name_filters[name_filter] = entry
 
     ##  Import single profile, file_url does not have to end with curaprofile
-    @pyqtSlot(QUrl, result="QVariantMap")
-    def importProfile(self, file_url: QUrl):
+    @pyqtSlot(QUrl, result = "QVariantMap")
+    def importProfile(self, file_url: QUrl) -> Dict[str, str]:
         if not file_url.isValid():
-            return
+            return {"status": "error", "message": catalog.i18nc("@info:status", "Invalid file URL:") + " " + file_url}
         path = file_url.toLocalFile()
         if not path:
-            return
+            return {"status": "error", "message": catalog.i18nc("@info:status", "Invalid file URL:") + " " + file_url}
         return self._container_registry.importProfile(path)
 
     @pyqtSlot(QObject, QUrl, str)

--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -422,10 +422,10 @@ class ContainerManager(QObject):
     @pyqtSlot(QUrl, result = "QVariantMap")
     def importProfile(self, file_url: QUrl) -> Dict[str, str]:
         if not file_url.isValid():
-            return {"status": "error", "message": catalog.i18nc("@info:status", "Invalid file URL:") + " " + file_url}
+            return {"status": "error", "message": catalog.i18nc("@info:status", "Invalid file URL:") + " " + str(file_url)}
         path = file_url.toLocalFile()
         if not path:
-            return {"status": "error", "message": catalog.i18nc("@info:status", "Invalid file URL:") + " " + file_url}
+            return {"status": "error", "message": catalog.i18nc("@info:status", "Invalid file URL:") + " " + str(file_url)}
         return self._container_registry.importProfile(path)
 
     @pyqtSlot(QObject, QUrl, str)

--- a/cura/Settings/CuraContainerRegistry.py
+++ b/cura/Settings/CuraContainerRegistry.py
@@ -5,8 +5,7 @@ import os
 import re
 import configparser
 
-from typing import cast, Optional
-
+from typing import cast, Dict, Optional
 from PyQt5.QtWidgets import QMessageBox
 
 from UM.Decorators import override
@@ -161,20 +160,20 @@ class CuraContainerRegistry(ContainerRegistry):
 
     ##  Imports a profile from a file
     #
-    #   \param file_name \type{str} the full path and filename of the profile to import
-    #   \return \type{Dict} dict with a 'status' key containing the string 'ok' or 'error', and a 'message' key
-    #       containing a message for the user
-    def importProfile(self, file_name):
+    #   \param file_name The full path and filename of the profile to import.
+    #   \return Dict with a 'status' key containing the string 'ok' or 'error',
+    #       and a 'message' key containing a message for the user.
+    def importProfile(self, file_name: str) -> Dict[str, str]:
         Logger.log("d", "Attempting to import profile %s", file_name)
         if not file_name:
-            return { "status": "error", "message": catalog.i18nc("@info:status Don't translate the XML tags <filename> or <message>!", "Failed to import profile from <filename>{0}</filename>: <message>{1}</message>", file_name, "Invalid path")}
+            return { "status": "error", "message": catalog.i18nc("@info:status Don't translate the XML tags <filename>!", "Failed to import profile from <filename>{0}</filename>: {1}", file_name, "Invalid path")}
 
         plugin_registry = PluginRegistry.getInstance()
         extension = file_name.split(".")[-1]
 
         global_stack = Application.getInstance().getGlobalContainerStack()
         if not global_stack:
-            return
+            return {"status": "error", "message": catalog.i18nc("@info:status Don't translate the XML tags <filename>!", "Can't import profile from <filename>{0}</filename> before a printer is added.", file_name)}
 
         machine_extruders = []
         for position in sorted(global_stack.extruders):

--- a/plugins/LegacyProfileReader/DictionaryOfDoom.json
+++ b/plugins/LegacyProfileReader/DictionaryOfDoom.json
@@ -1,6 +1,6 @@
 {
     "source_version": "15.04",
-    "target_version": 3,
+    "target_version": "4.5",
 
     "translation": {
         "machine_nozzle_size": "nozzle_size",

--- a/plugins/LegacyProfileReader/LegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/LegacyProfileReader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Ultimaker B.V.
+# Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 import configparser  # For reading the legacy profile INI files.

--- a/plugins/LegacyProfileReader/LegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/LegacyProfileReader.py
@@ -6,6 +6,7 @@ import io
 import json  # For reading the Dictionary of Doom.
 import math  # For mathematical operations included in the Dictionary of Doom.
 import os.path  # For concatenating the path to the plugin and the relative path to the Dictionary of Doom.
+from typing import Dict
 
 from UM.Application import Application  # To get the machine manager to create the new profile in.
 from UM.Logger import Logger  # Logging errors.
@@ -33,10 +34,11 @@ class LegacyProfileReader(ProfileReader):
     #   \param json The JSON file to load the default setting values from. This
     #   should not be a URL but a pre-loaded JSON handle.
     #   \return A dictionary of the default values of the legacy Cura version.
-    def prepareDefaults(self, json):
+    def prepareDefaults(self, json: Dict[str, Dict[str, str]]) -> Dict[str, str]:
         defaults = {}
-        for key in json["defaults"]:  # We have to copy over all defaults from the JSON handle to a normal dict.
-            defaults[key] = json["defaults"][key]
+        if "defaults" in json:
+            for key in json["defaults"]:  # We have to copy over all defaults from the JSON handle to a normal dict.
+                defaults[key] = json["defaults"][key]
         return defaults
 
     ##  Prepares the local variables that can be used in evaluation of computing

--- a/plugins/LegacyProfileReader/LegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/LegacyProfileReader.py
@@ -82,9 +82,9 @@ class LegacyProfileReader(ProfileReader):
         profile_id = container_registry.uniqueName("Imported Legacy Profile")
         profile = InstanceContainer(profile_id)  # Create an empty profile.
 
-        parser = configparser.ConfigParser(interpolation = None)
+        input_parser = configparser.ConfigParser(interpolation = None)
         try:
-            parser.read([file_name])  # Parse the INI file.
+            input_parser.read([file_name])  # Parse the INI file.
         except Exception as e:
             Logger.log("e", "Unable to open legacy profile %s: %s", file_name, str(e))
             return None
@@ -92,7 +92,7 @@ class LegacyProfileReader(ProfileReader):
         # Legacy Cura saved the profile under the section "profile_N" where N is the ID of a machine, except when you export in which case it saves it in the section "profile".
         # Since importing multiple machine profiles is out of scope, just import the first section we find.
         section = ""
-        for found_section in parser.sections():
+        for found_section in input_parser.sections():
             if found_section.startswith("profile"):
                 section = found_section
                 break
@@ -110,7 +110,7 @@ class LegacyProfileReader(ProfileReader):
             return None
 
         defaults = self.prepareDefaults(dict_of_doom)
-        legacy_settings = self.prepareLocals(parser, section, defaults) #Gets the settings from the legacy profile.
+        legacy_settings = self.prepareLocals(input_parser, section, defaults) #Gets the settings from the legacy profile.
 
         #Check the target version in the Dictionary of Doom with this application version.
         if "target_version" not in dict_of_doom:
@@ -152,15 +152,15 @@ class LegacyProfileReader(ProfileReader):
         profile.setDirty(True)
 
         #Serialise and deserialise in order to perform the version upgrade.
-        parser = configparser.ConfigParser(interpolation = None)
+        output_parser = configparser.ConfigParser(interpolation = None)
         data = profile.serialize()
-        parser.read_string(data)
-        parser["general"]["version"] = "1"
-        if parser.has_section("values"):
-            parser["settings"] = parser["values"]
-            del parser["values"]
+        output_parser.read_string(data)
+        output_parser["general"]["version"] = "1"
+        if output_parser.has_section("values"):
+            output_parser["settings"] = output_parser["values"]
+            del output_parser["values"]
         stream = io.StringIO()
-        parser.write(stream)
+        output_parser.write(stream)
         data = stream.getvalue()
         profile.deserialize(data)
 

--- a/plugins/LegacyProfileReader/LegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/LegacyProfileReader.py
@@ -139,7 +139,7 @@ class LegacyProfileReader(ProfileReader):
             definitions = current_printer_definition.findDefinitions(key = new_setting)
             if definitions:
                 if new_value != value_using_defaults and definitions[0].default_value != new_value:  # Not equal to the default in the new Cura OR the default in the legacy Cura.
-                    output_parser["values"][new_setting] = new_value # Store the setting in the profile!
+                    output_parser["values"][new_setting] = str(new_value) # Store the setting in the profile!
 
         if len(output_parser["values"]) == 0:
             Logger.log("i", "A legacy profile was imported but everything evaluates to the defaults, creating an empty profile.")

--- a/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
-import pytest #To register tests with.
+import configparser # An input for some functions we're testing.
+import pytest # To register tests with.
 
-from LegacyProfileReader import LegacyProfileReader #The module we're testing.
+from LegacyProfileReader import LegacyProfileReader # The module we're testing.
 
 @pytest.fixture
 def legacy_profile_reader():
@@ -11,7 +12,8 @@ def legacy_profile_reader():
 
 test_prepareDefaultsData = [
     {
-        "defaults": {
+        "defaults":
+        {
             "foo": "bar"
         },
         "cheese": "delicious"
@@ -29,3 +31,36 @@ def test_prepareDefaults(legacy_profile_reader, input):
         assert input["defaults"] == output
     else:
         assert output == {}
+
+test_prepareLocalsData = [
+    (
+        { # Parser data.
+            "profile":
+            {
+                "layer_height": "0.2",
+                "infill_density": "30"
+            }
+        },
+        "profile", # Config section.
+        { # Defaults.
+            "layer_height": "0.1",
+            "infill_density": "20",
+            "line_width": "0.4"
+        }
+    )
+]
+
+@pytest.mark.parametrize("parser_data, config_section, defaults", test_prepareLocalsData)
+def test_prepareLocals(legacy_profile_reader, parser_data, config_section, defaults):
+    parser = configparser.ConfigParser()
+    parser.read_dict(parser_data)
+
+    output = legacy_profile_reader.prepareLocals(parser, config_section, defaults)
+
+    assert set(defaults.keys()) <= set(output.keys()) # All defaults must be in there.
+    assert set(parser_data[config_section]) <= set(output.keys()) # All overwritten values must be in there.
+    for key in output:
+        if key in parser_data[config_section]:
+            assert output[key] == parser_data[config_section][key] # If overwritten, must be the overwritten value.
+        else:
+            assert output[key] == defaults[key] # Otherwise must be equal to the default.

--- a/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
@@ -85,18 +85,6 @@ test_prepareLocalsData = [
         { # Defaults.
             "foo": "bla"
         }
-    ),
-    ( # Section does not exist.
-        { # Parser data.
-            "some_other_name":
-            {
-                "foo": "bar"
-            },
-        },
-        "profile", # Config section.
-        { # Defaults.
-            "foo": "baz"
-        }
     )
 ]
 
@@ -114,3 +102,27 @@ def test_prepareLocals(legacy_profile_reader, parser_data, config_section, defau
             assert output[key] == parser_data[config_section][key] # If overwritten, must be the overwritten value.
         else:
             assert output[key] == defaults[key] # Otherwise must be equal to the default.
+
+test_prepareLocalsNoSectionErrorData = [
+    ( # Section does not exist.
+        { # Parser data.
+            "some_other_name":
+            {
+                "foo": "bar"
+            },
+        },
+        "profile", # Config section.
+        { # Defaults.
+            "foo": "baz"
+        }
+    )
+]
+
+##  Test cases where a key error is expected.
+@pytest.mark.parametrize("parser_data, config_section, defaults", test_prepareLocalsNoSectionErrorData)
+def test_prepareLocalsNoSectionError(legacy_profile_reader, parser_data, config_section, defaults):
+    parser = configparser.ConfigParser()
+    parser.read_dict(parser_data)
+
+    with pytest.raises(configparser.NoSectionError):
+        legacy_profile_reader.prepareLocals(parser, config_section, defaults)

--- a/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
@@ -2,8 +2,16 @@
 # Cura is released under the terms of the LGPLv3 or higher.
 
 import configparser # An input for some functions we're testing.
+import os.path # To find the integration test .ini files.
 import pytest # To register tests with.
+import unittest.mock # To mock the application, plug-in and container registry out.
 
+import UM.Application # To mock the application out.
+import UM.PluginRegistry # To mock the plug-in registry out.
+import UM.Settings.ContainerRegistry # To mock the container registry out.
+import UM.Settings.InstanceContainer # To intercept the serialised data from the read() function.
+
+import LegacyProfileReader as LegacyProfileReaderModule # To get the directory of the module.
 from LegacyProfileReader import LegacyProfileReader # The module we're testing.
 
 @pytest.fixture
@@ -121,3 +129,62 @@ def test_prepareLocalsNoSectionError(legacy_profile_reader, parser_data, default
 
     with pytest.raises(configparser.NoSectionError):
         legacy_profile_reader.prepareLocals(parser, "profile", defaults)
+
+intercepted_data = ""
+
+@pytest.mark.parametrize("file_name", ["normal_case.ini"])
+def test_read(legacy_profile_reader, file_name):
+    # Mock out all dependencies. Quite a lot!
+    global_stack = unittest.mock.MagicMock()
+    global_stack.getProperty = unittest.mock.MagicMock(return_value = 1) # For machine_extruder_count setting.
+    def getMetaDataEntry(key, default_value = ""):
+        if key == "quality_definition":
+            return "mocked_quality_definition"
+        if key == "has_machine_quality":
+            return "True"
+    global_stack.definition.getMetaDataEntry = getMetaDataEntry
+    global_stack.definition.getId = unittest.mock.MagicMock(return_value = "mocked_global_definition")
+    application = unittest.mock.MagicMock()
+    application.getGlobalContainerStack = unittest.mock.MagicMock(return_value = global_stack)
+    application_getInstance = unittest.mock.MagicMock(return_value = application)
+    container_registry = unittest.mock.MagicMock()
+    container_registry_getInstance = unittest.mock.MagicMock(return_value = container_registry)
+    container_registry.uniqueName = unittest.mock.MagicMock(return_value = "Imported Legacy Profile")
+    container_registry.findDefinitionContainers = unittest.mock.MagicMock(return_value = [global_stack.definition])
+    UM.Settings.InstanceContainer.setContainerRegistry(container_registry)
+    plugin_registry = unittest.mock.MagicMock()
+    plugin_registry_getInstance = unittest.mock.MagicMock(return_value = plugin_registry)
+    plugin_registry.getPluginPath = unittest.mock.MagicMock(return_value = os.path.dirname(LegacyProfileReaderModule.__file__))
+
+    # Mock out the resulting InstanceContainer so that we can intercept the data before it's passed through the version upgrader.
+    def deserialize(self, data): # Intercepts the serialised data that we'd perform the version upgrade from when deserializing.
+        global intercepted_data
+        intercepted_data = data
+
+        parser = configparser.ConfigParser()
+        parser.read_string(data)
+        self._metadata["position"] = parser["metadata"]["position"]
+    def duplicate(self, new_id, new_name):
+        self._metadata["id"] = new_id
+        self._metadata["name"] = new_name
+        return self
+
+    with unittest.mock.patch.object(UM.Application.Application, "getInstance", application_getInstance):
+        with unittest.mock.patch.object(UM.Settings.ContainerRegistry.ContainerRegistry, "getInstance", container_registry_getInstance):
+            with unittest.mock.patch.object(UM.PluginRegistry.PluginRegistry, "getInstance", plugin_registry_getInstance):
+                with unittest.mock.patch.object(UM.Settings.InstanceContainer.InstanceContainer, "deserialize", deserialize):
+                    with unittest.mock.patch.object(UM.Settings.InstanceContainer.InstanceContainer, "duplicate", duplicate):
+                        result = legacy_profile_reader.read(os.path.join(os.path.dirname(__file__), file_name))
+
+    assert len(result) == 1
+
+    # Let's see what's inside the actual output file that we generated.
+    parser = configparser.ConfigParser()
+    parser.read_string(intercepted_data)
+    assert parser["general"]["definition"] == "mocked_quality_definition"
+    assert parser["general"]["version"] == "4" # Yes, before we upgraded.
+    assert parser["general"]["name"] == "Imported Legacy Profile" # Because we overwrote uniqueName.
+    assert parser["metadata"]["type"] == "quality_changes"
+    assert parser["metadata"]["quality_type"] == "normal"
+    assert parser["metadata"]["position"] == "0"
+    assert parser["metadata"]["setting_version"] == "5" # Yes, before we upgraded.

--- a/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
@@ -41,7 +41,6 @@ test_prepareLocalsData = [
                 "infill_density": "30"
             }
         },
-        "profile", # Config section.
         { # Defaults.
             "layer_height": "0.1",
             "infill_density": "20",
@@ -54,7 +53,6 @@ test_prepareLocalsData = [
             {
             }
         },
-        "profile", # Config section.
         { # Defaults.
         }
     ),
@@ -64,7 +62,6 @@ test_prepareLocalsData = [
             {
             }
         },
-        "profile", # Config section.
         { # Defaults.
             "foo": "bar",
             "boo": "far"
@@ -81,25 +78,24 @@ test_prepareLocalsData = [
                 "foo": "baz" #Not the same as in some_other_name
             }
         },
-        "profile", # Config section.
         { # Defaults.
             "foo": "bla"
         }
     )
 ]
 
-@pytest.mark.parametrize("parser_data, config_section, defaults", test_prepareLocalsData)
-def test_prepareLocals(legacy_profile_reader, parser_data, config_section, defaults):
+@pytest.mark.parametrize("parser_data, defaults", test_prepareLocalsData)
+def test_prepareLocals(legacy_profile_reader, parser_data, defaults):
     parser = configparser.ConfigParser()
     parser.read_dict(parser_data)
 
-    output = legacy_profile_reader.prepareLocals(parser, config_section, defaults)
+    output = legacy_profile_reader.prepareLocals(parser, "profile", defaults)
 
     assert set(defaults.keys()) <= set(output.keys()) # All defaults must be in there.
-    assert set(parser_data[config_section]) <= set(output.keys()) # All overwritten values must be in there.
+    assert set(parser_data["profile"]) <= set(output.keys()) # All overwritten values must be in there.
     for key in output:
-        if key in parser_data[config_section]:
-            assert output[key] == parser_data[config_section][key] # If overwritten, must be the overwritten value.
+        if key in parser_data["profile"]:
+            assert output[key] == parser_data["profile"][key] # If overwritten, must be the overwritten value.
         else:
             assert output[key] == defaults[key] # Otherwise must be equal to the default.
 
@@ -111,7 +107,6 @@ test_prepareLocalsNoSectionErrorData = [
                 "foo": "bar"
             },
         },
-        "profile", # Config section.
         { # Defaults.
             "foo": "baz"
         }
@@ -119,10 +114,10 @@ test_prepareLocalsNoSectionErrorData = [
 ]
 
 ##  Test cases where a key error is expected.
-@pytest.mark.parametrize("parser_data, config_section, defaults", test_prepareLocalsNoSectionErrorData)
-def test_prepareLocalsNoSectionError(legacy_profile_reader, parser_data, config_section, defaults):
+@pytest.mark.parametrize("parser_data, defaults", test_prepareLocalsNoSectionErrorData)
+def test_prepareLocalsNoSectionError(legacy_profile_reader, parser_data, defaults):
     parser = configparser.ConfigParser()
     parser.read_dict(parser_data)
 
     with pytest.raises(configparser.NoSectionError):
-        legacy_profile_reader.prepareLocals(parser, config_section, defaults)
+        legacy_profile_reader.prepareLocals(parser, "profile", defaults)

--- a/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2018 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
+import pytest #To register tests with.
+
+from LegacyProfileReader import LegacyProfileReader #The module we're testing.
+
+@pytest.fixture
+def legacy_profile_reader():
+    return LegacyProfileReader()
+
+test_prepareDefaultsData = [
+    {
+        "defaults": {
+            "foo": "bar"
+        },
+        "cheese": "delicious"
+    },
+    {
+        "cat": "fluffy",
+        "dog": "floofy"
+    }
+]
+
+@pytest.mark.parametrize("input", test_prepareDefaultsData)
+def test_prepareDefaults(legacy_profile_reader, input):
+    output = legacy_profile_reader.prepareDefaults(input)
+    if "defaults" in input:
+        assert input["defaults"] == output
+    else:
+        assert output == {}

--- a/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
+++ b/plugins/LegacyProfileReader/tests/TestLegacyProfileReader.py
@@ -33,7 +33,7 @@ def test_prepareDefaults(legacy_profile_reader, input):
         assert output == {}
 
 test_prepareLocalsData = [
-    (
+    ( # Ordinary case.
         { # Parser data.
             "profile":
             {
@@ -46,6 +46,56 @@ test_prepareLocalsData = [
             "layer_height": "0.1",
             "infill_density": "20",
             "line_width": "0.4"
+        }
+    ),
+    ( # Empty data.
+        { # Parser data.
+            "profile":
+            {
+            }
+        },
+        "profile", # Config section.
+        { # Defaults.
+        }
+    ),
+    ( # All defaults.
+        { # Parser data.
+            "profile":
+            {
+            }
+        },
+        "profile", # Config section.
+        { # Defaults.
+            "foo": "bar",
+            "boo": "far"
+        }
+    ),
+    ( # Multiple config sections.
+        { # Parser data.
+            "some_other_name":
+            {
+                "foo": "bar"
+            },
+            "profile":
+            {
+                "foo": "baz" #Not the same as in some_other_name
+            }
+        },
+        "profile", # Config section.
+        { # Defaults.
+            "foo": "bla"
+        }
+    ),
+    ( # Section does not exist.
+        { # Parser data.
+            "some_other_name":
+            {
+                "foo": "bar"
+            },
+        },
+        "profile", # Config section.
+        { # Defaults.
+            "foo": "baz"
         }
     )
 ]

--- a/plugins/LegacyProfileReader/tests/normal_case.ini
+++ b/plugins/LegacyProfileReader/tests/normal_case.ini
@@ -1,0 +1,7 @@
+[profile]
+foo = bar
+boo = far
+fill_overlap = 3
+
+[alterations]
+some = values


### PR DESCRIPTION
It was very buggy in multiple ways:
* It was checking if the importer generated a file with the current version, but still performed the version upgrade (which should not upgrade if it has the current version).
* It was translating using the dictionary of doom to version 3.0, but the version in the file was explicitly overwritten to version 1.0.
* It was using an actual `Profile` instance to save the settings during translating, and serialised that (which serialises in version 4.5 at the moment) and then overwrites the version to 1.0. So the version upgrade system thought it was upgrading from version 1.0 to 4.5, but in actuality it was upgrading from version 4.5 to 4.5, which could corrupt the files.

Now it no longer uses the `Profile` class so that it stays stable even if Uranium/Cura changes. It no longer checks for the version so that the version upgrade system can do its job. And the version number in the file before upgrading is now set correctly.