### PR TITLE
Fix z-fighting on bottom layer of x-ray view

### DIFF
--- a/plugins/XRayView/XRayView.py
+++ b/plugins/XRayView/XRayView.py
@@ -17,6 +17,7 @@ from UM.View.RenderBatch import RenderBatch
 from UM.View.GL.OpenGL import OpenGL
 
 from cura.CuraApplication import CuraApplication
+from cura.Scene.ConvexHullNode import ConvexHullNode
 
 from . import XRayPass
 
@@ -41,6 +42,10 @@ class XRayView(View):
             self._xray_shader.setUniformValue("u_color", Color(*Application.getInstance().getTheme().getColor("xray").getRgb()))
 
         for node in BreadthFirstIterator(scene.getRoot()):
+            # We do not want to render ConvexHullNode as it conflicts with the bottom of the X-Ray (z-fighting).
+            if type(node) is ConvexHullNode:
+                continue
+
             if not node.render(renderer):
                 if node.getMeshData() and node.isVisible():
                     renderer.queueNode(node,


### PR DESCRIPTION
This PR fixes z-fighting in the X-Ray view, by not rendering convex hulls. It sort-of makes sense not to render a shadow in X-Ray view.

Example with a fairly flat model where the z-fighting is particularly distracting:
**Before**
![image](https://user-images.githubusercontent.com/143551/50715686-b0d23280-107e-11e9-9ecc-239a5048d9a3.png)

**After**
![image](https://user-images.githubusercontent.com/143551/50715697-b9c30400-107e-11e9-9dae-cb01387fe285.png)
