### PR TITLE
Reduce stair step height to 0 for PVA

### DIFF
--- a/resources/variants/ultimaker3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_bb0.8.inst.cfg
@@ -70,7 +70,7 @@ speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_angle = 60
 support_bottom_height = =layer_height * 2
 support_bottom_pattern = zigzag
-support_bottom_stair_step_height = =layer_height
+support_bottom_stair_step_height = 0
 support_infill_rate = 50
 support_infill_sparse_thickness = 0.4
 support_interface_enable = True

--- a/resources/variants/ultimaker3_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_bb04.inst.cfg
@@ -37,7 +37,7 @@ speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2
 support_bottom_pattern = zigzag
-support_bottom_stair_step_height = =layer_height
+support_bottom_stair_step_height = 0
 support_infill_rate = 50
 support_infill_sparse_thickness = 0.2
 support_interface_enable = True

--- a/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
@@ -70,7 +70,7 @@ speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_angle = 60
 support_bottom_height = =layer_height * 2
 support_bottom_pattern = zigzag
-support_bottom_stair_step_height = =layer_height
+support_bottom_stair_step_height = 0
 support_infill_rate = 50
 support_infill_sparse_thickness = 0.4
 support_interface_enable = True

--- a/resources/variants/ultimaker3_extended_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb04.inst.cfg
@@ -37,7 +37,7 @@ speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2
 support_bottom_pattern = zigzag
-support_bottom_stair_step_height = =layer_height
+support_bottom_stair_step_height = 0
 support_infill_rate = 50
 support_infill_sparse_thickness = 0.2
 support_interface_enable = True

--- a/resources/variants/ultimaker_s3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb0.8.inst.cfg
@@ -70,7 +70,7 @@ speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 support_angle = 60
 support_bottom_height = =layer_height * 2
 support_bottom_pattern = zigzag
-support_bottom_stair_step_height = =layer_height
+support_bottom_stair_step_height = 0
 support_infill_rate = 50
 support_infill_sparse_thickness = 0.4
 support_interface_enable = True

--- a/resources/variants/ultimaker_s3_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb04.inst.cfg
@@ -37,7 +37,7 @@ speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2
 support_bottom_pattern = zigzag
-support_bottom_stair_step_height = =layer_height
+support_bottom_stair_step_height = 0
 support_infill_rate = 50
 support_infill_sparse_thickness = 0.2
 support_interface_enable = True

--- a/resources/variants/ultimaker_s5_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb0.8.inst.cfg
@@ -70,7 +70,7 @@ speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 support_angle = 60
 support_bottom_height = =layer_height * 2
 support_bottom_pattern = zigzag
-support_bottom_stair_step_height = =layer_height
+support_bottom_stair_step_height = 0
 support_infill_rate = 50
 support_infill_sparse_thickness = 0.4
 support_interface_enable = True

--- a/resources/variants/ultimaker_s5_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb04.inst.cfg
@@ -37,7 +37,7 @@ speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2
 support_bottom_pattern = zigzag
-support_bottom_stair_step_height = =layer_height
+support_bottom_stair_step_height = 0
 support_infill_rate = 50
 support_infill_sparse_thickness = 0.2
 support_interface_enable = True


### PR DESCRIPTION
Given that:
* stair stepping is intended to be used to reduce the adhesion between support and the model, where the support rests on the model, and to reduce scarring, and
* PVA doesn't suffer from scarring or adhesion issues due to its water-solubility, and
* our current stair stepping algorithm has some bugs, causing support to disappear sometimes

we've decided to set stair stepping to 0 for all PVA profiles for UM3, UMS5 and UMS3.

Contributes to issue CURA-7311.