### PR TITLE
Add Check for stdout Being Defined for faulthandler

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -162,7 +162,7 @@ sys.excepthook = exceptHook
 # Enable dumping traceback for all threads
 if sys.stderr:
     faulthandler.enable(file = sys.stderr, all_threads = True)
-else:
+elif sys.stdout:
     faulthandler.enable(file = sys.stdout, all_threads = True)
 
 # Workaround for a race condition on certain systems where there


### PR DESCRIPTION
Purpose
=====
The purpose of this bug report is to allow running the source code using `pythonw`. `pythonw` will be used at the makerspace I work for to allow running modified source code without having to compile Cura. We don't want to have a command prompt window with a lot of debug information visible since it may confuse lab users.

Description
========
When running a Python script using `pythonw` instead of `python`, standard input, output, and error are not defined. The `faulthandler` module is used by Cura and is initialized with either `sys.stderr` if it is defined or `sys.stdout`. The problem is if `sys.stdout` is `None`, which will result in `faulthandler` being unable to initialize since the output is undefined. This results in a crash when starting using `pythonw`.

Changes
======
A check was added for `faulthandler` to check if `sys.stdout` is defined. This makes Cura able to be started using `pythonw`, but does mean that this functionality doesn't exist when running it.