### PR TITLE
Add 'Experimental' tag for quality profiles in the header.

### DIFF
--- a/resources/qml/Menus/ProfileMenu.qml
+++ b/resources/qml/Menus/ProfileMenu.qml
@@ -20,7 +20,7 @@ Menu
             text:
             {
                 var full_text = (model.layer_height != "") ? model.name + " - " + model.layer_height + model.layer_height_unit : model.name
-                full_text += model.is_experimental ? " - Experimental" : ""
+                full_text += model.is_experimental ? " - " + catalog.i18nc("@label", "Experimental") : ""
                 return full_text
             }
             checkable: true

--- a/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml
+++ b/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml
@@ -24,6 +24,7 @@ RowLayout
                 if (!Cura.MachineManager.hasNotSupportedQuality)
                 {
                     text += " " + layerHeight.properties.value + "mm"
+                    text += Cura.MachineManager.isActiveQualityExperimental ? " - " + catalog.i18nc("@label", "Experimental") : ""
                 }
                 return text
             }


### PR DESCRIPTION
When an experimental quality profile is active, the stage panel does not show that it is experimental.
It is however shown on the quality drop-down menu in Custom mode.

This commit also fixes the untranslated (hardcoded) 'Experimental' string in the dropdown in Custom.

Fixes the issue reported in CURA-6118.