### PR TITLE
CS-158 Fix monitor tab print status (4.3 cherry pick)

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml
@@ -46,7 +46,7 @@ Item
         text: printJob ? Math.round(printJob.progress * 100) + "%" : "0%"
         color: printJob && printJob.isActive ? UM.Theme.getColor("monitor_text_primary") : UM.Theme.getColor("monitor_text_disabled")
         width: contentWidth
-        font: UM.Theme.getFont("medium") // 14pt, regular
+        font: UM.Theme.getFont("default") // 12pt, regular
 
         // FIXED-LINE-HEIGHT:
         height: 18 * screenScaleFactor // TODO: Theme!
@@ -63,7 +63,7 @@ Item
             verticalCenter: parent.verticalCenter
         }
         color: UM.Theme.getColor("monitor_text_primary")
-        font: UM.Theme.getFont("medium") // 14pt, regular
+        font: UM.Theme.getFont("default") // 12pt, regular
         text:
         {
             if (!printJob)

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml
@@ -31,7 +31,7 @@ Item
             left: parent.left
         }
         value: printJob ? printJob.progress : 0
-        width: UM.Theme.getSize("monitor_column").width
+        width: UM.Theme.getSize("monitor_progress_bar").width
     }
 
     Label

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml
@@ -20,7 +20,7 @@ Item
     property var printJob: null
 
     width: childrenRect.width
-    height: 18 * screenScaleFactor // TODO: Theme!
+    height: UM.Theme.getSize("monitor_text_line").height
 
     UM.ProgressBar
     {
@@ -40,7 +40,7 @@ Item
         anchors
         {
             left: progressBar.right
-            leftMargin: 18 * screenScaleFactor // TODO: Theme!
+            leftMargin: UM.Theme.getSize("monitor_margin").width
             verticalCenter: parent.verticalCenter
         }
         text: printJob ? Math.round(printJob.progress * 100) + "%" : "0%"
@@ -49,7 +49,7 @@ Item
         font: UM.Theme.getFont("default") // 12pt, regular
 
         // FIXED-LINE-HEIGHT:
-        height: 18 * screenScaleFactor // TODO: Theme!
+        height: UM.Theme.getSize("monitor_text_line").height
         verticalAlignment: Text.AlignVCenter
         renderType: Text.NativeRendering
     }
@@ -59,7 +59,7 @@ Item
         anchors
         {
             left: percentLabel.right
-            leftMargin: 18 * screenScaleFactor // TODO: Theme!
+            leftMargin: UM.Theme.getSize("monitor_margin").width
             verticalCenter: parent.verticalCenter
         }
         color: UM.Theme.getColor("monitor_text_primary")
@@ -103,7 +103,7 @@ Item
         width: contentWidth
 
         // FIXED-LINE-HEIGHT:
-        height: 18 * screenScaleFactor // TODO: Theme!
+        height: UM.Theme.getSize("monitor_text_line").height
         verticalAlignment: Text.AlignVCenter
         renderType: Text.NativeRendering
     }

--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -619,6 +619,8 @@
         "monitor_empty_state_offset": [5.6, 5.6],
         "monitor_empty_state_size": [35.0, 25.0],
         "monitor_external_link_icon": [1.16, 1.16],
-        "monitor_column": [18.0, 1.0]
+        "monitor_column": [18.0, 1.0],
+        "monitor_progress_bar": [16.5, 1.0],
+        "monitor_margin": [1.5, 1.5]
     }
 }


### PR DESCRIPTION
> **Note:** Cherry picked some commits to a new branch from 4.3

This is two things in one to hopefully avoid having this bug from ever returning from the grave for a 3rd time:

1. Reduce text size from 'medium' to 'default'. It looks a little small, but there simply isn't more room in the design as it was created and wrapping to the next line looks silly.
2. Reduce the progress bar length a bit so that the percent label's left side as at the "column edge" (aligned with the 2nd extruder info).

![Screen Shot 2019-09-11 at 11 27 57](https://user-images.githubusercontent.com/1137232/64685818-e3db8a00-d487-11e9-9fa9-55fa72e8cab6.png)