### PR TITLE
feat: "Z-Seam Position" presets to ease XY setting

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1399,6 +1399,27 @@
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
                 },
+                "z_seam_position":
+                {
+                    "label": "Z Seam Position",
+                    "description": "The position near where to start printing each part in a layer.",
+                    "type": "enum",
+                    "options":
+                    {
+                        "backleft": "Back Left",
+                        "back": "Back",
+                        "backright": "Back Right",
+                        "right": "Right",
+                        "frontright": "Front Right",
+                        "front": "Front",
+                        "frontleft": "Front Left",
+                        "left": "Left"
+                    },
+                    "enabled": "z_seam_type == 'back'",
+                    "default_value": "back",
+                    "limit_to_extruder": "wall_0_extruder_nr",
+                    "settable_per_mesh": true
+                },
                 "z_seam_x":
                 {
                     "label": "Z Seam X",
@@ -1406,7 +1427,7 @@
                     "unit": "mm",
                     "type": "float",
                     "default_value": 100.0,
-                    "value": "machine_width / 2",
+                    "value": "0 if (z_seam_position == 'frontleft' or z_seam_position == 'left' or z_seam_position == 'backleft') else machine_width/2 if (z_seam_position == 'front' or z_seam_position == 'back') else machine_width",
                     "enabled": "z_seam_type == 'back'",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
@@ -1418,7 +1439,7 @@
                     "unit": "mm",
                     "type": "float",
                     "default_value": 100.0,
-                    "value": "machine_depth * 3",
+                    "value": "0 if (z_seam_position == 'frontleft' or z_seam_position == 'front' or z_seam_position == 'frontright') else machine_depth/2 if (z_seam_position == 'left' or z_seam_position == 'right') else machine_depth",
                     "enabled": "z_seam_type == 'back'",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1418,31 +1418,34 @@
                     "enabled": "z_seam_type == 'back'",
                     "default_value": "back",
                     "limit_to_extruder": "wall_0_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "z_seam_x":
-                {
-                    "label": "Z Seam X",
-                    "description": "The X coordinate of the position near where to start printing each part in a layer.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 100.0,
-                    "value": "0 if (z_seam_position == 'frontleft' or z_seam_position == 'left' or z_seam_position == 'backleft') else machine_width/2 if (z_seam_position == 'front' or z_seam_position == 'back') else machine_width",
-                    "enabled": "z_seam_type == 'back'",
-                    "limit_to_extruder": "wall_0_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "z_seam_y":
-                {
-                    "label": "Z Seam Y",
-                    "description": "The Y coordinate of the position near where to start printing each part in a layer.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 100.0,
-                    "value": "0 if (z_seam_position == 'frontleft' or z_seam_position == 'front' or z_seam_position == 'frontright') else machine_depth/2 if (z_seam_position == 'left' or z_seam_position == 'right') else machine_depth",
-                    "enabled": "z_seam_type == 'back'",
-                    "limit_to_extruder": "wall_0_extruder_nr",
-                    "settable_per_mesh": true
+                    "settable_per_mesh": true,
+                    "children":
+                    {
+                        "z_seam_x":
+                        {
+                            "label": "Z Seam X",
+                            "description": "The X coordinate of the position near where to start printing each part in a layer.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 100.0,
+                            "value": "0 if (z_seam_position == 'frontleft' or z_seam_position == 'left' or z_seam_position == 'backleft') else machine_width/2 if (z_seam_position == 'front' or z_seam_position == 'back') else machine_width",
+                            "enabled": "z_seam_type == 'back'",
+                            "limit_to_extruder": "wall_0_extruder_nr",
+                            "settable_per_mesh": true
+                        },
+                        "z_seam_y":
+                        {
+                            "label": "Z Seam Y",
+                            "description": "The Y coordinate of the position near where to start printing each part in a layer.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 100.0,
+                            "value": "0 if (z_seam_position == 'frontleft' or z_seam_position == 'front' or z_seam_position == 'frontright') else machine_depth/2 if (z_seam_position == 'left' or z_seam_position == 'right') else machine_depth",
+                            "enabled": "z_seam_type == 'back'",
+                            "limit_to_extruder": "wall_0_extruder_nr",
+                            "settable_per_mesh": true
+                        }
+                    }
                 },
                 "z_seam_corner":
                 {


### PR DESCRIPTION
Add a dropdown with position presets to quickly set Z-Seam X/Y when using `z_seam_type='back'`, eg. **User Specified** alignement.