### PR TITLE
Adjust max Z-axis jerk on Ender 3

### DIFF
--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -60,7 +60,7 @@
             "value": "jerk_print"
         },
         "machine_max_jerk_z": {
-            "default_value": 0.3,
+            "default_value": 0.3
         },
         "layer_height_0": {
             "default_value": 0.2

--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -59,6 +59,9 @@
         "jerk_travel": {
             "value": "jerk_print"
         },
+        "machine_max_jerk_z": {
+            "default_value": 0.3,
+        },
         "layer_height_0": {
             "default_value": 0.2
         },


### PR DESCRIPTION
I suggest a change to the value of max  Z-axis Jerk to be the same as on Marlin 1.1.9 firmware used by Ender 3. Its a small change, reducing 0,4 to 0,3. Having these settings match the firmware's configuration makes a print's estimated time more accurate.