### PR TITLE
Fix dimensions of print job information popup when using Qt 5.13.

### DIFF
--- a/resources/qml/ActionPanel/PrintInformationWidget.qml
+++ b/resources/qml/ActionPanel/PrintInformationWidget.qml
@@ -37,6 +37,9 @@ UM.RecolorImage
         opacity: opened ? 1 : 0
         Behavior on opacity { NumberAnimation { duration: 100 } }
 
+        contentWidth: printJobInformation.width
+        contentHeight: printJobInformation.implicitHeight
+
         contentItem: PrintJobInformation
         {
             id: printJobInformation


### PR DESCRIPTION
Remains compatible with Qt 5.10.

Tested using Qt 5.13 on Linux and Qt 5.10 on Windows.
