### PR TITLE
Prevent crashing on PermissionError when importing http.server

### DIFF
--- a/cura/OAuth2/LocalAuthorizationServer.py
+++ b/cura/OAuth2/LocalAuthorizationServer.py
@@ -2,17 +2,17 @@
 # Cura is released under the terms of the LGPLv3 or higher.
 
 import threading
-from typing import Optional, Callable, Any, TYPE_CHECKING
+from typing import Any, Callable, Optional, TYPE_CHECKING
 
 from UM.Logger import Logger
 
+got_server_type = False
 try:
     from cura.OAuth2.AuthorizationRequestServer import AuthorizationRequestServer
     from cura.OAuth2.AuthorizationRequestHandler import AuthorizationRequestHandler
+    got_server_type = True
 except PermissionError:  # Bug in http.server: Can't access MIME types. This will prevent the user from logging in. See Sentry bug Cura-3Q.
     Logger.error("Can't start a server due to a PermissionError when starting the http.server.")
-    AuthorizationRequestServer = None
-    AuthorizationRequestHandler = None
 
 if TYPE_CHECKING:
     from cura.OAuth2.Models import AuthenticationResponse
@@ -55,7 +55,7 @@ class LocalAuthorizationServer:
         Logger.log("d", "Starting local web server to handle authorization callback on port %s", self._web_server_port)
 
         # Create the server and inject the callback and code.
-        if AuthorizationRequestServer is not None and AuthorizationRequestHandler is not None:
+        if got_server_type:
             self._web_server = AuthorizationRequestServer(("0.0.0.0", self._web_server_port), AuthorizationRequestHandler)
             self._web_server.setAuthorizationHelpers(self._auth_helpers)
             self._web_server.setAuthorizationCallback(self._auth_state_changed_callback)

--- a/cura/OAuth2/LocalAuthorizationServer.py
+++ b/cura/OAuth2/LocalAuthorizationServer.py
@@ -10,6 +10,7 @@ try:
     from cura.OAuth2.AuthorizationRequestServer import AuthorizationRequestServer
     from cura.OAuth2.AuthorizationRequestHandler import AuthorizationRequestHandler
 except PermissionError:  # Bug in http.server: Can't access MIME types. This will prevent the user from logging in. See Sentry bug Cura-3Q.
+    Logger.error("Can't start a server due to a PermissionError when starting the http.server.")
     AuthorizationRequestServer = None
     AuthorizationRequestHandler = None
 


### PR DESCRIPTION
We got a crash report where a PermissionError was raised when http.server is imported. This PermissionError seems to be specific to the user's system. It's crashing somewhere internally in that library when it's trying to read the MIME types supported. Perhaps this user has elevated their computer's security in some way.

Instead of crashing, we don't start the web server. This means that instead of crashing Cura, you get an error in the browser after logging in that it can't reach the localhost page. In Cura you'll remain logged out, as it keeps waiting on the response from the log-in.

Fixes Sentry crash CURA-3Q.