### PR TITLE
CPE and CPE+ Comb retractions

### DIFF
--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_CPE_Normal_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_cpe
 variant = AA 0.25
 
 [values]
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 0.5
 speed_infill = =math.ceil(speed_print * 40 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Draft_Print.inst.cfg
@@ -29,7 +29,7 @@ material_print_temperature_layer_0 = =material_print_temperature
 multiple_mesh_overlap = 0
 prime_tower_enable = True
 prime_tower_wipe_enabled = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 1
 retraction_hop = 0.2
 retraction_hop_enabled = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print.inst.cfg
@@ -29,7 +29,7 @@ material_print_temperature_layer_0 = =material_print_temperature
 multiple_mesh_overlap = 0
 prime_tower_enable = True
 prime_tower_wipe_enabled = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 1
 retraction_hop = 0.2
 retraction_hop_enabled = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_High_Quality.inst.cfg
@@ -31,7 +31,7 @@ material_print_temperature_layer_0 = =material_print_temperature
 multiple_mesh_overlap = 0
 prime_tower_enable = True
 prime_tower_wipe_enabled = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 1
 retraction_hop = 0.2
 retraction_hop_enabled = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality.inst.cfg
@@ -31,7 +31,7 @@ material_print_temperature_layer_0 = =material_print_temperature
 multiple_mesh_overlap = 0
 prime_tower_enable = True
 prime_tower_wipe_enabled = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 1
 retraction_hop = 0.2
 retraction_hop_enabled = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Draft_Print.inst.cfg
@@ -15,6 +15,7 @@ variant = AA 0.4
 material_print_temperature = =default_material_print_temperature + 10
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+retraction_combing_max_distance = 50
 skin_overlap = 20
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)
@@ -24,5 +25,5 @@ speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
 wall_thickness = 1
 
 
-infill_pattern = zigzag
+infill_pattern = triangles
 speed_infill = =math.ceil(speed_print * 50 / 60)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print.inst.cfg
@@ -16,11 +16,12 @@ cool_min_speed = 7
 material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+retraction_combing_max_distance = 50
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_wall = =math.ceil(speed_print * 40 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
 
-infill_pattern = zigzag
+infill_pattern = triangles
 speed_infill = =math.ceil(speed_print * 50 / 60)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_High_Quality.inst.cfg
@@ -18,10 +18,11 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+retraction_combing_max_distance = 50
 speed_print = 50
 speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_wall = =math.ceil(speed_print * 30 / 50)
 
-infill_pattern = zigzag
+infill_pattern = triangles
 speed_infill = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality.inst.cfg
@@ -16,10 +16,11 @@ machine_nozzle_cool_down_speed = 0.85
 machine_nozzle_heat_up_speed = 1.5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+retraction_combing_max_distance = 50
 speed_print = 55
 speed_layer_0 = =math.ceil(speed_print * 20 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 speed_wall = =math.ceil(speed_print * 30 / 55)
 
-infill_pattern = zigzag
+infill_pattern = triangles
 speed_infill = =math.ceil(speed_print * 45 / 55)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPEP_Draft_Print.inst.cfg
@@ -30,7 +30,7 @@ material_print_temperature_layer_0 = =material_print_temperature
 multiple_mesh_overlap = 0
 prime_tower_enable = True
 prime_tower_wipe_enabled = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 1
 retraction_hop = 0.2
 retraction_hop_enabled = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPEP_Fast_Print.inst.cfg
@@ -30,7 +30,7 @@ material_print_temperature_layer_0 = =material_print_temperature
 multiple_mesh_overlap = 0
 prime_tower_enable = True
 prime_tower_wipe_enabled = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 1
 retraction_hop = 0.2
 retraction_hop_enabled = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPEP_High_Quality.inst.cfg
@@ -32,7 +32,7 @@ material_print_temperature_layer_0 = =material_print_temperature
 multiple_mesh_overlap = 0
 prime_tower_enable = True
 prime_tower_wipe_enabled = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 1
 retraction_hop = 0.2
 retraction_hop_enabled = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPEP_Normal_Quality.inst.cfg
@@ -32,7 +32,7 @@ material_print_temperature_layer_0 = =material_print_temperature
 multiple_mesh_overlap = 0
 prime_tower_enable = True
 prime_tower_wipe_enabled = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_extrusion_window = 1
 retraction_hop = 0.2
 retraction_hop_enabled = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPE_Draft_Print.inst.cfg
@@ -16,6 +16,7 @@ buildplate = Aluminum
 material_print_temperature = =default_material_print_temperature + 10
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+retraction_combing_max_distance = 50
 skin_overlap = 20
 speed_print = 60
 speed_layer_0 = 20
@@ -25,7 +26,7 @@ speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
 wall_thickness = 1
 
 
-infill_pattern = zigzag
+infill_pattern = triangles
 speed_infill = =math.ceil(speed_print * 50 / 60)
 prime_tower_purge_volume = 1
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPE_Fast_Print.inst.cfg
@@ -17,13 +17,14 @@ cool_min_speed = 7
 material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+retraction_combing_max_distance = 50
 speed_print = 60
 speed_layer_0 = 20
 speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_wall = =math.ceil(speed_print * 40 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
 
-infill_pattern = zigzag
+infill_pattern = triangles
 speed_infill = =math.ceil(speed_print * 50 / 60)
 prime_tower_purge_volume = 1
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPE_High_Quality.inst.cfg
@@ -19,12 +19,13 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+retraction_combing_max_distance = 50
 speed_print = 50
 speed_layer_0 = 20
 speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_wall = =math.ceil(speed_print * 30 / 50)
 
-infill_pattern = zigzag
+infill_pattern = triangles
 speed_infill = =math.ceil(speed_print * 40 / 50)
 prime_tower_purge_volume = 1
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_aluminum_CPE_Normal_Quality.inst.cfg
@@ -17,12 +17,13 @@ machine_nozzle_cool_down_speed = 0.85
 machine_nozzle_heat_up_speed = 1.5
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+retraction_combing_max_distance = 50
 speed_print = 55
 speed_layer_0 = 20
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 speed_wall = =math.ceil(speed_print * 30 / 55)
 
-infill_pattern = zigzag
+infill_pattern = triangles
 speed_infill = =math.ceil(speed_print * 45 / 55)
 prime_tower_purge_volume = 1
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Fast_Print.inst.cfg
@@ -22,7 +22,7 @@ material_print_temperature = =default_material_print_temperature - 10
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Superdraft_Print.inst.cfg
@@ -22,7 +22,7 @@ material_print_temperature = =default_material_print_temperature - 5
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Verydraft_Print.inst.cfg
@@ -22,7 +22,7 @@ material_print_temperature = =default_material_print_temperature - 7
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Draft_Print.inst.cfg
@@ -17,6 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature + 15
 material_standby_temperature = 100
 prime_tower_enable = True
+retraction_combing_max_distance = 50
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Superdraft_Print.inst.cfg
@@ -17,6 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature + 20
 material_standby_temperature = 100
 prime_tower_enable = True
+retraction_combing_max_distance = 50
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 30 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Verydraft_Print.inst.cfg
@@ -17,6 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature + 17
 material_standby_temperature = 100
 prime_tower_enable = True
+retraction_combing_max_distance = 50
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPEP_Fast_Print.inst.cfg
@@ -23,7 +23,7 @@ material_print_temperature = =default_material_print_temperature - 10
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPEP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPEP_Superdraft_Print.inst.cfg
@@ -23,7 +23,7 @@ material_print_temperature = =default_material_print_temperature - 5
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPEP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPEP_Verydraft_Print.inst.cfg
@@ -23,7 +23,7 @@ material_print_temperature = =default_material_print_temperature - 7
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing = off
+retraction_combing_max_distance = 50
 retraction_hop = 0.1
 retraction_hop_enabled = False
 skin_overlap = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPE_Draft_Print.inst.cfg
@@ -18,6 +18,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature + 15
 material_standby_temperature = 100
 prime_tower_enable = True
+retraction_combing_max_distance = 50
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPE_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPE_Superdraft_Print.inst.cfg
@@ -18,6 +18,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature + 20
 material_standby_temperature = 100
 prime_tower_enable = True
+retraction_combing_max_distance = 50
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 30 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPE_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_aluminum_CPE_Verydraft_Print.inst.cfg
@@ -18,6 +18,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature + 17
 material_standby_temperature = 100
 prime_tower_enable = True
+retraction_combing_max_distance = 50
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)


### PR DESCRIPTION
In this commit I changed all CPE and CPE+ profiles to have a 50mm combing max distance without retraction. This should decrease blobs caused by combing long distances.
I also reverted the CPE infill back to triangles, as we now connect this infill type as well.