### PR TITLE
Use printer type name instead of id

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
@@ -212,10 +212,7 @@ Cura.MachineAction
                         text:
                         {
                             if (base.selectedDevice) {
-                                // It would be great to use a more readable machine type here,
-                                // but the new discoveredPrintersModel is not used yet in the UM networking actions.
-                                // TODO: remove actions or replace 'connect via network' button with new flow?
-                                return base.selectedDevice.printerType
+                                return base.selectedDevice.printerTypeName
                             }
                             return ""
                         }

--- a/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
@@ -60,8 +60,12 @@ class UltimakerNetworkedPrinterOutputDevice(NetworkedPrinterOutputDevice):
         self._time_of_last_response = time()
         self._time_of_last_request = time()
 
-        # Set the display name from the properties
+        # Set the display name from the properties.
         self.setName(self.getProperty("name"))
+
+        # Set the display name of the printer type.
+        definitions = CuraApplication.getInstance().getContainerRegistry().findContainers(id = self.printerType)
+        self._printer_type_name = definitions[0].getName() if definitions else ""
 
         # Keeps track of all printers in the cluster.
         self._printers = []  # type: List[PrinterOutputModel]
@@ -86,6 +90,11 @@ class UltimakerNetworkedPrinterOutputDevice(NetworkedPrinterOutputDevice):
     @pyqtProperty(str, constant=True)
     def address(self) -> str:
         return self._address
+
+    ##  The display name of the printer.
+    @pyqtProperty(str, constant=True)
+    def printerTypeName(self) -> str:
+        return self._printer_type_name
 
     # Get all print jobs for this cluster.
     @pyqtProperty("QVariantList", notify=printJobsChanged)


### PR DESCRIPTION
This fixes an issue where the printer's type ID would be shown in the networking window instead of the display name (CS-298).

![image](https://user-images.githubusercontent.com/1134120/65795850-84f66000-e16b-11e9-84f6-2f7cf429bf2b.png)