### PR TITLE
Store in preferences if the user wants to hide the message

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py
+++ b/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py
@@ -28,7 +28,7 @@ class CloudFlowMessage(Message):
             lifetime=0,
             dismissable=True,
             option_state=False,
-            image_source=image_path,
+            image_source=QUrl.fromLocalFile(image_path),
             image_caption=I18N_CATALOG.i18nc("@info:status Ultimaker Cloud should not be translated.",
                                              "Connect to Ultimaker Cloud"),
         )

--- a/plugins/UM3NetworkPrinting/src/Messages/CloudPrinterDetectedMessage.py
+++ b/plugins/UM3NetworkPrinting/src/Messages/CloudPrinterDetectedMessage.py
@@ -2,7 +2,7 @@
 # Cura is released under the terms of the LGPLv3 or higher.
 from UM import i18nCatalog
 from UM.Message import Message
-
+from cura.CuraApplication import CuraApplication
 
 I18N_CATALOG = i18nCatalog("cura")
 
@@ -13,16 +13,25 @@ class CloudPrinterDetectedMessage(Message):
     # Singleton used to prevent duplicate messages of this type at the same time.
     __is_visible = False
 
+    # Store in preferences to hide this message in the future.
+    _preference_key = "cloud/block_new_printers_popup"
+
     def __init__(self) -> None:
         super().__init__(
             title=I18N_CATALOG.i18nc("@info:title", "New cloud printers found"),
             text=I18N_CATALOG.i18nc("@info:message", "New printers have been found connected to your account, "
                                                      "you can find them in your list of discovered printers."),
-            lifetime=10,
-            dismissable=True
+            lifetime=0,
+            dismissable=True,
+            option_state=False,
+            option_text=I18N_CATALOG.i18nc("@info:option_text", "Do not show this message again")
         )
+        self.optionToggled.connect(self._onDontAskMeAgain)
+        CuraApplication.getInstance().getPreferences().addPreference(self._preference_key, False)
 
     def show(self) -> None:
+        if CuraApplication.getInstance().getPreferences().getValue(self._preference_key):
+            return
         if CloudPrinterDetectedMessage.__is_visible:
             return
         super().show()
@@ -31,3 +40,6 @@ class CloudPrinterDetectedMessage(Message):
     def hide(self, send_signal = True) -> None:
         super().hide(send_signal)
         CloudPrinterDetectedMessage.__is_visible = False
+
+    def _onDontAskMeAgain(self, checked: bool) -> None:
+        CuraApplication.getInstance().getPreferences().setValue(self._preference_key, checked)


### PR DESCRIPTION
Users might not want to see the message that new cloud printers were found every time. This PR adds a checkbox to allow them to disable the message in the future.

Also fixed loading another popup's image on Windows.