### PR TITLE
Hide incorrect tooltip

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
@@ -243,10 +243,11 @@ Item
         enabled: !contextMenuButton.enabled
     }
 
-    MonitorInfoBlurb
-    {
-        id: contextMenuDisabledInfo
-        text: catalog.i18nc("@info", "Please update your printer's firmware to manage the queue remotely.")
-        target: contextMenuButton
-    }
+	// TODO: uncomment this tooltip as soon as the required firmware is released
+    // MonitorInfoBlurb
+    // {
+    //     id: contextMenuDisabledInfo
+    //     text: catalog.i18nc("@info", "Please update your printer's firmware to manage the queue remotely.")
+    //     target: contextMenuButton
+    // }
 }

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
@@ -81,7 +81,7 @@ Item
                     mipmap: true
                 }
             }
-            
+
 
             Item
             {
@@ -99,7 +99,7 @@ Item
                     height: 18 * screenScaleFactor // TODO: Theme!
                     width: parent.width
                     radius: 2 * screenScaleFactor // TODO: Theme!
-                    
+
                     Label
                     {
                         text: printer && printer.name ? printer.name : ""
@@ -202,12 +202,13 @@ Item
             enabled: !contextMenuButton.enabled
         }
 
-        MonitorInfoBlurb
-        {
-            id: contextMenuDisabledInfo
-            text: catalog.i18nc("@info", "Please update your printer's firmware to manage the queue remotely.")
-            target: contextMenuButton
-        }
+		// TODO: uncomment this tooltip as soon as the required firmware is released
+        // MonitorInfoBlurb
+        // {
+        //     id: contextMenuDisabledInfo
+        //     text: catalog.i18nc("@info", "Please update your printer's firmware to manage the queue remotely.")
+        //     target: contextMenuButton
+        // }
 
         CameraButton
         {


### PR DESCRIPTION
The preferred solution was to change the copywriting, but since we are after string freeze we cannot do this. This is the next best solution to prevent user confusion.