### PR TITLE
Update creality_ender3.def.json

### DIFF
--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -51,16 +51,13 @@
             "default_value": 500
         },
         "acceleration_travel": {
-            "default_value": 500
+            "value": 500
         },
         "jerk_enabled": {
             "default_value": true
         },
         "jerk_travel": {
-            "default_value": 20
-        },
-        "layer_height": {
-            "default_value": 0.10
+            "value": 20
         },
         "layer_height_0": {
             "default_value": 0.2

--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -51,13 +51,13 @@
             "default_value": 500
         },
         "acceleration_travel": {
-            "value": 500
+            "value": "acceleration_print"
         },
         "jerk_enabled": {
             "default_value": true
         },
         "jerk_travel": {
-            "value": 20
+            "value": "jerk_print"
         },
         "layer_height_0": {
             "default_value": 0.2


### PR DESCRIPTION
Changed override of "default_value" to "value" of acceleration_travel and jerk_travel to make slicer keep those values, as they were overrided by conditional in fdmprinter.def.json, and also removed layer height as it does nothing because it's overriden by preffered quality (draft) settings