### PR TITLE
Cs 278 ignore material empty

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterMaterialStationSlot.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterMaterialStationSlot.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2019 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
+from typing import Optional
+
 from .ClusterPrintCoreConfiguration import ClusterPrintCoreConfiguration
 
 
@@ -10,8 +12,11 @@ class ClusterPrinterMaterialStationSlot(ClusterPrintCoreConfiguration):
     #  \param slot_index: The index of the slot in the material station (ranging 0 to 5).
     #  \param compatible: Whether the configuration is compatible with the print core.
     #  \param material_remaining: How much material is remaining on the spool (between 0 and 1, or -1 for missing data).
-    def __init__(self, slot_index: int, compatible: bool, material_remaining: float, **kwargs):
+    #  \param material_empty: Whether the material spool is too empty to be used.
+    def __init__(self, slot_index: int, compatible: bool, material_remaining: float,
+                 material_empty: Optional[bool] = False, **kwargs):
         self.slot_index = slot_index
         self.compatible = compatible
         self.material_remaining = material_remaining
+        self.material_empty = material_empty
         super().__init__(**kwargs)

--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
@@ -115,7 +115,6 @@ class ClusterPrinterStatus(BaseModel):
     #  We filter out any slot that is not supported by the extruder index, print core type or if the material is empty.
     @staticmethod
     def _isSupportedConfiguration(slot: ClusterPrinterMaterialStationSlot, extruder_index: int) -> bool:
-        print("_isSupportedConfiguration", slot.material_empty)
         return slot.extruder_index == extruder_index and slot.compatible and not slot.material_empty
 
     ## Create an empty material slot with a fake empty material.

--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
@@ -115,7 +115,8 @@ class ClusterPrinterStatus(BaseModel):
     #  We filter out any slot that is not supported by the extruder index, print core type or if the material is empty.
     @staticmethod
     def _isSupportedConfiguration(slot: ClusterPrinterMaterialStationSlot, extruder_index: int) -> bool:
-        return slot.extruder_index == extruder_index and slot.compatible
+        print("_isSupportedConfiguration", slot.material_empty)
+        return slot.extruder_index == extruder_index and slot.compatible and not slot.material_empty
 
     ## Create an empty material slot with a fake empty material.
     @staticmethod


### PR DESCRIPTION
Materials in slots that are (nearly) empty should be ignored in the available configurations list as they are in fact not available for printing. As this field was added to the Connect API later it is supposed to be optional.