### PR TITLE
Update DisplayFilenameAndLayerOnLCD.py

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/DisplayFilenameAndLayerOnLCD.py
+++ b/plugins/PostProcessingPlugin/scripts/DisplayFilenameAndLayerOnLCD.py
@@ -72,7 +72,7 @@ class DisplayFilenameAndLayerOnLCD(Script):
             lcd_text = "M117 Printing " + name + " - Layer "
         i = self.getSettingValueByKey("startNum")
         for layer in data:
-            display_text = lcd_text + str(i) + " " + name
+            display_text = lcd_text + str(i)
             layer_index = data.index(layer)
             lines = layer.split("\n")
             for line in lines:
@@ -82,8 +82,13 @@ class DisplayFilenameAndLayerOnLCD(Script):
                 if line.startswith(";LAYER:"):
                     if self.getSettingValueByKey("maxlayer"):
                         display_text = display_text + " of " + max_layer
+                        if not self.getSettingValueByKey("scroll"):
+                            display_text = display_text + " " + name
                     else:
-                        display_text = display_text + "!"
+                        if not self.getSettingValueByKey("scroll"):
+                            display_text = display_text + " " + name + "!"
+                        else:
+                            display_text = display_text + "!"
                     line_index = lines.index(line)
                     lines.insert(line_index + 1, display_text)
                     i += 1


### PR DESCRIPTION
Fixed issues with the filename appearing in the wrong spots:

When scrolling was disabled and max layers was displayed, the file name appeared in the middle ("Layer X [filename] of Y"). This has been corrected to display the filename at the end.

When scrolling was enabled, the filename appeared twice. The extra text has now been removed.