### PR TITLE
Print job uploading

### DIFF
--- a/cura/PrinterOutput/NetworkedPrinterOutputDevice.py
+++ b/cura/PrinterOutput/NetworkedPrinterOutputDevice.py
@@ -35,8 +35,6 @@ class NetworkedPrinterOutputDevice(PrinterOutputDevice):
     def __init__(self, device_id, address: str, properties: Dict[bytes, bytes], connection_type: ConnectionType = ConnectionType.NetworkConnection, parent: QObject = None) -> None:
         super().__init__(device_id = device_id, connection_type = connection_type, parent = parent)
         self._manager = None    # type: Optional[QNetworkAccessManager]
-        self._last_manager_create_time = None       # type: Optional[float]
-        self._recreate_network_manager_time = 30
         self._timeout_time = 10  # After how many seconds of no response should a timeout occur?
 
         self._last_response_time = None     # type: Optional[float]
@@ -133,12 +131,6 @@ class NetworkedPrinterOutputDevice(PrinterOutputDevice):
 
             self.setConnectionState(ConnectionState.Closed)
 
-            # We need to check if the manager needs to be re-created. If we don't, we get some issues when OSX goes to
-            # sleep.
-            if time_since_last_response > self._recreate_network_manager_time:
-                if self._last_manager_create_time is None or time() - self._last_manager_create_time > self._recreate_network_manager_time:
-                    self._createNetworkManager()
-                assert(self._manager is not None)
         elif self._connection_state == ConnectionState.Closed:
             # Go out of timeout.
             if self._connection_state_before_timeout is not None:   # sanity check, but it should never be None here
@@ -317,7 +309,6 @@ class NetworkedPrinterOutputDevice(PrinterOutputDevice):
 
         self._manager = QNetworkAccessManager()
         self._manager.finished.connect(self._handleOnFinished)
-        self._last_manager_create_time = time()
         self._manager.authenticationRequired.connect(self._onAuthenticationRequired)
 
         if self._properties.get(b"temporary", b"false") != b"true":

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -171,7 +171,11 @@ class CloudOutputDeviceManager:
         machine.setName(device.name)
         machine.setMetaDataEntry(self.META_CLUSTER_ID, device.key)
         machine.setMetaDataEntry("group_name", device.name)
-
-        device.connect()
         machine.addConfiguredConnectionType(device.connectionType.value)
-        CuraApplication.getInstance().getOutputDeviceManager().addOutputDevice(device)
+
+        if not device.isConnected():
+            device.connect()
+
+        output_device_manager = CuraApplication.getInstance().getOutputDeviceManager()
+        if device.key not in output_device_manager.getOutputDeviceIds():
+            output_device_manager.addOutputDevice(device)

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
@@ -122,9 +122,6 @@ class LocalClusterOutputDevice(UltimakerNetworkedPrinterOutputDevice):
 
         self.writeStarted.emit(self)
 
-        # Make sure the printer is aware of all new materials as the new print job might contain one.
-        self.sendMaterialProfiles()
-
         # Export the scene to the correct file type.
         job = ExportFileJob(file_handler=file_handler, nodes=nodes, firmware_version=self.firmwareVersion)
         job.finished.connect(self._onPrintJobCreated)

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDeviceManager.py
@@ -236,7 +236,11 @@ class LocalClusterOutputDeviceManager:
         machine.setName(device.name)
         machine.setMetaDataEntry(self.META_NETWORK_KEY, device.key)
         machine.setMetaDataEntry("group_name", device.name)
-
-        device.connect()
         machine.addConfiguredConnectionType(device.connectionType.value)
-        CuraApplication.getInstance().getOutputDeviceManager().addOutputDevice(device)
+
+        if not device.isConnected():
+            device.connect()
+
+        output_device_manager = CuraApplication.getInstance().getOutputDeviceManager()
+        if device.key not in output_device_manager.getOutputDeviceIds():
+            output_device_manager.addOutputDevice(device)

--- a/plugins/UM3NetworkPrinting/src/Network/SendMaterialJob.py
+++ b/plugins/UM3NetworkPrinting/src/Network/SendMaterialJob.py
@@ -104,7 +104,6 @@ class SendMaterialJob(Job):
                 parts.append(self.device.createFormPart("name=\"signature_file\"; filename=\"{file_name}\""
                                                         .format(file_name = signature_file_name), f.read()))
 
-        Logger.log("d", "Syncing material %s with cluster.", material_id)
         # FIXME: move form posting to API client
         self.device.postFormWithParts(target = "/cluster-api/v1/materials/", parts = parts,
                                       on_finished = self._sendingFinished)
@@ -117,7 +116,6 @@ class SendMaterialJob(Job):
         body = reply.readAll().data().decode('utf8')
         if "not added" in body:
             # For some reason the cluster returns a 200 sometimes even when syncing failed.
-            Logger.log("w", "Error while syncing material: %s", body)
             return
         # Inform the user that materials have been synced. This message only shows itself when not already visible.
         # Because of the guards above it is not shown when syncing failed (which is not always an actual problem).


### PR DESCRIPTION
This PR is an investigation into the print job uploading issues we have experienced recently. Several small changes combined hopefully reduce the chance that a print job upload fails.

* Reduce logging for material syncing (which was found to be annoying).
* Disable material syncing when uploading print job to reduce network activity to the printer. This changes the current behavior but I think it is fine as the material profiles are still synced after installing a new material profile (which forces a Cura restart and thus device reconnect).
* Remove the re-creation of the network manager (I have found that job uploading got stuck while the network manager was re-created every 30 seconds). I'm aware this could cause new issues on MacOS (as described in the removed lines), but I think this has lower impact than users on all platforms having issues with job uploading.

Before these changes I could reproduce job upload being stuck around 1 in 10 times. After these changes I have yet to experience it (using Ubuntu 18.04 in combination with Connect 5.3.0).