### PR TITLE
CL-1173 Use short printer family tags

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
@@ -97,6 +97,7 @@ Item
                         return ""
                     }
                     visible: printJob
+                    width: 120 * screenScaleFactor // TODO: Theme!
 
                     // FIXED-LINE-HEIGHT:
                     height: 18 * screenScaleFactor // TODO: Theme!

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterPill.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterPill.qml
@@ -12,7 +12,19 @@ import UM 1.2 as UM
 Item
 {
     // The printer name
-    property alias text: printerNameLabel.text;
+    property var text: ""
+    property var tagText: {
+        switch(text) {
+            case "Ultimaker 3":
+                return "UM 3"
+            case "Ultimaker 3 Extended":
+                return "UM 3 EXT"
+            case "Ultimaker S5":
+                return "UM S5"
+            default:
+                return ""
+        }
+    }
 
     implicitHeight: 18 * screenScaleFactor // TODO: Theme!
     implicitWidth: printerNameLabel.contentWidth + 12 // TODO: Theme!
@@ -28,7 +40,7 @@ Item
         id: printerNameLabel
         anchors.centerIn: parent
         color: "#535369" // TODO: Theme!
-        text: ""
+        text: tagText
         font.pointSize: 10
     }
 }

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterPill.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterPill.qml
@@ -22,7 +22,7 @@ Item
             case "Ultimaker S5":
                 return "UM S5"
             default:
-                return ""
+                return text
         }
     }
 


### PR DESCRIPTION
> _Ian, why are you putting this kind of hack into our code base?_

Well I'll tell you: Because Cura Connect uses the printer name/type all over the place so until we have a new design for CC to match Cura 4.0, this was _actually_ a case where the quick solution was also the cleaner one. We can maybe think about adding a "tag" to Cura Connect but then it has to be treated differently than all other printers which use the `NetworkedPrinterOutputModel`.

Contributes to CL-1173.