### PR TITLE
Show link to help pages if connection fails

### DIFF
--- a/resources/qml/WelcomePages/AddPrinterByIpContent.qml
+++ b/resources/qml/WelcomePages/AddPrinterByIpContent.qml
@@ -159,6 +159,7 @@ Item
                     enabled: !addPrinterByIpScreen.hasRequestInProgress && !addPrinterByIpScreen.isPrinterDiscovered && (hostnameField.state != "invalid" && hostnameField.text != "")
                     onClicked:
                     {
+                        addPrinterByIpScreen.hasRequestFinished = false //In case it's pressed multiple times.
                         const address = hostnameField.text
                         if (!networkingUtil.isValidIP(address))
                         {

--- a/resources/qml/WelcomePages/AddPrinterByIpContent.qml
+++ b/resources/qml/WelcomePages/AddPrinterByIpContent.qml
@@ -197,17 +197,20 @@ Item
                     renderType: Text.NativeRendering
 
                     visible: addPrinterByIpScreen.hasRequestInProgress || (addPrinterByIpScreen.hasRequestFinished && !addPrinterByIpScreen.isPrinterDiscovered)
+                    textFormat: Text.RichText
                     text:
                     {
                         if (addPrinterByIpScreen.hasRequestFinished)
                         {
-                            catalog.i18nc("@label", "Could not connect to device.")
+                            return catalog.i18nc("@label", "Could not connect to device.");
                         }
                         else
                         {
-                            catalog.i18nc("@label", "The printer at this address has not responded yet.")
+                            return catalog.i18nc("@label", "The printer at this address has not responded yet.") + "<br /><br /><a href=\"https://www.ultimaker.com/\">"
+                                + catalog.i18nc("@label", "Can't connect to your printer?") + "</a>";
                         }
                     }
+                    onLinkActivated: Qt.openUrlExternally(link)
                 }
 
                 Item

--- a/resources/qml/WelcomePages/AddPrinterByIpContent.qml
+++ b/resources/qml/WelcomePages/AddPrinterByIpContent.qml
@@ -203,7 +203,8 @@ Item
                     {
                         if (addPrinterByIpScreen.hasRequestFinished)
                         {
-                            return catalog.i18nc("@label", "Could not connect to device.");
+                            return catalog.i18nc("@label", "Could not connect to device.") + "<br /><br /><a href=\"https://ultimaker.com/en/resources/52891-set-up-a-cloud-connection\">"
+                                + catalog.i18nc("@label", "Can't connect to your Ultimaker printer?") + "</a>";
                         }
                         else
                         {

--- a/resources/qml/WelcomePages/AddPrinterByIpContent.qml
+++ b/resources/qml/WelcomePages/AddPrinterByIpContent.qml
@@ -206,8 +206,8 @@ Item
                         }
                         else
                         {
-                            return catalog.i18nc("@label", "The printer at this address has not responded yet.") + "<br /><br /><a href=\"https://www.ultimaker.com/\">"
-                                + catalog.i18nc("@label", "Can't connect to your printer?") + "</a>";
+                            return catalog.i18nc("@label", "The printer at this address has not responded yet.") + "<br /><br /><a href=\"https://ultimaker.com/en/resources/52891-set-up-a-cloud-connection\">"
+                                + catalog.i18nc("@label", "Can't connect to your Ultimaker printer?") + "</a>";
                         }
                     }
                     onLinkActivated: Qt.openUrlExternally(link)


### PR DESCRIPTION
If the connection to your printer fails (or takes a long time), we show a link to a help page on Ultimaker's website. This only explains about Ultimaker's printers so the link is worded to only apply to Ultimaker's printers.

Implements CURA-7017.