### PR TITLE
Update DisplayFilenameAndLayerOnLCD.py

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/DisplayFilenameAndLayerOnLCD.py
+++ b/plugins/PostProcessingPlugin/scripts/DisplayFilenameAndLayerOnLCD.py
@@ -3,8 +3,9 @@
 # Date:     August 28, 2018
 
 # Description:  This plugin inserts a line at the start of each layer,
-#               M117 - displays the filename and layer height to the LCD
-#               Alternatively, user can override the filename to display alt text + layer height
+#               M117 displays the filename and layer height to the LCD
+#               ** user must enter 'filename'
+#               ** future update: include actual filename
 
 from ..Script import Script
 from UM.Application import Application
@@ -23,10 +24,19 @@ class DisplayFilenameAndLayerOnLCD(Script):
             {
                 "name":
                 {
-                    "label": "text to display:",
+                    "label": "Text to display:",
                     "description": "By default the current filename will be displayed on the LCD. Enter text here to override the filename and display something else.",
                     "type": "str",
                     "default_value": ""
+                },
+                "startNum":
+                {
+                    "label": "Initial layer number:",
+                    "description": "Choose which number you prefer for the initial layer, 0 or 1",
+                    "type": "int",
+                    "default_value": 0,
+                    "minimum_value": 0,
+                    "maximum_value": 1                    
                 }
             }
         }"""
@@ -36,10 +46,10 @@ class DisplayFilenameAndLayerOnLCD(Script):
             name = self.getSettingValueByKey("name")
         else:
             name = Application.getInstance().getPrintInformation().jobName       
-        lcd_text = "M117 " + name + " layer: "
-        i = 0
+        lcd_text = "M117 Layer "
+        i = self.getSettingValueByKey("startNum")
         for layer in data:
-            display_text = lcd_text + str(i)
+            display_text = lcd_text + str(i) + " " + name
             layer_index = data.index(layer)
             lines = layer.split("\n")
             for line in lines:
@@ -50,4 +60,4 @@ class DisplayFilenameAndLayerOnLCD(Script):
             final_lines = "\n".join(lines)
             data[layer_index] = final_lines
             
-        return data
+        return data 


### PR DESCRIPTION
updated to display layer count before filename (layer number was getting cut off in event of long filename).
updated to include option to start layer count at either 0 or 1.
removed ':' in the display string as it is a gcode command that was splitting the line into two different commands.