### PR TITLE
Return early from _checkStackForErrors() if top container is empty.

### DIFF
--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -107,7 +107,7 @@ class StartSliceJob(Job):
             return False
 
         # if there are no per-object settings we don't need to check the other settings here
-        if stack.getTop() == None or len(stack.getTop().getAllKeys()) == 0:
+        if stack.getTop() is None or not stack.getTop().getAllKeys():
             return False
 
         for key in stack.getAllKeys():

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -106,6 +106,10 @@ class StartSliceJob(Job):
         if stack is None:
             return False
 
+        # if there are no per-object settings we don't need to check the other settings here
+        if stack.getTop() == None or len(stack.getTop().getAllKeys()) == 0:
+            return False
+
         for key in stack.getAllKeys():
             validation_state = stack.getProperty(key, "validationState")
             if validation_state in (ValidatorState.Exception, ValidatorState.MaximumError, ValidatorState.MinimumError, ValidatorState.Invalid):


### PR DESCRIPTION
Checking the whole stack can be time consuming and we don't need to do it again if there are no per-object settings that could possibly cause errors.