### PR TITLE
Update printrbot_simple_extended.def.json

### DIFF
--- a/resources/definitions/printrbot_simple_extended.def.json
+++ b/resources/definitions/printrbot_simple_extended.def.json
@@ -5,7 +5,7 @@
     "metadata": {
         "visible": true,
         "author": "samsector",
-        "manufacturer": "PrintrBot",
+        "manufacturer": "Printrbot",
         "platform": "printrbot_simple_metal_upgrade.stl",
         "platform_offset": [0, -0.3, 0],
         "file_formats": "text/x-gcode",


### PR DESCRIPTION
manufacturer name changed from "PrintrBot" to "Printrbot" to allow the profile under the "Add a printer" menu
not appearing in version 4.2.1