### PR TITLE
CURA-6917_cannot_unlink_duplicated_materials

### DIFF
--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -339,7 +339,7 @@ class ContainerManager(QObject):
     #   \return A list of names of materials with the same GUID.
     @pyqtSlot("QVariant", bool, result = "QStringList")
     def getLinkedMaterials(self, material_node: "MaterialNode", exclude_self: bool = False) -> List[str]:
-        same_guid = ContainerRegistry.getInstance().findInstanceContainersMetadata(guid = material_node.guid)
+        same_guid = ContainerRegistry.getInstance().findInstanceContainersMetadata(GUID = material_node.guid)
         if exclude_self:
             return [metadata["name"] for metadata in same_guid if metadata["base_file"] != material_node.base_file]
         else:

--- a/resources/qml/Preferences/Materials/MaterialsView.qml
+++ b/resources/qml/Preferences/Materials/MaterialsView.qml
@@ -46,7 +46,7 @@ TabView
         {
             return ""
         }
-        return linkedMaterials.join(", ");
+        return linkedMaterials[0];
     }
 
     function getApproximateDiameter(diameter)


### PR DESCRIPTION
I'm not very knowledgeable about this area of the code. 
I'd say fixing the casing of the dict index is okay, 
but not sure why it worked originally (was the default for ignore_case changed?)

The getLinkedMaterials call returns 20+ materials after aforementioned fix. 
Not sure what amount to expect there. Depending on the answer it might 
be a good idea to only show the first result.