### PR TITLE
Lithophane defaults

### DIFF
--- a/plugins/ImageReader/ConfigUI.qml
+++ b/plugins/ImageReader/ConfigUI.qml
@@ -123,7 +123,7 @@ UM.Dialog
         UM.TooltipArea {
             Layout.fillWidth:true
             height: childrenRect.height
-            text: catalog.i18nc("@info:tooltip","By default, white pixels represent high points on the mesh and black pixels represent low points on the mesh. Change this option to reverse the behavior such that black pixels represent high points on the mesh and white pixels represent low points on the mesh.")
+            text: catalog.i18nc("@info:tooltip","By default, black pixels represent high points on the mesh and white pixels represent low points on the mesh. Change this option to reverse the behavior such that white pixels represent high points on the mesh and black pixels represent low points on the mesh. ")
             Row {
                 width: parent.width
 
@@ -136,7 +136,7 @@ UM.Dialog
                 ComboBox {
                     id: image_color_invert
                     objectName: "Image_Color_Invert"
-                    model: [ catalog.i18nc("@item:inlistbox","Lighter is higher"), catalog.i18nc("@item:inlistbox","Darker is higher") ]
+                    model: [ catalog.i18nc("@item:inlistbox","Darker is higher"), catalog.i18nc("@item:inlistbox","Lighter is higher") ]
                     width: 180 * screenScaleFactor
                     onCurrentIndexChanged: { manager.onImageColorInvertChanged(currentIndex) }
                 }

--- a/plugins/ImageReader/ConfigUI.qml
+++ b/plugins/ImageReader/ConfigUI.qml
@@ -123,7 +123,7 @@ UM.Dialog
         UM.TooltipArea {
             Layout.fillWidth:true
             height: childrenRect.height
-            text: catalog.i18nc("@info:tooltip","By default, black pixels represent high points on the mesh and white pixels represent low points on the mesh. Change this option to reverse the behavior such that white pixels represent high points on the mesh and black pixels represent low points on the mesh. ")
+            text: catalog.i18nc("@info:tooltip","For lithophanes dark pixels should correspond to thicker locations in order to block more light coming through. For height maps lighter pixels signify higher terrain, so lighter pixels should correspond to thicker locations in the generated 3D model.")
             Row {
                 width: parent.width
 

--- a/plugins/ImageReader/ConfigUI.qml
+++ b/plugins/ImageReader/ConfigUI.qml
@@ -134,8 +134,8 @@ UM.Dialog
                     anchors.verticalCenter: parent.verticalCenter
                 }
                 ComboBox {
-                    id: image_color_invert
-                    objectName: "Image_Color_Invert"
+                    id: lighter_is_higher
+                    objectName: "Lighter_Is_Higher"
                     model: [ catalog.i18nc("@item:inlistbox","Darker is higher"), catalog.i18nc("@item:inlistbox","Lighter is higher") ]
                     width: 180 * screenScaleFactor
                     onCurrentIndexChanged: { manager.onImageColorInvertChanged(currentIndex) }

--- a/plugins/ImageReader/ImageReader.py
+++ b/plugins/ImageReader/ImageReader.py
@@ -46,9 +46,9 @@ class ImageReader(MeshReader):
 
     def _read(self, file_name):
         size = max(self._ui.getWidth(), self._ui.getDepth())
-        return self._generateSceneNode(file_name, size, self._ui.peak_height, self._ui.base_height, self._ui.smoothing, 512, self._ui.image_color_invert)
+        return self._generateSceneNode(file_name, size, self._ui.peak_height, self._ui.base_height, self._ui.smoothing, 512, self._ui.lighter_is_higher)
 
-    def _generateSceneNode(self, file_name, xz_size, peak_height, base_height, blur_iterations, max_size, image_color_invert):
+    def _generateSceneNode(self, file_name, xz_size, peak_height, base_height, blur_iterations, max_size, lighter_is_higher):
         scene_node = SceneNode()
 
         mesh = MeshBuilder()
@@ -104,7 +104,7 @@ class ImageReader(MeshReader):
 
         Job.yieldThread()
 
-        if image_color_invert:
+        if not lighter_is_higher:
             height_data = 1 - height_data
 
         for _ in range(0, blur_iterations):

--- a/plugins/ImageReader/ImageReaderUI.py
+++ b/plugins/ImageReader/ImageReaderUI.py
@@ -30,10 +30,10 @@ class ImageReaderUI(QObject):
         self._width = self.default_width
         self._depth = self.default_depth
 
-        self.base_height = 1
-        self.peak_height = 10
+        self.base_height = 0.4
+        self.peak_height = 2.5
         self.smoothing = 1
-        self.image_color_invert = False;
+        self.image_color_invert = True;
 
         self._ui_lock = threading.Lock()
         self._cancelled = False

--- a/plugins/ImageReader/ImageReaderUI.py
+++ b/plugins/ImageReader/ImageReaderUI.py
@@ -33,7 +33,7 @@ class ImageReaderUI(QObject):
         self.base_height = 0.4
         self.peak_height = 2.5
         self.smoothing = 1
-        self.image_color_invert = True;
+        self.lighter_is_higher = False;
 
         self._ui_lock = threading.Lock()
         self._cancelled = False
@@ -143,4 +143,4 @@ class ImageReaderUI(QObject):
 
     @pyqtSlot(int)
     def onImageColorInvertChanged(self, value):
-        self.image_color_invert = (value == 1)
+        self.lighter_is_higher = (value == 1)


### PR DESCRIPTION
The defaults for image import were rather arbitrary.

I think more people use this option for lithophanes than for height fields.

I've also updated the tooltip to explain *when* to use which option, rather than only being descriptive.