### PR TITLE
Send the correct action name when using local network

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -422,6 +422,7 @@ class CloudOutputDevice(NetworkedPrinterOutputDevice):
         return [print_job for print_job in self._print_jobs if
                 print_job.assignedPrinter is not None and print_job.state != "queued"]
 
+    ##  Set the remote print job state.
     def setJobState(self, print_job_uuid: str, state: str) -> None:
         self._api.doPrintJobAction(self._cluster.cluster_id, print_job_uuid, state)
 

--- a/plugins/UM3NetworkPrinting/src/ClusterUM3OutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/ClusterUM3OutputDevice.py
@@ -390,6 +390,12 @@ class ClusterUM3OutputDevice(NetworkedPrinterOutputDevice):
         data = "{\"force\": true}"
         self.put("print_jobs/{uuid}".format(uuid=print_job_uuid), data, on_finished=None)
 
+    # Set the remote print job state.
+    def setJobState(self, print_job_uuid: str, state: str) -> None:
+        # We rewrite 'resume' to 'print' here because we are using the old print job action endpoints.
+        data = "{\"action\": \"%s\"}" % "print" if state == "resume" else state
+        self.put("print_jobs/%s/action" % print_job_uuid, data, on_finished=None)
+
     def _printJobStateChanged(self) -> None:
         username = self._getUserName()
 

--- a/plugins/UM3NetworkPrinting/src/ClusterUM3OutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/ClusterUM3OutputDevice.py
@@ -393,7 +393,8 @@ class ClusterUM3OutputDevice(NetworkedPrinterOutputDevice):
     # Set the remote print job state.
     def setJobState(self, print_job_uuid: str, state: str) -> None:
         # We rewrite 'resume' to 'print' here because we are using the old print job action endpoints.
-        data = "{\"action\": \"%s\"}" % "print" if state == "resume" else state
+        action = "print" if state == "resume" else state
+        data = "{\"action\": \"%s\"}" % action
         self.put("print_jobs/%s/action" % print_job_uuid, data, on_finished=None)
 
     def _printJobStateChanged(self) -> None:

--- a/plugins/UM3NetworkPrinting/src/ClusterUM3PrinterOutputController.py
+++ b/plugins/UM3NetworkPrinting/src/ClusterUM3PrinterOutputController.py
@@ -7,6 +7,7 @@ MYPY = False
 if MYPY:
     from cura.PrinterOutput.Models.PrintJobOutputModel import PrintJobOutputModel
 
+
 class ClusterUM3PrinterOutputController(PrinterOutputController):
     def __init__(self, output_device):
         super().__init__(output_device)
@@ -16,5 +17,4 @@ class ClusterUM3PrinterOutputController(PrinterOutputController):
         self.can_send_raw_gcode = False
 
     def setJobState(self, job: "PrintJobOutputModel", state: str):
-        data = "{\"action\": \"%s\"}" % state
-        self._output_device.put("print_jobs/%s/action" % job.key, data, on_finished=None)
+        self._output_device.setJobState(job.key, state)

--- a/plugins/UM3NetworkPrinting/src/ClusterUM3PrinterOutputController.py
+++ b/plugins/UM3NetworkPrinting/src/ClusterUM3PrinterOutputController.py
@@ -16,5 +16,5 @@ class ClusterUM3PrinterOutputController(PrinterOutputController):
         self.can_control_manually = False
         self.can_send_raw_gcode = False
 
-    def setJobState(self, job: "PrintJobOutputModel", state: str):
+    def setJobState(self, job: "PrintJobOutputModel", state: str) -> None:
         self._output_device.setJobState(job.key, state)


### PR DESCRIPTION
In the cloud and new local endpoints we're using 'resume' as the action, but Cura was still using the older endpoints which was using 'print' as state. For now this is just a quick fix to make it work with the existing endpoints, in the future we can switch to the newer endpoints on the CC API once enough people have updated their printer.