### PR TITLE
Overwrite prime_tower_position_* use value not default_value

### DIFF
--- a/resources/definitions/bibo2_dual.def.json
+++ b/resources/definitions/bibo2_dual.def.json
@@ -85,10 +85,10 @@
             "default_value": 2
         },
         "prime_tower_position_x": {
-            "default_value": 50
+            "value": "50"
         },
         "prime_tower_position_y": {
-            "default_value": 50
+            "value": "50"
         }
     }
 }


### PR DESCRIPTION
The default value here would not be used. Override must be `value` not `default_value` solves #6491 for BIBO but other printers may also be affected by #6491.