### PR TITLE
Fix values in print monitor preheat fields

### DIFF
--- a/resources/qml/PrinterOutput/ExtruderBox.qml
+++ b/resources/qml/PrinterOutput/ExtruderBox.qml
@@ -209,15 +209,15 @@ Item
                 anchors.verticalCenter: parent.verticalCenter
                 renderType: Text.NativeRendering
 
-                Component.onCompleted:
+                text:
                 {
                     if (!extruderTemperature.properties.value)
                     {
-                        text = "";
+                        return "";
                     }
                     else
                     {
-                        text = extruderTemperature.properties.value;
+                        return extruderTemperature.properties.value;
                     }
                 }
             }

--- a/resources/qml/PrinterOutput/HeatedBedBox.qml
+++ b/resources/qml/PrinterOutput/HeatedBedBox.qml
@@ -193,22 +193,22 @@ Item
                 anchors.verticalCenter: parent.verticalCenter
                 renderType: Text.NativeRendering
 
-                Component.onCompleted:
+                text:
                 {
                     if (!bedTemperature.properties.value)
                     {
-                        text = "";
+                        return "";
                     }
                     if ((bedTemperature.resolve != "None" && bedTemperature.resolve) && (bedTemperature.stackLevels[0] != 0) && (bedTemperature.stackLevels[0] != 1))
                     {
                         // We have a resolve function. Indicates that the setting is not settable per extruder and that
                         // we have to choose between the resolved value (default) and the global value
                         // (if user has explicitly set this).
-                        text = bedTemperature.resolve;
+                        return bedTemperature.resolve;
                     }
                     else
                     {
-                        text = bedTemperature.properties.value;
+                        return bedTemperature.properties.value;
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes the values shown in the preheat temperature fields on the Print Monitor (USB or OctoPrint). As reported in #7172, this functionality was broken in https://github.com/Ultimaker/Uranium/commit/2d4dab687afff47df33c6237910bb373fc99ebaa, but since that is a performance optimization this PR works around those changes instead of reverting them.

Fixes #7172