### PR TITLE
CURA-6153 wrong name on disconnect

### DIFF
--- a/cura/GlobalStacksModel.py
+++ b/cura/GlobalStacksModel.py
@@ -54,7 +54,7 @@ class GlobalStacksModel(ListModel):
                 continue
 
             # TODO: Remove reference to connect group name.
-            items.append({"name": container_stack.getMetaDataEntry("connect_group_name", container_stack.getName()),
+            items.append({"name": container_stack.getMetaDataEntry("group_name", container_stack.getName()),
                           "id": container_stack.getId(),
                           "hasRemoteConnection": has_remote_connection,
                           "metadata": container_stack.getMetaData().copy()})

--- a/cura/GlobalStacksModel.py
+++ b/cura/GlobalStacksModel.py
@@ -53,7 +53,6 @@ class GlobalStacksModel(ListModel):
             if container_stack.getMetaDataEntry("hidden", False) in ["True", True]:
                 continue
 
-            # TODO: Remove reference to connect group name.
             items.append({"name": container_stack.getMetaDataEntry("group_name", container_stack.getName()),
                           "id": container_stack.getId(),
                           "hasRemoteConnection": has_remote_connection,

--- a/cura/Machines/Models/MachineManagementModel.py
+++ b/cura/Machines/Models/MachineManagementModel.py
@@ -52,14 +52,14 @@ class MachineManagementModel(ListModel):
                                    "um_network_key": "*",
                                    "hidden": "False"}
         self._network_container_stacks = ContainerRegistry.getInstance().findContainerStacks(**network_filter_printers)
-        self._network_container_stacks.sort(key = lambda i: i.getMetaDataEntry("connect_group_name"))
+        self._network_container_stacks.sort(key = lambda i: i.getMetaDataEntry("group_name"))
 
         for container in self._network_container_stacks:
             metadata = container.getMetaData().copy()
             if container.getBottom():
                 metadata["definition_name"] = container.getBottom().getName()
 
-            items.append({"name": metadata["connect_group_name"],
+            items.append({"name": metadata["group_name"],
                           "id": container.getId(),
                           "metadata": metadata,
                           "group": catalog.i18nc("@info:title", "Network enabled printers")})

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -512,7 +512,7 @@ class MachineManager(QObject):
     @pyqtProperty(str, notify = globalContainerChanged)
     def activeMachineName(self) -> str:
         if self._global_container_stack:
-            return self._global_container_stack.getMetaDataEntry("connect_group_name", self._global_container_stack.getName())
+            return self._global_container_stack.getMetaDataEntry("group_name", self._global_container_stack.getName())
         return ""
 
     @pyqtProperty(str, notify = globalContainerChanged)
@@ -558,7 +558,7 @@ class MachineManager(QObject):
     @pyqtProperty(str, notify = printerConnectedStatusChanged)
     def activeMachineNetworkGroupName(self) -> str:
         if self._global_container_stack:
-            return self._global_container_stack.getMetaDataEntry("connect_group_name", "")
+            return self._global_container_stack.getMetaDataEntry("group_name", "")
         return ""
 
     @pyqtProperty(QObject, notify = globalContainerChanged)
@@ -1350,7 +1350,7 @@ class MachineManager(QObject):
             if not new_machine:
                 return
             new_machine.setMetaDataEntry("um_network_key", self.activeMachineNetworkKey())
-            new_machine.setMetaDataEntry("connect_group_name", self.activeMachineNetworkGroupName)
+            new_machine.setMetaDataEntry("group_name", self.activeMachineNetworkGroupName)
             new_machine.setMetaDataEntry("hidden", False)
             new_machine.setMetaDataEntry("connection_type", self._global_container_stack.getMetaDataEntry("connection_type"))
         else:
@@ -1420,7 +1420,7 @@ class MachineManager(QObject):
                 metadata_filter = {"um_network_key": self.activeMachineNetworkKey()}
                 containers = CuraContainerRegistry.getInstance().findContainerStacks(type = "machine", **metadata_filter)
                 for container in containers:
-                    container.setMetaDataEntry("connect_group_name", group_name)
+                    container.setMetaDataEntry("group_name", group_name)
 
     ##  This method checks if there is an instance connected to the given network_key
     def existNetworkInstances(self, network_key: str) -> bool:

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -512,7 +512,7 @@ class MachineManager(QObject):
     @pyqtProperty(str, notify = globalContainerChanged)
     def activeMachineName(self) -> str:
         if self._global_container_stack:
-            return self._global_container_stack.getName()
+            return self._global_container_stack.getMetaDataEntry("connect_group_name", self._global_container_stack.getName())
         return ""
 
     @pyqtProperty(str, notify = globalContainerChanged)

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -500,7 +500,7 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
 
         is_printer_group = False
         if machine_conflict:
-            group_name = existing_global_stack.getMetaDataEntry("connect_group_name")
+            group_name = existing_global_stack.getMetaDataEntry("group_name")
             if group_name is not None:
                 is_printer_group = True
                 machine_name = group_name

--- a/plugins/UM3NetworkPrinting/src/DiscoverUM3Action.py
+++ b/plugins/UM3NetworkPrinting/src/DiscoverUM3Action.py
@@ -106,13 +106,13 @@ class DiscoverUM3Action(MachineAction):
         global_container_stack = CuraApplication.getInstance().getGlobalContainerStack()
         if global_container_stack:
             meta_data = global_container_stack.getMetaData()
-            if "connect_group_name" in meta_data:
-                previous_connect_group_name = meta_data["connect_group_name"]
-                global_container_stack.setMetaDataEntry("connect_group_name", group_name)
+            if "group_name" in meta_data:
+                previous_connect_group_name = meta_data["group_name"]
+                global_container_stack.setMetaDataEntry("group_name", group_name)
                 # Find all the places where there is the same group name and change it accordingly
-                CuraApplication.getInstance().getMachineManager().replaceContainersMetadata(key = "connect_group_name", value = previous_connect_group_name, new_value = group_name)
+                CuraApplication.getInstance().getMachineManager().replaceContainersMetadata(key = "group_name", value = previous_connect_group_name, new_value = group_name)
             else:
-                global_container_stack.setMetaDataEntry("connect_group_name", group_name)
+                global_container_stack.setMetaDataEntry("group_name", group_name)
             # Set the default value for "hidden", which is used when you have a group with multiple types of printers
             global_container_stack.setMetaDataEntry("hidden", False)
 

--- a/plugins/VersionUpgrade/VersionUpgrade35to40/VersionUpgrade35to40.py
+++ b/plugins/VersionUpgrade/VersionUpgrade35to40/VersionUpgrade35to40.py
@@ -4,6 +4,7 @@ import io
 from UM.VersionUpgrade import VersionUpgrade
 from cura.PrinterOutputDevice import ConnectionType
 deleted_settings = {"bridge_wall_max_overhang"}  # type: Set[str]
+renamed_configurations = {"connect_group_name": "group_name"}  # type: Dict[str, str]
 
 
 class VersionUpgrade35to40(VersionUpgrade):
@@ -19,6 +20,13 @@ class VersionUpgrade35to40(VersionUpgrade):
         if parser["metadata"].get("um_network_key") is not None or parser["metadata"].get("octoprint_api_key") is not None:
             # Set the connection type if um_network_key or the octoprint key is set.
             parser["metadata"]["connection_type"] = str(ConnectionType.NetworkConnection.value)
+
+        if "metadata" in parser:
+            for old_name, new_name in renamed_configurations.items():
+                if old_name not in parser["metadata"]:
+                    continue
+                parser["metadata"][new_name] = parser["metadata"][old_name]
+                del parser["metadata"][old_name]
 
         result = io.StringIO()
         parser.write(result)

--- a/plugins/VersionUpgrade/VersionUpgrade35to40/VersionUpgrade35to40.py
+++ b/plugins/VersionUpgrade/VersionUpgrade35to40/VersionUpgrade35to40.py
@@ -1,8 +1,10 @@
 import configparser
-from typing import Tuple, List, Set
+from typing import Tuple, List, Set, Dict
 import io
+
 from UM.VersionUpgrade import VersionUpgrade
 from cura.PrinterOutputDevice import ConnectionType
+
 deleted_settings = {"bridge_wall_max_overhang"}  # type: Set[str]
 renamed_configurations = {"connect_group_name": "group_name"}  # type: Dict[str, str]
 
@@ -31,7 +33,6 @@ class VersionUpgrade35to40(VersionUpgrade):
         result = io.StringIO()
         parser.write(result)
         return [filename], [result.getvalue()]
-        pass
 
     def getCfgVersion(self, serialised: str) -> int:
         parser = configparser.ConfigParser(interpolation = None)

--- a/resources/qml/Menus/NetworkPrinterMenu.qml
+++ b/resources/qml/Menus/NetworkPrinterMenu.qml
@@ -14,9 +14,9 @@ Instantiator
     {
         property string connectGroupName:
         {
-            if("connect_group_name" in model.metadata)
+            if("group_name" in model.metadata)
             {
-                return model.metadata["connect_group_name"]
+                return model.metadata["group_name"]
             }
             return ""
         }

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -56,7 +56,7 @@ UM.ManagementPage
         {
             text: catalog.i18nc("@action:button", "Rename");
             iconName: "edit-rename";
-            enabled: base.currentItem != null && base.currentItem.metadata.connect_group_name == null
+            enabled: base.currentItem != null && base.currentItem.metadata.group_name == null
             onClicked: renameDialog.open();
         }
     ]

--- a/resources/qml/PrinterSelector/MachineSelectorList.qml
+++ b/resources/qml/PrinterSelector/MachineSelectorList.qml
@@ -38,7 +38,7 @@ ListView
             var result = Cura.MachineManager.activeMachineId == model.id
             if (Cura.MachineManager.activeMachineHasRemoteConnection)
             {
-                result |= Cura.MachineManager.activeMachineNetworkGroupName == model.metadata["connect_group_name"]
+                result |= Cura.MachineManager.activeMachineNetworkGroupName == model.metadata["group_name"]
             }
             return result
         }


### PR DESCRIPTION
Per @nallath 's request: Added a rename and a version-upgrade ('connect_group_name' is now 'group_name') to this, as this was a good opportunity to do just that. (The actual fix is in the first commit.)