### PR TITLE
Add Monoprice Ultimate based on Wanhao D6

### DIFF
--- a/resources/definitions/monoprice_ultimate.def.json
+++ b/resources/definitions/monoprice_ultimate.def.json
@@ -1,0 +1,52 @@
+{
+  "version": 2,
+  "name": "Monoprice Ultimate",
+  "inherits": "wanhao_d6",
+  "metadata": {
+    "visible": true,
+    "author": "Danny Tuppeny",
+    "manufacturer": "monoprice",
+    "file_formats": "text/x-gcode",
+    "icon": "wanhao-icon.png",
+    "has_materials": true,
+    "platform": "wanhao_200_200_platform.obj",
+    "platform_texture": "Wanhaobackplate.png",
+    "machine_extruder_trains": {
+      "0": "wanhao_d6_extruder_0"
+    },
+    "platform_offset": [
+      0,
+      -28,
+      0
+    ]
+  },
+  "overrides": {
+    "machine_name": {
+      "default_value": "Monoprice Ultimate"
+    },
+    "machine_max_acceleration_x": {
+      "default_value": 3000
+    },
+    "machine_max_acceleration_y": {
+      "default_value": 3000
+    },
+    "machine_max_acceleration_z": {
+      "default_value": 100
+    },
+    "machine_max_acceleration_e": {
+      "default_value": 500
+    },
+    "machine_acceleration": {
+      "default_value": 800
+    },
+    "machine_max_jerk_xy": {
+      "default_value": 10.0
+    },
+    "machine_max_jerk_z": {
+      "default_value": 0.4
+    },
+    "machine_max_jerk_e": {
+      "default_value": 1.0
+    }
+  }
+}


### PR DESCRIPTION
The default values on my Monoprice Ultimate are way different to what Cura has the Wanhao Duplicator 6 as. I'm guessing that Monoprice have changed these (if not, then maybe the Duplicator 6 file is wrong?). Without this profile, I had a 4hr print estimate for a piece that's only 55% through after 4hours. With this profile, it estimates 7:22 (which seems very accurate).

I got the default values from the printer when I connected Octoprint to it:

```
  21:20:56: Attempting to connect to printer
  21:20:56: Connection opened
< 21:20:57: start
> 21:20:57: N1 M110 *2
< 21:20:57: echo:Marlin 1.0.0
> 21:20:57: N2 M110 *1
< 21:20:57: echo: Last Updated: Jun 26 2016 12:14:19 | Author: Version DEV 3.01
> 21:20:57: N3 M115 *5
< 21:20:57: Compiled: Jun 26 2016
< 21:20:57: echo: Free Memory: 1961  PlannerBufferBytes: 1232
< 21:20:57: echo:Stored settings retrieved
< 21:20:57: echo:Steps per unit:
< 21:20:57: echo:  M92 X80.04 Y80.04 Z400.48 E94.30
< 21:20:57: echo:Maximum feedrates (mm/s):
< 21:20:57: echo:  M203 X300.00 Y300.00 Z5.00 E25.00
< 21:20:57: echo:Maximum Acceleration (mm/s2):
< 21:20:57: echo:  M201 X3000 Y3000 Z100 E500
< 21:20:57: echo:Acceleration: S=acceleration, T=retract acceleration
< 21:20:57: echo:  M204 S800.00 T800.00
< 21:20:57: echo:Advanced variables: S=Min feedrate (mm/s), T=Min travel feedrate (mm/s), B=minimum segment time (ms), X=maximum XY jerk (mm/s),  Z=maximum Z jerk (mm/s),  E=maximum E jerk (mm/s)
< 21:20:57: echo:  M205 S0.00 T0.00 B20000 X10.00 Z0.40 E1.00
< 21:20:57: echo:Home offset (mm):
< 21:20:57: echo:  M206 X0.00 Y0.00 Z0.40
```