### PR TITLE
Fix token expiry

### DIFF
--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -110,7 +110,7 @@ class AuthorizationService:
         # We have a fallback on a date far in the past for currently stored auth data in cura.cfg.
         received_at = datetime.strptime(self._auth_data.received_at, TOKEN_TIMESTAMP_FORMAT) \
             if self._auth_data.received_at else datetime(2000, 1, 1)
-        expiry_date = received_at + timedelta(seconds = float(self._auth_data.expires_in) - 60 or 0)
+        expiry_date = received_at + timedelta(seconds = float(self._auth_data.expires_in or 0) - 60)
         if datetime.now() > expiry_date:
             self.refreshAccessToken()
 

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -110,7 +110,7 @@ class AuthorizationService:
         # We have a fallback on a date far in the past for currently stored auth data in cura.cfg.
         received_at = datetime.strptime(self._auth_data.received_at, TOKEN_TIMESTAMP_FORMAT) \
             if self._auth_data.received_at else datetime(2000, 1, 1)
-        expiry_date = received_at + timedelta(seconds = float(self._auth_data.expires_in or 0))
+        expiry_date = received_at + timedelta(seconds = float(self._auth_data.expires_in) - 60 or 0)
         if datetime.now() > expiry_date:
             self.refreshAccessToken()
 

--- a/plugins/CuraDrive/src/DriveApiService.py
+++ b/plugins/CuraDrive/src/DriveApiService.py
@@ -54,7 +54,13 @@ class DriveApiService:
             Logger.log("w", "Could not get backups list from remote: %s", backup_list_request.text)
             Message(catalog.i18nc("@info:backup_status", "There was an error listing your backups."), title = catalog.i18nc("@info:title", "Backup")).show()
             return []
-        return backup_list_request.json()["data"]
+
+        backup_list_response = backup_list_request.json()
+        if "data" not in backup_list_response:
+            Logger.log("w", "Could not get backups from remote, actual response body was: %s", str(backup_list_response))
+            return []
+
+        return backup_list_response["data"]
 
     def createBackup(self) -> None:
         self.creatingStateChanged.emit(is_creating = True)


### PR DESCRIPTION
As the token was expired on the very last second, sometimes an API call could be made between the 'local expiry' and the actual expiry on the server. Having some overlap (1 minute) will prevent these time syncing issues.