### PR TITLE
Add StartupWMClass=cura.real to fix window grouping in most DEs.

### DIFF
--- a/cura.desktop.in
+++ b/cura.desktop.in
@@ -16,3 +16,4 @@ Type=Application
 MimeType=model/stl;application/vnd.ms-3mfdocument;application/prs.wavefront-obj;image/bmp;image/gif;image/jpeg;image/png;text/x-gcode;application/x-amf;application/x-ply;application/x-ctm;model/vnd.collada+xml;model/gltf-binary;model/gltf+json;model/vnd.collada+xml+zip;
 Categories=Graphics;
 Keywords=3D;Printing;Slicer;
+StartupWMClass=cura.real


### PR DESCRIPTION
This has been infuriating me for the past few weeks. The result of this change is that when you use Cura as built from source or via [thopiekar's PPA](https://github.com/thopiekar/Cura-packaging) the Gnome shortcut will act only as a launcher for potentially infinite instances of Cura. That is, if you keep clicking it, it will open up more and more instances of Cura. This is because the class cura.real is not present or specified in the desktop file. See this askubuntu thread on the topic;

https://askubuntu.com/questions/367396/what-does-the-startupwmclass-field-of-a-desktop-file-represent/367851#367851

Simply adding "StartupWMClass=cura.real" allows Cura to behave like a normal application in all desktop environments that implement .desktop. Cura can now spawn children and in gnome in particular has options for spawning a New Window, rather than a runaway "Spawn more instances" as you click the launcher. This has been particularly annoying for me, as in a makerspace I attend where I have set up a dedicated Cura machine people have been opening several instances of Cura because of this flaw.

## Before:
Clicking the gnome Cura favourite would be dysfunctional, as all it does is spawn new instances of Cura without grouping them, confusing users.

![Screenshot from 2019-09-27 02-54-02](https://user-images.githubusercontent.com/26458780/65736168-1a451600-e0d2-11e9-9526-bd28b7022c5c.png)

## After:
The proper functionality of window grouping in Gnome and probably other DEs is respected, including closing all children, making new windows and being unable to make new windows unless you explicitly ask for it. Previously every click of the Cura icon would spawn a new instance, you could not close all instances at once with a single button and the launcher was only there for you to click on with no actual functionality other than launching the application instances. 

![Screenshot from 2019-09-27 02-57-49](https://user-images.githubusercontent.com/26458780/65736360-9d666c00-e0d2-11e9-9170-d31a8979ca9b.png)
