### PR TITLE
CL-1250 set cloud build plate

### DIFF
--- a/cura/PrinterOutput/PrinterOutputModel.py
+++ b/cura/PrinterOutput/PrinterOutputModel.py
@@ -44,7 +44,7 @@ class PrinterOutputModel(QObject):
         self._printer_state = "unknown"
         self._is_preheating = False
         self._printer_type = ""
-        self._buildplate_name = ""
+        self._buildplate = ""
 
         self._printer_configuration.extruderConfigurations = [extruder.extruderConfiguration for extruder in
                                                               self._extruders]
@@ -86,12 +86,12 @@ class PrinterOutputModel(QObject):
 
     @pyqtProperty(str, notify = buildplateChanged)
     def buildplate(self) -> str:
-        return self._buildplate_name
+        return self._buildplate
 
-    def updateBuildplateName(self, buildplate_name: str) -> None:
-        if self._buildplate_name != buildplate_name:
-            self._buildplate_name = buildplate_name
-            self._printer_configuration.buildplateConfiguration = self._buildplate_name
+    def updateBuildplate(self, buildplate_name: str) -> None:
+        if self._buildplate != buildplate_name:
+            self._buildplate = buildplate_name
+            self._printer_configuration.buildplateConfiguration = self._buildplate
             self.buildplateChanged.emit()
             self.configurationChanged.emit()
 

--- a/cura/PrinterOutput/PrinterOutputModel.py
+++ b/cura/PrinterOutput/PrinterOutputModel.py
@@ -88,9 +88,9 @@ class PrinterOutputModel(QObject):
     def buildplate(self) -> str:
         return self._buildplate
 
-    def updateBuildplate(self, buildplate_name: str) -> None:
-        if self._buildplate != buildplate_name:
-            self._buildplate = buildplate_name
+    def updateBuildplate(self, buildplate: str) -> None:
+        if self._buildplate != buildplate:
+            self._buildplate = buildplate
             self._printer_configuration.buildplateConfiguration = self._buildplate
             self.buildplateChanged.emit()
             self.configurationChanged.emit()

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
@@ -55,7 +55,6 @@ class CloudClusterPrinterStatus(BaseCloudModel):
     #  \param controller - The controller of the model.
     def createOutputModel(self, controller: PrinterOutputController) -> PrinterOutputModel:
         model = PrinterOutputModel(controller, len(self.configuration), firmware_version = self.firmware_version)
-        model.updateBuildplate(self.build_plate.type)
         self.updateOutputModel(model)
         return model
 
@@ -66,6 +65,7 @@ class CloudClusterPrinterStatus(BaseCloudModel):
         model.updateName(self.friendly_name)
         model.updateType(self.machine_variant)
         model.updateState(self.status if self.enabled else "disabled")
+        model.updateBuildplate(self.build_plate.type)
 
         for configuration, extruder_output, extruder_config in \
                 zip(self.configuration, model.extruders, model.printerConfiguration.extruderConfigurations):

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
@@ -48,7 +48,7 @@ class CloudClusterPrinterStatus(BaseCloudModel):
         self.maintenance_required = maintenance_required
         self.firmware_update_status = firmware_update_status
         self.latest_available_firmware = latest_available_firmware
-        self.build_plate = self.parseModel(CloudClusterBuildPlate, build_plate)
+        self.build_plate = self.parseModel(CloudClusterBuildPlate, build_plate) if build_plate else None
         super().__init__(**kwargs)
 
     ## Creates a new output model.
@@ -65,7 +65,13 @@ class CloudClusterPrinterStatus(BaseCloudModel):
         model.updateName(self.friendly_name)
         model.updateType(self.machine_variant)
         model.updateState(self.status if self.enabled else "disabled")
-        model.updateBuildplate(self.build_plate.type)
+
+        # Make sure to set the build plate even though we don't use it. Since it's optional, use
+        # glass as a default
+        if self.build_plate:
+            model.updateBuildplate(self.build_plate.type)
+        else:
+            model.updateBuildplate("glass")
 
         for configuration, extruder_output, extruder_config in \
                 zip(self.configuration, model.extruders, model.printerConfiguration.extruderConfigurations):

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
@@ -65,13 +65,7 @@ class CloudClusterPrinterStatus(BaseCloudModel):
         model.updateName(self.friendly_name)
         model.updateType(self.machine_variant)
         model.updateState(self.status if self.enabled else "disabled")
-
-        # Make sure to set the build plate even though we don't use it. Since it's optional, use
-        # glass as a default
-        if self.build_plate:
-            model.updateBuildplate(self.build_plate.type)
-        else:
-            model.updateBuildplate("glass")
+        model.updateBuildplate(self.build_plate.type or "glass")
 
         for configuration, extruder_output, extruder_config in \
                 zip(self.configuration, model.extruders, model.printerConfiguration.extruderConfigurations):

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
@@ -55,6 +55,7 @@ class CloudClusterPrinterStatus(BaseCloudModel):
     #  \param controller - The controller of the model.
     def createOutputModel(self, controller: PrinterOutputController) -> PrinterOutputModel:
         model = PrinterOutputModel(controller, len(self.configuration), firmware_version = self.firmware_version)
+        model.updateBuildplateName(self.build_plate.type)
         self.updateOutputModel(model)
         return model
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
@@ -65,7 +65,13 @@ class CloudClusterPrinterStatus(BaseCloudModel):
         model.updateName(self.friendly_name)
         model.updateType(self.machine_variant)
         model.updateState(self.status if self.enabled else "disabled")
-        model.updateBuildplate(self.build_plate.type)
+
+        # Make sure to set the build plate even though we don't use it. Since it's optional, use
+        # glass as a default
+        if self.build_plate:
+            model.updateBuildplate(self.build_plate.type)
+        else:
+            model.updateBuildplate("glass")
 
         for configuration, extruder_output, extruder_config in \
                 zip(self.configuration, model.extruders, model.printerConfiguration.extruderConfigurations):

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
@@ -55,7 +55,7 @@ class CloudClusterPrinterStatus(BaseCloudModel):
     #  \param controller - The controller of the model.
     def createOutputModel(self, controller: PrinterOutputController) -> PrinterOutputModel:
         model = PrinterOutputModel(controller, len(self.configuration), firmware_version = self.firmware_version)
-        model.updateBuildplateName(self.build_plate.type)
+        model.updateBuildplate(self.build_plate.type)
         self.updateOutputModel(model)
         return model
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
@@ -48,7 +48,7 @@ class CloudClusterPrinterStatus(BaseCloudModel):
         self.maintenance_required = maintenance_required
         self.firmware_update_status = firmware_update_status
         self.latest_available_firmware = latest_available_firmware
-        self.build_plate = self.parseModel(CloudClusterBuildPlate, build_plate) if build_plate else None
+        self.build_plate = self.parseModel(CloudClusterBuildPlate, build_plate)
         super().__init__(**kwargs)
 
     ## Creates a new output model.
@@ -65,13 +65,7 @@ class CloudClusterPrinterStatus(BaseCloudModel):
         model.updateName(self.friendly_name)
         model.updateType(self.machine_variant)
         model.updateState(self.status if self.enabled else "disabled")
-
-        # Make sure to set the build plate even though we don't use it. Since it's optional, use
-        # glass as a default
-        if self.build_plate:
-            model.updateBuildplate(self.build_plate.type)
-        else:
-            model.updateBuildplate("glass")
+        model.updateBuildplate(self.build_plate.type)
 
         for configuration, extruder_output, extruder_config in \
                 zip(self.configuration, model.extruders, model.printerConfiguration.extruderConfigurations):

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterPrinterStatus.py
@@ -65,7 +65,7 @@ class CloudClusterPrinterStatus(BaseCloudModel):
         model.updateName(self.friendly_name)
         model.updateType(self.machine_variant)
         model.updateState(self.status if self.enabled else "disabled")
-        model.updateBuildplate(self.build_plate.type or "glass")
+        model.updateBuildplate(self.build_plate.type if self.build_plate else "glass")
 
         for configuration, extruder_output, extruder_config in \
                 zip(self.configuration, model.extruders, model.printerConfiguration.extruderConfigurations):

--- a/plugins/UM3NetworkPrinting/src/ClusterUM3OutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/ClusterUM3OutputDevice.py
@@ -627,7 +627,7 @@ class ClusterUM3OutputDevice(NetworkedPrinterOutputDevice):
 
         # Do not store the build plate information that comes from connect if the current printer has not build plate information
         if "build_plate" in data and machine_definition.getMetaDataEntry("has_variant_buildplates", False):
-            printer.updateBuildplateName(data["build_plate"]["type"])
+            printer.updateBuildplate(data["build_plate"]["type"])
         if not data["enabled"]:
             printer.updateState("disabled")
         else:


### PR DESCRIPTION
This makes sure cloud printers set their build plate so Cura doesn't try to handle an empty build plate.

This includes a fix where the `buildplate` (e.g. "glass") was misidentified as `buildplate_name` (e.g. "Glass").