### PR TITLE
Fix creating QUrl to EmptyViewMenuComponent.qml

### DIFF
--- a/cura/CuraView.py
+++ b/cura/CuraView.py
@@ -18,8 +18,8 @@ class CuraView(View):
     def __init__(self, parent = None, use_empty_menu_placeholder: bool = False) -> None:
         super().__init__(parent)
 
-        self._empty_menu_placeholder_url = QUrl(Resources.getPath(CuraApplication.ResourceTypes.QmlFiles,
-                                                                  "EmptyViewMenuComponent.qml"))
+        self._empty_menu_placeholder_url = QUrl.fromLocalFile(Resources.getPath(CuraApplication.ResourceTypes.QmlFiles,
+                                                                                "EmptyViewMenuComponent.qml"))
         self._use_empty_menu_placeholder = use_empty_menu_placeholder
 
     @pyqtProperty(QUrl, constant = True)


### PR DESCRIPTION
This PR fixes the QUrl to the local file holding the placeholder from view menu components.

Before the PR:
````QUrl('c:%5CUsers%5CAldo%5CDocuments%5CCode Projects%5CUM%5CCura%5Ccura%5C..%5Cresources%5Cqml%5CEmptyViewMenuComponent.qml')```` (which is not a valid URL)
After the PR:
```QUrl('file:///C:/Users/Aldo/Documents/Code Projects/UM/Cura/cura/../resources/qml/EmptyViewMenuComponent.qml')```