### PR TITLE
Set BIBO print speed to 40mm/s

### DIFF
--- a/resources/definitions/bibo2_dual.def.json
+++ b/resources/definitions/bibo2_dual.def.json
@@ -78,6 +78,9 @@
         "machine_end_gcode": {
             "default_value": ";End GCode\nM104 T0 S0                     ;extruder heater off\nM104 T1 S0                     ;extruder heater off\nM140 S0                     ;heated bed heater off (if you have it)\nG91\nG1 Z1 F100                                        ;relative positioning\nG1 E-1 F300                            ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-2 X-20 Y-20 F300 ;move Z up a bit and retract filament even more\nG28 X0 Y0                              ;move X/Y to min endstops, so the head is out of the way\nM84                         ;steppers off\nG90                         ;absolute positioning"
         },
+        "speed_print": {
+            "default_value": 40
+        },
         "machine_extruder_count": {
             "default_value": 2
         },


### PR DESCRIPTION
BIBO and members from the BIBO group on Facebook say this printer should be run at 40-45mm/s and not the FDMprinter default of 60mm/s. BIBO provided test gcode files also show that they are setting 40mm/s in the slicer to create their test files.

This change sets the print speed override so the printer profile does not start at the FDMPrinter print speed default of 60mm/s but at the reccommended value of 40mm/s