### PR TITLE
CL-1255 Manually create printer properties for cloud output device

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -67,8 +67,8 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
         # An example of why this is needed is the selection of the compatible file type when exporting the tool path.
         properties = {
             b"address": b"",
-            b"name": cluster.host_name.encode(),
-            b"firmware_version": cluster.host_version.encode(),
+            b"name": cluster.host_name.encode() if cluster.host_name else b"",
+            b"firmware_version": cluster.host_version.encode() if cluster.host_version else b"",
             b"printer_type": b""
         }
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -61,8 +61,19 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
     #  \param cluster: The device response received from the cloud API.
     #  \param parent: The optional parent of this output device.
     def __init__(self, api_client: CloudApiClient, cluster: CloudClusterResponse, parent: QObject = None) -> None:
+
+        # The following properties are expected on each networked output device.
+        # Because the cloud connection does not off all of these, we manually construct this version here.
+        # An example of why this is needed is the selection of the compatible file type when exporting the tool path.
+        properties = {
+            b"address": b"",
+            b"name": cluster.host_name.encode(),
+            b"firmware_version": cluster.host_version.encode(),
+            b"printer_type": b""
+        }
+
         super().__init__(device_id = cluster.cluster_id, address = "",
-                         connection_type = ConnectionType.CloudConnection, properties = {}, parent = parent)
+                         connection_type = ConnectionType.CloudConnection, properties = properties, parent = parent)
         self._api = api_client
         self._cluster = cluster
 

--- a/plugins/UM3NetworkPrinting/tests/Cloud/TestCloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/tests/Cloud/TestCloudOutputDevice.py
@@ -21,6 +21,7 @@ class TestCloudOutputDevice(TestCase):
     JOB_ID = "ABCDefGHIjKlMNOpQrSTUvYxWZ0-1234567890abcDE="
     HOST_NAME = "ultimakersystem-ccbdd30044ec"
     HOST_GUID = "e90ae0ac-1257-4403-91ee-a44c9b7e8050"
+    HOST_VERSION = "5.2.0"
 
     STATUS_URL = "{}/connect/v1/clusters/{}/status".format(CuraCloudAPIRoot, CLUSTER_ID)
     PRINT_URL = "{}/connect/v1/clusters/{}/print/{}".format(CuraCloudAPIRoot, CLUSTER_ID, JOB_ID)
@@ -36,7 +37,7 @@ class TestCloudOutputDevice(TestCase):
             patched_method.start()
 
         self.cluster = CloudClusterResponse(self.CLUSTER_ID, self.HOST_GUID, self.HOST_NAME, is_online=True,
-                                            status="active")
+                                            status="active", host_version=self.HOST_VERSION)
 
         self.network = NetworkManagerMock()
         self.account = MagicMock(isLoggedIn=True, accessToken="TestAccessToken")
@@ -55,6 +56,11 @@ class TestCloudOutputDevice(TestCase):
         finally:
             for patched_method in self.patches:
                 patched_method.stop()
+
+    # We test for these in order to make sure the correct file type is selected depending on the firmware version.
+    def test_properties(self):
+        self.assertEqual(self.device.firmwareVersion, self.HOST_VERSION)
+        self.assertEqual(self.device.name, self.HOST_NAME)
 
     def test_status(self):
         self.device._update()

--- a/plugins/UM3NetworkPrinting/tests/Cloud/TestCloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/tests/Cloud/TestCloudOutputDevice.py
@@ -146,7 +146,7 @@ class TestCloudOutputDevice(TestCase):
 
         self.network.flushReplies()
         self.assertEqual(
-            {"data": {"content_type": "application/x-ufp", "job_name": "FileName"}},
+            {"data": {"content_type": "application/x-ufp", "file_size": 52, "job_name": "FileName"}},
             json.loads(self.network.getRequestBody("PUT", self.REQUEST_UPLOAD_URL).decode())
         )
         self.assertIsNone(self.network.getRequestBody("POST", self.PRINT_URL))

--- a/plugins/UM3NetworkPrinting/tests/Cloud/TestCloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/tests/Cloud/TestCloudOutputDevice.py
@@ -142,11 +142,14 @@ class TestCloudOutputDevice(TestCase):
             lambda stream, nodes: stream.write(str(nodes).encode())
 
         scene_nodes = [SceneNode()]
+        expected_mesh = str(scene_nodes).encode()
         self.device.requestWrite(scene_nodes, file_handler=file_handler, file_name="FileName")
 
         self.network.flushReplies()
         self.assertEqual(
-            {"data": {"content_type": "application/x-ufp", "file_size": 52, "job_name": "FileName"}},
+            {"data": {"content_type": "application/x-ufp", "file_size": len(expected_mesh), "job_name": "FileName"}},
             json.loads(self.network.getRequestBody("PUT", self.REQUEST_UPLOAD_URL).decode())
         )
+        self.assertEqual(expected_mesh,
+                         self.network.getRequestBody("PUT", request_upload_response["data"]["upload_url"]))
         self.assertIsNone(self.network.getRequestBody("POST", self.PRINT_URL))


### PR DESCRIPTION
This fixes UFP not being selected as default file type when printing over cloud.