### PR TITLE
Add cool_fan_lag setting that specifies the time taken for large cooling fan speed changes.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -3706,6 +3706,17 @@
                     "default_value": false,
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
+                },
+                "cool_fan_lag":
+                {
+                    "label": "Cooling Fan Lag",
+                    "description": "The time it takes the cooling fan to accelerate from 0 to 100%.",
+                    "unit": "s",
+                    "type": "float",
+                    "default_value": 1,
+                    "minimum_value": "0",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
                 }
             }
         },


### PR DESCRIPTION
This PR makes print cooling fan speed overrides happen earlier so that the requested speed change has been achieved by the time the nozzle reaches the override zone.

Engine PR is https://github.com/Ultimaker/CuraEngine/pull/1049.