### PR TITLE
Let each stage create its own action panel

### DIFF
--- a/plugins/PrepareStage/PrepareMain.qml
+++ b/plugins/PrepareStage/PrepareMain.qml
@@ -1,5 +1,5 @@
-// Copyright (c) 2019 Ultimaker B.V.
-// Cura is released under the terms of the LGPLv3 or higher.
+//Copyright (c) 2019 Ultimaker B.V.
+//Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.4
 import QtQuick.Controls 1.2
@@ -11,12 +11,7 @@ import Cura 1.0 as Cura
 
 Item
 {
-    Loader
-    {
-        id: previewMain
-
-        source: UM.Controller.activeView != null && UM.Controller.activeView.mainComponent != null ? UM.Controller.activeView.mainComponent : ""
-    }
+    id: prepareMain
 
     Cura.ActionPanelWidget
     {

--- a/plugins/PrepareStage/PrepareStage.py
+++ b/plugins/PrepareStage/PrepareStage.py
@@ -1,12 +1,10 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2019 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
+
 import os.path
 from UM.Application import Application
 from UM.PluginRegistry import PluginRegistry
-from UM.Resources import Resources
 from cura.Stages.CuraStage import CuraStage
-
-
 
 ##  Stage for preparing model (slicing).
 class PrepareStage(CuraStage):
@@ -16,4 +14,6 @@ class PrepareStage(CuraStage):
 
     def _engineCreated(self):
         menu_component_path = os.path.join(PluginRegistry.getInstance().getPluginPath("PrepareStage"), "PrepareMenu.qml")
+        main_component_path = os.path.join(PluginRegistry.getInstance().getPluginPath("PrepareStage"), "PrepareMain.qml")
         self.addDisplayComponent("menu", menu_component_path)
+        self.addDisplayComponent("main", main_component_path)

--- a/plugins/PreviewStage/PreviewMain.qml
+++ b/plugins/PreviewStage/PreviewMain.qml
@@ -25,5 +25,6 @@ Item
         anchors.bottom: parent.bottom
         anchors.rightMargin: UM.Theme.getSize("thick_margin").width
         anchors.bottomMargin: UM.Theme.getSize("thick_margin").height
+        hasPreviewButton: false
     }
 }

--- a/resources/qml/ActionPanel/ActionPanelWidget.qml
+++ b/resources/qml/ActionPanel/ActionPanelWidget.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Ultimaker B.V.
+// Copyright (c) 2019 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.7
@@ -17,6 +17,7 @@ Item
     id: base
     width: childrenRect.width
     height: childrenRect.height
+    visible: CuraApplication.platformActivity
 
     Rectangle
     {

--- a/resources/qml/ActionPanel/ActionPanelWidget.qml
+++ b/resources/qml/ActionPanel/ActionPanelWidget.qml
@@ -19,6 +19,8 @@ Item
     height: childrenRect.height
     visible: CuraApplication.platformActivity
 
+    property bool hasPreviewButton: true
+
     Rectangle
     {
         id: actionPanelWidget
@@ -47,6 +49,13 @@ Item
                 rightMargin: UM.Theme.getSize("thick_margin").width
             }
             sourceComponent: actionPanelWidget.outputAvailable ? outputProcessWidget : sliceProcessWidget
+            onLoaded:
+            {
+                if(actionPanelWidget.outputAvailable)
+                {
+                    loader.item.hasPreviewButton = base.hasPreviewButton;
+                }
+            }
         }
 
         Component

--- a/resources/qml/ActionPanel/OutputProcessWidget.qml
+++ b/resources/qml/ActionPanel/OutputProcessWidget.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Ultimaker B.V.
+// Copyright (c) 2019 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.7
@@ -19,6 +19,7 @@ Column
 
     spacing: UM.Theme.getSize("thin_margin").height
     property bool preSlicedData: PrintInformation.preSliced
+    property alias hasPreviewButton: previewStageShortcut.visible
 
     UM.I18nCatalog
     {
@@ -120,7 +121,6 @@ Column
             toolTipContentAlignment: Cura.ToolTip.ContentAlignment.AlignLeft
 
             onClicked: UM.Controller.setActiveStage("PreviewStage")
-            visible: UM.Controller.activeStage != null && UM.Controller.activeStage.stageId != "PreviewStage"
         }
 
         Cura.OutputDevicesActionButton

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -246,30 +246,6 @@ UM.MainWindow
                 }
             }
 
-            Cura.ActionPanelWidget
-            {
-                id: actionPanelWidget
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-                anchors.rightMargin: UM.Theme.getSize("thick_margin").width
-                anchors.bottomMargin: UM.Theme.getSize("thick_margin").height
-
-                /*
-                Show this panel only if there is something on the build plate, and there is NOT an opaque item in front of the build plate.
-                This cannot be solved by Z indexing! If you want to try solving this, please increase this counter when you're done:
-                Number of people having tried to fix this by z-indexing: 2
-                The problem arises from the following render order requirements:
-                - The stage menu must be rendered above the stage main.
-                - The stage main must be rendered above the action panel (because the monitor page must be rendered above the action panel).
-                - The action panel must be rendered above the expandable components drop-down.
-                However since the expandable components drop-downs are child elements of the stage menu,
-                they can't be rendered lower than elements that are lower than the stage menu.
-                Therefore we opted to forego the second requirement and hide the action panel instead when something obscures it (except the expandable components).
-                We assume that QQuickRectangles are always opaque and any other item is not.
-                */
-                visible: CuraApplication.platformActivity && (main.item == null || !qmlTypeOf(main.item, "QQuickRectangle"))
-            }
-
             Loader
             {
                 // A stage can control this area. If nothing is set, it will therefore show the 3D view.


### PR DESCRIPTION
The positioning and configuration of the action panel greatly differs per stage. In this pull request we make the stage create its own action panel widget. This way it can choose for itself whether or not it even wants an action panel, where the action panel is located and whether or not the preview button is visible on that panel.

Contributes to issue CURA-6086.

@fieldOfView You might want to check if this has any influence on your sidebar plug-in. It should behave the same, but you never know.