### PR TITLE
Fixes for networkprinters that are not part of Cura Connect

### DIFF
--- a/cura/PrinterOutput/ConfigurationModel.py
+++ b/cura/PrinterOutput/ConfigurationModel.py
@@ -54,7 +54,7 @@ class ConfigurationModel(QObject):
         for configuration in self._extruder_configurations:
             if configuration is None:
                 return False
-        return self._printer_type is not None
+        return self._printer_type != ""
 
     def __str__(self):
         message_chunks = []

--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -136,9 +136,9 @@ Cura.ExpandablePopup
 
         onVisibleChanged:
         {
-            is_connected = Cura.MachineManager.activeMachineHasRemoteConnection && Cura.MachineManager.printerConnected //Re-evaluate.
+            is_connected = Cura.MachineManager.activeMachineHasRemoteConnection && Cura.MachineManager.printerConnected && Cura.MachineManager.printerOutputDevices[0].uniqueConfigurations.length > 0 //Re-evaluate.
 
-            // If the printer is not connected, we switch always to the custom mode. If is connected instead, the auto mode
+            // If the printer is not connected or does not have configurations, we switch always to the custom mode. If is connected instead, the auto mode
             // or the previous state is selected
             configuration_method = is_connected ? (manual_selected_method == -1 ? ConfigurationMenu.ConfigurationMethod.Auto : manual_selected_method) : ConfigurationMenu.ConfigurationMethod.Custom
         }

--- a/resources/qml/Menus/NetworkPrinterMenu.qml
+++ b/resources/qml/Menus/NetworkPrinterMenu.qml
@@ -12,10 +12,18 @@ Instantiator
     model: Cura.GlobalStacksModel {}
     MenuItem
     {
-        text: model.metadata["connect_group_name"]
+        property string connectGroupName:
+        {
+            if("connect_group_name" in model.metadata)
+            {
+                return model.metadata["connect_group_name"]
+            }
+            return ""
+        }
+        text: connectGroupName
         checkable: true
         visible: model.hasRemoteConnection
-        checked: Cura.MachineManager.activeMachineNetworkGroupName == model.metadata["connect_group_name"]
+        checked: Cura.MachineManager.activeMachineNetworkGroupName == connectGroupName
         exclusiveGroup: group
         onTriggered: Cura.MachineManager.setActiveMachine(model.id)
     }

--- a/resources/qml/PrinterSelector/MachineSelector.qml
+++ b/resources/qml/PrinterSelector/MachineSelector.qml
@@ -26,7 +26,14 @@ Cura.ExpandablePopup
 
     headerItem: Cura.IconWithText
     {
-        text: isNetworkPrinter ? Cura.MachineManager.activeMachineNetworkGroupName : Cura.MachineManager.activeMachineName
+        text:
+        {
+            if (isNetworkPrinter && Cura.MachineManager.activeMachineNetworkGroupName != "")
+            {
+                Cura.MachineManager.activeMachineNetworkGroupName
+            }
+            return Cura.MachineManager.activeMachineName
+        }
         source:
         {
             if (isNetworkPrinter)


### PR DESCRIPTION
This PR fixes how connected networkprinters that are not part of Cura Connect are handled in the interface. Network printers that are using eg OctoPrint (but also others, such as Repetier) don't have "connect_group_name"  metadata and may not have the concept of configurations. The PR also fixes a repeating QML warning for every non-networked printer that is added to Cura (including UM2+).