### PR TITLE
Fixing default bed temperature for MP Mini Delta

### DIFF
--- a/resources/definitions/mp_mini_delta.def.json
+++ b/resources/definitions/mp_mini_delta.def.json
@@ -51,6 +51,7 @@
             "default_value": 0.21,
             "minimum_value": 0.07
         },
+        "material_bed_temperature": { "value": 40 },
         "line_width": { "value": "round(machine_nozzle_size * 0.875, 2)" },
         "material_print_temperature_layer_0": { "value": "material_print_temperature + 5" },
         "material_bed_temperature_layer_0": { "value": "material_bed_temperature + 5" },


### PR DESCRIPTION
This was pointed out to me by new users during Cura 4.5 Beta testing. I would greatly appreciate it if this could be included with the final release of Cura 4.5, but I understand if it needs to wait.

The stock Monoprice Mini Delta 3D printer has trouble reaching 60 C. Setting the bed temperature to 40 C so that it doesn't confuse newcomers to the hobby when the printer sits forever waiting for the bed to reach a temperature that it cannot attain. 