### PR TITLE
Fix skip (or late) pause at height.

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -219,7 +219,7 @@ class PauseAtHeight(Script):
 
                     current_height = current_z - layer_0_z
                     if current_height < pause_height:
-                        break  # Try the next layer.
+                        continue  # Scan the enitre layer, z-changes are not always on the same/first line.
 
                 # Pause at layer
                 else:


### PR DESCRIPTION
Previously, the line after the layer change would also contain the z height.
If not found, the could would break the per-line reading, and skip to the next layer.
However, if the code doesn't contain the Z on the first gcode line of the layer, this would cause it to skip past all layers, until there was a layer with the Z in the first line (so this also explains the 'late' pauses).
I just ignored the optimization and made it a continue.
I checked, and I don't think there's any way this causes the postproc.-gcode to be inserted twice, since it returns the complete data after insering it once.

CURA-6965

Tagging @DonExo ; Was looking at this as well.