### PR TITLE
Hide 'move to top' option from actions

### DIFF
--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -97,7 +97,7 @@ Rectangle
                 horizontalCenter: parent.horizontalCenter
             }
             visible: isNetworkConfigured && !isConnected
-            text: catalog.i18nc("@info", "Please make sure your printer has a connection:\n- Check if the printer is turned on.\n- Check if the printer is connected to the network.")
+            text: catalog.i18nc("@info", "Please make sure your printer has a connection:\n- Check if the printer is turned on.\n- Check if the printer is connected to the network.\n- Check if you are signed in to discover cloud-connected printers.")
             font: UM.Theme.getFont("medium")
             color: UM.Theme.getColor("monitor_text_primary")
             wrapMode: Text.WordWrap

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
@@ -46,6 +46,9 @@ Item
 
                 spacing: Math.floor(UM.Theme.getSize("default_margin").height / 2)
 
+                // Due to an issue with the ordering if print jobs caused by the Qt list models,
+                // we hide the 'move to top' feature for now as it's not displayed on the appropriate elements.
+                // Solving the ordering issue will cost more time than we currently have available.
                 PrintJobContextMenuItem {
                     onClicked: {
                         sendToTopConfirmationDialog.visible = true;
@@ -53,11 +56,11 @@ Item
                     }
                     text: catalog.i18nc("@label", "Move to top");
                     visible: {
-                        if (printJob && (printJob.state == "queued" || printJob.state == "error") && !isAssigned(printJob)) {
-                            if (OutputDevice && OutputDevice.queuedPrintJobs[0]) {
-                                return OutputDevice.queuedPrintJobs[0].key != printJob.key;
-                            }
-                        }
+//                        if (printJob && (printJob.state == "queued" || printJob.state == "error") && !isAssigned(printJob)) {
+//                            if (OutputDevice && OutputDevice.queuedPrintJobs[0]) {
+//                                return OutputDevice.queuedPrintJobs[0].key != printJob.key;
+//                            }
+//                        }
                         return false;
                     }
                 }


### PR DESCRIPTION
Due to an issue with Qt list models the order of the queued print jobs is not the actual order of them in the print queue. This can be solved by adding a custom sort to the list model, but we currently have no data to base this sorting on as the cluster API does not return the order of a print job in the queue (and fields like UUID or creation date are not appropriate for sorting either). For now we have decided to just hide the 'move to top' option that is somewhat useless at the moment (you will still be able to use it via the cloud or connect web interfaces).