### PR TITLE
Renkforce printers: Use defaults for retraction hop

### DIFF
--- a/resources/definitions/renkforce_rf100.def.json
+++ b/resources/definitions/renkforce_rf100.def.json
@@ -158,9 +158,6 @@
         "retraction_enable": {
             "value": "True"
         },
-        "retraction_hop": {
-            "value": "1.0"
-        },
         "retraction_min_travel": {
             "value": "1.5"
         },

--- a/resources/definitions/renkforce_rf100_v2.def.json
+++ b/resources/definitions/renkforce_rf100_v2.def.json
@@ -158,9 +158,6 @@
         "retraction_enable": {
             "value": "True"
         },
-        "retraction_hop": {
-            "value": "1.0"
-        },
         "retraction_min_travel": {
             "value": "1.5"
         },

--- a/resources/definitions/renkforce_rf100_xl.def.json
+++ b/resources/definitions/renkforce_rf100_xl.def.json
@@ -146,9 +146,6 @@
         "retraction_enable": {
             "value": "True"
         },
-        "retraction_hop": {
-            "value": "1.0"
-        },
         "retraction_min_travel": {
             "value": "1.5"
         },


### PR DESCRIPTION
Retraction hop enable has default value, the height value is fine by default, too.
This cleans up confusion after merging 7e1162093c7d6814db114877bc68677d49bd1cdb (which is a dead branch?)