### PR TITLE
Fix typing in __init__ methods to appease MYPY

### DIFF
--- a/cura/CuraPackageManager.py
+++ b/cura/CuraPackageManager.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class CuraPackageManager(PackageManager):
-    def __init__(self, application: "QtApplication", parent: Optional["QObject"] = None):
+    def __init__(self, application: "QtApplication", parent: Optional["QObject"] = None) -> None:
         super().__init__(application, parent)
 
     def initialize(self) -> None:

--- a/cura/OneAtATimeIterator.py
+++ b/cura/OneAtATimeIterator.py
@@ -122,6 +122,6 @@ class _ObjectOrder:
     #   \param order List of indices in which to print objects, ordered by printing
     #   order.
     #   \param todo: List of indices which are not yet inserted into the order list.
-    def __init__(self, order: List[SceneNode], todo: List[SceneNode]):
+    def __init__(self, order: List[SceneNode], todo: List[SceneNode]) -> None:
         self.order = order
         self.todo = todo

--- a/cura/Operations/PlatformPhysicsOperation.py
+++ b/cura/Operations/PlatformPhysicsOperation.py
@@ -8,7 +8,7 @@ from UM.Scene.SceneNode import SceneNode
 
 ##  A specialised operation designed specifically to modify the previous operation.
 class PlatformPhysicsOperation(Operation):
-    def __init__(self, node: SceneNode, translation: Vector):
+    def __init__(self, node: SceneNode, translation: Vector) -> None:
         super().__init__()
         self._node = node
         self._old_transformation = node.getLocalTransformation()

--- a/cura/Operations/SetParentOperation.py
+++ b/cura/Operations/SetParentOperation.py
@@ -14,7 +14,7 @@ class SetParentOperation(Operation.Operation):
     #
     #   \param node The node which will be reparented.
     #   \param parent_node The node which will be the parent.
-    def __init__(self, node: SceneNode, parent_node: Optional[SceneNode]):
+    def __init__(self, node: SceneNode, parent_node: Optional[SceneNode]) -> None:
         super().__init__()
         self._node = node
         self._parent = parent_node

--- a/plugins/PostProcessingPlugin/scripts/Stretch.py
+++ b/plugins/PostProcessingPlugin/scripts/Stretch.py
@@ -35,7 +35,7 @@ class GCodeStep():
     Class to store the current value of each G_Code parameter
     for any G-Code step
     """
-    def __init__(self, step, in_relative_movement: bool = False):
+    def __init__(self, step, in_relative_movement: bool = False) -> None:
         self.step = step
         self.step_x = 0
         self.step_y = 0

--- a/plugins/SimulationView/SimulationViewProxy.py
+++ b/plugins/SimulationView/SimulationViewProxy.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class SimulationViewProxy(QObject):
-    def __init__(self, simulation_view: "SimulationView", parent=None):
+    def __init__(self, simulation_view: "SimulationView", parent=None) -> None:
         super().__init__(parent)
         self._simulation_view = simulation_view
         self._current_layer = 0

--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterMaterialStationSlot.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrinterMaterialStationSlot.py
@@ -14,7 +14,7 @@ class ClusterPrinterMaterialStationSlot(ClusterPrintCoreConfiguration):
     #  \param material_remaining: How much material is remaining on the spool (between 0 and 1, or -1 for missing data).
     #  \param material_empty: Whether the material spool is too empty to be used.
     def __init__(self, slot_index: int, compatible: bool, material_remaining: float,
-                 material_empty: Optional[bool] = False, **kwargs):
+                 material_empty: Optional[bool] = False, **kwargs) -> None:
         self.slot_index = slot_index
         self.compatible = compatible
         self.material_remaining = material_remaining


### PR DESCRIPTION
This PR adds a number of typing fixes in __init__ statements, because MYPY is complaining about them.