### PR TITLE
CS-59: Message when new cloud printers were added to your account

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Messages/CloudPrinterDetectedMessage.py
+++ b/plugins/UM3NetworkPrinting/src/Messages/CloudPrinterDetectedMessage.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2019 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+from UM import i18nCatalog
+from UM.Message import Message
+
+
+I18N_CATALOG = i18nCatalog("cura")
+
+
+## Message shown when a new printer was added to your account but not yet in Cura.
+class CloudPrinterDetectedMessage(Message):
+
+    # Singleton used to prevent duplicate messages of this type at the same time.
+    __is_visible = False
+
+    def __init__(self) -> None:
+        super().__init__(
+            title=I18N_CATALOG.i18nc("@info:title", "New cloud printers found"),
+            text=I18N_CATALOG.i18nc("@info:message", "New printers have been found connected to your account, "
+                                                     "you can find them in your list of discovered printers."),
+            lifetime=10,
+            dismissable=True
+        )
+
+    def show(self) -> None:
+        if CloudPrinterDetectedMessage.__is_visible:
+            return
+        super().show()
+        CloudPrinterDetectedMessage.__is_visible = True
+
+    def hide(self, send_signal = True) -> None:
+        super().hide(send_signal)
+        CloudPrinterDetectedMessage.__is_visible = False


### PR DESCRIPTION
When a cloud printer was added to your account (e.g. via teams sharing) you might not be aware. This PR lets the user see a message when that happened. It shows a message (1 at a time) when:

1) The user started Cura and is signed in.
2) The user just signed in.
3) A printer was just added to the account and the user is signed in.

It will not show a message if the newly found printer was already added to Cura as machine stack (by checking against all machine stacks' cluster ID meta data key).

> Note that this PR is pointed at master because it introduces new strings. Therefore it will not be available in Cura 4.3.