### PR TITLE
Adjust retraction distance and retraction speed on Ender 3

### DIFF
--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -69,10 +69,10 @@
             "default_value": 0.6
         },
         "retraction_amount": {
-            "default_value": 5
+            "default_value": 6
         },
         "retraction_speed": {
-            "default_value": 40
+            "default_value": 25
         },
         "cool_min_layer_time": {
             "default_value": 10


### PR DESCRIPTION
#5701 Adjusted retraction distance and retraction speed for Ender 3. 

These settings work well for me. I can't say for certain if these settings really improve the print over the previous settings. 

Chuck talks about these numbers specifically in his video: https://www.youtube.com/watch?time_continue=6&v=GXSqZ68UdsE