### PR TITLE
JSON: new setting infill_randomize_start_location

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1729,7 +1729,7 @@
                     "description": "Randomize which infill line is printed first. This prevents one segment becoming the strongest, but it does so at the cost of an additional travel move.",
                     "type": "bool",
                     "default_value": false,
-                    "value": "infill_pattern == 'grid' or infill_pattern == 'triangles' or infill_pattern == 'trihexagon' or infill_pattern == 'triangles' or infill_pattern == 'cubic' or infill_pattern == 'cubicsubdiv' or infill_pattern == 'tetrahedral' or infill_pattern == 'quarter_cubic'",
+                    "value": "infill_pattern in ('grid', 'triangles', 'trihexagon', 'cubic', 'cubicsubdiv', 'tetrahedral', 'quarter_cubic')",
                     "enabled": "not ((infill_pattern == 'cross' and connect_infill_polygons) or infill_pattern == 'concentric')",
                     "limit_to_extruder": "infill_extruder_nr",
                     "settable_per_mesh": true

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1728,7 +1728,7 @@
                     "label": "Randomize Infill Start",
                     "description": "Randomize which infill line is printed first. This prevents one segment becoming the strongest, but it does so at the cost of an additional travel move.",
                     "type": "bool",
-                    "default_value": true,
+                    "default_value": false,
                     "value": "infill_pattern == 'grid' or infill_pattern == 'triangles' or infill_pattern == 'trihexagon' or infill_pattern == 'triangles' or infill_pattern == 'cubic' or infill_pattern == 'cubicsubdiv' or infill_pattern == 'tetrahedral' or infill_pattern == 'quarter_cubic'",
                     "enabled": "not ((infill_pattern == 'cross' and connect_infill_polygons) or infill_pattern == 'concentric')",
                     "limit_to_extruder": "infill_extruder_nr",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1723,6 +1723,17 @@
                     "limit_to_extruder": "infill_extruder_nr",
                     "settable_per_mesh": true
                 },
+                "infill_randomize_start_location":
+                {
+                    "label": "Randomize Infill Start",
+                    "description": "Randomize which infill line is printed first. This prevents one segment becoming the strongest, but it does so at the cost of an additional travel move.",
+                    "type": "bool",
+                    "default_value": true,
+                    "value": "infill_pattern == 'grid' or infill_pattern == 'triangles' or infill_pattern == 'trihexagon' or infill_pattern == 'triangles' or infill_pattern == 'cubic' or infill_pattern == 'cubicsubdiv' or infill_pattern == 'tetrahedral' or infill_pattern == 'quarter_cubic'",
+                    "enabled": "not ((infill_pattern == 'cross' and connect_infill_polygons) or infill_pattern == 'concentric')",
+                    "limit_to_extruder": "infill_extruder_nr",
+                    "settable_per_mesh": true
+                },
                 "infill_multiplier":
                 {
                     "label": "Infill Line Multiplier",


### PR DESCRIPTION
Research into the physical properties of print paths by Peter Sap has indicated that starting the infill pattern at the same location on each layer reduces the stiffness of the print.

This is the case for line-based infill patterns which contain crossings, e.g. grid and triangle.

Those crossings cause problems; when a print path crosses an already printed path the second path gets interrupted and the connection between the two print paths is not strong. When the same ordering of the infill paths is present on each layer, you get one strong wall and all other walls of the infill pattern are weaker.

In tensile tests you can easily see this is the case because you will end up with the infill pattern broken apart and hanging on to those initial lines.

By randomizing the start position where we start to print the infill we prevent the accumulative effect which causes whole vertical segments to become 'significantly' weaker than the initial segments.

The tests have been performed on the 2D infill patterns. It seems logical that the same effect also occurs on 3D infill patterns, but to a lesser degree because the infill patterns themselves shift a bit each layer.

It should be noted that the problem occurs when the geometry over several layers is quite similar. When the geometry of the model changes enough per layer the infill starting position is auto-randomized.

PS:
This reverts commit cc9aa1129a7795a9bcc13bf4916d38a2c4b11375.
Reintroduce the feature which I reverted on master (because I accidentally pushed to master).