### PR TITLE
Creat Original_Prusa_i3_MK3S_MK3.def.json

### DIFF
--- a/resources/definitions/Original_Prusa_i3_MK3S_MK3.def.json
+++ b/resources/definitions/Original_Prusa_i3_MK3S_MK3.def.json
@@ -1,0 +1,53 @@
+{
+    "version": 2,
+    "name": "Original Prusa i3 MK3S/MK3",
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": true,
+        "author": "Prusa Research",
+        "manufacturer": "Prusa3D",
+        "file_formats": "text/x-gcode",
+        "icon": "icon_ultimaker2",
+        "platform": "Original_Prusa_i3_MK3S_MK3_platform.stl",
+        "has_materials": true,
+		 "machine_extruder_trains":
+        {
+            "0": "Original_Prusa_i3_MK3S_MK3_extruder_0"
+        }
+    },
+
+    "overrides": {
+		"machine_name": { "default_value": "Original Prusa i3 MK3S/MK3" },
+        "machine_heated_bed": { "default_value": true },
+        "machine_width": { "default_value": 250 },
+        "machine_height": { "default_value": 210 },
+        "machine_depth": { "default_value": 210 },
+        "machine_center_is_zero": { "default_value": false },
+        "material_diameter": { "default_value": 1.75 },
+        "material_bed_temperature": { "default_value": 60 },
+        "machine_nozzle_size": { "default_value": 0.4 },
+        "layer_height": { "default_value": 0.15 },
+        "layer_height_0": { "default_value": 0.2 },
+        "retraction_amount": { "default_value": 0.8 },
+        "retraction_speed": { "default_value": 35 },
+        "retraction_retract_speed": { "default_value": 35 },
+        "retraction_prime_speed": { "default_value": 35 },
+        "adhesion_type": { "default_value": "skirt" },
+        "machine_head_with_fans_polygon": { "default_value": [[-31,31],[34,31],[34,-40],[-31,-40]] },
+        "gantry_height": { "default_value": 28 },
+        "machine_max_feedrate_z": { "default_value": 12 },
+        "machine_max_feedrate_e": { "default_value": 120 },
+        "machine_max_acceleration_z": { "default_value": 500 },
+        "machine_acceleration": { "default_value": 1000 },
+        "machine_max_jerk_xy": { "default_value": 10 },
+        "machine_max_jerk_z": { "default_value": 0.2 },
+        "machine_max_jerk_e": { "default_value": 2.5 },
+        "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
+        "machine_start_gcode": {
+            "default_value": "G21 ; set units to millimeters\nG90 ; use absolute positioning\nM82 ; absolute extrusion mode\nM104 S{material_print_temperature_layer_0} ; set extruder temp\nM140 S{material_bed_temperature_layer_0} ; set bed temp\nM190 S{material_bed_temperature_layer_0} ; wait for bed temp\nM109 S{material_print_temperature_layer_0} ; wait for extruder temp\nG28 W ; home all without mesh bed level\nG80 ; mesh bed leveling\nG92 E0.0 ; reset extruder distance position\nG1 Y-3.0 F1000.0 ; go outside print area\nG1 X60.0 E9.0 F1000.0 ; intro line\nG1 X100.0 E21.5 F1000.0 ; intro line\nG92 E0.0 ; reset extruder distance position"
+        },
+        "machine_end_gcode": {
+            "default_value": "M104 S0 ; turn off extruder\nM140 S0 ; turn off heatbed\nM107 ; turn off fan\nG1 X0 Y210; home X axis and push Y forward\nM84 ; disable motors"
+        }
+    }
+}


### PR DESCRIPTION
This is the latest definition for Prusa i3 MK3/MK3s made by Prusa Research with minor modification to fit in Prusa folder under "add printer"
reference :
https://manual.prusa3d.com/Guide/How+to+import+profiles+to+Cura+4.x+(Windows+&+macOS)/1421#_ga=2.78043415.205833688.1568467545-859345073.1567270611