### PR TITLE
add CR-10 Max and Ender-5 Plus definitions

### DIFF
--- a/resources/definitions/creality_cr10max.def.json
+++ b/resources/definitions/creality_cr10max.def.json
@@ -1,0 +1,32 @@
+{
+    "name": "Creality CR-10 Max",
+    "version": 2,
+    "inherits": "creality_base",
+    "overrides": {
+        "machine_name": { "default_value": "Creality CR-10 Max" },
+        "machine_start_gcode": { "default_value": "M201 X500.00 Y500.00 Z100.00 E5000.00 ;Setup machine max acceleration\nM203 X500.00 Y500.00 Z10.00 E50.00 ;Setup machine max feedrate\nM204 P500.00 R1000.00 T500.00 ;Setup Print/Retract/Travel acceleration\nM205 X8.00 Y8.00 Z0.40 E5.00 ;Setup Jerk\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\n\nG28 ;Home\nM420 S1 Z2 ;Enable ABL using saved Mesh and Fade Height\n\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position\nG1 X10.1 Y200.0 Z0.28 F1500.0 E15 ;Draw the first line\nG1 X10.4 Y200.0 Z0.28 F5000.0 ;Move to side a little\nG1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\n"},
+        "machine_width": { "default_value": 450 },
+        "machine_depth": { "default_value": 450 },
+        "machine_height": { "default_value": 470 },
+        "machine_head_polygon": { "default_value": [
+                [-44, 34],
+                [-44, -34],
+                [18, -34],
+                [18, 34]
+            ]
+        },
+        "machine_head_with_fans_polygon": { "default_value": [
+                [-44, 34],
+                [-44, -34],
+                [38, -34],
+                [38, 34]
+            ]
+        },
+
+        "gantry_height": { "value": 30 }
+
+    },
+    "metadata": {
+        "quality_definition": "creality_base"
+    }
+}

--- a/resources/definitions/creality_ender5plus.def.json
+++ b/resources/definitions/creality_ender5plus.def.json
@@ -1,0 +1,34 @@
+{
+    "name": "Creality Ender-5 Plus",
+    "version": 2,
+    "inherits": "creality_base",
+    "overrides": {
+        "machine_name": { "default_value": "Creality Ender-5 Plus" },
+        "machine_start_gcode": { "default_value": "M201 X500.00 Y500.00 Z100.00 E5000.00 ;Setup machine max acceleration\nM203 X500.00 Y500.00 Z10.00 E50.00 ;Setup machine max feedrate\nM204 P500.00 R1000.00 T500.00 ;Setup Print/Retract/Travel acceleration\nM205 X8.00 Y8.00 Z0.40 E5.00 ;Setup Jerk\nM220 S100 ;Reset Feedrate\nM221 S100 ;Reset Flowrate\n\nG28 ;Home\nM420 S1 Z2 ;Enable ABL using saved Mesh and Fade Height\n\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position\nG1 X10.1 Y200.0 Z0.28 F1500.0 E15 ;Draw the first line\nG1 X10.4 Y200.0 Z0.28 F5000.0 ;Move to side a little\nG1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\n"},
+        "machine_width": { "default_value": 350 },
+        "machine_depth": { "default_value": 350 },
+        "machine_height": { "default_value": 400 },
+        "machine_head_polygon": { "default_value": [
+                [-26, 34],
+                [-26, -32],
+                [22, -32],
+                [22, 34]
+            ]
+        },
+        "machine_head_with_fans_polygon": { "default_value": [
+                [-26, 34],
+                [-26, -32],
+                [32, -32],
+                [32, 34]
+            ]
+        },
+
+        "gantry_height": { "value": 25 },
+
+        "speed_print": { "value": 80.0 }
+
+    },
+    "metadata": {
+        "quality_definition": "creality_base"
+    }
+}


### PR DESCRIPTION
CR-10 Max uses same print head as CR-10S Pro, but has bigger build volume.
Ender-5 Plus uses same print head as Ender-5, with bigger volume too.

Nothing fancy here, just inherit base Creality definitions.