### PR TITLE
Cura 7333 fix reloading 3mf files with many objects

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1574,7 +1574,6 @@ class CuraApplication(QtApplication):
     fileCompleted = pyqtSignal(str)
 
     def _reloadMeshFinished(self, job):
-        # TODO; This needs to be fixed properly. We now make the assumption that we only load a single mesh!
         job_result = job.getResult()
         object_to_be_reloaded = job.object_to_be_reloaded
         if len(job_result) == 0:

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 import time
-from typing import cast, TYPE_CHECKING, Optional, Callable, List, Any
+from typing import cast, TYPE_CHECKING, Optional, Callable, List, Any, Dict
 
 import numpy
 from PyQt5.QtCore import QObject, QTimer, QUrl, pyqtSignal, pyqtProperty, QEvent, Q_ENUMS
@@ -1383,7 +1383,7 @@ class CuraApplication(QtApplication):
         if not nodes:
             return
 
-        objects_in_filename = {}
+        objects_in_filename = {}  # type: Dict[str, List[CuraSceneNode]]
         for node in nodes:
             mesh_data = node.getMeshData()
             if mesh_data:

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1580,7 +1580,7 @@ class CuraApplication(QtApplication):
     fileLoaded = pyqtSignal(str)
     fileCompleted = pyqtSignal(str)
 
-    def _reloadMeshFinished(self, job: ReadMeshJob) -> None:
+    def _reloadMeshFinished(self, job) -> None:
         """
         Function called whenever a ReadMeshJob finishes in the background. It reloads a specific node object in the
         scene from its source file. The function gets all the nodes that exist in the file through the job result, and

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1424,6 +1424,8 @@ class CuraApplication(QtApplication):
         if file_name in node_name:
             # if the file_name exists inside the node_name, remove it along with all parenthesis and spaces
             node_str_index = re.sub(r'[() ]', '', node_name.replace(file_name, ""))
+            if node_str_index == "":
+                node_str_index = "0"
             try:
                 node_int_index = int(node_str_index)
             except ValueError:


### PR DESCRIPTION
There was an issue where when reloading muliple objects from a 3mf file, object 1 was being replicated everywhere. 

This PR only fixes that issue to make sure that object 1 is not replicated, when the number of objects has not been changed. There is still undefined behavior when the number of objects or their positional indexes inside the file change.

Requires 

- https://github.com/Ultimaker/libSavitar/pull/24
- https://github.com/Ultimaker/Uranium/pull/596