### PR TITLE
Feature: "Separate Line Distance For Interface Closest to Part and Support"

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4424,6 +4424,89 @@
                         }
                     }
                 },
+                "support_interface_closest_layers_count":
+                {
+                    "label": "Support Interface Closest Layers Count",
+                    "description": "Number of the top interface layers closest to the part / bottom interface layers closest to the support for separately controlled line distance.",
+                    "type": "int",
+                    "default_value": 0,
+                    "minimum_value": "0",
+                    "limit_to_extruder": "support_interface_extruder_nr",
+                    "enabled": "support_interface_enable and (support_enable or support_tree_enable)",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true,
+                    "children":
+                    {
+                        "support_roof_closest_layers_count": 
+                        {
+                            "label": "Support Roof Closest Layers Count",
+                            "description": "Number of the top interface layers closest to the part for separately controlled line distance.",
+                            "type": "int",
+                            "minimum_value": "0",
+                            "default_value": 0,
+                            "limit_to_extruder": "support_roof_extruder_nr",
+                            "enabled": "support_roof_enable and (support_enable or support_tree_enable)",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        },
+                        "support_bottom_closest_layers_count": 
+                        {
+                            "label": "Support Floor Closest Layers Count",
+                            "description": "Number of the bottom interface layers closest to the support for separately controlled line distance.",
+                            "type": "int",
+                            "minimum_value": "0",
+                            "default_value": 0,
+                            "limit_to_extruder": "support_bottom_extruder_nr",
+                            "enabled": "support_bottom_enable and (support_enable or support_tree_enable)",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        }
+                    }
+                },
+                "support_interface_closest_layers_line_distance":
+                {
+                    "label": "Support Interface Closest Layers Line Distance",
+                    "description": "Separate line distance for the top interface layers closest to the part / bottom interface layers closest to the support.",
+                    "unit": "mm",
+                    "type": "float",
+                    "default_value": 0.4,
+                    "minimum_value": "0",
+                    "limit_to_extruder": "support_interface_extruder_nr",
+                    "enabled": "support_interface_enable and (support_enable or support_tree_enable)",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true,
+                    "children":
+                    {
+                        "support_roof_closest_layers_line_distance":
+                        {
+                            "label": "Support Roof Closest Layers Line Distance",
+                            "description": "Separate line distance for the top interface layers closest to the part.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 0.4,
+                            "minimum_value": "0",
+                            "minimum_value_warning": "support_roof_line_width - 0.0001",
+                            "limit_to_extruder": "support_roof_extruder_nr",
+                            "enabled": "support_roof_enable and (support_enable or support_tree_enable)",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        },
+                        "support_bottom_closest_layers_line_distance":
+                        {
+                            "label": "Support Floor Closest Layers Line Distance",
+                            "description": "Separate line distance for the bottom interface layers closest to the support.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 0.4,
+                            "minimum_value": "0",
+                            "minimum_value_warning": "support_bottom_line_width - 0.0001",
+                            "limit_to_extruder": "support_bottom_extruder_nr",
+                            "enabled": "support_bottom_enable and (support_enable or support_tree_enable)",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        }
+                    }
+                },
                 "support_fan_enable":
                 {
                     "label": "Fan Speed Override",


### PR DESCRIPTION
Feature: "Separate Line Distance For Interface Closest to Part and Support"
Separately control the line distance for the top interface layers closest to the part and for the bottom layers closest to the support.
General behavior is shown below:
![separatelinedistance](https://user-images.githubusercontent.com/33023143/48561261-3b58aa00-e8f8-11e8-9a98-cbf6b184c6e3.png)

New Settings:
- "Support Interface Closest Layers Count"("Support Roof Closest Layers Count", "Support Floor Closest Layers Count") - number of the top interface layers closest to the part / bottom interface layers closest to the support for separately controlled line distance.
- "Support Interface Closest Layers Line Distance"("Support Roof Closest Layers Line Distance", "Support Floor Closest Layers Line Distance") - value of the separate line distance.

This PR is frontend settings for backend implementation: https://github.com/Ultimaker/CuraEngine/pull/912