### PR TITLE
Fix an issue when loading Gcode to the New UI

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1663,7 +1663,9 @@ class CuraApplication(QtApplication):
             is_non_sliceable = "." + file_extension in self._non_sliceable_extensions
 
             if is_non_sliceable:
-                self.callLater(lambda: self.getController().setActiveView("SimulationView"))
+                # Need to switch first to the preview stage and then to layer view
+                self.callLater(lambda: (self.getController().setActiveStage("PreviewStage"),
+                                        self.getController().setActiveView("SimulationView")))
 
                 block_slicing_decorator = BlockSlicingDecorator()
                 node.addDecorator(block_slicing_decorator)

--- a/resources/qml/ActionPanel/OutputProcessWidget.qml
+++ b/resources/qml/ActionPanel/OutputProcessWidget.qml
@@ -18,6 +18,7 @@ Column
     id: widget
 
     spacing: UM.Theme.getSize("thin_margin").height
+    property bool preSlicedData: PrintInformation.preSliced
 
     UM.I18nCatalog
     {
@@ -48,7 +49,7 @@ Column
                 id: estimatedTime
                 width: parent.width
 
-                text: PrintInformation.currentPrintTime.getDisplayString(UM.DurationFormat.Long)
+                text: preSlicedData ? catalog.i18nc("@label", "No time estimation available") : PrintInformation.currentPrintTime.getDisplayString(UM.DurationFormat.Long)
                 source: UM.Theme.getIcon("clock")
                 font: UM.Theme.getFont("small")
             }
@@ -63,6 +64,10 @@ Column
 
                 text:
                 {
+                    if (preSlicedData)
+                    {
+                        return catalog.i18nc("@label", "No cost estimation available")
+                    }
                     var totalLengths = 0
                     var totalWeights = 0
                     if (printMaterialLengths)
@@ -86,6 +91,7 @@ Column
         PrintInformationWidget
         {
             id: printInformationPanel
+            visible: !preSlicedData
 
             anchors
             {

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -212,7 +212,7 @@ UM.MainWindow
                     verticalCenter: parent.verticalCenter
                     left: parent.left
                 }
-                visible: CuraApplication.platformActivity
+                visible: CuraApplication.platformActivity && !PrintInformation.preSliced
             }
 
             ObjectsList


### PR DESCRIPTION
I also decided to hide some elements that are not necessary when looking at a gcode file, such as the Toolbar or the  print time estimations.