### PR TITLE
Add valueFromContainer() functions for profiles

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -393,6 +393,8 @@ class CuraApplication(QtApplication):
         SettingFunction.registerOperator("extruderValues", self._cura_formula_functions.getValuesInAllExtruders)
         SettingFunction.registerOperator("resolveOrValue", self._cura_formula_functions.getResolveOrValue)
         SettingFunction.registerOperator("defaultExtruderPosition", self._cura_formula_functions.getDefaultExtruderPosition)
+        SettingFunction.registerOperator("valueFromContainer", self._cura_formula_functions.getValueFromContainerAtIndex)
+        SettingFunction.registerOperator("extruderValueFromContainer", self._cura_formula_functions.getValueFromContainerAtIndexInExtruder)
 
     # Adds all resources and container related resources.
     def __addAllResourcesAndContainerResources(self) -> None:

--- a/cura/Settings/CuraFormulaFunctions.py
+++ b/cura/Settings/CuraFormulaFunctions.py
@@ -145,7 +145,7 @@ class CuraFormulaFunctions:
         return global_stack.getProperty(property_key, "value", context = context)
 
     # Gets the extruder value for the given setting key starting from the given container index.
-    def getValueFromContainerAtIndexInExtruder(self, extruder_index: int, property_key: str, container_index: int,
+    def getValueFromContainerAtIndexInExtruder(self, extruder_position: int, property_key: str, container_index: int,
                                                context: Optional["PropertyEvaluationContext"] = None) -> Any:
         machine_manager = self._application.getMachineManager()
         global_stack = machine_manager.activeMachine
@@ -163,7 +163,7 @@ class CuraFormulaFunctions:
         context = self.createContextForDefaultValueEvaluation(extruder_stack)
         context.context["evaluate_from_container_index"] = container_index
 
-        return self.getValueInExtruder(extruder_index, property_key, context)
+        return self.getValueInExtruder(extruder_position, property_key, context)
 
     # Creates a context for evaluating default values (skip the user_changes container).
     def createContextForDefaultValueEvaluation(self, source_stack: "CuraContainerStack") -> "PropertyEvaluationContext":

--- a/cura/Settings/CuraFormulaFunctions.py
+++ b/cura/Settings/CuraFormulaFunctions.py
@@ -133,6 +133,38 @@ class CuraFormulaFunctions:
         context = self.createContextForDefaultValueEvaluation(global_stack)
         return self.getResolveOrValue(property_key, context = context)
 
+    # Gets the value for the given setting key starting from the given container index.
+    def getValueFromContainerAtIndex(self, property_key: str, container_index: int,
+                                     context: Optional["PropertyEvaluationContext"] = None) -> Any:
+        machine_manager = self._application.getMachineManager()
+        global_stack = machine_manager.activeMachine
+
+        context = self.createContextForDefaultValueEvaluation(global_stack)
+        context.context["evaluate_from_container_index"] = container_index
+
+        return global_stack.getProperty(property_key, "value", context = context)
+
+    # Gets the extruder value for the given setting key starting from the given container index.
+    def getValueFromContainerAtIndexInExtruder(self, extruder_index: int, property_key: str, container_index: int,
+                                               context: Optional["PropertyEvaluationContext"] = None) -> Any:
+        machine_manager = self._application.getMachineManager()
+        global_stack = machine_manager.activeMachine
+
+        if extruder_position == -1:
+            extruder_position = int(machine_manager.defaultExtruderPosition)
+
+        global_stack = machine_manager.activeMachine
+        try:
+            extruder_stack = global_stack.extruderList[int(extruder_position)]
+        except IndexError:
+            Logger.log("w", "Value for %s of extruder %s was requested, but that extruder is not available. " % (property_key, extruder_position))
+            return None
+
+        context = self.createContextForDefaultValueEvaluation(extruder_stack)
+        context.context["evaluate_from_container_index"] = container_index
+
+        return self.getValueInExtruder(extruder_index, property_key, context)
+
     # Creates a context for evaluating default values (skip the user_changes container).
     def createContextForDefaultValueEvaluation(self, source_stack: "CuraContainerStack") -> "PropertyEvaluationContext":
         context = PropertyEvaluationContext(source_stack)


### PR DESCRIPTION
This PR adds CuraFormulaFunctions to get a value for a key from a stack starting at a specified container index. This enables a writer of profiles to eg refer to inherited values for a key from a formula for the same setting, eg:

A quality profile can use this formula to specify a temperature 5 degrees higher than the temperature specified in the material container:
`material_print_temperature = = valueFromContainer("material_print_temperature", 4) + 5`
A setting referencing itself without this function will create an infinite loop.
