### PR TITLE
CURA-7211_pos_infill_defaults_0

### DIFF
--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -159,7 +159,7 @@ Item
             }
         }
 
-        Column // Settings Dialog
+        Column // List of selected Settings to override for the selected object
         {
             // This is to ensure that the panel is first increasing in size up to 200 and then shows a scrollbar.
             // It kinda looks ugly otherwise (big panel, no content on it)

--- a/plugins/PerObjectSettingsTool/PerObjectSettingsTool.py
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsTool.py
@@ -82,6 +82,7 @@ class PerObjectSettingsTool(Tool):
             selected_object.addDecorator(SettingOverrideDecorator())
             stack = selected_object.callDecoration("getStack")
 
+        settings_visibility_changed = False
         settings = stack.getTop()
         for property_key in ["infill_mesh", "cutting_mesh", "support_mesh", "anti_overhang_mesh"]:
             if property_key != mesh_type:
@@ -103,11 +104,14 @@ class PerObjectSettingsTool(Tool):
                     new_instance.setProperty("value", 0)
                     new_instance.resetState()  # Ensure that the state is not seen as a user state.
                     settings.addInstance(new_instance)
-                    visible = self.visibility_handler.getVisible()
-                    visible.add(property_key)
-                    self.visibility_handler.setVisible(visible)
+                    settings_visibility_changed = True
+
             elif old_mesh_type == "infill_mesh" and settings.getInstance(property_key) and settings.getProperty(property_key, "value") == 0:
                 settings.removeInstance(property_key)
+                settings_visibility_changed = True
+
+        if settings_visibility_changed:
+            self.visibility_handler.forceVisibilityChanged()
 
         self.propertyChanged.emit()
         return True


### PR DESCRIPTION
The problem: When infill mesh is set, wall_thickness and top_bottom_thickness are added to the settings.
Then these settings are set to visible on the visibility_handler.
It appears however, that the visibility_handler considers all added settings to be visible. It thus concludes that no UI update is necessary because the settings are already added.