### PR TITLE
CL-1055 Show "sliced for" pills on print jobs

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
@@ -158,14 +158,9 @@ Item
                     spacing: 6 // TODO: Theme!
                     visible: printJob
 
-                    Repeater
+                    MonitorPrinterPill
                     {
-                        id: compatiblePills
-                        delegate: MonitorPrinterPill
-                        {
-                            text: modelData
-                        }
-                        model: printJob ? printJob.compatibleMachineFamilies : []
+                        text: printJob.configuration.printerType
                     }
                 }
             }

--- a/plugins/UM3NetworkPrinting/src/ClusterUM3OutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/ClusterUM3OutputDevice.py
@@ -535,6 +535,7 @@ class ClusterUM3OutputDevice(NetworkedPrinterOutputDevice):
             extruder.setMaterial(self._createMaterialOutputModel(extruder_data.get("material", {})))
 
         configuration.setExtruderConfigurations(extruders)
+        configuration.setPrinterType(data.get("machine_variant", ""))
         print_job.updateConfiguration(configuration)
         print_job.setCompatibleMachineFamilies(data.get("compatible_machine_families", []))
         print_job.stateChanged.connect(self._printJobStateChanged)


### PR DESCRIPTION
Formerly the pills were rendered based on the print job's `compatible_machine_families` property.

This property is always the intersection of printers in the group and printers the job can use.* In the case of an S5 print job in a group with no S5 machines, the print job has no compatible machine families to show a pill for, and hence there's no pill and this bug exists. Although logical, this is not ideal because knowing what the print job was sliced for is exactly the case where it's very important to see the pill next to the blocked print job.

For this reason I have switched to using the `configuration.machine_variant` instead of `compatible_machine_families`.

*This is sort of a lie. In the Cura Connect code, the print job's side of the matching never uses more than a single printer type: whatever is set as the `machine_variant` property.