### PR TITLE
Qt 5.13 compatibility - fix size of ExpandablePopup background.

### DIFF
--- a/resources/qml/ExpandablePopup.qml
+++ b/resources/qml/ExpandablePopup.qml
@@ -225,6 +225,7 @@ Item
             border.width: UM.Theme.getSize("default_lining").width
             border.color: UM.Theme.getColor("lining")
             radius: UM.Theme.getSize("default_radius").width
+            height: contentItem.implicitHeight || content.height
         }
 
         contentItem: Item {}


### PR DESCRIPTION
Without this, the view selector dropdown has no background.

Tested with Qt 5.13 on Linux and Qt 5.10 on Windows.