### PR TITLE
Amazing fixes for cloud discovery

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -58,14 +58,6 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
     # Therefore we create a private signal used to trigger the printersChanged signal.
     _clusterPrintersChanged = pyqtSignal()
 
-    # Map of Cura Connect machine_variant field to Cura machine types.
-    # Needed for printer discovery stack creation.
-    _host_machine_variant_to_machine_type_map = {
-        "Ultimaker 3": "ultimaker3",
-        "Ultimaker 3 Extended": "ultimaker3_extended",
-        "Ultimaker S5": "ultimaker_s5"
-    }
-
     ## Creates a new cloud output device
     #  \param api_client: The client that will run the API calls
     #  \param cluster: The device response received from the cloud API.
@@ -105,7 +97,6 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
 
         # We keep track of which printer is visible in the monitor page.
         self._active_printer = None  # type: Optional[PrinterOutputModel]
-        self._host_machine_type = cluster.printer_type  # type: str
 
         # Properties to populate later on with received cloud data.
         self._print_jobs = []  # type: List[UM3PrintJobOutputModel]
@@ -245,11 +236,6 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
     def _updatePrinters(self, printers: List[CloudClusterPrinterStatus]) -> None:
         previous = {p.key: p for p in self._printers}  # type: Dict[str, PrinterOutputModel]
         received = {p.uuid: p for p in printers}  # type: Dict[str, CloudClusterPrinterStatus]
-
-        if len(printers) > 0:
-            # We need the machine type of the host (1st list entry) to allow discovery to work.
-            self._host_machine_type = printers[0].machine_variant
-
         removed_printers, added_printers, updated_printers = findChanges(previous, received)
 
         for removed_printer in removed_printers:
@@ -372,13 +358,6 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
             lifetime = 5
         ).show()
         self.writeFinished.emit()
-
-    ##  Gets the printer type of the cluster host. Falls back to the printer type in the device properties.
-    @pyqtProperty(str, notify=_clusterPrintersChanged)
-    def printerType(self) -> str:
-        if self._host_machine_type in self._host_machine_variant_to_machine_type_map:
-            return self._host_machine_variant_to_machine_type_map[self._host_machine_type]
-        return super().printerType
 
     ##  Gets the number of printers in the cluster.
     #   We use a minimum of 1 because cloud devices are always a cluster and printer discovery needs it.

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -79,6 +79,7 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
             b"address": cluster.host_internal_ip.encode() if cluster.host_internal_ip else b"",
             b"name": cluster.friendly_name.encode() if cluster.friendly_name else b"",
             b"firmware_version": cluster.host_version.encode() if cluster.host_version else b"",
+            b"printer_type": cluster.printer_type.encode() if cluster.printer_type else b"",
             b"cluster_size": b"1"  # cloud devices are always clusters of at least one
         }
 
@@ -104,7 +105,7 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
 
         # We keep track of which printer is visible in the monitor page.
         self._active_printer = None  # type: Optional[PrinterOutputModel]
-        self._host_machine_type = ""
+        self._host_machine_type = cluster.printer_type  # type: str
 
         # Properties to populate later on with received cloud data.
         self._print_jobs = []  # type: List[UM3PrintJobOutputModel]
@@ -375,7 +376,7 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
     ##  Gets the printer type of the cluster host. Falls back to the printer type in the device properties.
     @pyqtProperty(str, notify=_clusterPrintersChanged)
     def printerType(self) -> str:
-        if self._printers and self._host_machine_type in self._host_machine_variant_to_machine_type_map:
+        if self._host_machine_type in self._host_machine_variant_to_machine_type_map:
             return self._host_machine_variant_to_machine_type_map[self._host_machine_type]
         return super().printerType
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -96,7 +96,7 @@ class CloudOutputDeviceManager:
             device = CloudOutputDevice(self._api, cluster)
             self._remote_clusters[cluster.cluster_id] = device
             self._application.getDiscoveredPrintersModel().addDiscoveredPrinter(
-                    cluster.cluster_id,
+                    device.key,
                     device.key,
                     cluster.friendly_name,
                     self._createMachineFromDiscoveredPrinter,
@@ -109,7 +109,7 @@ class CloudOutputDeviceManager:
         for device, cluster in updates:
             device.clusterData = cluster
             self._application.getDiscoveredPrintersModel().updateDiscoveredPrinter(
-                    cluster.cluster_id,
+                    device.key,
                     cluster.friendly_name,
                     device.printerType,
             )

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterResponse.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterResponse.py
@@ -17,10 +17,10 @@ class CloudClusterResponse(BaseCloudModel):
     #  \param host_version: The firmware version of the cluster host. This is where the Stardust client is running on.
     #  \param host_internal_ip: The internal IP address of the host printer.
     #  \param friendly_name: The human readable name of the host printer.
-    #  \param printer_type: The machine type of the host printer, for example "Ultimaker 3".
+    #  \param printer_type: The machine type of the host printer.
     def __init__(self, cluster_id: str, host_guid: str, host_name: str, is_online: bool, status: str,
                  host_internal_ip: Optional[str] = None, host_version: Optional[str] = None,
-                 friendly_name: Optional[str] = None, printer_type: str = "Ultimaker 3", **kwargs) -> None:
+                 friendly_name: Optional[str] = None, printer_type: str = "ultimaker3", **kwargs) -> None:
         self.cluster_id = cluster_id
         self.host_guid = host_guid
         self.host_name = host_name

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterResponse.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterResponse.py
@@ -20,7 +20,7 @@ class CloudClusterResponse(BaseCloudModel):
     #  \param printer_type: The machine type of the host printer.
     def __init__(self, cluster_id: str, host_guid: str, host_name: str, is_online: bool, status: str,
                  host_internal_ip: Optional[str] = None, host_version: Optional[str] = None,
-                 friendly_name: Optional[str] = None, printer_type: Optional[str] = "Ultimaker 3", **kwargs) -> None:
+                 friendly_name: Optional[str] = None, printer_type: str = "Ultimaker 3", **kwargs) -> None:
         self.cluster_id = cluster_id
         self.host_guid = host_guid
         self.host_name = host_name

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterResponse.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterResponse.py
@@ -17,7 +17,7 @@ class CloudClusterResponse(BaseCloudModel):
     #  \param host_version: The firmware version of the cluster host. This is where the Stardust client is running on.
     #  \param host_internal_ip: The internal IP address of the host printer.
     #  \param friendly_name: The human readable name of the host printer.
-    #  \param printer_type: The machine type of the host printer.
+    #  \param printer_type: The machine type of the host printer, for example "Ultimaker 3".
     def __init__(self, cluster_id: str, host_guid: str, host_name: str, is_online: bool, status: str,
                  host_internal_ip: Optional[str] = None, host_version: Optional[str] = None,
                  friendly_name: Optional[str] = None, printer_type: str = "Ultimaker 3", **kwargs) -> None:

--- a/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterResponse.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/Models/CloudClusterResponse.py
@@ -15,9 +15,12 @@ class CloudClusterResponse(BaseCloudModel):
     #  \param is_online: Whether this cluster is currently connected to the cloud.
     #  \param status: The status of the cluster authentication (active or inactive).
     #  \param host_version: The firmware version of the cluster host. This is where the Stardust client is running on.
+    #  \param host_internal_ip: The internal IP address of the host printer.
+    #  \param friendly_name: The human readable name of the host printer.
+    #  \param printer_type: The machine type of the host printer.
     def __init__(self, cluster_id: str, host_guid: str, host_name: str, is_online: bool, status: str,
                  host_internal_ip: Optional[str] = None, host_version: Optional[str] = None,
-                 friendly_name: Optional[str] = None, **kwargs) -> None:
+                 friendly_name: Optional[str] = None, printer_type: Optional[str] = "Ultimaker 3", **kwargs) -> None:
         self.cluster_id = cluster_id
         self.host_guid = host_guid
         self.host_name = host_name
@@ -26,6 +29,7 @@ class CloudClusterResponse(BaseCloudModel):
         self.host_version = host_version
         self.host_internal_ip = host_internal_ip
         self.friendly_name = friendly_name
+        self.printer_type = printer_type
         super().__init__(**kwargs)
 
     # Validates the model, raising an exception if the model is invalid.


### PR DESCRIPTION
This PR fixes some small bugs in the cloud discovery flow and make it more robust:

* Allow printer_type field from cloud cluster list endpoint (will make a cloud PR that adds this field to the /clusters endpoint so we know the printer type without having to do a 2nd call to /status). This is more robust than the current solution that tries to map the machine variant to printer type.
* Use a default value for printer type (discovered printer list does not always fully refresh once actual data comes in).
* Using `device.key` instead of `cluster.cluster_id` to be more consistent between the add, update and remove function calls for discovered devices.
* Added some missing documentation.