### PR TITLE
Fix (USB) print monitor in dark theme

### DIFF
--- a/plugins/USBPrinting/MonitorItem.qml
+++ b/plugins/USBPrinting/MonitorItem.qml
@@ -13,6 +13,8 @@ Component
     {
         Rectangle
         {
+            color: UM.Theme.getColor("main_background")
+
             anchors.right: parent.right
             width: parent.width * 0.3
             anchors.top: parent.top

--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -12,7 +12,7 @@ import Cura 1.0 as Cura
 import "PrinterOutput"
 
 
-Rectangle
+Item
 {
     id: base
     UM.I18nCatalog { id: catalog; name: "cura"}


### PR DESCRIPTION
This PR fixes two instances of an unthemed rectangle, which causes the print monitor (USB/OctoPrint) to look bad in dark themes.