### PR TITLE
Hide deltabot from Add Printer dialog

### DIFF
--- a/resources/definitions/deltabot.def.json
+++ b/resources/definitions/deltabot.def.json
@@ -3,7 +3,7 @@
     "version": 2,
     "inherits": "fdmprinter",
     "metadata": {
-        "visible": true,
+        "visible": false,
         "author": "Ultimaker",
         "manufacturer": "Custom",
         "file_formats": "text/x-gcode",


### PR DESCRIPTION
This PR hides the Deltabot definition from the Add Printer dialog. The Deltabot is used as a generic stub for delta-style printers. We want users to use the "Custom FFF Printer" instead, which is more fully featured (supports multiple extruders) and has the appropriate options to set an elliptical build plate and origin at center.

With this PR, user that have already configured a Deltabot can keep using their configuration, but users wanting to add a new delta-style printer for which there is no premade configuration will only be able to pick the Custom FFF Printer.

Contributes to #6688