### PR TITLE
Add support for printers that have multiple extruders that share a single heater

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -314,6 +314,18 @@ Item
                     onGlobalContainerChanged: extruderCountModel.update()
                 }
             }
+
+            Cura.SimpleCheckBox  // "Shared Heater"
+            {
+                id: sharedHeaterCheckBox
+                containerStackId: machineStackId
+                settingKey: "machine_extruders_share_heater"
+                settingStoreIndex: propertyStoreIndex
+                labelText: catalog.i18nc("@label", "Shared Heater")
+                labelFont: base.labelFont
+                labelWidth: base.labelWidth
+                forceUpdateOnChangeFunction: forceUpdateFunction
+            }
         }
     }
 

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -375,6 +375,16 @@
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false
                 },
+                "machine_extruders_share_heater":
+                {
+                    "label": "Extruders Share Heater",
+                    "description": "Whether the extruders share a single heater rather than each extruder having its own heater.",
+                    "type": "bool",
+                    "default_value": false,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false
+                },
                 "machine_disallowed_areas":
                 {
                     "label": "Disallowed Areas",
@@ -2113,7 +2123,7 @@
                     "minimum_value": "-273.15",
                     "minimum_value_warning": "material_standby_temperature",
                     "maximum_value_warning": "material_print_temperature",
-                    "enabled": "machine_nozzle_temp_enabled",
+                    "enabled": "machine_nozzle_temp_enabled and not machine_extruders_share_heater",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
@@ -2128,7 +2138,7 @@
                     "minimum_value": "-273.15",
                     "minimum_value_warning": "material_standby_temperature",
                     "maximum_value_warning": "material_print_temperature",
-                    "enabled": "machine_nozzle_temp_enabled",
+                    "enabled": "machine_nozzle_temp_enabled and not machine_extruders_share_heater",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },


### PR DESCRIPTION
This PR adds the machine_extruders_share_heater setting and an associated checkbox in the printer settings dialog. Defaults to false.

See #5770.
