### PR TITLE
PrintSetupSelector: "G code" -> "G-code"

### DIFF
--- a/resources/qml/PrintSetupSelector/PrintSetupSelector.qml
+++ b/resources/qml/PrintSetupSelector/PrintSetupSelector.qml
@@ -16,7 +16,7 @@ Cura.ExpandableComponent
     contentPadding: UM.Theme.getSize("default_lining").width
     contentHeaderTitle: catalog.i18nc("@label", "Print settings")
     enabled: !preSlicedData
-    disabledText: catalog.i18nc("@label shown when we load a Gcode file", "Print setup disabled. G code file can not be modified.")
+    disabledText: catalog.i18nc("@label shown when we load a Gcode file", "Print setup disabled. G-code file can not be modified.")
 
     UM.I18nCatalog
     {


### PR DESCRIPTION
Noticed that "g-code" is written at some places with and without a hyphen.
Since it think it should be written with, I'm correcting it at this point.