### PR TITLE
Update printrbot_simple.def.json

### DIFF
--- a/resources/definitions/printrbot_simple.def.json
+++ b/resources/definitions/printrbot_simple.def.json
@@ -5,7 +5,7 @@
     "metadata": {
         "visible": true,
         "author": "Calvindog717",
-        "manufacturer": "PrintrBot",
+        "manufacturer": "Printrbot",
         "platform": "printrbot_simple_metal_platform.stl",
         "platform_offset": [0, -3.45, 0],
         "file_formats": "text/x-gcode",


### PR DESCRIPTION
manufacturer name changed from "PrintrBot" to "Printrbot" to allow the profile under the "Add a printer" menu
not appearing in version 4.2.1