### PR TITLE
Added bridge_sparse_infill_max_density to specify max density of sparse infill.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6758,6 +6758,7 @@
                     "type": "float",
                     "default_value": 0,
                     "minimum_value": "0",
+                    "enabled": "bridge_settings_enabled",
                     "settable_per_mesh": true
                 },
                 "bridge_wall_coast":

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6750,6 +6750,16 @@
                     "enabled": "bridge_settings_enabled",
                     "settable_per_mesh": true
                 },
+                "bridge_sparse_infill_max_density":
+                {
+                    "label": "Bridge Sparse Infill Max Density",
+                    "description": "Maximum density of infill considered to be sparse. Skin over sparse infill is considered to be unsupported and so may be treated as a bridge skin.",
+                    "unit": "%",
+                    "type": "float",
+                    "default_value": 0,
+                    "minimum_value": "0",
+                    "settable_per_mesh": true
+                },
                 "bridge_wall_coast":
                 {
                     "label": "Bridge Wall Coasting",


### PR DESCRIPTION
A skin that is over sparse infill is considered to be unsupported for bridging purposes.

As discussed in https://community.ultimaker.com/topic/22195-introducing-the-experimental-bridging-settings/?do=findComment&comment=237649