### PR TITLE
Fix crash when adding printers with empty profile layers

### DIFF
--- a/cura/Machines/Models/IntentModel.py
+++ b/cura/Machines/Models/IntentModel.py
@@ -74,6 +74,8 @@ class IntentModel(ListModel):
         active_material_node = active_variant_node.materials[active_extruder.material.getMetaDataEntry("base_file")]
         layer_heights_added = []
         for quality_id, quality_node in active_material_node.qualities.items():
+            if quality_node.quality_type not in quality_groups:  # Don't add the empty quality type (or anything else that would crash, defensively).
+                continue
             quality_group = quality_groups[quality_node.quality_type]
             layer_height = self._fetchLayerHeight(quality_group)
 

--- a/cura/Settings/cura_empty_instance_containers.py
+++ b/cura/Settings/cura_empty_instance_containers.py
@@ -25,6 +25,9 @@ EMPTY_MATERIAL_CONTAINER_ID = "empty_material"
 empty_material_container = copy.deepcopy(empty_container)
 empty_material_container.setMetaDataEntry("id", EMPTY_MATERIAL_CONTAINER_ID)
 empty_material_container.setMetaDataEntry("type", "material")
+empty_material_container.setMetaDataEntry("base_file", "empty_material")
+empty_material_container.setMetaDataEntry("GUID", "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")
+empty_material_container.setMetaDataEntry("material", "empty")
 
 # Empty quality
 EMPTY_QUALITY_CONTAINER_ID = "empty_quality"


### PR DESCRIPTION
When adding some printers you would get a crash when you add them. This happened if the material or quality profile layer ended up empty. No longer.

Fixes CURA-6775.