### PR TITLE
CURA-7038/Remove the label(s) from the compatibility dialog if there are no pac…

### DIFF
--- a/plugins/Toolbox/resources/qml/dialogs/CompatibilityDialog.qml
+++ b/plugins/Toolbox/resources/qml/dialogs/CompatibilityDialog.qml
@@ -48,6 +48,7 @@ UM.Dialog{
                 {
                     font: UM.Theme.getFont("default")
                     text: catalog.i18nc("@label", "The following packages will be added:")
+                    visible: toolbox.has_compatible_packages
                     color: UM.Theme.getColor("text")
                     height: contentHeight + UM.Theme.getSize("default_margin").height
                 }
@@ -59,8 +60,8 @@ UM.Dialog{
                         Item
                         {
                             width: parent.width
-                            property var lineHeight: 60
-                            visible: model.is_compatible == "True" ? true : false
+                            property int lineHeight: 60
+                            visible: model.is_compatible === "True" ? true : false
                             height: visible ? (lineHeight + UM.Theme.getSize("default_margin").height) : 0 // We only show the compatible packages here
                             Image
                             {
@@ -90,6 +91,7 @@ UM.Dialog{
                 {
                     font: UM.Theme.getFont("default")
                     text: catalog.i18nc("@label", "The following packages can not be installed because of incompatible Cura version:")
+                    visible: toolbox.has_incompatible_packages
                     color: UM.Theme.getColor("text")
                     height: contentHeight + UM.Theme.getSize("default_margin").height
                 }
@@ -101,8 +103,8 @@ UM.Dialog{
                         Item
                         {
                             width: parent.width
-                            property var lineHeight: 60
-                            visible: model.is_compatible == "True" ? false : true
+                            property int lineHeight: 60
+                            visible: model.is_compatible === "True" ? false : true
                             height: visible ? (lineHeight + UM.Theme.getSize("default_margin").height) : 0 // We only show the incompatible packages here
                             Image
                             {

--- a/plugins/Toolbox/resources/qml/dialogs/CompatibilityDialog.qml
+++ b/plugins/Toolbox/resources/qml/dialogs/CompatibilityDialog.qml
@@ -61,7 +61,7 @@ UM.Dialog{
                         {
                             width: parent.width
                             property int lineHeight: 60
-                            visible: model.is_compatible === "True" ? true : false
+                            visible: model.is_compatible
                             height: visible ? (lineHeight + UM.Theme.getSize("default_margin").height) : 0 // We only show the compatible packages here
                             Image
                             {
@@ -104,7 +104,7 @@ UM.Dialog{
                         {
                             width: parent.width
                             property int lineHeight: 60
-                            visible: model.is_compatible === "True" ? false : true
+                            visible: !model.is_compatible
                             height: visible ? (lineHeight + UM.Theme.getSize("default_margin").height) : 0 // We only show the incompatible packages here
                             Image
                             {

--- a/plugins/Toolbox/src/SubscribedPackagesModel.py
+++ b/plugins/Toolbox/src/SubscribedPackagesModel.py
@@ -35,9 +35,9 @@ class SubscribedPackagesModel(ListModel):
                 continue
             package = {"name": item["display_name"], "sdk_versions": item["sdk_versions"]}
             if self._sdk_version not in item["sdk_versions"]:
-                package.update({"is_compatible": "False"})
+                package.update({"is_compatible": False})
             else:
-                package.update({"is_compatible": "True"})
+                package.update({"is_compatible": True})
             try:
                 package.update({"icon_url": item["icon_url"]})
             except KeyError:  # There is no 'icon_url" in the response payload for this package
@@ -50,13 +50,13 @@ class SubscribedPackagesModel(ListModel):
     def has_compatible_packages(self):
         has_compatible_items  = False
         for item in self._items:
-            if item['is_compatible'] == 'True':
+            if item['is_compatible'] == True:
                 has_compatible_items = True
         return has_compatible_items
 
     def has_incompatible_packages(self):
         has_incompatible_items  = False
         for item in self._items:
-            if item['is_compatible'] == 'False':
+            if item['is_compatible'] == False:
                 has_incompatible_items = True
         return has_incompatible_items

--- a/plugins/Toolbox/src/SubscribedPackagesModel.py
+++ b/plugins/Toolbox/src/SubscribedPackagesModel.py
@@ -45,7 +45,6 @@ class SubscribedPackagesModel(ListModel):
 
             self._items.append(package)
         self.setItems(self._items)
-        print(self._items)
 
     def has_compatible_packages(self):
         has_compatible_items  = False

--- a/plugins/Toolbox/src/SubscribedPackagesModel.py
+++ b/plugins/Toolbox/src/SubscribedPackagesModel.py
@@ -10,6 +10,7 @@ class SubscribedPackagesModel(ListModel):
     def __init__(self, parent = None):
         super().__init__(parent)
 
+        self._items = []
         self._metadata = None
         self._discrepancies = None
         self._sdk_version = ApplicationMetadata.CuraSDKVersion
@@ -27,7 +28,7 @@ class SubscribedPackagesModel(ListModel):
             self._discrepancies = discrepancy
 
     def update(self):
-        items = []
+        self._items.clear()
 
         for item in self._metadata:
             if item["package_id"] not in self._discrepancies:
@@ -42,5 +43,20 @@ class SubscribedPackagesModel(ListModel):
             except KeyError:  # There is no 'icon_url" in the response payload for this package
                 package.update({"icon_url": ""})
 
-            items.append(package)
-        self.setItems(items)
+            self._items.append(package)
+        self.setItems(self._items)
+        print(self._items)
+
+    def has_compatible_packages(self):
+        has_compatible_items  = False
+        for item in self._items:
+            if item['is_compatible'] == 'True':
+                has_compatible_items = True
+        return has_compatible_items
+
+    def has_incompatible_packages(self):
+        has_incompatible_items  = False
+        for item in self._items:
+            if item['is_compatible'] == 'False':
+                has_incompatible_items = True
+        return has_incompatible_items

--- a/plugins/Toolbox/src/SubscribedPackagesModel.py
+++ b/plugins/Toolbox/src/SubscribedPackagesModel.py
@@ -46,14 +46,14 @@ class SubscribedPackagesModel(ListModel):
             self._items.append(package)
         self.setItems(self._items)
 
-    def has_compatible_packages(self):
+    def hasCompatiblePackages(self):
         has_compatible_items  = False
         for item in self._items:
             if item['is_compatible'] == True:
                 has_compatible_items = True
         return has_compatible_items
 
-    def has_incompatible_packages(self):
+    def hasIncompatiblePackages(self):
         has_incompatible_items  = False
         for item in self._items:
             if item['is_compatible'] == False:

--- a/plugins/Toolbox/src/Toolbox.py
+++ b/plugins/Toolbox/src/Toolbox.py
@@ -794,11 +794,11 @@ class Toolbox(QObject, Extension):
 
     @pyqtProperty(bool, constant=True)
     def has_compatible_packages(self) -> str:
-        return self._models["subscribed_packages"].has_compatible_packages()
+        return self._models["subscribed_packages"].hasCompatiblePackages()
 
     @pyqtProperty(bool, constant=True)
     def has_incompatible_packages(self) -> str:
-        return self._models["subscribed_packages"].has_incompatible_packages()
+        return self._models["subscribed_packages"].hasIncompatiblePackages()
 
     @pyqtProperty(QObject, constant = True)
     def packagesModel(self) -> PackagesModel:

--- a/plugins/Toolbox/src/Toolbox.py
+++ b/plugins/Toolbox/src/Toolbox.py
@@ -792,6 +792,14 @@ class Toolbox(QObject, Extension):
     def subscribedPackagesModel(self) -> SubscribedPackagesModel:
         return cast(SubscribedPackagesModel, self._models["subscribed_packages"])
 
+    @pyqtProperty(bool, constant=True)
+    def has_compatible_packages(self) -> str:
+        return self._models["subscribed_packages"].has_compatible_packages()
+
+    @pyqtProperty(bool, constant=True)
+    def has_incompatible_packages(self) -> str:
+        return self._models["subscribed_packages"].has_incompatible_packages()
+
     @pyqtProperty(QObject, constant = True)
     def packagesModel(self) -> PackagesModel:
         return cast(PackagesModel, self._models["packages"])


### PR DESCRIPTION
_Addition to #6845 , but since it got merged and its branch deleted - thought it'll be wiser to create a new branch for this addition._

Added checks in place, if there are no (in)compatible packages to be shown in the compatibility Dialog - the label won't be shown at all, as suggested by @evtrados in CURA-7038.