### PR TITLE
[4.0] CURA-5994 Cura used wrong firmware version for UMO+. The firmware was from UMO.

### DIFF
--- a/resources/definitions/ultimaker_original_plus.def.json
+++ b/resources/definitions/ultimaker_original_plus.def.json
@@ -16,7 +16,8 @@
         {
             "0": "ultimaker_original_plus_extruder_0"
         },
-        "firmware_file": "MarlinUltimaker-UMOP-{baudrate}.hex"
+        "firmware_file": "MarlinUltimaker-UMOP-{baudrate}.hex",
+        "firmware_hbk_file": "MarlinUltimaker-UMOP-{baudrate}.hex"
     },
 
     "overrides": {


### PR DESCRIPTION
The reason of this issue because it used a heated firmware from his
parent(UMO) printer. To avoid this case we need to define externally
the firmware_hbk_file property in umo+ defintion file
