### PR TITLE
CURA-6994/Prevent deleting comments from Start/End G-codes

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade41to42/VersionUpgrade41to42.py
+++ b/plugins/VersionUpgrade/VersionUpgrade41to42/VersionUpgrade41to42.py
@@ -239,7 +239,7 @@ class VersionUpgrade41to42(VersionUpgrade):
     #
     #   This renames the renamed settings in the containers.
     def upgradeInstanceContainer(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
-        parser = configparser.ConfigParser(interpolation = None)
+        parser = configparser.ConfigParser(interpolation = None, comment_prefixes=())
         parser.read_string(serialized)
 
         # Update version number.

--- a/plugins/VersionUpgrade/VersionUpgrade42to43/VersionUpgrade42to43.py
+++ b/plugins/VersionUpgrade/VersionUpgrade42to43/VersionUpgrade42to43.py
@@ -104,7 +104,7 @@ class VersionUpgrade42to43(VersionUpgrade):
     #
     #   This renames the renamed settings in the containers.
     def upgradeInstanceContainer(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
-        parser = configparser.ConfigParser(interpolation = None)
+        parser = configparser.ConfigParser(interpolation = None, comment_prefixes=())
         parser.read_string(serialized)
 
         # Update version number.

--- a/plugins/VersionUpgrade/VersionUpgrade43to44/VersionUpgrade43to44.py
+++ b/plugins/VersionUpgrade/VersionUpgrade43to44/VersionUpgrade43to44.py
@@ -52,7 +52,7 @@ class VersionUpgrade43to44(VersionUpgrade):
     #
     #   This renames the renamed settings in the containers.
     def upgradeInstanceContainer(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
-        parser = configparser.ConfigParser(interpolation = None)
+        parser = configparser.ConfigParser(interpolation = None, comment_prefixes=())
         parser.read_string(serialized)
 
         # Update version number.


### PR DESCRIPTION
Prevent deleting comments from Start/End G-codes by changing the `comment_prefixes` in ConfigParser" -m "CURA/6994".

Note: We should add this in every future VersionUpgrade.

Fixes #6689 