### PR TITLE
Fix xray composite shader for opengl 2.1

### DIFF
--- a/plugins/XRayView/XRayView.py
+++ b/plugins/XRayView/XRayView.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 import os.path
@@ -91,16 +91,17 @@ class XRayView(CuraView):
 
             if not self._xray_error_image:
                 self._xray_error_image = OpenGL.getInstance().createTexture()
-                img = QImage(1, 1, QImage.Format_RGB888)
+                dummy_image = QImage(1, 1, QImage.Format_RGB888)
                 theme = Application.getInstance().getTheme()
-                img.setPixelColor(0, 0, theme.getColor("xray_error"))
-                self._xray_error_image.setImage(img)
+                dummy_image.setPixelColor(0, 0, theme.getColor("xray_error"))
+                self._xray_error_image.setImage(dummy_image)
 
             if not self._xray_composite_shader:
                 self._xray_composite_shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "xray_composite.shader"))
                 self._xray_composite_shader.setUniformValue("u_background_color", Color(*theme.getColor("viewport_background").getRgb()))
                 self._xray_composite_shader.setUniformValue("u_outline_color", Color(*theme.getColor("model_selection_outline").getRgb()))
                 self._xray_composite_shader.setUniformValue("u_xray_error_strength", 0.8)
+                self._xray_composite_shader.setUniformValue("u_xray_error_scale", [1, 1]) # irrelevant, because we don't use an actual texture
                 self._xray_composite_shader.setTexture(3, self._xray_error_image)
 
             if not self._composite_pass:

--- a/resources/shaders/xray_composite.shader
+++ b/resources/shaders/xray_composite.shader
@@ -25,6 +25,7 @@ fragment =
     uniform sampler2D u_layer2; //X-ray pass.
     uniform sampler2D u_xray_error; //X-ray error image.
 
+    uniform vec2 u_xray_error_scale;
     uniform vec2 u_offset[9];
 
     uniform float u_outline_strength;
@@ -55,8 +56,7 @@ fragment =
         float rest = mod(intersection_count + .01, 2.0);
         if (rest > 1.0 && rest < 1.5 && intersection_count < 49)
         {
-            vec2 scaling = textureSize(u_layer0, 0) / textureSize(u_xray_error, 0);
-            result = result * (1.0 - u_xray_error_strength) + u_xray_error_strength * texture(u_xray_error, v_uvs * scaling);
+            result = result * (1.0 - u_xray_error_strength) + u_xray_error_strength * texture(u_xray_error, v_uvs * u_xray_error_scale);
         }
 
         vec4 sum = vec4(0.0);
@@ -100,6 +100,7 @@ fragment41core =
     uniform sampler2D u_layer2; //X-ray pass.
     uniform sampler2D u_xray_error; //X-ray error image.
 
+    uniform vec2 u_xray_error_scale;
     uniform vec2 u_offset[9];
 
     uniform float u_outline_strength;
@@ -131,8 +132,7 @@ fragment41core =
         float rest = mod(intersection_count + .01, 2.0);
         if (rest > 1.0 && rest < 1.5 && intersection_count < 49)
         {
-            vec2 scaling = textureSize(u_layer0, 0) / textureSize(u_xray_error, 0);
-            result = result * (1.0 - u_xray_error_strength) + u_xray_error_strength * texture(u_xray_error, v_uvs * scaling);
+            result = result * (1.0 - u_xray_error_strength) + u_xray_error_strength * texture(u_xray_error, v_uvs * u_xray_error_scale);
         }
 
         vec4 sum = vec4(0.0);


### PR DESCRIPTION
This PR fixes the xray_in_solid_view branch to work on legacy opengl renderers. textureSize() is not available in opengl 2.1, so we calculate the xray error image scale outside the shader (which is also a theoretical performance improvement because now the scale does not get computed over and over for each pixel)

This PR builds on top of https://github.com/Ultimaker/Cura/pull/6569 and has that branch as target.