### PR TITLE
None-check for material diameter.

### DIFF
--- a/cura/Machines/VariantNode.py
+++ b/cura/Machines/VariantNode.py
@@ -84,7 +84,7 @@ class VariantNode(ContainerNode):
                 return material_node
         # First fallback: Choose any material with matching diameter.
         for material_node in self.materials.values():
-            if approximate_diameter == int(material_node.getMetaDataEntry("approximate_diameter")):
+            if material_node.getMetaDataEntry("approximate_diameter") and approximate_diameter == int(material_node.getMetaDataEntry("approximate_diameter")):
                 return material_node
         fallback = next(iter(self.materials.values()))  # Should only happen with empty material node.
         Logger.log("w", "Could not find preferred material {preferred_material} with diameter {diameter} for variant {variant_id}, falling back to {fallback}.".format(


### PR DESCRIPTION
Fixes a crash for materials which don't have that metadata-entry,
such as an empty material (UM2)

CURA-6873