### PR TITLE
Check if printerConfiguration is actually set before trying to access it

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
@@ -66,7 +66,7 @@ class ClusterPrinterStatus(BaseModel):
     ## Creates a new output model.
     #  \param controller - The controller of the model.
     def createOutputModel(self, controller: PrinterOutputController) -> PrinterOutputModel:
-        model = PrinterOutputModel(controller, len(self.configuration), firmware_version = self.firmware_version)
+        model = PrinterOutputModel(controller, 2, firmware_version = self.firmware_version)
         self.updateOutputModel(model)
         return model
 

--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
@@ -80,6 +80,11 @@ class ClusterPrinterStatus(BaseModel):
         model.updateBuildplate(self.build_plate.type if self.build_plate else "glass")
         model.setCameraUrl(QUrl("http://{}:8080/?action=stream".format(self.ip_address)))
 
+        if not model.printerConfiguration:
+            # Prevent accessing printer configuration when not available.
+            # This sometimes happens when a printer was just added to a group and Cura is connected to that group.
+            return
+
         # Set the possible configurations based on whether a Material Station is present or not.
         if self.material_station and self.material_station.material_slots:
             self._updateAvailableConfigurations(model)

--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterStatus.py
@@ -66,6 +66,10 @@ class ClusterPrinterStatus(BaseModel):
     ## Creates a new output model.
     #  \param controller - The controller of the model.
     def createOutputModel(self, controller: PrinterOutputController) -> PrinterOutputModel:
+        # FIXME
+        # Note that we're using '2' here as extruder count. We have hardcoded this for now to prevent issues where the
+        # amount of extruders coming back from the API is actually lower (which it can be if a printer was just added
+        # to a cluster). This should be fixed in the future, probably also on the cluster API side.
         model = PrinterOutputModel(controller, 2, firmware_version = self.firmware_version)
         self.updateOutputModel(model)
         return model


### PR DESCRIPTION
When a printer is just added to a group, it might happen that its configurations aren't known yet. In this case we should not access properties on it (and wait for the next status update). Also setting the amount of expected extruders to 2 (all UM networked printers have 2 extruders) because the first status call the number of configurations in the API might not be 2 (and it cannot be changed in the model later on).