### PR TITLE
CURA-6577/Implementation of logic for syncing packages from Cura MP to Cloud MP

### DIFF
--- a/plugins/Toolbox/resources/qml/dialogs/ToolboxLicenseDialog.qml
+++ b/plugins/Toolbox/resources/qml/dialogs/ToolboxLicenseDialog.qml
@@ -57,6 +57,7 @@ UM.Dialog
             {
                 licenseDialog.close();
                 toolbox.install(licenseDialog.pluginFileLocation);
+                toolbox.subscribe(licenseDialog.pluginName);
             }
         },
         Button

--- a/plugins/Toolbox/src/Toolbox.py
+++ b/plugins/Toolbox/src/Toolbox.py
@@ -164,6 +164,14 @@ class Toolbox(QObject, Extension):
 
         self._application.getHttpRequestManager().put(url, headers_dict = self._request_headers,
                                                       data = data.encode())
+    @pyqtSlot(str)
+    def subscribe(self, package_id: str) -> None:
+        if self._application.getCuraAPI().account.isLoggedIn:
+            data = "{\"data\": {\"package_id\": \"%s\", \"sdk_version\": \"%s\"}}" % (package_id, self._sdk_version)
+            self._application.getHttpRequestManager().put(url=self._api_url_user_packages,
+                                                          headers_dict=self._request_headers,
+                                                          data=data.encode()
+                                                          )
 
     @pyqtSlot(result = str)
     def getLicenseDialogPluginName(self) -> str:
@@ -733,6 +741,7 @@ class Toolbox(QObject, Extension):
             return
 
         self.install(file_path)
+        self.subscribe(package_info["package_id"])
 
     # Getter & Setters for Properties:
     # --------------------------------------------------------------------------


### PR DESCRIPTION
Implemented the logic for syncing packages from Cura MP to Cloud MP when a user installs a package.

Re-based version of #6924 with latest HttpRequestManager.