### PR TITLE
Store/retreive SceneNode name in/from <object> attribute

### DIFF
--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -88,7 +88,10 @@ class ThreeMFReader(MeshReader):
     #   \returns Scene node.
     def _convertSavitarNodeToUMNode(self, savitar_node: Savitar.SceneNode, file_name: str = "") -> Optional[SceneNode]:
         self._object_count += 1
-        node_name = "Object %s" % self._object_count
+
+        node_name = savitar_node.getName()
+        if none_name == "":
+            node_name = "Object %s" % self._object_count
 
         active_build_plate = CuraApplication.getInstance().getMultiBuildPlateModel().activeBuildPlate
 

--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -90,7 +90,7 @@ class ThreeMFReader(MeshReader):
         self._object_count += 1
 
         node_name = savitar_node.getName()
-        if none_name == "":
+        if node_name == "":
             node_name = "Object %s" % self._object_count
 
         active_build_plate = CuraApplication.getInstance().getMultiBuildPlateModel().activeBuildPlate

--- a/plugins/3MFWriter/ThreeMFWriter.py
+++ b/plugins/3MFWriter/ThreeMFWriter.py
@@ -77,6 +77,7 @@ class ThreeMFWriter(MeshWriter):
             return
 
         savitar_node = Savitar.SceneNode()
+        savitar_node.setName(um_node.getName())
 
         node_matrix = um_node.getLocalTransformation()
 


### PR DESCRIPTION
This PR stores and retreives the SceneNode name as attributes of the `<object.` node in 3mf files, in accordance with the spec:
https://github.com/3MFConsortium/spec_core/blob/master/3MF%20Core%20Specification.md#attributes-3
It requires https://github.com/Ultimaker/libSavitar/pull/23 and CI will (should) fail until that PR is merged.

This PR solves the problem that after saving a project and loading it back in to Cura, all model names are changed to `Object n` (where n is a number referring to the order objects are stored in the 3mf file). This makes it hard to find models back in the model list, and makes eg the postprocessing script to display model names useless for projects. Additionally, the PR follows the 3MF spec more closely by supporting a known metadata entry that was previously unsupported.