### PR TITLE
Move the permanent entries in the profiles and materials menus to the top

### DIFF
--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -39,6 +39,16 @@ Menu
 
     MenuItem
     {
+        action: Cura.Actions.manageMaterials
+    }
+
+    MenuSeparator
+    {
+        visible: favoriteMaterialsModel.items.length > 0
+    }
+
+    MenuItem
+    {
         text: catalog.i18nc("@label:category menu label", "Favorites")
         enabled: false
         visible: favoriteMaterialsModel.items.length > 0
@@ -128,12 +138,5 @@ Menu
 
     ExclusiveGroup {
         id: group
-    }
-
-    MenuSeparator {}
-
-    MenuItem
-    {
-        action: Cura.Actions.manageMaterials
     }
 }

--- a/resources/qml/Menus/ProfileMenu.qml
+++ b/resources/qml/Menus/ProfileMenu.qml
@@ -11,6 +11,13 @@ Menu
 {
     id: menu
 
+    MenuItem { action: Cura.Actions.addProfile }
+    MenuItem { action: Cura.Actions.updateProfile }
+    MenuItem { action: Cura.Actions.resetProfile }
+    MenuSeparator { }
+    MenuItem { action: Cura.Actions.manageProfiles }
+    MenuSeparator { }
+
     Instantiator
     {
         model: Cura.QualityProfilesDropDownMenuModel
@@ -73,12 +80,4 @@ Menu
     }
 
     ExclusiveGroup { id: group; }
-
-    MenuSeparator { id: profileMenuSeparator }
-
-    MenuItem { action: Cura.Actions.addProfile }
-    MenuItem { action: Cura.Actions.updateProfile }
-    MenuItem { action: Cura.Actions.resetProfile }
-    MenuSeparator { }
-    MenuItem { action: Cura.Actions.manageProfiles }
 }


### PR DESCRIPTION
This saves you having to scroll through lots of profiles/materials to get to them.

As discussed in #6127.