### PR TITLE
Creality machines - lower Z-hop speed to 5

### DIFF
--- a/resources/definitions/creality_base.def.json
+++ b/resources/definitions/creality_base.def.json
@@ -52,6 +52,7 @@
         "speed_prime_tower": { "value": "speed_topbottom" },
         "speed_support": { "value": "speed_wall_0" },
         "speed_support_interface": { "value": "speed_topbottom" },
+        "speed_z_hop": {"value": 5},
 
         "skirt_brim_speed": { "value": "speed_layer_0" },
 


### PR DESCRIPTION
Follow up to https://github.com/Ultimaker/Cura/commit/1d7f2e645e3489eedac41fb20f98b9f66c100b28

Setting Z speed too high may lead to skipped steps and losing Z accuracy, which is super important with Z hop enabled.

