### PR TITLE
Get rid of any hard-coded references to machines

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
@@ -250,29 +250,13 @@ Cura.MachineAction
                         renderType: Text.NativeRendering
                         text:
                         {
-                            if(base.selectedDevice)
-                            {
-                                if (base.selectedDevice.printerType == "ultimaker3")
-                                {
-                                    return "Ultimaker 3";
-                                }
-                                else if (base.selectedDevice.printerType == "ultimaker3_extended")
-                                {
-                                    return "Ultimaker 3 Extended";
-                                }
-                                else if (base.selectedDevice.printerType == "ultimaker_s5")
-                                {
-                                    return "Ultimaker S5";
-                                }
-                                else
-                                {
-                                    return catalog.i18nc("@label", "Unknown") // We have no idea what type it is. Should not happen 'in the field'
-                                }
+                            if (base.selectedDevice) {
+                                // It would be great to use a more readable machine type here,
+                                // but the new discoveredPrintersModel is not used yet in the UM networking actions.
+                                // TODO: remove actions or replace 'connect via network' button with new flow?
+                                return base.selectedDevice.printerType
                             }
-                            else
-                            {
-                                return ""
-                            }
+                            return ""
                         }
                     }
                     Label

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterPill.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterPill.qml
@@ -11,20 +11,8 @@ import UM 1.2 as UM
  */
 Item
 {
-    // The printer name
+    id: monitorPrinterPill
     property var text: ""
-    property var tagText: {
-        switch(text) {
-            case "Ultimaker 3":
-                return "UM 3"
-            case "Ultimaker 3 Extended":
-                return "UM 3 EXT"
-            case "Ultimaker S5":
-                return "UM S5"
-            default:
-                return text
-        }
-    }
 
     implicitHeight: 18 * screenScaleFactor // TODO: Theme!
     implicitWidth: Math.max(printerNameLabel.contentWidth + 12 * screenScaleFactor, 36 * screenScaleFactor) // TODO: Theme!
@@ -40,9 +28,9 @@ Item
         id: printerNameLabel
         anchors.centerIn: parent
         color: UM.Theme.getColor("monitor_text_primary")
-        text: tagText
+        text: monitorPrinterPill.text
         font.pointSize: 10 // TODO: Theme!
-        visible: text !== ""
+        visible: monitorPrinterPill.text !== ""
         renderType: Text.NativeRendering
     }
 }


### PR DESCRIPTION
There were some hard-coded references to machine types and BOM numbers. These are already in the definition files so don't need to be in the actual code. This PR fixes that.