### PR TITLE
Switch Ultimaker Account OAuth2 client

### DIFF
--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -38,13 +38,12 @@ class Account(QObject):
 
         self._callback_port = 32118
         self._oauth_root = "https://account.ultimaker.com"
-        self._cloud_api_root = "https://api.ultimaker.com"
 
         self._oauth_settings = OAuth2Settings(
             OAUTH_SERVER_URL= self._oauth_root,
             CALLBACK_PORT=self._callback_port,
             CALLBACK_URL="http://localhost:{}/callback".format(self._callback_port),
-            CLIENT_ID="um---------------ultimaker_cura_drive_plugin",
+            CLIENT_ID="um----------------------------ultimaker_cura",
             CLIENT_SCOPES="account.user.read drive.backup.read drive.backup.write packages.download packages.rating.read packages.rating.write",
             AUTH_DATA_PREFERENCE_KEY="general/ultimaker_auth_data",
             AUTH_SUCCESS_REDIRECT="{}/app/auth-success".format(self._oauth_root),


### PR DESCRIPTION
The new client has access to more permissions and is labeled as "Ultimaker Cura" instead of "Cura Backups Plugin".
Also removes `self._cloud_api_root` as that's not used anymore now that `self._oauth_root` is used for the redirect URLs.