### PR TITLE
Fix PPA crashing on single-extruder printers

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -894,8 +894,8 @@ class MachineManager(QObject):
 
     @pyqtSlot(int, bool)
     def setExtruderEnabled(self, position: int, enabled: bool) -> None:
-        if self._global_container_stack is None:
-            Logger.log("w", "Could not find extruder on position %s", position)
+        if self._global_container_stack is None or position not in self._global_container_stack.extruders:
+            Logger.log("w", "Could not find extruder on position %s.", position)
             return
         extruder = self._global_container_stack.extruderList[position]
 

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -894,7 +894,7 @@ class MachineManager(QObject):
 
     @pyqtSlot(int, bool)
     def setExtruderEnabled(self, position: int, enabled: bool) -> None:
-        if self._global_container_stack is None or position not in self._global_container_stack.extruders:
+        if self._global_container_stack is None or str(position) not in self._global_container_stack.extruders:
             Logger.log("w", "Could not find extruder on position %s.", position)
             return
         extruder = self._global_container_stack.extruderList[position]


### PR DESCRIPTION
The machine manager was leading to a crash when trying to enable
the second extruder in single-extrusion printers, because the check
for the second extruder was not correctly implemented. This commit
fixes that issue by checking if the global stack has the specified
extruder. If it does not, then the function returns while logging the
issue.

CURA-7048