### PR TITLE
CL-1331 Extending the Cura API for the Network Printing Plugin

### DIFF
--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -7,7 +7,7 @@ from UM.i18n import i18nCatalog
 from UM.Logger import Logger
 if TYPE_CHECKING:
     from cura.CuraApplication import CuraApplication
-    from cura.PrinterOutput.PrinterOutputDevice import PrinterOutputDevice
+    from cura.PrinterOutput.PrinterOutputDevice import PrinterOutputDevice, ConnectionType
 
 i18n_catalog = i18nCatalog("cura")
 

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -7,6 +7,7 @@ from UM.i18n import i18nCatalog
 from UM.Logger import Logger
 if TYPE_CHECKING:
     from cura.CuraApplication import CuraApplication
+    from cura.PrinterOutput.PrinterOutputDevice import PrinterOutputDevice
 
 i18n_catalog = i18nCatalog("cura")
 
@@ -37,7 +38,7 @@ class Machines(QObject):
         self._application = application
 
     @pyqtSlot(result="QVariantMap")
-    def getCurrentMachine(self) -> "QVariantMap":
+    def getCurrentMachine(self) -> Machine:
         fake_machine = Machine() # type: Machine
         global_stack = self._application.getGlobalContainerStack()
         if global_stack:

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -68,6 +68,7 @@ class Machines(QObject):
     ##  Set the current machine's configuration from an (optional) output device.
     #   If no output device is given, the first one available on the machine will be used.
     #   NOTE: Group and machine are used interchangeably.
+    #   NOTE: This doesn't seem to be used anywhere. Maybe delete?
     @pyqtSlot(QObject)
     def updateCurrentMachineConfiguration(self, output_device: Optional["PrinterOutputDevice"]) -> None:
 

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
-from typing import Optional, Dict, TYPE_CHECKING
+from typing import Optional, Dict,  List, TYPE_CHECKING
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, pyqtProperty
 from UM.i18n import i18nCatalog
 from UM.Logger import Logger

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -27,20 +27,26 @@ class Machines(QObject):
 
     @pyqtSlot(result=dict)
     def getCurrentMachine(self) -> dict:
+        # Since Cura doesn't have a machine class, we're going to make a fake one to make our
+        # lives a little bit easier.
+        fake_machine = {
+            "hostname": "",
+            "group_id": "",
+            "group_name": "",
+            "um_network_key": "",
+            "configuration": {}
+        }
         global_stack = self._application.getGlobalContainerStack()
         if global_stack:
             metadata = global_stack.getMetaData()
-        
-            # Since Cura doesn't have a machine class, we're going to make a fake one to make our
-            # lives a little bit easier.
-            fake_machine = {
-                "hostname": "",
-                "group_id": global_stack.getMetaDataEntry("group_id") if "group_id" in metadata else "",
-                "group_name": global_stack.getMetaDataEntry("group_name") if "group_name" in metadata else "",
-                "um_network_key": global_stack.getMetaDataEntry("um_network_key") if "um_network_key" in metadata else "",
-                "configuration": {}
-            }
-            return fake_machine
+            if "group_id" in metadata:
+                fake_machine["group_id"] = global_stack.getMetaDataEntry("group_id")
+            if "group_name" in metadata:
+                fake_machine["group_name"] = global_stack.getMetaDataEntry("group_name")
+            if "um_network_key" in metadata:
+                fake_machine["um_network_key"] = global_stack.getMetaDataEntry("um_network_key")
+            
+        return fake_machine
 
     ##  Set the current machine's friendy name.
     #   This is the same as "group name" since we use "group" and "current machine" interchangeably.

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
-from typing import Optional, Dict,  List, TYPE_CHECKING
+from typing import Optional, Dict,  List, TYPE_CHECKING, Any
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, pyqtProperty
 from UM.i18n import i18nCatalog
 from UM.Logger import Logger

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -25,6 +25,58 @@ class Machines(QObject):
         super().__init__(parent)
         self._application = application
 
+    @pyqtSlot(result=dict)
+    def getCurrentMachine(self) -> dict:
+        global_stack = self._application.getGlobalContainerStack()
+        if global_stack:
+            metadata = global_stack.getMetaData()
+        
+            # Since Cura doesn't have a machine class, we're going to make a fake one to make our
+            # lives a little bit easier.
+            fake_machine = {
+                "hostname": "",
+                "group_id": global_stack.getMetaDataEntry("group_id") if "group_id" in metadata else "",
+                "group_name": global_stack.getMetaDataEntry("group_name") if "group_name" in metadata else "",
+                "um_network_key": global_stack.getMetaDataEntry("um_network_key") if "um_network_key" in metadata else "",
+                "configuration": {}
+            }
+            return fake_machine
+
+    ##  Set the current machine's friendy name.
+    #   This is the same as "group name" since we use "group" and "current machine" interchangeably.
+    #   TODO: Maybe make this "friendly name" to distinguish from "hostname"?
+    @pyqtSlot(str)
+    def setCurrentMachineGroupName(self, group_name: str):
+        Logger.log("d", "Attempting to set the group name of the active machine to %s", group_name)
+        global_stack = self._application.getGlobalContainerStack()
+        if global_stack:
+            # Update a GlobalStacks in the same group with the new group name.
+            group_id = global_stack.getMetaDataEntry("group_id")
+            machine_manager = self._application.getMachineManager()
+            for machine in machine_manager.getMachinesInGroup(group_id):
+                machine.setMetaDataEntry("group_name", group_name)
+
+            # Set the default value for "hidden", which is used when you have a group with multiple types of printers
+            global_stack.setMetaDataEntry("hidden", False)
+
+    ##  Set the current machine's configuration from an (optional) output device.
+    #   If no output device is given, the first one available on the machine will be used.
+    #   NOTE: Group and machine are used interchangeably.
+    @pyqtSlot(QObject)
+    def updateCurrentMachineConfiguration(self, output_device: Optional["PrinterOutputDevice"]) -> None:
+
+        if output_device is None:
+            machine_manager = self._application.getMachineManager()
+            output_device = machine_manager.printerOutputDevices[0]
+        
+        hotend_ids = output_device.hotendIds
+        for index in range(len(hotend_ids)):
+            output_device.hotendIdChanged.emit(index, hotend_ids[index])
+        
+        material_ids = output_device.materialIds
+        for index in range(len(material_ids)):
+            output_device.materialIdChanged.emit(index, material_ids[index])
+
     ##  Add an output device to the current machine.
     #   In practice, this means:
     #   - Setting the output device's network key in the current machine's metadata
@@ -32,33 +84,31 @@ class Machines(QObject):
     #     types.
     #   TODO: CHANGE TO HOSTNAME
     @pyqtSlot(QObject)
-    def addOutputDeviceToCurrentMachine(self, output_device):
+    def addOutputDeviceToCurrentMachine(self, output_device: "PrinterOutputDevice") -> None:
         if not output_device:
             return
-
         Logger.log("d",
             "Attempting to set the network key of the active machine to %s",
             output_device.key)
-
-        global_container_stack = self._application.getGlobalContainerStack()
-        if not global_container_stack:
+        global_stack = self._application.getGlobalContainerStack()
+        if not global_stack:
             return
+        metadata = global_stack.getMetaData()
 
-        metadata = global_container_stack.getMetaData()
-
-        if "um_network_key" in metadata:  # Global stack already had a connection, but it's changed.
+        # Global stack already had a connection, but it's changed.
+        if "um_network_key" in metadata: 
             old_network_key = metadata["um_network_key"]
+
             # Since we might have a bunch of hidden stacks, we also need to change it there.
             metadata_filter = {"um_network_key": old_network_key}
             containers = self._application.getContainerRegistry().findContainerStacks(
                 type = "machine", **metadata_filter)
-
             for container in containers:
                 container.setMetaDataEntry("um_network_key", output_device.key)
 
                 # Delete old authentication data.
                 Logger.log("d", "Removing old authentication id %s for device %s",
-                    global_container_stack.getMetaDataEntry("network_authentication_id", None),
+                    global_stack.getMetaDataEntry("network_authentication_id", None),
                     output_device.key)
 
                 container.removeMetaDataEntry("network_authentication_id")
@@ -69,8 +119,8 @@ class Machines(QObject):
                 container.addConfiguredConnectionType(output_device.connectionType.value)
 
         else:  # Global stack didn't have a connection yet, configure it.
-            global_container_stack.setMetaDataEntry("um_network_key", output_device.key)
-            global_container_stack.addConfiguredConnectionType(output_device.connectionType.value)
+            global_stack.setMetaDataEntry("um_network_key", output_device.key)
+            global_stack.addConfiguredConnectionType(output_device.connectionType.value)
 
         return None
     

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -25,8 +25,8 @@ class Machines(QObject):
         super().__init__(parent)
         self._application = application
 
-    @pyqtSlot(result=dict)
-    def getCurrentMachine(self) -> dict:
+    @pyqtSlot(result="QVariantMap")
+    def getCurrentMachine(self) -> "QVariantMap":
         # Since Cura doesn't have a machine class, we're going to make a fake one to make our
         # lives a little bit easier.
         fake_machine = {

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -18,7 +18,18 @@ i18n_catalog = i18nCatalog("cura")
 #       api = CuraAPI()
 #       api.machines.addOutputDeviceToCurrentMachine()
 #       ```
-#
+
+##  Since Cura doesn't have a machine class, we're going to make a fake one to make our lives a
+#   little bit easier.
+class Machine():
+    def __init__(self) -> None:
+        self.hostname = "" # type: str
+        self.group_id = "" # type: str
+        self.group_name = "" # type: str
+        self.um_network_key = "" # type: str
+        self.configuration = {} # type: Dict
+        self.connection_types = [] # type: List
+
 class Machines(QObject):
 
     def __init__(self, application: "CuraApplication", parent = None) -> None:
@@ -27,27 +38,18 @@ class Machines(QObject):
 
     @pyqtSlot(result="QVariantMap")
     def getCurrentMachine(self) -> "QVariantMap":
-        # Since Cura doesn't have a machine class, we're going to make a fake one to make our
-        # lives a little bit easier.
-        fake_machine = {
-            "hostname": "",
-            "group_id": "",
-            "group_name": "",
-            "um_network_key": "",
-            "configuration": {},
-            "connection_types": []
-        }
+        fake_machine = Machine() # type: Machine
         global_stack = self._application.getGlobalContainerStack()
         if global_stack:
             metadata = global_stack.getMetaData()
             if "group_id" in metadata:
-                fake_machine["group_id"] = global_stack.getMetaDataEntry("group_id")
+                fake_machine.group_id = global_stack.getMetaDataEntry("group_id")
             if "group_name" in metadata:
-                fake_machine["group_name"] = global_stack.getMetaDataEntry("group_name")
+                fake_machine.group_name = global_stack.getMetaDataEntry("group_name")
             if "um_network_key" in metadata:
-                fake_machine["um_network_key"] = global_stack.getMetaDataEntry("um_network_key")
+                fake_machine.um_network_key = global_stack.getMetaDataEntry("um_network_key")
 
-            fake_machine["connection_types"] = global_stack.configuredConnectionTypes
+            fake_machine.connection_types = global_stack.configuredConnectionTypes
             
         return fake_machine
 

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -28,8 +28,8 @@ class Machine():
         self.group_id = "" # type: str
         self.group_name = "" # type: str
         self.um_network_key = "" # type: str
-        self.configuration = {} # type: Dict
-        self.connection_types = [] # type: List
+        self.configuration = {} # type: Dict[str, any]
+        self.connection_types = [] # type: List["ConnectionType"]
 
 class Machines(QObject):
 
@@ -58,7 +58,7 @@ class Machines(QObject):
     #   This is the same as "group name" since we use "group" and "current machine" interchangeably.
     #   TODO: Maybe make this "friendly name" to distinguish from "hostname"?
     @pyqtSlot(str)
-    def setCurrentMachineGroupName(self, group_name: str):
+    def setCurrentMachineGroupName(self, group_name: str) -> None:
         Logger.log("d", "Attempting to set the group name of the active machine to %s", group_name)
         global_stack = self._application.getGlobalContainerStack()
         if global_stack:

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -7,7 +7,7 @@ from UM.i18n import i18nCatalog
 from UM.Logger import Logger
 if TYPE_CHECKING:
     from cura.CuraApplication import CuraApplication
-    from cura.PrinterOutput.PrinterOutputDevice import PrinterOutputDevice, ConnectionType
+    from cura.PrinterOutput.PrinterOutputDevice import PrinterOutputDevice
 
 i18n_catalog = i18nCatalog("cura")
 
@@ -29,7 +29,7 @@ class Machine():
         self.group_name = "" # type: str
         self.um_network_key = "" # type: str
         self.configuration = {} # type: Dict[str, any]
-        self.connection_types = [] # type: List["ConnectionType"]
+        self.connection_types = [] # type: List[int]
 
 class Machines(QObject):
 

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -28,7 +28,7 @@ class Machine():
         self.group_id = "" # type: str
         self.group_name = "" # type: str
         self.um_network_key = "" # type: str
-        self.configuration = {} # type: Dict[str, any]
+        self.configuration = {} # type: Dict[str, Any]
         self.connection_types = [] # type: List[int]
 
 class Machines(QObject):

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2019 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
+from typing import Optional, Dict, TYPE_CHECKING
+from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, pyqtProperty
+from UM.i18n import i18nCatalog
+from UM.Logger import Logger
+if TYPE_CHECKING:
+    from cura.CuraApplication import CuraApplication
+
+i18n_catalog = i18nCatalog("cura")
+
+##  The account API provides a version-proof bridge to use Ultimaker Accounts
+#
+#   Usage:
+#       ```
+#       from cura.API import CuraAPI
+#       api = CuraAPI()
+#       api.machines.addOutputDeviceToCurrentMachine()
+#       ```
+#
+class Machines(QObject):
+
+    def __init__(self, application: "CuraApplication", parent = None) -> None:
+        super().__init__(parent)
+        self._application = application
+
+    ##  Add an output device to the current machine.
+    #   In practice, this means:
+    #   - Setting the output device's network key in the current machine's metadata
+    #   - Adding the output device's connection type to the current machine's configured connection
+    #     types.
+    #   TODO: CHANGE TO HOSTNAME
+    @pyqtSlot(QObject)
+    def addOutputDeviceToCurrentMachine(self, output_device):
+        if not output_device:
+            return
+
+        Logger.log("d",
+            "Attempting to set the network key of the active machine to %s",
+            output_device.key)
+
+        global_container_stack = self._application.getGlobalContainerStack()
+        if not global_container_stack:
+            return
+
+        metadata = global_container_stack.getMetaData()
+
+        if "um_network_key" in metadata:  # Global stack already had a connection, but it's changed.
+            old_network_key = metadata["um_network_key"]
+            # Since we might have a bunch of hidden stacks, we also need to change it there.
+            metadata_filter = {"um_network_key": old_network_key}
+            containers = self._application.getContainerRegistry().findContainerStacks(
+                type = "machine", **metadata_filter)
+
+            for container in containers:
+                container.setMetaDataEntry("um_network_key", output_device.key)
+
+                # Delete old authentication data.
+                Logger.log("d", "Removing old authentication id %s for device %s",
+                    global_container_stack.getMetaDataEntry("network_authentication_id", None),
+                    output_device.key)
+
+                container.removeMetaDataEntry("network_authentication_id")
+                container.removeMetaDataEntry("network_authentication_key")
+
+                # Ensure that these containers do know that they are configured for the given
+                # connection type (can be more than one type; e.g. LAN & Cloud)
+                container.addConfiguredConnectionType(output_device.connectionType.value)
+
+        else:  # Global stack didn't have a connection yet, configure it.
+            global_container_stack.setMetaDataEntry("um_network_key", output_device.key)
+            global_container_stack.addConfiguredConnectionType(output_device.connectionType.value)
+
+        return None
+    

--- a/cura/API/Machines.py
+++ b/cura/API/Machines.py
@@ -34,7 +34,8 @@ class Machines(QObject):
             "group_id": "",
             "group_name": "",
             "um_network_key": "",
-            "configuration": {}
+            "configuration": {},
+            "connection_types": []
         }
         global_stack = self._application.getGlobalContainerStack()
         if global_stack:
@@ -45,6 +46,8 @@ class Machines(QObject):
                 fake_machine["group_name"] = global_stack.getMetaDataEntry("group_name")
             if "um_network_key" in metadata:
                 fake_machine["um_network_key"] = global_stack.getMetaDataEntry("um_network_key")
+
+            fake_machine["connection_types"] = global_stack.configuredConnectionTypes
             
         return fake_machine
 

--- a/cura/API/__init__.py
+++ b/cura/API/__init__.py
@@ -6,6 +6,7 @@ from PyQt5.QtCore import QObject, pyqtProperty
 
 from cura.API.Backups import Backups
 from cura.API.Interface import Interface
+from cura.API.Machines import Machines
 from cura.API.Account import Account
 
 if TYPE_CHECKING:
@@ -44,6 +45,9 @@ class CuraAPI(QObject):
         # Backups API
         self._backups = Backups(self._application)
 
+        # Machines API
+        self._machines = Machines(self._application)
+
         # Interface API
         self._interface = Interface(self._application)
 
@@ -57,6 +61,10 @@ class CuraAPI(QObject):
     @property
     def backups(self) -> "Backups":
         return self._backups
+
+    @property
+    def machines(self) -> "Machines":
+        return self._machines
 
     @property
     def interface(self) -> "Interface":

--- a/cura/API/__init__.py
+++ b/cura/API/__init__.py
@@ -62,7 +62,7 @@ class CuraAPI(QObject):
     def backups(self) -> "Backups":
         return self._backups
 
-    @property
+    @pyqtProperty(QObject)
     def machines(self) -> "Machines":
         return self._machines
 

--- a/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
@@ -27,13 +27,14 @@ Cura.MachineAction
         {
             var printerKey = base.selectedDevice.key
             var printerName = base.selectedDevice.name  // TODO To change when the groups have a name
-            if (manager.getStoredKey() != printerKey)
+            if (Cura.API.machines.getCurrentMachine()["um_network_key"] != printerKey)
             {
                 // Check if there is another instance with the same key
                 if (!manager.existsKey(printerKey))
                 {
-                    manager.associateActiveMachineWithPrinterDevice(base.selectedDevice)
-                    manager.setGroupName(printerName)   // TODO To change when the groups have a name
+                    Cura.API.machines.addOutputDeviceToCurrentMachine(base.selectedDevice)
+                    Cura.API.machines.setCurrentMachineGroupName(printerName)   // TODO To change when the groups have a name
+                    manager.refreshConnections()
                     completed()
                 }
                 else
@@ -156,7 +157,7 @@ Cura.MachineAction
                             var selectedKey = manager.getLastManualEntryKey()
                             // If there is no last manual entry key, then we select the stored key (if any)
                             if (selectedKey == "")
-                                selectedKey = manager.getStoredKey()
+                                selectedKey = Cura.API.machines.getCurrentMachine()["um_network_key"]
                             for(var i = 0; i < model.length; i++) {
                                 if(model[i].key == selectedKey)
                                 {

--- a/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
@@ -27,7 +27,7 @@ Cura.MachineAction
         {
             var printerKey = base.selectedDevice.key
             var printerName = base.selectedDevice.name  // TODO To change when the groups have a name
-            if (Cura.API.machines.getCurrentMachine()["um_network_key"] != printerKey)
+            if (Cura.API.machines.getCurrentMachine().um_network_key != printerKey) // TODO: change to hostname
             {
                 // Check if there is another instance with the same key
                 if (!manager.existsKey(printerKey))
@@ -157,7 +157,7 @@ Cura.MachineAction
                             var selectedKey = manager.getLastManualEntryKey()
                             // If there is no last manual entry key, then we select the stored key (if any)
                             if (selectedKey == "")
-                                selectedKey = Cura.API.machines.getCurrentMachine()["um_network_key"]
+                                selectedKey = Cura.API.machines.getCurrentMachine().um_network_key // TODO: change to host name
                             for(var i = 0; i < model.length; i++) {
                                 if(model[i].key == selectedKey)
                                 {

--- a/plugins/UM3NetworkPrinting/src/DiscoverUM3Action.py
+++ b/plugins/UM3NetworkPrinting/src/DiscoverUM3Action.py
@@ -108,32 +108,10 @@ class DiscoverUM3Action(MachineAction):
         else:
             return []
 
-    # # TODO: Should be able to just access the API from QML.
-    # @pyqtSlot(str)
-    # def setGroupName(self, group_name: str) -> None:
-    #     self._api.machines.setCurrentMachineGroupName(group_name)
-    #     if self._network_plugin:
-    #         self._network_plugin.refreshConnections()
-
-    # # TODO: Should be able to just access the API from QML.
-    # @pyqtSlot(QObject)
-    # def associateActiveMachineWithPrinterDevice(self, output_device: Optional["PrinterOutputDevice"]) -> None:
-    #     self._api.machines.addOutputDeviceToCurrentMachine(output_device)
-
     @pyqtSlot()
     def refreshConnections(self) -> None:
         if self._network_plugin:
             self._network_plugin.refreshConnections()
-
-    # # TODO: Better naming needed. Stored where? This is current machine's key.
-    # # TODO: CHANGE TO HOSTNAME
-    # # TODO: Should be able to just access the API from QML.
-    # @pyqtSlot(result = str)
-    # def getStoredKey(self) -> str:
-    #     current_machine = self._api.machines.getCurrentMachine()
-    #     if current_machine:
-    #         return current_machine["um_network_key"]
-    #     return ""
 
     # TODO: CHANGE TO HOSTNAME
     @pyqtSlot(result = str)
@@ -149,11 +127,6 @@ class DiscoverUM3Action(MachineAction):
         metadata_filter = {"um_network_key": key}
         containers = CuraContainerRegistry.getInstance().findContainerStacks(type="machine", **metadata_filter)
         return bool(containers)
-
-    # TODO: Should be able to just access the API from QML.
-    @pyqtSlot()
-    def loadConfigurationFromPrinter(self) -> None:
-        self._api.machines.updateCurrentMachineConfiguration()
 
     def _createAdditionalComponentsView(self) -> None:
         Logger.log("d", "Creating additional ui components for UM3.")

--- a/plugins/UM3NetworkPrinting/src/DiscoverUM3Action.py
+++ b/plugins/UM3NetworkPrinting/src/DiscoverUM3Action.py
@@ -108,27 +108,32 @@ class DiscoverUM3Action(MachineAction):
         else:
             return []
 
-    # TODO: Should be able to just access the API from QML.
-    @pyqtSlot(str)
-    def setGroupName(self, group_name: str) -> None:
-        self._api.machines.setCurrentMachineGroupName(group_name)
+    # # TODO: Should be able to just access the API from QML.
+    # @pyqtSlot(str)
+    # def setGroupName(self, group_name: str) -> None:
+    #     self._api.machines.setCurrentMachineGroupName(group_name)
+    #     if self._network_plugin:
+    #         self._network_plugin.refreshConnections()
+
+    # # TODO: Should be able to just access the API from QML.
+    # @pyqtSlot(QObject)
+    # def associateActiveMachineWithPrinterDevice(self, output_device: Optional["PrinterOutputDevice"]) -> None:
+    #     self._api.machines.addOutputDeviceToCurrentMachine(output_device)
+
+    @pyqtSlot()
+    def refreshConnections(self) -> None:
         if self._network_plugin:
             self._network_plugin.refreshConnections()
 
-    # TODO: Should be able to just access the API from QML.
-    @pyqtSlot(QObject)
-    def associateActiveMachineWithPrinterDevice(self, output_device: Optional["PrinterOutputDevice"]) -> None:
-        self._api.machines.addOutputDeviceToCurrentMachine(output_device)
-        if self._network_plugin:
-            self._network_plugin.refreshConnections()
-
-    # TODO: Better naming needed. Stored where? This is current machine's key.
-    # TODO: CHANGE TO HOSTNAME
-    # TODO: Should be able to just access the API from QML.
-    @pyqtSlot(result = str)
-    def getStoredKey(self) -> str:
-        current_machine = self._api.machines.getCurrentMachine()
-        return current_machine["um_network_key"]
+    # # TODO: Better naming needed. Stored where? This is current machine's key.
+    # # TODO: CHANGE TO HOSTNAME
+    # # TODO: Should be able to just access the API from QML.
+    # @pyqtSlot(result = str)
+    # def getStoredKey(self) -> str:
+    #     current_machine = self._api.machines.getCurrentMachine()
+    #     if current_machine:
+    #         return current_machine["um_network_key"]
+    #     return ""
 
     # TODO: CHANGE TO HOSTNAME
     @pyqtSlot(result = str)

--- a/plugins/UM3NetworkPrinting/src/DiscoverUM3Action.py
+++ b/plugins/UM3NetworkPrinting/src/DiscoverUM3Action.py
@@ -113,6 +113,7 @@ class DiscoverUM3Action(MachineAction):
         if self._network_plugin:
             self._network_plugin.refreshConnections()
 
+    # TODO: Improve naming
     # TODO: CHANGE TO HOSTNAME
     @pyqtSlot(result = str)
     def getLastManualEntryKey(self) -> str:

--- a/plugins/UM3NetworkPrinting/src/UM3OutputDevicePlugin.py
+++ b/plugins/UM3NetworkPrinting/src/UM3OutputDevicePlugin.py
@@ -280,7 +280,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
         # ensure that the connection states are refreshed.
         self.refreshConnections()
 
-    def _checkManualDevice(self, address: str) -> None:
+    def _checkManualDevice(self, address: str):
         # Check if a UM3 family device exists at this address.
         # If a printer responds, it will replace the preliminary printer created above
         # origin=manual is for tracking back the origin of the call

--- a/plugins/UM3NetworkPrinting/src/UM3OutputDevicePlugin.py
+++ b/plugins/UM3NetworkPrinting/src/UM3OutputDevicePlugin.py
@@ -67,11 +67,11 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
 
     def __init__(self):
         super().__init__()
-        
         self._zero_conf = None
         self._zero_conf_browser = None
 
         self._application = CuraApplication.getInstance()
+        self._api = self._application.getCuraAPI()
 
         # Create a cloud output device manager that abstracts all cloud connection logic away.
         self._cloud_output_device_manager = CloudOutputDeviceManager()
@@ -96,7 +96,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
         self._cluster_api_prefix = "/cluster-api/v" + self._cluster_api_version + "/"
 
         # Get list of manual instances from preferences
-        self._preferences = CuraApplication.getInstance().getPreferences()
+        self._preferences = self._application.getPreferences()
         self._preferences.addPreference("um3networkprinting/manual_instances",
                                         "")  # A comma-separated list of ip adresses or hostnames
 
@@ -116,7 +116,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
         self._service_changed_request_thread = Thread(target=self._handleOnServiceChangedRequests, daemon=True)
         self._service_changed_request_thread.start()
 
-        self._account = self._application.getCuraAPI().account
+        self._account = self._api.account
 
         # Check if cloud flow is possible when user logs in
         self._account.loginStateChanged.connect(self.checkCloudFlowIsPossible)
@@ -170,7 +170,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
         self.resetLastManualDevice()
 
     def refreshConnections(self):
-        active_machine = CuraApplication.getInstance().getGlobalContainerStack()
+        active_machine = self._application.getGlobalContainerStack()
         if not active_machine:
             return
 
@@ -197,7 +197,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
             return
         if self._discovered_devices[key].isConnected():
             # Sometimes the status changes after changing the global container and maybe the device doesn't belong to this machine
-            um_network_key = CuraApplication.getInstance().getGlobalContainerStack().getMetaDataEntry("um_network_key")
+            um_network_key = self._application.getGlobalContainerStack().getMetaDataEntry("um_network_key")
             if key == um_network_key:
                 self.getOutputDeviceManager().addOutputDevice(self._discovered_devices[key])
                 self.checkCloudFlowIsPossible(None)
@@ -273,38 +273,11 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
 
         self._application.getMachineManager().addMachine(machine_type_id, group_name)
         # connect the new machine to that network printer
-        self.associateActiveMachineWithPrinterDevice(discovered_device)
+        self._api.machines.addOutputDeviceToCurrentMachine(discovered_device)
         # ensure that the connection states are refreshed.
         self.refreshConnections()
 
-    def associateActiveMachineWithPrinterDevice(self, printer_device: Optional["PrinterOutputDevice"]) -> None:
-        if not printer_device:
-            return
-
-        Logger.log("d", "Attempting to set the network key of the active machine to %s", printer_device.key)
-
-        machine_manager = CuraApplication.getInstance().getMachineManager()
-        global_container_stack = machine_manager.activeMachine
-        if not global_container_stack:
-            return
-
-        for machine in machine_manager.getMachinesInGroup(global_container_stack.getMetaDataEntry("group_id")):
-            machine.setMetaDataEntry("um_network_key", printer_device.key)
-            machine.setMetaDataEntry("group_name", printer_device.name)
-
-            # Delete old authentication data.
-            Logger.log("d", "Removing old authentication id %s for device %s",
-                       global_container_stack.getMetaDataEntry("network_authentication_id", None), printer_device.key)
-
-            machine.removeMetaDataEntry("network_authentication_id")
-            machine.removeMetaDataEntry("network_authentication_key")
-
-            # Ensure that these containers do know that they are configured for network connection
-            machine.addConfiguredConnectionType(printer_device.connectionType.value)
-
-        self.refreshConnections()
-
-    def _checkManualDevice(self, address: str) -> "QNetworkReply":
+    def _checkManualDevice(self, address: str) -> None:
         # Check if a UM3 family device exists at this address.
         # If a printer responds, it will replace the preliminary printer created above
         # origin=manual is for tracking back the origin of the call
@@ -426,7 +399,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
         self._discovered_devices[device.getId()] = device
         self.discoveredDevicesChanged.emit()
 
-        global_container_stack = CuraApplication.getInstance().getGlobalContainerStack()
+        global_container_stack = self._application.getGlobalContainerStack()
         if global_container_stack and device.getId() == global_container_stack.getMetaDataEntry("um_network_key"):
             # Ensure that the configured connection type is set.
             global_container_stack.addConfiguredConnectionType(device.connectionType.value)
@@ -446,7 +419,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
             self._service_changed_request_event.wait(timeout = 5.0)
 
             # Stop if the application is shutting down
-            if CuraApplication.getInstance().isShuttingDown():
+            if self._application.isShuttingDown():
                 return
 
             self._service_changed_request_event.clear()

--- a/plugins/UM3NetworkPrinting/src/UM3OutputDevicePlugin.py
+++ b/plugins/UM3NetworkPrinting/src/UM3OutputDevicePlugin.py
@@ -280,7 +280,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
         # ensure that the connection states are refreshed.
         self.refreshConnections()
 
-    def _checkManualDevice(self, address: str):
+    def _checkManualDevice(self, address: str) -> Optional[QNetworkReply]:
         # Check if a UM3 family device exists at this address.
         # If a printer responds, it will replace the preliminary printer created above
         # origin=manual is for tracking back the origin of the call

--- a/plugins/UM3NetworkPrinting/src/UM3OutputDevicePlugin.py
+++ b/plugins/UM3NetworkPrinting/src/UM3OutputDevicePlugin.py
@@ -167,8 +167,9 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
         for address in self._manual_instances:
             if address:
                 self.addManualDevice(address)
-        self.resetLastManualDevice()
-
+        self.resetLastManu
+    
+    # TODO: CHANGE TO HOSTNAME
     def refreshConnections(self):
         active_machine = self._application.getGlobalContainerStack()
         if not active_machine:
@@ -272,8 +273,10 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
                    key, group_name, machine_type_id)
 
         self._application.getMachineManager().addMachine(machine_type_id, group_name)
+        
         # connect the new machine to that network printer
         self._api.machines.addOutputDeviceToCurrentMachine(discovered_device)
+
         # ensure that the connection states are refreshed.
         self.refreshConnections()
 
@@ -285,6 +288,7 @@ class UM3OutputDevicePlugin(OutputDevicePlugin):
         name_request = QNetworkRequest(url)
         return self._network_manager.get(name_request)
 
+    ##  This is the function which handles the above network request's reply when it comes back.
     def _onNetworkRequestFinished(self, reply: "QNetworkReply") -> None:
         reply_url = reply.url().toString()
 


### PR DESCRIPTION
> Heavily WIP! Mainly a conversation starter for now.

This PR is intended to make the network printing plugin less knowledgable about the internal structure of Cura in the hope that it will make it easier to maintain.

Specifically this means:

1. No more touching of container stacks. That's Cura's internal way to represent things and should not be our concern. We only want to handle "printers" and their respective connection types.
2. Output devices, container stacks, and metadata are all often different pieces of data related to a single physical machine (or cluster) which we want to operate on. Since Cura doesn't have a machine class (yet), we bundle that data into a more usable object via the API.
3. Reduced use of signals because they are icky and you never know who is triggering them to emit and who is listening on the other end of the line and what other pieces of the code you might be triggering to run. I know they're handy sometime but maintainability and readability is improved if their use is moderated.
4. General reduction of the scope of the plugin so that it serves as a minimalist-as-possible glue layer between Zeroconf, Ultimaker Cloud, and the rest of Cura.