### PR TITLE
CMake: Fixing warning about path conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-set(URANIUM_DIR "${CMAKE_SOURCE_DIR}/../Uranium" CACHE DIRECTORY "The location of the Uranium repository")
-set(URANIUM_SCRIPTS_DIR "${URANIUM_DIR}/scripts" CACHE DIRECTORY "The location of the scripts directory of the Uranium repository")
+set(URANIUM_DIR "${CMAKE_SOURCE_DIR}/../Uranium" CACHE PATH "The location of the Uranium repository")
+set(URANIUM_SCRIPTS_DIR "${URANIUM_DIR}/scripts" CACHE PATH "The location of the scripts directory of the Uranium repository")
 
 # Tests
 include(CuraTests)


### PR DESCRIPTION
According to what I found in the docs[1], there is no "DIRECTORY" available as <type>.
Therefore, correcting it to "PATH", which is according to the docs correct.

At the moment I'm getting the following error[2]:
```
CMake Warning (dev) at CMakeLists.txt:8 (set):
  implicitly converting 'DIRECTORY' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:9 (set):
  implicitly converting 'DIRECTORY' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
[1] https://cmake.org/cmake/help/v3.6/command/set.html
[2] https://launchpadlibrarian.net/464670600/buildlog_ubuntu-focal-amd64.cura_1%3A4.5~202002121434~rev4433~pkg330~ubuntu20.04.1_BUILDING.txt.gz