### PR TITLE
CL-1154 Monitor empty states

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -536,6 +536,12 @@ class MachineManager(QObject):
             return has_remote_connection
         return False
 
+    @pyqtProperty("QVariantList", notify=globalContainerChanged)
+    def activeMachineConfiguredConnectionTypes(self):
+        if self._global_container_stack:
+            return self._global_container_stack.configuredConnectionTypes
+        return []
+
     @pyqtProperty(bool, notify = printerConnectedStatusChanged)
     def activeMachineIsGroup(self) -> bool:
         return bool(self._printer_output_devices) and len(self._printer_output_devices[0].printers) > 1

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -2,7 +2,7 @@
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.10
-import QtQuick.Controls 1.4
+import QtQuick.Controls 2.0
 
 import UM 1.3 as UM
 import Cura 1.0 as Cura
@@ -12,6 +12,10 @@ import Cura 1.0 as Cura
 Rectangle
 {
     id: viewportOverlay
+
+    property bool isConnected: Cura.MachineManager.activeMachineHasActiveNetworkConnection || Cura.MachineManager.activeMachineHasActiveCloudConnection
+    property string printerName: Cura.MachineManager.activeMachineDefinitionName
+    property bool isNetworkEnabled: ["Ultimaker 3", "Ultimaker 3 Extended", "Ultimaker S5"].indexOf(printerName) > -1
 
     color: UM.Theme.getColor("viewport_overlay")
     anchors.fill: parent
@@ -41,5 +45,98 @@ Rectangle
         property real maximumHeight: parent.height
 
         sourceComponent: Cura.MachineManager.printerOutputDevices.length > 0 ? Cura.MachineManager.printerOutputDevices[0].monitorItem : null
+    }
+
+    Column
+    {
+        anchors
+        {
+            top: parent.top
+            topMargin: 67 * screenScaleFactor
+            horizontalCenter: parent.horizontalCenter
+        }
+        width: 480 * screenScaleFactor
+        spacing: UM.Theme.getSize("default_margin").height
+
+        Label
+        {
+            anchors
+            {
+                horizontalCenter: parent.horizontalCenter
+            }
+            visible: isNetworkEnabled && !isConnected
+            text: "Please smake sure your printer has connection:\n- Check if the printer is turned on.\n- Check if the printer is connected to the network."
+            font: UM.Theme.getFont("medium")
+            color: UM.Theme.getColor("monitor_text_primary")
+            wrapMode: Text.WordWrap
+            lineHeight: 28 * screenScaleFactor
+            lineHeightMode: Text.FixedHeight
+            width: contentWidth
+        }
+
+        Cura.PrimaryButton
+        {
+            anchors
+            {
+                horizontalCenter: parent.horizontalCenter
+            }
+            visible: isNetworkEnabled && !isConnected
+            text: "Reconnect"
+            onClicked:
+            {
+                // nothing
+            }
+        }
+
+        Label
+        {
+            anchors
+            {
+                horizontalCenter: parent.horizontalCenter
+            }
+            visible: !isNetworkEnabled
+            text: "Please select a network connected printer to monitor the status and queue or connect your Ultimaker printer to your local network."
+            font: UM.Theme.getFont("medium")
+            color: UM.Theme.getColor("monitor_text_primary")
+            wrapMode: Text.WordWrap
+            width: parent.width
+            lineHeight: 28 * screenScaleFactor
+            lineHeightMode: Text.FixedHeight
+        }
+        Item
+        {
+            anchors
+            {
+                left: parent.left
+            }
+            visible: !isNetworkEnabled
+            height: 18 * screenScaleFactor // TODO: Theme!
+            width: childrenRect.width
+
+            UM.RecolorImage
+            {
+                id: externalLinkIcon
+                anchors.verticalCenter: parent.verticalCenter
+                color: UM.Theme.getColor("monitor_text_link")
+                source: UM.Theme.getIcon("external_link")
+                width: 16 * screenScaleFactor // TODO: Theme! (Y U NO USE 18 LIKE ALL OTHER ICONS?!)
+                height: 16 * screenScaleFactor // TODO: Theme! (Y U NO USE 18 LIKE ALL OTHER ICONS?!)
+            }
+            Label
+            {
+                id: manageQueueText
+                anchors
+                {
+                    left: externalLinkIcon.right
+                    leftMargin: 6 * screenScaleFactor // TODO: Theme!
+                    verticalCenter: externalLinkIcon.verticalCenter
+                }
+                color: UM.Theme.getColor("monitor_text_link")
+                font: UM.Theme.getFont("medium") // 14pt, regular
+                linkColor: UM.Theme.getColor("monitor_text_link")
+                text: catalog.i18nc("@label link to technical assistance", "More information on connecting the printer")
+                renderType: Text.NativeRendering
+            }
+        }
     }
 }

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -20,6 +20,12 @@ Rectangle
     color: UM.Theme.getColor("viewport_overlay")
     anchors.fill: parent
 
+    UM.I18nCatalog
+    {
+        id: catalog
+        name: "cura"
+    }
+
     // This mouse area is to prevent mouse clicks to be passed onto the scene.
     MouseArea
     {
@@ -47,15 +53,21 @@ Rectangle
         sourceComponent: Cura.MachineManager.printerOutputDevices.length > 0 ? Cura.MachineManager.printerOutputDevices[0].monitorItem : null
     }
 
+    /**
+     * In an ideal world, this code would go in the UM3NetworkingPlugin but that plugin is never even loaded unless we
+     * manage to connect to them. Moving the conditional in monitorViewComponent.sourceComponent would allow us to
+     * always load the UM3NetworkingPlugin and then evaluate what UI to show, but it would break any other plugins which
+     * use this plugin. So putting some code here felt like the lesser evil.
+     */
     Column
     {
         anchors
         {
             top: parent.top
-            topMargin: 67 * screenScaleFactor
+            topMargin: 67 * screenScaleFactor // TODO: Theme!
             horizontalCenter: parent.horizontalCenter
         }
-        width: 480 * screenScaleFactor
+        width: 480 * screenScaleFactor // TODO: Theme!
         spacing: UM.Theme.getSize("default_margin").height
 
         Label
@@ -65,11 +77,11 @@ Rectangle
                 horizontalCenter: parent.horizontalCenter
             }
             visible: isNetworkEnabled && !isConnected
-            text: "Please smake sure your printer has connection:\n- Check if the printer is turned on.\n- Check if the printer is connected to the network."
+            text: catalog.i18nc("@info", "Please smake sure your printer has connection:\n- Check if the printer is turned on.\n- Check if the printer is connected to the network.")
             font: UM.Theme.getFont("medium")
             color: UM.Theme.getColor("monitor_text_primary")
             wrapMode: Text.WordWrap
-            lineHeight: 28 * screenScaleFactor
+            lineHeight: 28 * screenScaleFactor // TODO: Theme!
             lineHeightMode: Text.FixedHeight
             width: contentWidth
         }
@@ -81,11 +93,8 @@ Rectangle
                 horizontalCenter: parent.horizontalCenter
             }
             visible: isNetworkEnabled && !isConnected
-            text: "Reconnect"
-            onClicked:
-            {
-                // nothing
-            }
+            text: catalog.i18nc("@action:button", "Reconnect")
+            onClicked: Cura.MachineManager.setActiveMachine(Cura.MachineManager.activeMachineId) // Try to refresh
         }
 
         Label
@@ -95,12 +104,12 @@ Rectangle
                 horizontalCenter: parent.horizontalCenter
             }
             visible: !isNetworkEnabled
-            text: "Please select a network connected printer to monitor the status and queue or connect your Ultimaker printer to your local network."
+            text: catalog.i18nc("@info", "Please select a network connected printer to monitor the status and queue or connect your Ultimaker printer to your local network.")
             font: UM.Theme.getFont("medium")
             color: UM.Theme.getColor("monitor_text_primary")
             wrapMode: Text.WordWrap
             width: parent.width
-            lineHeight: 28 * screenScaleFactor
+            lineHeight: 28 * screenScaleFactor // TODO: Theme!
             lineHeightMode: Text.FixedHeight
         }
         Item
@@ -119,8 +128,8 @@ Rectangle
                 anchors.verticalCenter: parent.verticalCenter
                 color: UM.Theme.getColor("monitor_text_link")
                 source: UM.Theme.getIcon("external_link")
-                width: 16 * screenScaleFactor // TODO: Theme! (Y U NO USE 18 LIKE ALL OTHER ICONS?!)
-                height: 16 * screenScaleFactor // TODO: Theme! (Y U NO USE 18 LIKE ALL OTHER ICONS?!)
+                width: 16 * screenScaleFactor // TODO: Theme!
+                height: 16 * screenScaleFactor // TODO: Theme!
             }
             Label
             {

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -94,7 +94,12 @@ Rectangle
             }
             visible: isNetworkEnabled && !isConnected
             text: catalog.i18nc("@action:button", "Reconnect")
-            onClicked: Cura.MachineManager.setActiveMachine(Cura.MachineManager.activeMachineId) // Try to refresh
+
+            /**
+             * This is essentially a "close doors" button on the elevator; it doesn't really force a
+             * connection but it does make people feel like Cura is workin' on it.
+             */
+            onClicked: Cura.MachineManager.setActiveMachine(Cura.MachineManager.activeMachineId)
         }
 
         Label

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -115,11 +115,27 @@ Rectangle
             lineHeight: UM.Theme.getSize("monitor_text_line_large").height
             lineHeightMode: Text.FixedHeight
         }
+        Label
+        {
+            id: noNetworkUltimakerLabel
+            anchors
+            {
+                horizontalCenter: parent.horizontalCenter
+            }
+            visible: !isNetworkConfigured && isNetworkConfigurable
+            text: catalog.i18nc("@info", "Please connect your Ultimaker printer to your local network.")
+            font: UM.Theme.getFont("medium")
+            color: UM.Theme.getColor("monitor_text_primary")
+            wrapMode: Text.WordWrap
+            width: contentWidth
+            lineHeight: UM.Theme.getSize("monitor_text_line_large").height
+            lineHeightMode: Text.FixedHeight
+        }
         Item
         {
             anchors
             {
-                left: noNetworkLabel.left
+                left: noNetworkUltimakerLabel.left
             }
             visible: !isNetworkConfigured && isNetworkConfigurable
             height: UM.Theme.getSize("monitor_text_line").height

--- a/plugins/UM3NetworkPrinting/resources/qml/ExpandableCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/ExpandableCard.qml
@@ -39,6 +39,7 @@ Item
         color: base.enabled && headerMouseArea.containsMouse ? headerHoverColor : headerBackgroundColor
         height: childrenRect.height
         width: parent.width
+        radius: 2 * screenScaleFactor // TODO: Theme!
         Behavior on color
         {
             ColorAnimation
@@ -77,6 +78,7 @@ Item
         color: headerBackgroundColor
         height: base.expanded ? childrenRect.height : 0
         width: parent.width
+        radius: 2 * screenScaleFactor // TODO: Theme!
         Behavior on height
         {
             NumberAnimation

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
@@ -58,6 +58,7 @@ Item
                     width: Math.round(parent.width / 2)
                     height: parent.height
                     visible: !printJob
+                    radius: 2 * screenScaleFactor // TODO: Theme!
                 }
                 Label
                 {
@@ -84,6 +85,7 @@ Item
                     width: Math.round(parent.width / 3)
                     height: parent.height
                     visible: !printJob
+                    radius: 2 * screenScaleFactor // TODO: Theme!
                 }
                 Label
                 {
@@ -111,6 +113,7 @@ Item
                     width: 72 * screenScaleFactor // TODO: Theme!
                     height: parent.height
                     visible: !printJob
+                    radius: 2 * screenScaleFactor // TODO: Theme!
                 }
 
                 Label

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml
@@ -57,9 +57,9 @@ Item
                 verticalCenter: externalLinkIcon.verticalCenter
             }
             color: UM.Theme.getColor("monitor_text_link")
-            font: UM.Theme.getFont("default") // 12pt, regular
+            font: UM.Theme.getFont("medium") // 14pt, regular
             linkColor: UM.Theme.getColor("monitor_text_link")
-            text: catalog.i18nc("@label link to connect manager", "Manage queue in Cura Connect")
+            text: catalog.i18nc("@label link to connect manager", "Go to Cura Connect")
             renderType: Text.NativeRendering
         }
     }
@@ -172,6 +172,89 @@ Item
                 return OutputDevice.receivedPrintJobs ? OutputDevice.queuedPrintJobs : [null,null]
             }
             spacing: 6  // TODO: Theme!
+        }
+    }
+
+    Rectangle
+    {
+        anchors
+        {
+            horizontalCenter: parent.horizontalCenter
+            top: printJobQueueHeadings.bottom
+            topMargin: 12 * screenScaleFactor // TODO: Theme!
+        }
+        height: 48 * screenScaleFactor // TODO: Theme!
+        width: parent.width
+        color: UM.Theme.getColor("monitor_card_background")
+        border.color: UM.Theme.getColor("monitor_card_border")
+        radius: 2 * screenScaleFactor // TODO: Theme!
+
+        visible: printJobList.model.length == 0
+
+        Row
+        {
+            anchors
+            {
+                left: parent.left
+                leftMargin: 18 * screenScaleFactor // TODO: Theme!
+                verticalCenter: parent.verticalCenter
+            }
+            spacing: 18 * screenScaleFactor // TODO: Theme!
+            height: 18 * screenScaleFactor // TODO: Theme!
+
+            Label
+            {
+                text: "All jobs are printed."
+                color: UM.Theme.getColor("monitor_text_primary")
+                font: UM.Theme.getFont("medium") // 14pt, regular
+            }
+
+            Item
+            {
+                id: viewPrintHistoryLabel
+                
+                height: 18 * screenScaleFactor // TODO: Theme!
+                width: childrenRect.width
+
+                UM.RecolorImage
+                {
+                    id: printHistoryIcon
+                    anchors.verticalCenter: manageQueueLabel.verticalCenter
+                    color: UM.Theme.getColor("monitor_text_link")
+                    source: UM.Theme.getIcon("external_link")
+                    width: 16 * screenScaleFactor // TODO: Theme! (Y U NO USE 18 LIKE ALL OTHER ICONS?!)
+                    height: 16 * screenScaleFactor // TODO: Theme! (Y U NO USE 18 LIKE ALL OTHER ICONS?!)
+                }
+                Label
+                {
+                    id: viewPrintHistoryText
+                    anchors
+                    {
+                        left: printHistoryIcon.right
+                        leftMargin: 6 * screenScaleFactor // TODO: Theme!
+                        verticalCenter: printHistoryIcon.verticalCenter
+                    }
+                    color: UM.Theme.getColor("monitor_text_link")
+                    font: UM.Theme.getFont("medium") // 14pt, regular
+                    linkColor: UM.Theme.getColor("monitor_text_link")
+                    text: catalog.i18nc("@label link to connect manager", "View print history")
+                    renderType: Text.NativeRendering
+                }
+                MouseArea
+                {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: Cura.MachineManager.printerOutputDevices[0].openPrintJobControlPanel()
+                    onEntered:
+                    {
+                        viewPrintHistoryText.font.underline = true
+                    }
+                    onExited:
+                    {
+                        viewPrintHistoryText.font.underline = false
+                    }
+                }
+            }
         }
     }
 }

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml
@@ -160,7 +160,17 @@ Item
                 }
                 printJob: modelData
             }
-            model: OutputDevice.receivedPrintJobs ? OutputDevice.queuedPrintJobs : [null,null]
+            model:
+            {
+                // When printing over the cloud we don't recieve print jobs until there is one, so
+                // unless there's at least one print job we'll be stuck with skeleton loading
+                // indefinitely.
+                if (Cura.MachineManager.activeMachineHasActiveCloudConnection)
+                {
+                    return OutputDevice.queuedPrintJobs
+                }
+                return OutputDevice.receivedPrintJobs ? OutputDevice.queuedPrintJobs : [null,null]
+            }
             spacing: 6  // TODO: Theme!
         }
     }

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml
@@ -219,7 +219,7 @@ Item
                 UM.RecolorImage
                 {
                     id: printHistoryIcon
-                    anchors.verticalCenter: manageQueueLabel.verticalCenter
+                    anchors.verticalCenter: parent.verticalCenter
                     color: UM.Theme.getColor("monitor_text_link")
                     source: UM.Theme.getIcon("external_link")
                     width: 16 * screenScaleFactor // TODO: Theme! (Y U NO USE 18 LIKE ALL OTHER ICONS?!)

--- a/resources/themes/cura-dark/theme.json
+++ b/resources/themes/cura-dark/theme.json
@@ -9,7 +9,7 @@
         "wide_lining": [31, 36, 39, 255],
         "thick_lining": [255, 255, 255, 30],
         "lining": [64, 69, 72, 255],
-        "viewport_overlay": [0, 6, 9, 222],
+        "viewport_overlay": [30, 36, 39, 255],
 
         "primary": [12, 169, 227, 255],
         "primary_hover": [48, 182, 231, 255],

--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -146,7 +146,7 @@
         "wide_lining": [245, 245, 245, 255],
         "thick_lining": [127, 127, 127, 255],
         "lining": [192, 193, 194, 255],
-        "viewport_overlay": [0, 0, 0, 192],
+        "viewport_overlay": [246, 246, 246, 255],
 
         "primary": [50, 130, 255, 255],
         "primary_shadow": [64, 47, 205, 255],

--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -609,10 +609,14 @@
 
         "monitor_config_override_box": [1.0, 14.0],
         "monitor_extruder_circle": [2.75, 2.75],
-        "monitor_text_line": [1.16, 1.16],
+        "monitor_text_line": [1.5, 1.5],
+        "monitor_text_line_large": [2.33, 2.33],
         "monitor_thick_lining": [0.16, 0.16],
         "monitor_corner_radius": [0.3, 0.3],
         "monitor_shadow_radius": [0.4, 0.4],
-        "monitor_shadow_offset": [0.15, 0.15]
+        "monitor_shadow_offset": [0.15, 0.15],
+        "monitor_empty_state_offset": [5.6, 5.6],
+        "monitor_empty_state_size": [35.0, 25.0],
+        "monitor_external_link_icon": [1.16, 1.16]
     }
 }


### PR DESCRIPTION
- When you have a UM network-enabled printer, configured for network printing, connected, you should see the monitor tab, and if there are no jobs, see a link to Cura Connect.
- When you have a UM network-enabled printer, configured for network printing, not connected, you should see a warning to check that the printer is on and has connection.
- When you have a UM network-enabled printer, not configured for network printing, you should see a message telling you to select a network-enabled printer to monitor, and a link to the UM website with printer manuals.
- When you have any non-network enabled printer, you should see only the message telling you to select a network-enabled printer to monitor.