### PR TITLE
Fix for to display the text in the dark theme (Menu - Preferences - Materials).

### DIFF
--- a/resources/qml/Preferences/Materials/MaterialsTypeSection.qml
+++ b/resources/qml/Preferences/Materials/MaterialsTypeSection.qml
@@ -29,7 +29,7 @@ Item
             }
             else
             {
-                return "transparent"
+                return UM.Theme.getColor("favorites_subheader_hover")
             }
         }
         width: parent.width

--- a/resources/themes/cura-dark/theme.json
+++ b/resources/themes/cura-dark/theme.json
@@ -216,6 +216,10 @@
         "toolbox_header_button_text_inactive": [128, 128, 128, 255],
         "toolbox_header_button_text_hovered": [255, 255, 255, 255],
 
+        "favorites_header_bar": [90, 90, 90, 255],
+        "favorites_row_selected": [70, 80, 100, 255],
+        "favorites_subheader_hover": [60, 60, 60, 255],
+
         "monitor_printer_family_tag": [86, 86, 106, 255],
         "monitor_text_primary": [229, 229, 229, 255],
         "monitor_text_disabled": [102, 102, 102, 255],


### PR DESCRIPTION
This fix and improvement а for to display the text in "Menu - Preferences - Materials - (element ScrollView)" in the dark theme.

Before corrections:
![image](https://user-images.githubusercontent.com/35381319/54883052-1a89fd80-4e72-11e9-8924-b70d8904c8fb.png)

After corrections:
![image](https://user-images.githubusercontent.com/35381319/54883070-473e1500-4e72-11e9-8933-64aaed9115a0.png)

Note: 
1. To run the application using the command:
 "QT_QUICK_CONTROLS_STYLE=Desktop /home/User/Cura/AppRun"
2. I did not change line 141 in the file "MaterialsTypeSection.qml". The reason for its change is not clear to me.
