### PR TITLE
CURA-6449 Disable printers that are not host of a group

### DIFF
--- a/cura/Machines/Models/DiscoveredPrintersModel.py
+++ b/cura/Machines/Models/DiscoveredPrintersModel.py
@@ -62,12 +62,14 @@ class DiscoveredPrinter(QObject):
         from cura.CuraApplication import CuraApplication
         readable_type = CuraApplication.getInstance().getMachineManager().getMachineTypeNameFromId(self._machine_type)
         if not readable_type:
-            readable_type = "unknown"
+            readable_type = catalog.i18nc("@label", "Unknown")
         return readable_type
 
     @pyqtProperty(bool, notify = machineTypeChanged)
     def isUnknownMachineType(self) -> bool:
-        return self.readableMachineType == "unknown"
+        from cura.CuraApplication import CuraApplication
+        readable_type = CuraApplication.getInstance().getMachineManager().getMachineTypeNameFromId(self._machine_type)
+        return not readable_type
 
     @pyqtProperty(QObject, constant = True)
     def device(self) -> "NetworkedPrinterOutputDevice":

--- a/cura/Machines/Models/DiscoveredPrintersModel.py
+++ b/cura/Machines/Models/DiscoveredPrintersModel.py
@@ -81,7 +81,7 @@ class DiscoveredPrinter(QObject):
         if self.isUnknownMachineType or not self.isHostOfGroup:
             return catalog.i18nc("@label", "The printer(s) below cannot be connected because they are part of a group")
         else:
-            return catalog.i18nc("@label", "Available network printers")
+            return catalog.i18nc("@label", "Available networked printers")
 
 
 #

--- a/cura/Machines/Models/DiscoveredPrintersModel.py
+++ b/cura/Machines/Models/DiscoveredPrintersModel.py
@@ -61,12 +61,12 @@ class DiscoveredPrinter(QObject):
         from cura.CuraApplication import CuraApplication
         readable_type = CuraApplication.getInstance().getMachineManager().getMachineTypeNameFromId(self._machine_type)
         if not readable_type:
-            readable_type = catalog.i18nc("@label", "Unknown")
+            readable_type = "unknown"
         return readable_type
 
     @pyqtProperty(bool, notify = machineTypeChanged)
     def isUnknownMachineType(self) -> bool:
-        return self.readableMachineType == catalog.i18nc("@label", "Unknown")
+        return self.readableMachineType == "unknown"
 
     @pyqtProperty(QObject, constant = True)
     def device(self) -> "NetworkedPrinterOutputDevice":

--- a/resources/qml/PrinterSelector/MachineSelectorButton.qml
+++ b/resources/qml/PrinterSelector/MachineSelectorButton.qml
@@ -53,7 +53,7 @@ Button
                 verticalCenter: parent.verticalCenter
             }
             text: machineSelectorButton.text
-            color: UM.Theme.getColor("text")
+            color: enabled ? UM.Theme.getColor("text") : UM.Theme.getColor("small_button_text")
             font: UM.Theme.getFont("medium")
             visible: text != ""
             renderType: Text.NativeRendering

--- a/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml
+++ b/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml
@@ -71,6 +71,10 @@ Item
                 anchors.fill: parent
                 model: CuraApplication.getDiscoveredPrintersModel().discoveredPrinters
 
+                section.property: "modelData.sectionName"
+                section.criteria: ViewSection.FullString
+                section.delegate: sectionHeading
+
                 Component.onCompleted:
                 {
                     // Select the first one that's not "unknown" by default.
@@ -84,6 +88,23 @@ Item
                     }
                 }
 
+                Component
+                {
+                    id: sectionHeading
+
+                    Label
+                    {
+                        anchors.left: parent.left
+                        anchors.leftMargin: UM.Theme.getSize("default_margin").width
+                        height: UM.Theme.getSize("setting_control").height
+                        text: section
+                        font: UM.Theme.getFont("default")
+                        color: UM.Theme.getColor("small_button_text")
+                        verticalAlignment: Text.AlignVCenter
+                        renderType: Text.NativeRendering
+                    }
+                }
+
                 delegate: MachineSelectorButton
                 {
                     text: modelData.device.name
@@ -93,7 +114,7 @@ Item
                     anchors.rightMargin: UM.Theme.getSize("default_margin").width
                     outputDevice: modelData.device
 
-                    enabled: !modelData.isUnknownMachineType
+                    enabled: !modelData.isUnknownMachineType && modelData.isHostOfGroup
 
                     printerTypeLabelAutoFit: true
 


### PR DESCRIPTION
 - Group printers into hosts and non-hosts and of unknown type.
 - Show available/connectable printers first in the list.
 - Show sections for connectable and non-connectable printers.