### PR TITLE
Add variant to the configuration menu headerItem

### DIFF
--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -61,6 +61,27 @@ Cura.ExpandablePopup
                     width: height
                 }
 
+                // Label that shows the name of the variant
+                Label
+                {
+                    id: variantLabel
+
+                    visible: Cura.MachineManager.hasVariants
+
+                    text: model.variant
+                    elide: Text.ElideRight
+                    font: UM.Theme.getFont("medium")
+                    color: UM.Theme.getColor("text")
+                    renderType: Text.NativeRendering
+
+                    anchors
+                    {
+                        left: extruderIcon.right
+                        leftMargin: UM.Theme.getSize("default_margin").width
+                        verticalCenter: parent.verticalCenter
+                    }
+                }
+
                 // Label for the brand of the material
                 Label
                 {
@@ -74,7 +95,7 @@ Cura.ExpandablePopup
 
                     anchors
                     {
-                        left: extruderIcon.right
+                        left: variantLabel.visible ? variantLabel.right : extruderIcon.right
                         leftMargin: UM.Theme.getSize("default_margin").width
                         right: parent.right
                         rightMargin: UM.Theme.getSize("default_margin").width
@@ -92,7 +113,7 @@ Cura.ExpandablePopup
 
                     anchors
                     {
-                        left: extruderIcon.right
+                        left: variantLabel.visible ? variantLabel.right : extruderIcon.right
                         leftMargin: UM.Theme.getSize("default_margin").width
                         right: parent.right
                         rightMargin: UM.Theme.getSize("default_margin").width


### PR DESCRIPTION
This PR adds the variant name (print-core / nozzle size) to the headerItem of the configuration menu:
![image](https://user-images.githubusercontent.com/143551/50646276-f820cc00-0f75-11e9-92b3-967d675d91c1.png)

This makes the header a better "summary" of the extruder configuration. Without this, the print core/nozzle size is only shown when expanding the configuration menu for the extruders.