### PR TITLE
CURA-7041_add_misp_material_settings

### DIFF
--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -1106,7 +1106,7 @@ class XmlMaterialProfile(InstanceContainer):
         "break position": "material_break_retracted_position",
         "flush purge speed": "material_flush_purge_speed",
         "flush purge length": "material_flush_purge_length",
-        "end of filament purge speed": "material_end_of_material_purge_speed",
+        "end of filament purge speed": "material_end_of_filament_purge_speed",
         "end of filament purge length": "material_end_of_filament_purge_length",
         "maximum park duration": "material_maximum_park_duration",
         "no load move factor": "material_no_load_move_factor",

--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -1104,6 +1104,12 @@ class XmlMaterialProfile(InstanceContainer):
         "break preparation speed": "material_break_preparation_speed",
         "break preparation temperature": "material_break_preparation_temperature",
         "break position": "material_break_retracted_position",
+        "flush purge speed": "material_flush_purge_speed",
+        "flush purge length": "material_flush_purge_length",
+        "end of filament purge speed": "material_end_of_material_purge_speed",
+        "end of filament purge length": "material_end_of_filament_purge_length",
+        "maximum park duration": "material_maximum_park_duration",
+        "no load move factor": "material_no_load_move_factor",
         "break speed": "material_break_speed",
         "break temperature": "material_break_temperature"
     }  # type: Dict[str, str]

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2408,6 +2408,54 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
+                "material_flush_purge_speed":
+                {
+                    "label": "Flush Purge Speed",
+                    "description": "Material Station internal value",
+                    "type": "float",
+                    "default_value": 0.5,
+                    "enabled": false
+                },
+                "material_flush_purge_length":
+                {
+                    "label": "Flush Purge Length",
+                    "description": "Material Station internal value",
+                    "type": "float",
+                    "default_value": 60,
+                    "enabled": false
+                },
+                "material_end_of_filament_purge_speed":
+                {
+                    "label": "End Of Filament Purge Speed",
+                    "description": "Material Station internal value",
+                    "type": "float",
+                    "default_value": 0.5,
+                    "enabled": false
+                },
+                "material_end_of_filament_purge_length":
+                {
+                    "label": "End Of Filament Purge Length",
+                    "description": "Material Station internal value",
+                    "type": "float",
+                    "default_value": 20,
+                    "enabled": false
+                },
+                "material_maximum_park_duration":
+                {
+                    "label": "Maximum Park Duration",
+                    "description": "Material Station internal value",
+                    "type": "float",
+                    "default_value": 300,
+                    "enabled": false
+                },
+                "material_no_load_move_factor":
+                {
+                    "label": "No Load Move Factor",
+                    "description": "Material Station internal value",
+                    "type": "float",
+                    "default_value": 0.940860215,
+                    "enabled": false
+                },
                 "material_flow":
                 {
                     "label": "Flow",


### PR DESCRIPTION
These settings are currently unused by cura, but passed into the PPA
output. Some considerations:
- material_ prepended to all. Even though they are not all
  material specific. The consistency is more developer-friendly imho
- defaults taken from generic_pla
- type is float for all, consistent with what I found in this file

CURA-7041