### PR TITLE
Add method to add separators to extension menus

### DIFF
--- a/resources/qml/MainWindow/ApplicationMenu.qml
+++ b/resources/qml/MainWindow/ApplicationMenu.qml
@@ -74,7 +74,7 @@ Item
                             property var modelText: model.text
                             property var extensionName: name
 
-                            sourceComponent: modelText == "" ? extensionsMenuSeparator : extensionsMenuItem
+                            sourceComponent: modelText.trim() == "" ? extensionsMenuSeparator : extensionsMenuItem
                         }
 
                         onObjectAdded: sub_menu.insertItem(index, object.item)

--- a/resources/qml/MainWindow/ApplicationMenu.qml
+++ b/resources/qml/MainWindow/ApplicationMenu.qml
@@ -68,13 +68,17 @@ Item
                     Instantiator
                     {
                         model: actions
-                        MenuItem
+                        Loader
                         {
-                            text: model.text
-                            onTriggered: extensions.model.subMenuTriggered(name, model.text)
+                            property var extensionsModel: extensions.model
+                            property var modelText: model.text
+                            property var extensionName: name
+
+                            sourceComponent: modelText == "" ? extensionsMenuSeparator : extensionsMenuItem
                         }
-                        onObjectAdded: sub_menu.insertItem(index, object)
-                        onObjectRemoved: sub_menu.removeItem(object)
+
+                        onObjectAdded: sub_menu.insertItem(index, object.item)
+                        onObjectRemoved: sub_menu.removeItem(object.item)
                     }
                 }
 
@@ -105,6 +109,25 @@ Item
             MenuItem { action: Cura.Actions.about }
         }
     }
+
+    Component
+    {
+        id: extensionsMenuItem
+
+        MenuItem
+        {
+            text: modelText
+            onTriggered: extensionsModel.subMenuTriggered(extensionName, modelText)
+        }
+    }
+
+    Component
+    {
+        id: extensionsMenuSeparator
+
+        MenuSeparator {}
+    }
+
 
     // ###############################################################################################
     // Definition of other components that are linked to the menus


### PR DESCRIPTION
This PR allows extensions to add separators between menuitems in their Extensions submenu like this:
`        self.addMenuItem("", lambda: None)`
The method of reusing the existing `addMenuItem` instead of eg an `addMenuSeparator` means that (1) the method is fully backward compatible in the sense that this menuItem just renders as an empty menuitem and (2) confines the changes to Cura instead of requiring a change in both Cura and Uranium.
