### PR TITLE
Changed the JG Aurora z603s definition to send the print head to the …

### DIFF
--- a/resources/definitions/jgaurora_z_603s.def.json
+++ b/resources/definitions/jgaurora_z_603s.def.json
@@ -21,7 +21,7 @@
             "default_value": "; -- START GCODE --\nG21                     ;set units to millimetres\nG90                     ;set to absolute positioning\nM106 S0                 ;set fan speed to zero (turned off)\nG28                     ;home all axis\nM420 S1                 ;turn on mesh bed levelling if enabled in firmware\nG92 E0                  ;zero the extruded length\nG1 Z1 F1000             ;move up slightly\nG1 X60.0 Z0 E9.0 F1000.0;intro line\nG1 X100.0 E21.5 F1000.0 ;continue line\nG92 E0                  ;zero the extruded length again\n; -- end of START GCODE --"
         },
         "machine_end_gcode": {
-            "default_value": "; -- END GCODE --\nM104 S0                 ;turn off nozzle heater\nM140 S0                 ;turn off bed heater\nG91                     ;set to relative positioning\nG1 E-10 F300            ;retract the filament slightly\nG90                     ;set to absolute positioning\nG28 X0                  ;move to the X-axis origin (Home)\nG28 Y0            ;move to the Y-axis origin (Home) for easy print removal\nM84                     ;turn off stepper motors\n; -- end of END GCODE --"
+            "default_value": "; -- END GCODE --\nM104 S0                 ;turn off nozzle heater\nM140 S0                 ;turn off bed heater\nG91                     ;set to relative positioning\nG1 E-10 F300            ;retract the filament slightly\nG90                     ;set to absolute positioning\nG28 X0 Y0 F600                  ;move to the X/Y-axis origin (Home)\nM84                     ;turn off stepper motors\n; -- end of END GCODE --"
         },        
         "machine_width": {
             "default_value": 280

--- a/resources/definitions/jgaurora_z_603s.def.json
+++ b/resources/definitions/jgaurora_z_603s.def.json
@@ -21,7 +21,7 @@
             "default_value": "; -- START GCODE --\nG21                     ;set units to millimetres\nG90                     ;set to absolute positioning\nM106 S0                 ;set fan speed to zero (turned off)\nG28                     ;home all axis\nM420 S1                 ;turn on mesh bed levelling if enabled in firmware\nG92 E0                  ;zero the extruded length\nG1 Z1 F1000             ;move up slightly\nG1 X60.0 Z0 E9.0 F1000.0;intro line\nG1 X100.0 E21.5 F1000.0 ;continue line\nG92 E0                  ;zero the extruded length again\n; -- end of START GCODE --"
         },
         "machine_end_gcode": {
-            "default_value": "; -- END GCODE --\nM104 S0                 ;turn off nozzle heater\nM140 S0                 ;turn off bed heater\nG91                     ;set to relative positioning\nG1 E-10 F300            ;retract the filament slightly\nG90                     ;set to absolute positioning\nG28 X0                  ;move to the X-axis origin (Home)\nG0 Y280 F600            ;bring the bed to the front for easy print removal\nM84                     ;turn off stepper motors\n; -- end of END GCODE --"
+            "default_value": "; -- END GCODE --\nM104 S0                 ;turn off nozzle heater\nM140 S0                 ;turn off bed heater\nG91                     ;set to relative positioning\nG1 E-10 F300            ;retract the filament slightly\nG90                     ;set to absolute positioning\nG28 X0                  ;move to the X-axis origin (Home)\nG28 Y0            ;move to the Y-axis origin (Home) for easy print removal\nM84                     ;turn off stepper motors\n; -- end of END GCODE --"
         },        
         "machine_width": {
             "default_value": 280


### PR DESCRIPTION
…rear of the printer. The z603S is a COREXY style printer, unlike the other JG Aurora printers where moving the Y-axis shifts the bed to the front for easy print removal. On the z603s, it shoves the print head into the frame of the printer, the X-axis bar and the print head are then in the way, making it difficult to remove the print. The z603S should have the print head homed on X and Y axis to tuck it out of the way in the rear right of the printer at the end of a print.