### PR TITLE
BIBO printer definition fix

### DIFF
--- a/resources/definitions/bibo2_dual.def.json
+++ b/resources/definitions/bibo2_dual.def.json
@@ -72,7 +72,7 @@
             "default_value": "RepRap (Marlin/Sprinter)"
         },
         "machine_start_gcode": {
-            "default_value": "G21        ;metric values\nG90        ;absolute positioning\nM107       ;start with the fan off\nG28 X0 Y0  ;move X/Y to min endstops\nG28 Z0     ;move Z to min endstops\nG1 Z2.0 F400 ;move the platform down 15mm\nT0\nG92 E0\nG28\nG1 Y0 F1200 E0\nG92 E0\nM117 BIBO Printing..."
+            "default_value": "G21        ;metric values\nG90        ;absolute positioning\nM107       ;start with the fan off\nG28 X0 Y0  ;move X/Y to min endstops\nG28 Z0     ;move Z to min endstops\nG1 Z2.0 F400 ;move the platform down 15mm\nG92 E0\nG28\nG1 Y0 F1200 E0\nG92 E0\nM117 BIBO Printing..."
         },
         "machine_end_gcode": {
             "default_value": ";End GCode\nM104 T0 S0                     ;extruder heater off\nM104 T1 S0                     ;extruder heater off\nM140 S0                     ;heated bed heater off (if you have it)\nG91\nG1 Z1 F100                                        ;relative positioning\nG1 E-1 F300                            ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-2 X-20 Y-20 F300 ;move Z up a bit and retract filament even more\nG28 X0 Y0                              ;move X/Y to min endstops, so the head is out of the way\nM84                         ;steppers off\nG90                         ;absolute positioning"


### PR DESCRIPTION
T0 gcode removed from "machine_start_gcode" since it causes issue when active extruder is set to 1 (left one). Printer attempts to extrude filament from an unheated nozzle 2 (right one).