### PR TITLE
Fix freezing on SKR-E3-mini-v1.2 board

### DIFF
--- a/plugins/USBPrinting/AutoDetectBaudJob.py
+++ b/plugins/USBPrinting/AutoDetectBaudJob.py
@@ -5,7 +5,6 @@ from UM.Job import Job
 from UM.Logger import Logger
 
 from .avr_isp import ispBase
-from .avr_isp.stk500v2 import Stk500v2
 
 from time import time, sleep
 from serial import Serial, SerialException
@@ -28,13 +27,7 @@ class AutoDetectBaudJob(Job):
         read_timeout = 3
         tries = 2
 
-        programmer = Stk500v2()
         serial = None
-        try:
-            programmer.connect(self._serial_port)
-            serial = programmer.leaveISP()
-        except ispBase.IspError:
-            programmer.close()
 
         for retry in range(tries):
             for baud_rate in self._all_baud_rates:


### PR DESCRIPTION
When attached to a BigTreeTech SKR-E3-mini-v1.2 board, Cura+USB seems to reliably hang the printer; sometimes you'll hear an alarm sound, other times the printer will just freeze entirely.

The leaveISP() function claims that the serial port is still valid, but as far as I can tell this isn't an actually-valid assumption; it was first introduced in b4df277c but I can't quite track context behind that. This might be true for a bunch of devices but I doubt it's true generally.

My hypothesis here is that leaveISP causes the STM32F103RCT6 to reboot, which then wigs out the power-selector circuit (there's now USB power where there wasn't before), and now all of a sudden the chip is in an entirely different state. But that's mostly a guess.

It doesn't look like the programmer is necessary, however; it simply connects, loads a register for a READ/WRITE command to use, checks the availability of a checksum byte, and then returns. Since we don't care for that, we can just open individual serial connections as/when they're needed with the various different baud rates. This stops my personal SKR-E3-mini-v.2 board from failing, and since this looks like the same fix as https://www.reddit.com/r/BIGTREETECH/comments/dp6k6r/skr_mini_e3_v12_and_curausb/fbv808j/ I'm going to guess that it works for everyone with this board, and shouldn't interfere with other printers since, again, all the STK600 communication is mostly noise.

I suspect this also fixes issue #6531.