### PR TITLE
Reverse Y coordinates when importing AMF files so it isn't mirrored

### DIFF
--- a/plugins/AMFReader/AMFReader.py
+++ b/plugins/AMFReader/AMFReader.py
@@ -94,7 +94,7 @@ class AMFReader(MeshReader):
                                 if t.tag == "x":
                                     v[0] = float(t.text) * scale
                                 elif t.tag == "y":
-                                    v[2] = float(t.text) * scale
+                                    v[2] = - float(t.text) * scale
                                 elif t.tag == "z":
                                     v[1] = float(t.text) * scale
                             amf_mesh_vertices.append(v)


### PR DESCRIPTION
When an AMF file is imported, the Y axis is reversed, creating a mirrored object. 

Here are an AMF and a STL files exported from the same FreeCAD project and print screens showing the object being imported correctly as STL but having the Y axis reversed when the AMF is imported, and the AMF being imported correctly to Slic3r.

- [AMF mirror test.zip](https://github.com/Ultimaker/Cura/files/3705114/AMF.mirror.test.zip)

This change reverses the Y coordinates so the object is imported correctly. It's just a quick workaround to mask something that is likely not right in the AMFReader code.