### PR TITLE
Show active postprocessing scripts count

### DIFF
--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -484,15 +484,36 @@ UM.Dialog
         onClicked: dialog.accept()
     }
 
-    Cura.SecondaryButton
+    Item
     {
         objectName: "postProcessingSaveAreaButton"
         visible: activeScriptsList.count > 0
         height: UM.Theme.getSize("action_button").height
         width: height
-        tooltip: catalog.i18nc("@info:tooltip", "Change active post-processing scripts")
-        onClicked: dialog.show()
-        iconSource: "postprocessing.svg"
-        fixedWidthMode: true
+
+        Cura.SecondaryButton
+        {
+            height: UM.Theme.getSize("action_button").height
+            tooltip: catalog.i18nc("@info:tooltip", "Change active post-processing scripts")
+            toolTipContentAlignment: Cura.ToolTip.ContentAlignment.AlignLeft
+            onClicked: dialog.show()
+            iconSource: "postprocessing.svg"
+            fixedWidthMode: false
+        }
+
+        Cura.NotificationIcon
+        {
+            id: activeScriptCountIcon
+            visible: activeScriptsList.count > 0
+            anchors
+            {
+                top: parent.top
+                right: parent.right
+                rightMargin: (-0.5 * width) | 0
+                topMargin: (-0.5 * height) | 0
+            }
+
+            labelText: activeScriptsList.count
+        }
     }
 }

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -494,7 +494,24 @@ UM.Dialog
         Cura.SecondaryButton
         {
             height: UM.Theme.getSize("action_button").height
-            tooltip: catalog.i18nc("@info:tooltip", "Change active post-processing scripts")
+            tooltip:
+            {
+                var tipText = catalog.i18nc("@info:tooltip", "Change active post-processing scripts.");
+                if (activeScriptsList.count > 0)
+                {
+                    tipText += "<br><br>" + catalog.i18ncp("@info:tooltip",
+                        "The following script is active:",
+                        "The following scripts are active:",
+                        activeScriptsList.count
+                    ) + "<ul>";
+                    for(var i = 0; i < activeScriptsList.count; i++)
+                    {
+                        tipText += "<li>" + manager.getScriptLabelByKey(manager.scriptList[i]) + "</li>";
+                    }
+                    tipText += "</ul>";
+                }
+                return tipText
+            }
             toolTipContentAlignment: Cura.ToolTip.ContentAlignment.AlignLeft
             onClicked: dialog.show()
             iconSource: "postprocessing.svg"

--- a/resources/qml/ActionButton.qml
+++ b/resources/qml/ActionButton.qml
@@ -145,6 +145,7 @@ Button
             }
             return true;
         }
+        targetPoint: Qt.point(parent.x, Math.round(parent.y + parent.height / 2))
     }
 
     BusyIndicator

--- a/resources/qml/ActionButton.qml
+++ b/resources/qml/ActionButton.qml
@@ -133,7 +133,18 @@ Button
     Cura.ToolTip
     {
         id: tooltip
-        visible: button.hovered && buttonTextMetrics.elidedText != buttonText.text
+        visible:
+        {
+            if (!button.hovered)
+            {
+                return false;
+            }
+            if (tooltipText == button.text)
+            {
+                return buttonTextMetrics.elidedText != buttonText.text;
+            }
+            return true;
+        }
     }
 
     BusyIndicator


### PR DESCRIPTION
This PR adds a "notification" count to the button that indicates there are postprocessing scripts active. It also adds a descriptive tooltip text, showing the name(s) of the active scripts without having to open the PostProcessing plugin dialog to inspect.

![image](https://user-images.githubusercontent.com/143551/75591030-fd48b080-5a7e-11ea-883e-433d30e8bd57.png)

While fixing this, I also fixed some missing tooltips for ActionButtons.

Fixes #7159 