### PR TITLE
Create Original_Prusa_i3_MK3S_MK3_extruder_0.def

### DIFF
--- a/resources/extruders/Original_Prusa_i3_MK3S_MK3_extruder_0.def.json
+++ b/resources/extruders/Original_Prusa_i3_MK3S_MK3_extruder_0.def.json
@@ -1,0 +1,16 @@
+{
+    "id": "Original_Prusa_i3_MK3S_MK3_extruder_0",
+    "version": 2,
+    "name": "Extruder 1",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "Original_Prusa_i3_MK3S_MK3",
+        "position": "0"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 0 },
+        "machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 }
+    }
+}


### PR DESCRIPTION
This is the latest extruder definition for Prusa i3 MK3/MK3s .
reference :
https://manual.prusa3d.com/Guide/How+to+import+profiles+to+Cura+4.x+(Windows+&+macOS)/1421#_ga=2.78043415.205833688.1568467545-859345073.1567270611