### PR TITLE
Fix for weird home directories on Windows

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -23,7 +23,10 @@ known_args = vars(parser.parse_known_args()[0])
 if not known_args["debug"]:
     def get_cura_dir_path():
         if Platform.isWindows():
-            return os.path.expanduser("~/AppData/Roaming/" + CuraAppName)
+            appdata_path = os.getenv("APPDATA")
+            if not appdata_path: #Defensive against the environment variable missing (should never happen).
+                appdata_path = "."
+            return os.path.join(appdata_path, CuraAppName)
         elif Platform.isLinux():
             return os.path.expanduser("~/.local/share/" + CuraAppName)
         elif Platform.isOSX():


### PR DESCRIPTION
The expanduser function will expand to a combination of HOMEDRIVE and HOMEPATH which might not be the same as APPDATA if your configuration is very weird (e.g. you've changed your APPDATA location).

Contributes to CURA-6418.
Hopefully fixes #5471.