### PR TITLE
Cura 6799 pause at height resume speed

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -154,7 +154,7 @@ class PauseAtHeight(Script):
         # use offset to calculate the current height: <current_height> = <current_z> - <layer_0_z>
         layer_0_z = 0
         current_z = 0
-        current_f = 0
+        current_extrusion_f = 0
         got_first_g_cmd_on_layer_0 = False
         current_t = 0 #Tracks the current extruder for tracking the target temperature.
         target_temperature = {} #Tracks the current target temperature for each extruder.
@@ -188,9 +188,9 @@ class PauseAtHeight(Script):
                 if not layers_started:
                     continue
 
-                # If a F instruction is in the line, read the current F
-                if self.getValue(line, "F") is not None:
-                    current_f = self.getValue(line, "F")
+                # Look for the feed rate of an extrusion instruction
+                if self.getValue(line, "F") is not None and self.getValue(line, "E") is not None:
+                    current_extrusion_f = self.getValue(line, "F")
 
                 # If a Z instruction is in the line, read the current Z
                 if self.getValue(line, "Z") is not None:
@@ -328,8 +328,8 @@ class PauseAtHeight(Script):
                         else:
                             prepend_gcode += self.putValue(G = 1, E = retraction_amount, F = retraction_speed * 60) + "\n"
 
-                    if current_f != 0:
-                        prepend_gcode += self.putValue(G = 1, F = current_f) + "\n"
+                    if current_extrusion_f != 0:
+                        prepend_gcode += self.putValue(G = 1, F = current_extrusion_f) + " ; restore extrusion feedrate\n"
                     else:
                         Logger.log("w", "No previous feedrate found in gcode, feedrate for next layer(s) might be incorrect")
 

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -4,6 +4,8 @@
 from ..Script import Script
 
 from UM.Application import Application #To get the current printer's settings.
+from UM.Logger import Logger
+
 from typing import List, Tuple
 
 class PauseAtHeight(Script):
@@ -152,6 +154,7 @@ class PauseAtHeight(Script):
         # use offset to calculate the current height: <current_height> = <current_z> - <layer_0_z>
         layer_0_z = 0
         current_z = 0
+        current_f = 0
         got_first_g_cmd_on_layer_0 = False
         current_t = 0 #Tracks the current extruder for tracking the target temperature.
         target_temperature = {} #Tracks the current target temperature for each extruder.
@@ -184,6 +187,10 @@ class PauseAtHeight(Script):
 
                 if not layers_started:
                     continue
+
+                # If a F instruction is in the line, read the current F
+                if self.getValue(line, "F") is not None:
+                    current_f = self.getValue(line, "F")
 
                 # If a Z instruction is in the line, read the current Z
                 if self.getValue(line, "Z") is not None:
@@ -320,7 +327,12 @@ class PauseAtHeight(Script):
                                 prepend_gcode += self.putValue(G = 11) + "\n"
                         else:
                             prepend_gcode += self.putValue(G = 1, E = retraction_amount, F = retraction_speed * 60) + "\n"
-                    prepend_gcode += self.putValue(G = 1, F = 9000) + "\n"
+
+                    if current_f != 0:
+                        prepend_gcode += self.putValue(G = 1, F = current_f) + "\n"
+                    else:
+                        Logger.log("w", "No previous feedrate found in gcode, feedrate for next layer(s) might be incorrect")
+
                     prepend_gcode += self.putValue(M = 82) + " ; switch back to absolute E values\n"
 
                     # reset extrude value to pre pause value

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
@@ -1,3 +1,4 @@
+from UM.Logger import Logger
 from ..Script import Script
 class PauseAtHeightforRepetier(Script):
     def __init__(self):
@@ -73,6 +74,7 @@ class PauseAtHeightforRepetier(Script):
     def execute(self, data):
         x = 0.
         y = 0.
+        current_f = 0
         current_z = 0.
         pause_z = self.getSettingValueByKey("pause_height")
         retraction_amount = self.getSettingValueByKey("retraction_amount")
@@ -94,6 +96,7 @@ class PauseAtHeightforRepetier(Script):
 
                 if self.getValue(line, 'G') == 1 or self.getValue(line, 'G') == 0:
                     current_z = self.getValue(line, 'Z')
+                    current_f = self.getValue(line, 'F', current_f)
                     x = self.getValue(line, 'X', x)
                     y = self.getValue(line, 'Y', y)
                     if current_z != None:
@@ -150,7 +153,12 @@ class PauseAtHeightforRepetier(Script):
                             prepend_gcode +="G1 X%f Y%f F9000\n" % (x, y)
                             if retraction_amount != 0:
                                 prepend_gcode +="G1 E%f F6000\n" % (retraction_amount)
-                            prepend_gcode +="G1 F9000\n"
+
+                            if current_f != 0:
+                                prepend_gcode += self.putValue(G=1, F=current_f) + "\n"
+                            else:
+                                Logger.log("w", "No previous feedrate found in gcode, feedrate for next layer(s) might be incorrect")
+
                             prepend_gcode +="M82\n"
 
                             # reset extrude value to pre pause value

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
@@ -74,7 +74,7 @@ class PauseAtHeightforRepetier(Script):
     def execute(self, data):
         x = 0.
         y = 0.
-        current_f = 0
+        current_extrusion_f = 0
         current_z = 0.
         pause_z = self.getSettingValueByKey("pause_height")
         retraction_amount = self.getSettingValueByKey("retraction_amount")
@@ -96,10 +96,11 @@ class PauseAtHeightforRepetier(Script):
 
                 if self.getValue(line, 'G') == 1 or self.getValue(line, 'G') == 0:
                     current_z = self.getValue(line, 'Z')
-                    current_f = self.getValue(line, 'F', current_f)
+                    if self.getValue(line, 'F') is not None and self.getValue(line, 'E') is not None:
+                        current_extrusion_f = self.getValue(line, 'F', current_extrusion_f)
                     x = self.getValue(line, 'X', x)
                     y = self.getValue(line, 'Y', y)
-                    if current_z != None:
+                    if current_z is not None:
                         if current_z >= pause_z:
 
                             index = data.index(layer)
@@ -154,8 +155,8 @@ class PauseAtHeightforRepetier(Script):
                             if retraction_amount != 0:
                                 prepend_gcode +="G1 E%f F6000\n" % (retraction_amount)
 
-                            if current_f != 0:
-                                prepend_gcode += self.putValue(G=1, F=current_f) + "\n"
+                            if current_extrusion_f != 0:
+                                prepend_gcode += self.putValue(G=1, F=current_extrusion_f) + " ; restore extrusion feedrate\n"
                             else:
                                 Logger.log("w", "No previous feedrate found in gcode, feedrate for next layer(s) might be incorrect")
 


### PR DESCRIPTION
Curretly the Feedrate is set to 9000 at the end of the Pause at height script. @ChrisTerBeke, please let me know if there was a valid reason for that.
After a Pause at a certain height, the previous feed rate should be restored. This PR implements it for the general Pause At height script and the Repetier script.

The Duet and BQ, scripts should be unaffected by this issue and thus not need a change