### PR TITLE
CURA-5867 Fix: if load a model and scale it up to 0.1mm and then load another m…

### DIFF
--- a/cura/Arranging/Arrange.py
+++ b/cura/Arranging/Arrange.py
@@ -66,6 +66,11 @@ class Arrange:
                 continue
             vertices = vertices.getMinkowskiHull(Polygon.approximatedCircle(min_offset))
             points = copy.deepcopy(vertices._points)
+
+            # After scaling (like up to 0.1 mm) the node might not have points
+            if len(points) == 0:
+                continue
+
             shape_arr = ShapeArray.fromPolygon(points, scale = scale)
             arranger.place(0, 0, shape_arr)
 


### PR DESCRIPTION
…odel then Cura will crash. It happens because the model 1 does not

have any points for arranging it on the build plate
