### PR TITLE
Fix cloud connection auto fallback

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -124,11 +124,11 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
     def matchesNetworkKey(self, network_key: str) -> bool:
         # Typically, a network key looks like "ultimakersystem-aabbccdd0011._ultimaker._tcp.local."
         # the host name should then be "ultimakersystem-aabbccdd0011"
-        if network_key.startswith(str(self.clusterData.host_name)):
+        if network_key.startswith(str(self.clusterData.host_name or "")):
             return True
         # However, for manually added printers, the local IP address is used in lieu of a proper
         # network key, so check for that as well. It is in the format "manual:10.1.10.1".
-        if network_key.endswith(str(self.clusterData.host_internal_ip)):
+        if network_key.endswith(str(self.clusterData.host_internal_ip or "")):
             return True
         return False
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -124,11 +124,11 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
     def matchesNetworkKey(self, network_key: str) -> bool:
         # Typically, a network key looks like "ultimakersystem-aabbccdd0011._ultimaker._tcp.local."
         # the host name should then be "ultimakersystem-aabbccdd0011"
-        if network_key.startswith(self.clusterData.host_name):
+        if network_key.startswith(str(self.clusterData.host_name)):
             return True
         # However, for manually added printers, the local IP address is used in lieu of a proper
         # network key, so check for that as well. It is in the format "manual:10.1.10.1".
-        if network_key.endswith(self.clusterData.host_internal_ip):
+        if network_key.endswith(str(self.clusterData.host_internal_ip)):
             return True
         return False
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -127,8 +127,8 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         if network_key.startswith(self.clusterData.host_name):
             return True
         # However, for manually added printers, the local IP address is used in lieu of a proper
-        # network key, so check for that as well
-        if self.clusterData.host_internal_ip is not None and network_key in self.clusterData.host_internal_ip:
+        # network key, so check for that as well. It is in the format "manual:10.1.10.1".
+        if network_key.endswith(self.clusterData.host_internal_ip):
             return True
         return False
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -144,6 +144,9 @@ class CloudOutputDeviceManager:
         # Create a new machine and activate it.
         # We do not use use MachineManager.addMachine here because we need to set the cluster ID before activating it.
         new_machine = CuraStackBuilder.createMachine(device.name, device.printerType)
+        if not new_machine:
+            Logger.log("e", "Failed creating a new machine")
+            return
         new_machine.setMetaDataEntry(self.META_CLUSTER_ID, device.key)
         CuraApplication.getInstance().getMachineManager().setActiveMachine(new_machine.getId())
         self._connectToOutputDevice(device, new_machine)

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDeviceManager.py
@@ -208,6 +208,9 @@ class LocalClusterOutputDeviceManager:
         # We do not use use MachineManager.addMachine here because we need to set the network key before activating it.
         # If we do not do this the auto-pairing with the cloud-equivalent device will not work.
         new_machine = CuraStackBuilder.createMachine(device.name, device.printerType)
+        if not new_machine:
+            Logger.log("e", "Failed creating a new machine")
+            return
         new_machine.setMetaDataEntry(self.META_NETWORK_KEY, device.key)
         CuraApplication.getInstance().getMachineManager().setActiveMachine(new_machine.getId())
         self._connectToOutputDevice(device, new_machine)

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDeviceManager.py
@@ -9,6 +9,7 @@ from UM.Signal import Signal
 from UM.Version import Version
 
 from cura.CuraApplication import CuraApplication
+from cura.Settings.CuraStackBuilder import CuraStackBuilder
 from cura.Settings.GlobalStack import GlobalStack
 
 from .ZeroConfClient import ZeroConfClient
@@ -203,12 +204,13 @@ class LocalClusterOutputDeviceManager:
         if device is None:
             return
 
-        # The newly added machine is automatically activated.
-        CuraApplication.getInstance().getMachineManager().addMachine(device.printerType, device.name)
-        active_machine = CuraApplication.getInstance().getGlobalContainerStack()
-        if not active_machine:
-            return
-        self._connectToOutputDevice(device, active_machine)
+        # Create a new machine and activate it.
+        # We do not use use MachineManager.addMachine here because we need to set the network key before activating it.
+        # If we do not do this the auto-pairing with the cloud-equivalent device will not work.
+        new_machine = CuraStackBuilder.createMachine(device.name, device.printerType)
+        new_machine.setMetaDataEntry(self.META_NETWORK_KEY, device.key)
+        CuraApplication.getInstance().getMachineManager().setActiveMachine(new_machine.getId())
+        self._connectToOutputDevice(device, new_machine)
         self._showCloudFlowMessage(device)
 
     ## Add an address to the stored preferences.


### PR DESCRIPTION
Due to a race between setting some required metadata entries and actually switching to the stack containing them, sometimes the right data would not be there on time, and the auto-pairing to cloud discovered devices would not work.

Additionally there was an error in logic for auto pairing cloud devices for manually added local devices.