### PR TITLE
Set _slicing before assigning to gcode_dict to avoid potential race.

### DIFF
--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -264,8 +264,8 @@ class CuraEngineBackend(QObject, Backend):
         self.processingProgress.emit(0.0)
         self.backendStateChange.emit(BackendState.NotStarted)
 
-        self._scene.gcode_dict[build_plate_to_be_sliced] = [] #type: ignore #[] indexed by build plate number
         self._slicing = True
+        self._scene.gcode_dict[build_plate_to_be_sliced] = [] #type: ignore #[] indexed by build plate number
         self.slicingStarted.emit()
 
         self.determineAutoSlicing()  # Switch timer on or off if appropriate


### PR DESCRIPTION
Asynchronously, _the entry in gcode_dict could be cleared if _slicing is false.

Maybe fixes https://github.com/Ultimaker/Cura/issues/6245.