### PR TITLE
Fix auto-resetting settings when discarding user changes

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -893,13 +893,6 @@ class MachineManager(QObject):
         result = []  # type: List[str]
         for setting_instance in container.findInstances():
             setting_key = setting_instance.definition.key
-            setting_enabled = self._global_container_stack.getProperty(setting_key, "enabled")
-            if not setting_enabled:
-                # A setting is not visible anymore
-                result.append(setting_key)
-                Logger.log("d", "Reset setting [%s] from [%s] because the setting is no longer enabled", setting_key, container)
-                continue
-
             if not self._global_container_stack.getProperty(setting_key, "type") in ("extruder", "optional_extruder"):
                 continue
 


### PR DESCRIPTION
This fixes a bug where settings are being reset to "0" (or whatever the default extruder number is) when discarding current changes to settings. This happens to all settings that are:
* In the quality-changes profile.
* Not currently visible.

Why would it need to reset all invisible settings? It shouldn't matter whether a setting is visible or not.
This is causing bugs because the settings that are being reset are not necessarily extruder-type settings (as that is checked below). They are being reset to the value self._default_extruder, which is not always a valid setting value.

Reproduce steps:
1. Ultimaker 3, 0.4mm nozzle, PLA, 0.1mm layer height to start with.
2. Enable support.
3. Set Support Placement to the non-default (=Touching Buildplate).
4. Disable support.
5. Save the current changes to a profile.
6. Change any other setting.
7. Discard current changes.
8. Enable support to see the broken setting value for Support Placement.

Fixes #4274.