### PR TITLE
Fix the layout of the head jogging controls with newer Qt versions

### DIFF
--- a/resources/qml/PrinterOutput/ManualPrinterControl.qml
+++ b/resources/qml/PrinterOutput/ManualPrinterControl.qml
@@ -90,16 +90,16 @@ Item
                     verticalAlignment: Text.AlignVCenter
                     horizontalAlignment: Text.AlignHCenter
 
-                    Layout.row: 1
-                    Layout.column: 2
+                    Layout.row: 0
+                    Layout.column: 1
                     Layout.preferredWidth: width
                     Layout.preferredHeight: height
                 }
 
                 Button
                 {
-                    Layout.row: 2
-                    Layout.column: 2
+                    Layout.row: 1
+                    Layout.column: 1
                     Layout.preferredWidth: width
                     Layout.preferredHeight: height
                     iconSource: UM.Theme.getIcon("arrow_top");
@@ -115,8 +115,8 @@ Item
 
                 Button
                 {
-                    Layout.row: 3
-                    Layout.column: 1
+                    Layout.row: 2
+                    Layout.column: 0
                     Layout.preferredWidth: width
                     Layout.preferredHeight: height
                     iconSource: UM.Theme.getIcon("arrow_left");
@@ -132,8 +132,8 @@ Item
 
                 Button
                 {
-                    Layout.row: 3
-                    Layout.column: 3
+                    Layout.row: 2
+                    Layout.column: 2
                     Layout.preferredWidth: width
                     Layout.preferredHeight: height
                     iconSource: UM.Theme.getIcon("arrow_right");
@@ -149,8 +149,8 @@ Item
 
                 Button
                 {
-                    Layout.row: 4
-                    Layout.column: 2
+                    Layout.row: 3
+                    Layout.column: 1
                     Layout.preferredWidth: width
                     Layout.preferredHeight: height
                     iconSource: UM.Theme.getIcon("arrow_bottom");
@@ -166,8 +166,8 @@ Item
 
                 Button
                 {
-                    Layout.row: 3
-                    Layout.column: 2
+                    Layout.row: 2
+                    Layout.column: 1
                     Layout.preferredWidth: width
                     Layout.preferredHeight: height
                     iconSource: UM.Theme.getIcon("home");


### PR DESCRIPTION
This PR fixes the Layout of the buttons used to jog the head for output devices that support it (eg USB, OctoPrint) with newer Qt versions than what is currently used in official releases (eg people running from source or unofficial distributions on Linux).

The GridLayout was using incorrect row and column indexes. The Qt versions used in official releases sofar would accept the incorrect indexes, but newer Qt versions apparently truncate the GridLayout, as seen in the screenshot below:
![truncated](https://user-images.githubusercontent.com/142754/74626379-16637000-5115-11ea-9445-9052ef003841.png)
Please do not git blame to find out who thought the indices within a GridLayout start at 1.

This PR fixes https://github.com/fieldOfView/Cura-OctoPrintPlugin/issues/149