### PR TITLE
Fixed PauseAtHeight.py to resume at starting height

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -265,7 +265,7 @@ class PauseAtHeight(Script):
 
                 if not is_griffin:
                     # Retraction
-                    prepend_gcode += self.putValue(M = 83) + "\n"
+                    prepend_gcode += self.putValue(M = 83) + " ; switch to relative E values for any needed retraction\n"
                     if retraction_amount != 0:
                         if firmware_retract: #Can't set the distance directly to what the user wants. We have to choose ourselves.
                             retraction_count = 1 if control_temperatures else 3 #Retract more if we don't control the temperature.
@@ -275,25 +275,25 @@ class PauseAtHeight(Script):
                             prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = retraction_speed * 60) + "\n"
 
                     # Move the head away
-                    prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + "\n"
+                    prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + " ; move up a millimeter to get out of the way\n"
 
                     # This line should be ok
                     prepend_gcode += self.putValue(G = 1, X = park_x, Y = park_y, F = 9000) + "\n"
 
                     if current_z < 15:
-                        prepend_gcode += self.putValue(G = 1, Z = 15, F = 300) + "\n"
+                        prepend_gcode += self.putValue(G = 1, Z = 15, F = 300) + " ; too close to bed--move to at least 15mm\n"
 
                     if control_temperatures:
                         # Set extruder standby temperature
-                        prepend_gcode += self.putValue(M = 104, S = standby_temperature) + "; standby temperature\n"
+                        prepend_gcode += self.putValue(M = 104, S = standby_temperature) + " ; standby temperature\n"
 
                 # Wait till the user continues printing
-                prepend_gcode += self.putValue(M = 0) + ";Do the actual pause\n"
+                prepend_gcode += self.putValue(M = 0) + " ; Do the actual pause\n"
 
                 if not is_griffin:
                     if control_temperatures:
                         # Set extruder resume temperature
-                        prepend_gcode += self.putValue(M = 109, S = int(target_temperature.get(current_t, 0))) + "; resume temperature\n"
+                        prepend_gcode += self.putValue(M = 109, S = int(target_temperature.get(current_t, 0))) + " ; resume temperature\n"
 
                     # Push the filament back,
                     if retraction_amount != 0:
@@ -309,8 +309,10 @@ class PauseAtHeight(Script):
                         prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = retraction_speed * 60) + "\n"
 
                     # Move the head back
-                    prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + "\n"
+                    if current_z < 15:
+                        prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + "\n"
                     prepend_gcode += self.putValue(G = 1, X = x, Y = y, F = 9000) + "\n"
+                    prepend_gcode += self.putValue(G = 1, Z = current_z, F = 300) + " ; move back down to resume height\n"
                     if retraction_amount != 0:
                         if firmware_retract: #Can't set the distance directly to what the user wants. We have to choose ourselves.
                             retraction_count = 1 if control_temperatures else 3 #Retract more if we don't control the temperature.
@@ -319,7 +321,7 @@ class PauseAtHeight(Script):
                         else:
                             prepend_gcode += self.putValue(G = 1, E = retraction_amount, F = retraction_speed * 60) + "\n"
                     prepend_gcode += self.putValue(G = 1, F = 9000) + "\n"
-                    prepend_gcode += self.putValue(M = 82) + "\n"
+                    prepend_gcode += self.putValue(M = 82) + " ; switch back to absolute E values\n"
 
                     # reset extrude value to pre pause value
                     prepend_gcode += self.putValue(G = 92, E = current_e) + "\n"


### PR DESCRIPTION
See issue #5924 

PauseAtHeight.py was resuming 1mm higher than it paused at (line 312). If the original script doesn't happen to move to the correct Z height before resuming the layer, the entire layer will be printed 1mm too high.

I modified code to resume at the same level it paused at _after_ the X-Y jog completes (to avoid hitting any prints). Also added additional comments to generated code.