### PR TITLE
Remove working directory from sys.path

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2019 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
+
+# Remove the working directory from sys.path.
+# This fixes a security issue where Cura could import Python packages from the
+# current working directory, and therefore be made to execute locally installed
+# code (e.g. in the user's home directory where AppImages by default run from).
+# See issue CURA-7081.
+import sys
+if "" in sys.path:
+    sys.path.remove("")
 
 import argparse
 import faulthandler
 import os
-import sys
 
 # Workaround for a race condition on certain systems where there
 # is a race condition between Arcus and PyQt. Importing Arcus


### PR DESCRIPTION
This prevents accidentally loading packages from the working directory that are not in Cura's build.

Contributes to issue CURA-7081.