### PR TITLE
Added Ender 3 Prime Line to Start G-code

### DIFF
--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -26,9 +26,7 @@
                 [32, 34]
             ]
         },
-         "machine_start_gcode":
-        {
-            "default_value": "
+         "machine_start_gcode": { "default_value": "
             ; Ender 3 Custom Start G-code
             G92 E0 ; Reset Extruder
             G28 ; Home all axes

--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -26,6 +26,20 @@
                 [32, 34]
             ]
         },
+         "machine_start_gcode":
+        {
+            "default_value": "; Ender 3 Custom Start G-code
+            G92 E0 ; Reset Extruder
+            G28 ; Home all axes
+            G1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed
+            G1 X0.1 Y20 Z0.3 F5000.0 ; Move to start position
+            G1 X0.1 Y200.0 Z0.3 F1500.0 E15 ; Draw the first line
+            G1 X0.4 Y200.0 Z0.3 F5000.0 ; Move to side a little
+            G1 X0.4 Y20 Z0.3 F1500.0 E30 ; Draw the second line
+            G92 E0 ; Reset Extruder
+            G1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed
+            G1 X5 Y20 Z0.3 F5000.0 ; Move over to prevent blob squish"
+        },
 
         "gantry_height": { "value": 25 }
     }

--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -28,7 +28,8 @@
         },
          "machine_start_gcode":
         {
-            "default_value": "; Ender 3 Custom Start G-code
+            "default_value": "
+            ; Ender 3 Custom Start G-code
             G92 E0 ; Reset Extruder
             G28 ; Home all axes
             G1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed


### PR DESCRIPTION
Added the popular prime line for the Ender 3 as the default starting g-code and added a modification that works around the Cura 4.3.0 update that moves the print head to Z0 before starting the print, which moves the printhead down into the filament.