### PR TITLE
Not activate materials if the printer has no materials.

### DIFF
--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -83,7 +83,7 @@ Item
         {
             text: catalog.i18nc("@action:button", "Activate")
             iconName: "list-activate"
-            enabled: !isCurrentItemActivated && Cura.MachineManager.hasMaterials()
+            enabled: !isCurrentItemActivated && Cura.MachineManager.hasMaterials
             onClicked:
             {
                 forceActiveFocus()

--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -83,7 +83,7 @@ Item
         {
             text: catalog.i18nc("@action:button", "Activate")
             iconName: "list-activate"
-            enabled: !isCurrentItemActivated
+            enabled: !isCurrentItemActivated && Cura.MachineManager.hasMaterials()
             onClicked:
             {
                 forceActiveFocus()


### PR DESCRIPTION
Do not allow the user to activate a material if the printer is not defined to have materials. In 3.0.4 it was like this, but it was changed in some refactor.

Contributes to #4550.