### PR TITLE
Fix token refresh

### DIFF
--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -57,7 +57,6 @@ class Account(QObject):
 
     def initialize(self) -> None:
         self._authorization_service.initialize(self._application.getPreferences())
-
         self._authorization_service.onAuthStateChanged.connect(self._onLoginStateChanged)
         self._authorization_service.onAuthenticationError.connect(self._onLoginStateChanged)
         self._authorization_service.loadAuthDataFromPreferences()

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -104,8 +104,7 @@ class AuthorizationHelpers:
         return UserProfile(
             user_id = user_data["user_id"],
             username = user_data["username"],
-            profile_image_url = user_data.get("profile_image_url", ""),
-            generated_at = datetime.now()
+            profile_image_url = user_data.get("profile_image_url", "")
         )
 
     @staticmethod

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
+from datetime import datetime
 import json
 import random
 from hashlib import sha512
 from base64 import b64encode
-from typing import Dict, Optional
+from typing import Optional
 
 import requests
 
@@ -75,7 +76,8 @@ class AuthorizationHelpers:
                                       access_token=token_data["access_token"],
                                       refresh_token=token_data["refresh_token"],
                                       expires_in=token_data["expires_in"],
-                                      scope=token_data["scope"])
+                                      scope=token_data["scope"],
+                                      received_at=datetime.now())
 
     #   Calls the authentication API endpoint to get the token data.
     #   \param access_token: The encoded JWT token.
@@ -99,7 +101,8 @@ class AuthorizationHelpers:
         return UserProfile(
             user_id = user_data["user_id"],
             username = user_data["username"],
-            profile_image_url = user_data.get("profile_image_url", "")
+            profile_image_url = user_data.get("profile_image_url", ""),
+            generated_at = datetime.now()
         )
 
     @staticmethod

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -14,6 +14,9 @@ from UM.Logger import Logger
 from cura.OAuth2.Models import AuthenticationResponse, UserProfile, OAuth2Settings
 
 
+TOKEN_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
 #   Class containing several helpers to deal with the authorization flow.
 class AuthorizationHelpers:
     def __init__(self, settings: "OAuth2Settings") -> None:
@@ -77,7 +80,7 @@ class AuthorizationHelpers:
                                       refresh_token=token_data["refresh_token"],
                                       expires_in=token_data["expires_in"],
                                       scope=token_data["scope"],
-                                      received_at=datetime.now())
+                                      received_at=datetime.now().strftime(TOKEN_TIMESTAMP_FORMAT))
 
     #   Calls the authentication API endpoint to get the token data.
     #   \param access_token: The encoded JWT token.

--- a/cura/OAuth2/AuthorizationRequestHandler.py
+++ b/cura/OAuth2/AuthorizationRequestHandler.py
@@ -9,6 +9,7 @@ from cura.OAuth2.Models import AuthenticationResponse, ResponseData, HTTP_STATUS
 
 if TYPE_CHECKING:
     from cura.OAuth2.Models import ResponseStatus
+    from cura.OAuth2.AuthorizationHelpers import AuthorizationHelpers
 
 
 #   This handler handles all HTTP requests on the local web server.
@@ -18,7 +19,7 @@ class AuthorizationRequestHandler(BaseHTTPRequestHandler):
         super().__init__(request, client_address, server)
 
         # These values will be injected by the HTTPServer that this handler belongs to.
-        self.authorization_helpers = None  # type: Optional["AuthorizationHelpers"]
+        self.authorization_helpers = None  # type: Optional[AuthorizationHelpers]
         self.authorization_callback = None  # type: Optional[Callable[[AuthenticationResponse], None]]
         self.verification_code = None  # type: Optional[str]
 

--- a/cura/OAuth2/AuthorizationRequestHandler.py
+++ b/cura/OAuth2/AuthorizationRequestHandler.py
@@ -9,7 +9,6 @@ from cura.OAuth2.Models import AuthenticationResponse, ResponseData, HTTP_STATUS
 
 if TYPE_CHECKING:
     from cura.OAuth2.Models import ResponseStatus
-    from cura.OAuth2.AuthorizationHelpers import AuthorizationHelpers
 
 
 #   This handler handles all HTTP requests on the local web server.

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -94,6 +94,7 @@ class AuthorizationService:
             return None
 
         # Check if the current access token is expired and refresh it if that is the case.
+        # We have a fallback on a date far in the past for currently stored auth data in cura.cfg.
         received_at = datetime.strptime(self._auth_data.received_at, TOKEN_TIMESTAMP_FORMAT) \
             if self._auth_data.received_at else datetime(2000, 1, 1)
         expiry_date = received_at + timedelta(seconds = float(self._auth_data.expires_in or 0))

--- a/cura/OAuth2/Models.py
+++ b/cura/OAuth2/Models.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
-from datetime import datetime
 from typing import Optional
 
 
@@ -38,13 +37,13 @@ class AuthenticationResponse(BaseModel):
     expires_in = None  # type: Optional[str]
     scope = None  # type: Optional[str]
     err_message = None  # type: Optional[str]
-    received_at = None  # type: Optional[datetime]
+    received_at = None  # type: Optional[str]
 
 
 # Response status template.
 class ResponseStatus(BaseModel):
     code = 200  # type: int
-    message = ""  # type str
+    message = ""  # type: str
 
 
 # Response data template.

--- a/cura/OAuth2/Models.py
+++ b/cura/OAuth2/Models.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
-
+from datetime import datetime
 from typing import Optional
 
 
@@ -38,6 +38,7 @@ class AuthenticationResponse(BaseModel):
     expires_in = None  # type: Optional[str]
     scope = None  # type: Optional[str]
     err_message = None  # type: Optional[str]
+    received_at = None  # type: Optional[datetime]
 
 
 # Response status template.

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py
@@ -103,8 +103,9 @@ class CloudApiClient:
         request = QNetworkRequest(QUrl(path))
         if content_type:
             request.setHeader(QNetworkRequest.ContentTypeHeader, content_type)
-        if self._account.isLoggedIn:
-            request.setRawHeader(b"Authorization", "Bearer {}".format(self._account.accessToken).encode())
+        access_token = self._account.accessToken
+        if access_token:
+            request.setRawHeader(b"Authorization", "Bearer {}".format(access_token).encode())
         return request
 
     ## Parses the given JSON network reply into a status code and a dictionary, handling unexpected errors as well.


### PR DESCRIPTION
This PR adds proper refreshing of access tokens before they are used in an API call that. By storing the creation date (and using the already stored expiry time) we calculate the expected expiry date. If the access token is requested from the account object after this time, we do a token refresh before returning the (new) access token. This prevents API calls to result in a 401.