### PR TITLE
plugins: Reweighting stages

### DIFF
--- a/plugins/MonitorStage/__init__.py
+++ b/plugins/MonitorStage/__init__.py
@@ -12,7 +12,7 @@ def getMetaData():
     return {
         "stage": {
             "name": i18n_catalog.i18nc("@item:inmenu", "Monitor"),
-            "weight": 2
+            "weight": 30
         }
     }
 

--- a/plugins/PrepareStage/__init__.py
+++ b/plugins/PrepareStage/__init__.py
@@ -10,7 +10,7 @@ def getMetaData():
     return {
         "stage": {
             "name": i18n_catalog.i18nc("@item:inmenu", "Prepare"),
-            "weight": 0
+            "weight": 10
         }
     }
 

--- a/plugins/PreviewStage/__init__.py
+++ b/plugins/PreviewStage/__init__.py
@@ -11,7 +11,7 @@ def getMetaData():
     return {
         "stage": {
             "name": i18n_catalog.i18nc("@item:inmenu", "Preview"),
-            "weight": 1
+            "weight": 20
         }
     }
 


### PR DESCRIPTION
In theory, it should be possible to add stages, but there is no possibility to add to any other stage in between. Therefore, I moved the weights by 10+n×10. So we can add 10 before prepare and 9 stages between those 3 known stages.
It is probably possible to set the same weight to multiple stages, but I'm not sure how Cura decides, which stage to take first then. By the moment the plugin's init is called? Or by alphabet?
Therefore, putting some space in between the weights should give some clarity.

Related to: https://github.com/tetonsim/is-cura-ui/issues/1