### PR TITLE
Remember opened state of settings panel

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -500,6 +500,7 @@ class CuraApplication(QtApplication):
         preferences.addPreference("cura/choice_on_open_project", "always_ask")
         preferences.addPreference("cura/use_multi_build_plate", False)
         preferences.addPreference("view/settings_list_height", 600)
+        preferences.addPreference("view/settings_visible", False)
         preferences.addPreference("cura/currency", "€")
         preferences.addPreference("cura/material_settings", "{}")
 

--- a/resources/qml/ExpandableComponent.qml
+++ b/resources/qml/ExpandableComponent.qml
@@ -64,7 +64,7 @@ Item
     property alias iconSize: collapseButton.height
 
     // Is the "drawer" open?
-    readonly property alias expanded: contentContainer.visible
+    property alias expanded: contentContainer.visible
 
     // What should the radius of the header be. This is also influenced by the headerCornerSide
     property alias headerRadius: background.radius

--- a/resources/qml/PrintSetupSelector/PrintSetupSelector.qml
+++ b/resources/qml/PrintSetupSelector/PrintSetupSelector.qml
@@ -29,4 +29,7 @@ Cura.ExpandableComponent
     property var extrudersModel: CuraApplication.getExtrudersModel()
 
     contentItem: PrintSetupSelectorContents {}
+
+    onExpandedChanged: UM.Preferences.setValue("view/settings_visible", expanded)
+    Component.onCompleted: expanded = UM.Preferences.getValue("view/settings_visible")
 }


### PR DESCRIPTION
So if you restart Cura while the settings panel was open, it'll stay open when Cura is started back up.

Implements issue CURA-6069.