### PR TITLE
Add UI support for Truncated Octahedron infill

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1722,7 +1722,7 @@
                         "cross": "Cross",
                         "cross_3d": "Cross 3D",
                         "gyroid": "Gyroid",
-                        "truncated_octahedron": "Truncated Octahedron",
+                        "truncated_octahedron": "Truncated Octahedron"
                     },
                     "default_value": "grid",
                     "enabled": "infill_sparse_density > 0",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1721,7 +1721,8 @@
                         "zigzag": "Zig Zag",
                         "cross": "Cross",
                         "cross_3d": "Cross 3D",
-                        "gyroid": "Gyroid"
+                        "gyroid": "Gyroid",
+                        "truncated_octahedron": "Truncated Octahedron",
                     },
                     "default_value": "grid",
                     "enabled": "infill_sparse_density > 0",

--- a/resources/i18n/fdmprinter.def.json.pot
+++ b/resources/i18n/fdmprinter.def.json.pot
@@ -1792,7 +1792,8 @@ msgid ""
 "triangle, tri-hexagon, cubic, octet, quarter cubic, cross and concentric "
 "patterns are fully printed every layer. Gyroid, cubic, quarter cubic and "
 "octet infill change with every layer to provide a more equal distribution of "
-"strength over each direction."
+"strength over each direction. Truncated octahedron infill generates a fast"
+"constructed honeycomb structure out of squares and hexagons."
 msgstr ""
 
 #: fdmprinter.def.json
@@ -1858,6 +1859,11 @@ msgstr ""
 #: fdmprinter.def.json
 msgctxt "infill_pattern option gyroid"
 msgid "Gyroid"
+msgstr ""
+
+#: fdmprinter.def.json
+msgctxt "infill_pattern option truncated_octahedron"
+msgid "Truncated Octahedron"
 msgstr ""
 
 #: fdmprinter.def.json

--- a/resources/i18n/fdmprinter.def.json.pot
+++ b/resources/i18n/fdmprinter.def.json.pot
@@ -1792,7 +1792,7 @@ msgid ""
 "triangle, tri-hexagon, cubic, octet, quarter cubic, cross and concentric "
 "patterns are fully printed every layer. Gyroid, cubic, quarter cubic and "
 "octet infill change with every layer to provide a more equal distribution of "
-"strength over each direction. Truncated octahedron infill generates a fast"
+"strength over each direction. Truncated octahedron infill generates a fast "
 "constructed honeycomb structure out of squares and hexagons."
 msgstr ""
 


### PR DESCRIPTION
This PR is the other half of the support for the Truncated Octahedron Infill, https://github.com/Ultimaker/CuraEngine/pull/1167 has the CuraEngine side.

With both PRs applied, I took a screenshot of a model with the new infill type selected:
https://spot.fedorapeople.org/truncated-octahedron-infill-example.png