### PR TITLE
SentrySDK: Turn on deep integration on demand

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -12,7 +12,11 @@ from UM.Platform import Platform
 from cura import ApplicationMetadata
 from cura.ApplicationMetadata import CuraAppName
 
-import sentry_sdk
+try:
+    import sentry_sdk
+    with_sentry_sdk = True
+except ImportError:
+    with_sentry_sdk = False
 
 parser = argparse.ArgumentParser(prog = "cura",
                                  add_help = False)
@@ -24,21 +28,22 @@ parser.add_argument("--debug",
 
 known_args = vars(parser.parse_known_args()[0])
 
-sentry_env = "production"
-if ApplicationMetadata.CuraVersion == "master":
-    sentry_env = "development"
-try:
-    if ApplicationMetadata.CuraVersion.split(".")[2] == "99":
-        sentry_env = "nightly"
-except IndexError:
-    pass
-
-sentry_sdk.init("https://5034bf0054fb4b889f82896326e79b13@sentry.io/1821564",
-                environment = sentry_env,
-                release = "cura%s" % ApplicationMetadata.CuraVersion,
-                default_integrations = False,
-                max_breadcrumbs = 300,
-                server_name = "cura")
+if with_sentry_sdk:
+    sentry_env = "production"
+    if ApplicationMetadata.CuraVersion == "master":
+        sentry_env = "development"
+    try:
+        if ApplicationMetadata.CuraVersion.split(".")[2] == "99":
+            sentry_env = "nightly"
+    except IndexError:
+        pass
+    
+    sentry_sdk.init("https://5034bf0054fb4b889f82896326e79b13@sentry.io/1821564",
+                    environment = sentry_env,
+                    release = "cura%s" % ApplicationMetadata.CuraVersion,
+                    default_integrations = False,
+                    max_breadcrumbs = 300,
+                    server_name = "cura")
 
 if not known_args["debug"]:
     def get_cura_dir_path():


### PR DESCRIPTION
Only whenever the sentry_sdk module is there functions of this module will be used.
The only changes, which were needed to be made, are done on cura_app.py and cura.CrashHandler.
Whenever the module is not available, it's functions will be omitted.

The if-clauses could happen earlier, but this at least the bare minimum, and, to be honest, on Ultimaker's distribution it won't speed up anything.
I expect the if-clause to take the same amount of runtime sooner or later. The check is the same and it should be on Ultimaker's distribution always be "True".

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)