### PR TITLE
CURA-6959_collapse_categories

### DIFF
--- a/plugins/PerObjectSettingsTool/PerObjectCategory.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectCategory.qml
@@ -58,5 +58,5 @@ Button {
     checkable: true
     checked: definition.expanded
 
-    onClicked: definition.expanded ? settingDefinitionsModel.collapse(definition.key) : settingDefinitionsModel.expandRecursive(definition.key)
+    onClicked: definition.expanded ? settingDefinitionsModel.collapseRecursive(definition.key) : settingDefinitionsModel.expandRecursive(definition.key)
 }

--- a/resources/qml/Menus/SettingVisibilityPresetsMenu.qml
+++ b/resources/qml/Menus/SettingVisibilityPresetsMenu.qml
@@ -15,6 +15,7 @@ Menu
     property QtObject settingVisibilityPresetsModel: CuraApplication.getSettingVisibilityPresetsModel()
 
     signal showAllSettings()
+    signal collapseAllCategories()
 
     Instantiator
     {
@@ -45,6 +46,15 @@ Menu
         onTriggered:
         {
             showAllSettings();
+        }
+    }
+    MenuSeparator {}
+    MenuItem
+    {
+        text: catalog.i18nc("@action:inmenu", "Collapse All Categories")
+        onTriggered:
+        {
+            collapseAllCategories();
         }
     }
     MenuSeparator {}

--- a/resources/qml/Settings/SettingCategory.qml
+++ b/resources/qml/Settings/SettingCategory.qml
@@ -30,11 +30,11 @@ Button
             {
                 return UM.Theme.getColor("setting_category_disabled")
             }
-            else if (base.hovered && base.checkable && base.checked)
+            else if (base.hovered && base.expanded)
             {
                 return UM.Theme.getColor("setting_category_active_hover")
             }
-            else if (base.pressed || (base.checkable && base.checked))
+            else if (base.pressed || (base.expanded))
             {
                 return UM.Theme.getColor("setting_category_active")
             }
@@ -55,6 +55,7 @@ Button
     signal setActiveFocusToNextSetting(bool forward)
 
     property var focusItem: base
+    property bool expanded: definition.expanded
 
     contentItem: Item
     {
@@ -79,10 +80,10 @@ Button
                 if (!base.enabled)
                 {
                     return UM.Theme.getColor("setting_category_disabled_text")
-                } else if ((base.hovered || base.activeFocus) && base.checkable && base.checked)
+                } else if ((base.hovered || base.activeFocus) && base.expanded)
                 {
                     return UM.Theme.getColor("setting_category_active_hover_text")
-                } else if (base.pressed || (base.checkable && base.checked))
+                } else if (base.pressed || base.expanded)
                 {
                     return UM.Theme.getColor("setting_category_active_text")
                 } else if (base.hovered || base.activeFocus)
@@ -123,11 +124,11 @@ Button
             {
                 return UM.Theme.getColor("setting_category_disabled_text")
             }
-            else if((base.hovered || base.activeFocus) && base.checkable && base.checked)
+            else if((base.hovered || base.activeFocus) && base.expanded)
             {
                 return UM.Theme.getColor("setting_category_active_hover_text")
             }
-            else if(base.pressed || (base.checkable && base.checked))
+            else if(base.pressed || base.expanded)
             {
                 return UM.Theme.getColor("setting_category_active_text")
             }
@@ -143,9 +144,6 @@ Button
         sourceSize.width: width + 15 * screenScaleFactor
         sourceSize.height: width + 15 * screenScaleFactor
     }
-
-    checkable: true
-    checked: definition.expanded
 
     onClicked:
     {
@@ -226,7 +224,6 @@ Button
         onClicked:
         {
             settingDefinitionsModel.expandRecursive(definition.key)
-            base.checked = true //todo should not be necessary and also breaks binding, right?
             base.showAllHiddenInheritedSettings(definition.key)
         }
 

--- a/resources/qml/Settings/SettingCategory.qml
+++ b/resources/qml/Settings/SettingCategory.qml
@@ -34,7 +34,7 @@ Button
             {
                 return UM.Theme.getColor("setting_category_active_hover")
             }
-            else if (base.pressed || (base.expanded))
+            else if (base.pressed || base.expanded)
             {
                 return UM.Theme.getColor("setting_category_active")
             }

--- a/resources/qml/Settings/SettingCategory.qml
+++ b/resources/qml/Settings/SettingCategory.qml
@@ -107,7 +107,7 @@ Button
             height: UM.Theme.getSize("standard_arrow").height
             sourceSize.height: width
             color: UM.Theme.getColor("setting_control_button")
-            source: base.checked ? UM.Theme.getIcon("arrow_bottom") : UM.Theme.getIcon("arrow_left")
+            source: definition.expanded ? UM.Theme.getIcon("arrow_bottom") : UM.Theme.getIcon("arrow_left")
         }
     }
 
@@ -226,7 +226,7 @@ Button
         onClicked:
         {
             settingDefinitionsModel.expandRecursive(definition.key)
-            base.checked = true
+            base.checked = true //todo should not be necessary and also breaks binding, right?
             base.showAllHiddenInheritedSettings(definition.key)
         }
 

--- a/resources/qml/Settings/SettingCategory.qml
+++ b/resources/qml/Settings/SettingCategory.qml
@@ -151,7 +151,7 @@ Button
     {
         if (definition.expanded)
         {
-            settingDefinitionsModel.collapse(definition.key)
+            settingDefinitionsModel.collapseRecursive(definition.key)
         }
         else
         {

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -195,8 +195,10 @@ Item
 
             onCollapseAllCategories:
             {
+                settingsSearchTimer.stop()
+                filter.text = "" // clear search field
+                filter.editingFinished()
                 definitionsModel.collapseAllCategories()
-                filter.updateDefinitionModel()
             }
         }
     }

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -192,6 +192,12 @@ Item
                 definitionsModel.setAllVisible(true)
                 filter.updateDefinitionModel()
             }
+
+            onCollapseAllCategories:
+            {
+                definitionsModel.collapseAllCategories()
+                filter.updateDefinitionModel()
+            }
         }
     }
 


### PR DESCRIPTION
Adds a menu item in the Custom Print Settings list to collapse all categories

Does not work when a search is active. See Accompanying Uranium PR.