### PR TITLE
Cura 6917 unlink duplicated material

### DIFF
--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -341,9 +341,9 @@ class ContainerManager(QObject):
     def getLinkedMaterials(self, material_node: "MaterialNode", exclude_self: bool = False) -> List[str]:
         same_guid = ContainerRegistry.getInstance().findInstanceContainersMetadata(GUID = material_node.guid)
         if exclude_self:
-            return [metadata["name"] for metadata in same_guid if metadata["base_file"] != material_node.base_file]
+            return list({meta["name"] for meta in same_guid if meta["base_file"] != material_node.base_file})
         else:
-            return [metadata["name"] for metadata in same_guid]
+            return list({meta["name"] for meta in same_guid})
 
     ##  Unlink a material from all other materials by creating a new GUID
     #   \param material_id \type{str} the id of the material to create a new GUID for.

--- a/cura/Settings/ContainerManager.py
+++ b/cura/Settings/ContainerManager.py
@@ -339,7 +339,7 @@ class ContainerManager(QObject):
     #   \return A list of names of materials with the same GUID.
     @pyqtSlot("QVariant", bool, result = "QStringList")
     def getLinkedMaterials(self, material_node: "MaterialNode", exclude_self: bool = False) -> List[str]:
-        same_guid = ContainerRegistry.getInstance().findInstanceContainersMetadata(guid = material_node.guid)
+        same_guid = ContainerRegistry.getInstance().findInstanceContainersMetadata(GUID = material_node.guid)
         if exclude_self:
             return [metadata["name"] for metadata in same_guid if metadata["base_file"] != material_node.base_file]
         else:

--- a/resources/qml/Preferences/Materials/MaterialsView.qml
+++ b/resources/qml/Preferences/Materials/MaterialsView.qml
@@ -46,7 +46,7 @@ TabView
         {
             return ""
         }
-        return linkedMaterials[0];
+        return linkedMaterials;
     }
 
     function getApproximateDiameter(diameter)

--- a/resources/qml/Preferences/Materials/MaterialsView.qml
+++ b/resources/qml/Preferences/Materials/MaterialsView.qml
@@ -46,7 +46,7 @@ TabView
         {
             return ""
         }
-        return linkedMaterials.join(", ");
+        return linkedMaterials[0];
     }
 
     function getApproximateDiameter(diameter)


### PR DESCRIPTION
I'm not very knowledgeable about this area of the code.
I'd say fixing the casing of the dict index is okay,
but not sure why it worked originally (was the default for ignore_case changed?)

The getLinkedMaterials call returns 20+ materials after aforementioned fix.
Not sure what amount to expect there. Depending on the answer it might
be a good idea to only show the first result.

I re-made this PR because the base should be 4.4 branch