### PR TITLE
CL-1188 hide print job on unavailable printer

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
@@ -306,7 +306,7 @@ Item
                     }
                     if (printer && printer.state == "unreachable")
                     {
-                        return catalog.i18nc("@label:status", "Unavailable")
+                        return catalog.i18nc("@label:status", "Unreachable")
                     }
                     if (printer && !printer.activePrintJob && printer.state == "idle")
                     {
@@ -398,6 +398,7 @@ Item
                 font: UM.Theme.getFont("default")
                 text: catalog.i18nc("@label:status", "Requires configuration changes")
                 visible: printer && printer.activePrintJob && printer.activePrintJob.configurationChanges.length > 0 && !printerStatus.visible
+                color: UM.Theme.getColor("monitor_text_primary")
 
                 // FIXED-LINE-HEIGHT:
                 height: 18 * screenScaleFactor // TODO: Theme!


### PR DESCRIPTION
NOTE: The original issue of the print job requiring action showing up alongside a printer status has been fixed already, so this ticket now just fixes the issue of "unreachable" printers being labeled "unavailable." They're now labeled correctly.