### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+colorlog
+pyserial
+sentry-sdk
+shapely
+PyQt5==5.10
+trimesh
+zeroconf

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ shapely
 PyQt5==5.10
 trimesh
 zeroconf
+numpy-stl
+requests


### PR DESCRIPTION
The wiki page for bulding from source mentions some pip
dependencies but misses others. I suggest to put them here
and add a `pip3 install -r requirements.txt` to the wiki