### PR TITLE
Remove the link to the compatibility chart

### DIFF
--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -175,59 +175,6 @@ Cura.ExpandablePopup
             }
         }
 
-        Item
-        {
-            height: visible ? childrenRect.height: 0
-            anchors.right: parent.right
-            anchors.rightMargin: UM.Theme.getSize("default_margin").width
-            width: childrenRect.width + UM.Theme.getSize("default_margin").width
-            visible: popupItem.configuration_method == ConfigurationMenu.ConfigurationMethod.Custom
-            UM.RecolorImage
-            {
-                id: externalLinkIcon
-                anchors.left: parent.left
-                anchors.leftMargin: UM.Theme.getSize("default_margin").width
-                height: materialInfoLabel.height
-                width: height
-                sourceSize.height: width
-                color: UM.Theme.getColor("text_link")
-                source: UM.Theme.getIcon("external_link")
-            }
-
-            Label
-            {
-                id: materialInfoLabel
-                wrapMode: Text.WordWrap
-                text: catalog.i18nc("@label", "See the material compatibility chart")
-                font: UM.Theme.getFont("default")
-                color: UM.Theme.getColor("text_link")
-                linkColor: UM.Theme.getColor("text_link")
-                anchors.left: externalLinkIcon.right
-                anchors.leftMargin: UM.Theme.getSize("narrow_margin").width
-                renderType: Text.NativeRendering
-
-                MouseArea
-                {
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    onClicked:
-                    {
-                        // open the material URL with web browser
-                        var url = "https://ultimaker.com/incoming-links/cura/material-compatibilty"
-                        Qt.openUrlExternally(url)
-                    }
-                    onEntered:
-                    {
-                        materialInfoLabel.font.underline = true
-                    }
-                    onExited:
-                    {
-                        materialInfoLabel.font.underline = false
-                    }
-                }
-            }
-        }
-
         Rectangle
         {
             id: separator


### PR DESCRIPTION
Actually it only made sense for Ultimaker materials. Now that we can include instruction link in every materials, a specific link for every material can be used instead. This is done in https://github.com/Ultimaker/fdm_materials/pull/78

Contributes to CURA-6423.