### PR TITLE
Add Infill Vertical Scaling setting

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1790,13 +1790,13 @@
                 "infill_scaling_z":
                 {
                     "label": "Infill Vertical Scaling",
-                    "description": "Scales the vertical infill pattern. Values larger than 100% stretch the pattern, values less than 100% compress the pattern.",
+                    "description": "Scales the vertical infill pattern. Values larger than 100% stretch the pattern, values less than 100% compress the pattern. Note that some infill patterns do not work well with scaling values that differ greatly from 100%.",
                     "unit": "%",
                     "minimum_value": "1",
                     "maximum_value": "1000000",
                     "default_value": 100,
                     "type": "float",
-                    "enabled": "infill_sparse_density > 0 and infill_pattern.startswith('gyroid')",
+                    "enabled": "infill_sparse_density > 0 and (infill_pattern.startswith('gyroid') or infill_pattern in ('cubic', 'cubicsubdiv', 'quarter_cubic', 'tetrahedral', 'cross_3d'))",
                     "settable_per_mesh": true
                 },
                 "infill_randomize_start_location":

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1787,6 +1787,18 @@
                     "limit_to_extruder": "infill_extruder_nr",
                     "settable_per_mesh": true
                 },
+                "infill_scaling_z":
+                {
+                    "label": "Infill Vertical Scaling",
+                    "description": "Scales the vertical infill pattern. Values larger than 100% stretch the pattern, values less than 100% compress the pattern.",
+                    "unit": "%",
+                    "minimum_value": "1",
+                    "maximum_value": "1000000",
+                    "default_value": 100,
+                    "type": "float",
+                    "enabled": "infill_sparse_density > 0 and infill_pattern.startswith('gyroid')",
+                    "settable_per_mesh": true
+                },
                 "infill_randomize_start_location":
                 {
                     "label": "Randomize Infill Start",

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -80,6 +80,7 @@ infill_multiplier
 infill_angles
 infill_offset_x
 infill_offset_y
+infill_scaling_z
 sub_div_rad_add
 infill_overlap
 infill_overlap_mm


### PR DESCRIPTION
Adds setting that scales (stretches/shrinks) infill pattern vertically. Currently only implemented by gyroid pattern.

See https://github.com/Ultimaker/CuraEngine/pull/1135.