### PR TITLE
Create UsePrevProbeMeasure.py

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
+++ b/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
@@ -1,0 +1,46 @@
+# Cura PostProcessingPlugin
+# Author:   Amanda de Castilho
+# Date:     January 5,2019
+
+# Description:  This plugin overrides probing command and inserts code to ensure
+#               previous probe measurements are loaded and bed leveling enabled
+#               (searches for G29 and replaces it with M501 & M420 S1)
+#               *** Assumes G29 is in the start code, will do nothing if it isn't ***
+
+from ..Script import Script
+
+class UsePrevProbeMeasure(Script):
+    def __init__(self):
+        super().__init__()
+
+    def getSettingDataString(self):
+        return """{
+            "name": "Use Previous Probe Measurements",
+            "key": "UsePrevProbeMeasure",
+            "metadata": {},
+            "version": 2,
+            "settings":
+            {
+                "usePrevMeas":
+                {
+                    "label": "Use last measurement?",
+                    "description": "Selecting this will remove the G29 probing command and instead ensure previous measurements are loaded and enabled",
+                    "type": "bool",
+                    "default_value": false
+                }
+            }
+        }"""
+    
+    def execute(self, data):
+        text = "M501 ;load bed level data\nM420 S1 ;enable bed leveling"
+        if self.getSettingValueByKey("usePrevMeas"):
+            for layer in data:
+                layer_index = data.index(layer)
+                lines = layer.split("\n")
+                for line in lines:
+                    if line.startswith("G29"):
+                        line_index = lines.index(line)
+                        lines[line_index] = text
+                final_lines = "\n".join(lines)
+                data[layer_index] = final_lines
+        return data

--- a/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
+++ b/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
@@ -23,7 +23,7 @@ class UsePreviousProbeMeasurements(Script):
             {
                 "use_previous_measurements":
                 {
-                    "label": "Use last measurement?",
+                    "label": "Use last measurement",
                     "description": "Selecting this will remove the G29 probing command and instead ensure previous measurements are loaded and enabled",
                     "type": "bool",
                     "default_value": false

--- a/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
+++ b/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
@@ -9,7 +9,7 @@
 
 from ..Script import Script
 
-class UsePrevProbeMeasure(Script):
+class UsePreviousProbeMeasurements(Script):
     def __init__(self):
         super().__init__()
 

--- a/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
+++ b/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
@@ -21,7 +21,7 @@ class UsePreviousProbeMeasurements(Script):
             "version": 2,
             "settings":
             {
-                "usePrevMeas":
+                "use_previous_measurements":
                 {
                     "label": "Use last measurement?",
                     "description": "Selecting this will remove the G29 probing command and instead ensure previous measurements are loaded and enabled",

--- a/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
+++ b/plugins/PostProcessingPlugin/scripts/UsePrevProbeMeasure.py
@@ -33,7 +33,7 @@ class UsePreviousProbeMeasurements(Script):
     
     def execute(self, data):
         text = "M501 ;load bed level data\nM420 S1 ;enable bed leveling"
-        if self.getSettingValueByKey("usePrevMeas"):
+        if self.getSettingValueByKey("use_previous_measurements"):
             for layer in data:
                 layer_index = data.index(layer)
                 lines = layer.split("\n")

--- a/plugins/PostProcessingPlugin/scripts/UsePreviousProbeMeasurements.py
+++ b/plugins/PostProcessingPlugin/scripts/UsePreviousProbeMeasurements.py
@@ -16,14 +16,14 @@ class UsePreviousProbeMeasurements(Script):
     def getSettingDataString(self):
         return """{
             "name": "Use Previous Probe Measurements",
-            "key": "UsePrevProbeMeasure",
+            "key": "UsePreviousProbeMeasurements",
             "metadata": {},
             "version": 2,
             "settings":
             {
                 "use_previous_measurements":
                 {
-                    "label": "Use last measurement",
+                    "label": "Use last measurement?",
                     "description": "Selecting this will remove the G29 probing command and instead ensure previous measurements are loaded and enabled",
                     "type": "bool",
                     "default_value": false


### PR DESCRIPTION
I wrote this plugin to override the G29 in the start code. When used, instead of probing the bed, it retrieves the last probing measurement from EEPROM and ensures bed leveling is activated.