### PR TITLE
Don't load containers with a wrong setting version

### DIFF
--- a/cura/Settings/CuraContainerRegistry.py
+++ b/cura/Settings/CuraContainerRegistry.py
@@ -1,11 +1,11 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2019 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 import os
 import re
 import configparser
 
-from typing import cast, Dict, Optional
+from typing import Any, cast, Dict, Optional
 from PyQt5.QtWidgets import QMessageBox
 
 from UM.Decorators import override
@@ -326,6 +326,23 @@ class CuraContainerRegistry(ContainerRegistry):
         super().load()
         self._registerSingleExtrusionMachinesExtruderStacks()
         self._connectUpgradedExtruderStacksToMachines()
+
+    ##  Check if the metadata for a container is okay before adding it.
+    #
+    #   This overrides the one from UM.Settings.ContainerRegistry because we
+    #   also require that the setting_version is correct.
+    @override(ContainerRegistry)
+    def _isMetadataValid(self, metadata: Optional[Dict[str, Any]]) -> bool:
+        if metadata is None:
+            return False
+        if "setting_version" not in metadata:
+            return False
+        try:
+            if int(metadata["setting_version"]) != cura.CuraApplication.CuraApplication.SettingVersion:
+                return False
+        except ValueError: #Not parsable as int.
+            return False
+        return True
 
     ##  Update an imported profile to match the current machine configuration.
     #

--- a/resources/definitions/fdmextruder.def.json
+++ b/resources/definitions/fdmextruder.def.json
@@ -6,7 +6,7 @@
         "type": "extruder",
         "author": "Ultimaker",
         "manufacturer": "Unknown",
-        "setting_version": 1,
+        "setting_version": 6,
         "visible": false,
         "position": "0"
     },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -7,7 +7,7 @@
         "author": "Ultimaker",
         "category": "Other",
         "manufacturer": "Unknown",
-        "setting_version": 1,
+        "setting_version": 6,
         "file_formats": "text/x-gcode;application/x-stl-ascii;application/x-stl-binary;application/x-wavefront-obj;application/x3g",
         "visible": false,
         "has_materials": true,

--- a/tests/Settings/TestCuraContainerRegistry.py
+++ b/tests/Settings/TestCuraContainerRegistry.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2019 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 import os #To find the directory with test files and find the test files.
+import pytest #To parameterize tests.
 import unittest.mock #To mock and monkeypatch stuff.
 
 from UM.Settings.DefinitionContainer import DefinitionContainer
@@ -97,3 +98,62 @@ def test_addContainerBadSettingVersion(container_registry, definition_container)
         container_registry.addContainer(instance)
 
     mock_super_add_container.assert_not_called() #Should not get passed on to UM.Settings.ContainerRegistry.addContainer, because the setting_version doesn't match its definition!
+
+test_loadMetaDataValidation_data = [
+    {
+        "id": "valid_container",
+        "is_valid": True,
+        "metadata": {
+            "id": "valid_container",
+            "setting_version": None, #The tests sets this to the current version so it's always correct.
+            "foo": "bar"
+        }
+    },
+    {
+        "id": "wrong_setting_version",
+        "is_valid": False,
+        "metadata": {
+            "id": "wrong_setting_version",
+            "setting_version": "5",
+            "foo": "bar"
+        }
+    },
+    {
+        "id": "missing_setting_version",
+        "is_valid": False,
+        "metadata": {
+            "id": "missing_setting_version",
+            "foo": "bar"
+        }
+    },
+    {
+        "id": "unparsable_setting_version",
+        "is_valid": False,
+        "metadata": {
+            "id": "unparsable_setting_version",
+            "setting_version": "Not an integer!",
+            "foo": "bar"
+        }
+    }
+]
+
+@pytest.mark.parametrize("parameters", test_loadMetaDataValidation_data)
+def test_loadMetadataValidation(container_registry, definition_container, parameters):
+    from cura.CuraApplication import CuraApplication
+    definition_container.getMetaData()["setting_version"] = CuraApplication.SettingVersion
+    container_registry.addContainer(definition_container)
+    if "setting_version" in parameters["metadata"] and parameters["metadata"]["setting_version"] is None: #Signal that the setting_version must be set to the currently correct version.
+        parameters["metadata"]["setting_version"] = CuraApplication.SettingVersion
+
+    mock_provider = unittest.mock.MagicMock()
+    mock_provider.getAllIds = unittest.mock.MagicMock(return_value = [parameters["id"]])
+    mock_provider.loadMetadata = unittest.mock.MagicMock(return_value = parameters["metadata"])
+    container_registry._providers = [mock_provider]
+
+    container_registry.loadAllMetadata() #Run the test.
+
+    if parameters["is_valid"]:
+        assert parameters["id"] in container_registry.metadata
+        assert container_registry.metadata[parameters["id"]] == parameters["metadata"]
+    else:
+        assert parameters["id"] not in container_registry.metadata

--- a/tests/Settings/conftest.py
+++ b/tests/Settings/conftest.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2018 Ultimaker B.V.
-# Uranium is released under the terms of the LGPLv3 or higher.
+# Copyright (c) 2019 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
 
 # The purpose of this class is to create fixtures or methods that can be shared among all settings tests.
 
@@ -49,6 +49,6 @@ def global_stack(definition_changes_container) -> GlobalStack:
 # There is a restriction here that the definition changes cannot be an empty container. Added in CURA-5281
 @pytest.fixture()
 def extruder_stack(definition_changes_container) -> ExtruderStack:
-    extruder_stack= ExtruderStack("TestExtruderStack")
+    extruder_stack = ExtruderStack("TestExtruderStack")
     extruder_stack._containers[cura.Settings.CuraContainerStack._ContainerIndexes.DefinitionChanges] = definition_changes_container
     return extruder_stack


### PR DESCRIPTION
When a container had an incorrect setting version, the metadata was still being loaded (but the complete container was not). This PR corrects that.

This PR depends on https://github.com/Ultimaker/Uranium/pull/471.

Implements CURA-6270.