### PR TITLE
Version upgrade 4.6 to 4.7 for Maximum Deviation changes

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -124,7 +124,7 @@ class CuraApplication(QtApplication):
     # SettingVersion represents the set of settings available in the machine/extruder definitions.
     # You need to make sure that this version number needs to be increased if there is any non-backwards-compatible
     # changes of the settings.
-    SettingVersion = 12
+    SettingVersion = 13
 
     Created = False
 

--- a/plugins/VersionUpgrade/VersionUpgrade45to46/VersionUpgrade45to46.py
+++ b/plugins/VersionUpgrade/VersionUpgrade45to46/VersionUpgrade45to46.py
@@ -18,10 +18,16 @@ class VersionUpgrade45to46(VersionUpgrade):
         setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
         return format_version * 1000000 + setting_version
 
-    ##  Upgrades Preferences to have the new version number.
-    #
-    #   This renames the renamed settings in the list of visible settings.
     def upgradePreferences(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades preferences to have the new version number.
+
+        This removes any settings that were removed in the new Cura version.
+        :param serialized: The original contents of the preferences file.
+        :param filename: The file name of the preferences file.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
         parser = configparser.ConfigParser(interpolation = None)
         parser.read_string(serialized)
 
@@ -39,11 +45,16 @@ class VersionUpgrade45to46(VersionUpgrade):
         parser.write(result)
         return [filename], [result.getvalue()]
 
-    ##  Upgrades instance containers to have the new version
-    #   number.
-    #
-    #   This renames the renamed settings in the containers.
     def upgradeInstanceContainer(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades instance containers to have the new version number.
+
+        This removes any settings that were removed in the new Cura version.
+        :param serialized: The original contents of the instance container.
+        :param filename: The original file name of the instance container.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
         parser = configparser.ConfigParser(interpolation = None, comment_prefixes = ())
         parser.read_string(serialized)
 
@@ -59,8 +70,14 @@ class VersionUpgrade45to46(VersionUpgrade):
         parser.write(result)
         return [filename], [result.getvalue()]
 
-    ##  Upgrades stacks to have the new version number.
     def upgradeStack(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades stacks to have the new version number.
+        :param serialized: The original contents of the stack.
+        :param filename: The original file name of the stack.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
         parser = configparser.ConfigParser(interpolation = None)
         parser.read_string(serialized)
 

--- a/plugins/VersionUpgrade/VersionUpgrade46to47/VersionUpgrade46to47.py
+++ b/plugins/VersionUpgrade/VersionUpgrade46to47/VersionUpgrade46to47.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2020 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
+import configparser
+from typing import Tuple, List
+import io
+from UM.VersionUpgrade import VersionUpgrade
+
+class VersionUpgrade46to47(VersionUpgrade):
+    def getCfgVersion(self, serialised: str) -> int:
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialised)
+        format_version = int(parser.get("general", "version"))  # Explicitly give an exception when this fails. That means that the file format is not recognised.
+        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
+        return format_version * 1000000 + setting_version
+
+    def upgradePreferences(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades preferences to have the new version number.
+        :param serialized: The original contents of the preferences file.
+        :param filename: The file name of the preferences file.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialized)
+
+        # Update version number.
+        parser["metadata"]["setting_version"] = "13"
+
+        result = io.StringIO()
+        parser.write(result)
+        return [filename], [result.getvalue()]
+
+    def upgradeInstanceContainer(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades instance containers to have the new version number.
+
+        This changes the maximum deviation setting if that setting was present
+        in the profile.
+        :param serialized: The original contents of the instance container.
+        :param filename: The original file name of the instance container.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
+        parser = configparser.ConfigParser(interpolation = None, comment_prefixes = ())
+        parser.read_string(serialized)
+
+        # Update version number.
+        parser["metadata"]["setting_version"] = "13"
+
+        if "values" in parser:
+            # Maximum Deviation's effect was corrected. Previously the deviation
+            # ended up being only half of what the user had entered. This was
+            # fixed in Cura 4.7 so there we need to halve the deviation that the
+            # user had entered.
+            if "meshfix_maximum_deviation" in parser["values"]:
+                maximum_deviation = parser["values"]["meshfix_maximum_deviation"]
+                if maximum_deviation.startswith("="):
+                    maximum_deviation = maximum_deviation[1:]
+                maximum_deviation = "=(" + maximum_deviation + ") / 2"
+                parser["values"]["meshfix_maximum_deviation"] = maximum_deviation
+
+        result = io.StringIO()
+        parser.write(result)
+        return [filename], [result.getvalue()]
+
+    def upgradeStack(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades stacks to have the new version number.
+        :param serialized: The original contents of the stack.
+        :param filename: The original file name of the stack.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialized)
+
+        # Update version number.
+        if "metadata" not in parser:
+            parser["metadata"] = {}
+        parser["metadata"]["setting_version"] = "13"
+
+        result = io.StringIO()
+        parser.write(result)
+        return [filename], [result.getvalue()]

--- a/plugins/VersionUpgrade/VersionUpgrade46to47/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade46to47/__init__.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2020 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
+from typing import Any, Dict, TYPE_CHECKING
+
+from . import VersionUpgrade46to47
+
+if TYPE_CHECKING:
+    from UM.Application import Application
+
+upgrade = VersionUpgrade46to47.VersionUpgrade46to47()
+
+def getMetaData() -> Dict[str, Any]:
+    return {
+        "version_upgrade": {
+            # From                           To                              Upgrade function
+            ("preferences", 6000012):        ("preferences", 6000013,        upgrade.upgradePreferences),
+            ("machine_stack", 4000012):      ("machine_stack", 4000013,      upgrade.upgradeStack),
+            ("extruder_train", 4000012):     ("extruder_train", 4000013,     upgrade.upgradeStack),
+            ("definition_changes", 4000012): ("definition_changes", 4000013, upgrade.upgradeInstanceContainer),
+            ("quality_changes", 4000012):    ("quality_changes", 4000013,    upgrade.upgradeInstanceContainer),
+            ("quality", 4000012):            ("quality", 4000013,            upgrade.upgradeInstanceContainer),
+            ("user", 4000012):               ("user", 4000013,               upgrade.upgradeInstanceContainer),
+        },
+        "sources": {
+            "preferences": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"."}
+            },
+            "machine_stack": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./machine_instances"}
+            },
+            "extruder_train": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./extruders"}
+            },
+            "definition_changes": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./definition_changes"}
+            },
+            "quality_changes": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./quality_changes"}
+            },
+            "quality": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./quality"}
+            },
+            "user": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./user"}
+            }
+        }
+    }
+
+
+def register(app: "Application") -> Dict[str, Any]:
+    return {"version_upgrade": upgrade}

--- a/plugins/VersionUpgrade/VersionUpgrade46to47/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade46to47/plugin.json
@@ -1,0 +1,8 @@
+{
+    "name": "Version Upgrade 4.6 to 4.7",
+    "author": "Ultimaker B.V.",
+    "version": "1.0.0",
+    "description": "Upgrades configurations from Cura 4.6 to Cura 4.7.",
+    "api": "7.1",
+    "i18n-catalog": "cura"
+}

--- a/resources/definitions/fdmextruder.def.json
+++ b/resources/definitions/fdmextruder.def.json
@@ -6,7 +6,7 @@
         "type": "extruder",
         "author": "Ultimaker",
         "manufacturer": "Unknown",
-        "setting_version": 12,
+        "setting_version": 13,
         "visible": false,
         "position": "0"
     },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5984,7 +5984,7 @@
                     "description": "The maximum deviation allowed when reducing the resolution for the Maximum Resolution setting. If you increase this, the print will be less accurate, but the g-code will be smaller. Maximum Deviation is a limit for Maximum Resolution, so if the two conflict the Maximum Deviation will always be held true.",
                     "type": "float",
                     "unit": "mm",
-                    "default_value": 0.05,
+                    "default_value": 0.025,
                     "minimum_value": "0.001",
                     "minimum_value_warning": "0.01",
                     "maximum_value_warning": "0.3",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -7,7 +7,7 @@
         "author": "Ultimaker",
         "category": "Other",
         "manufacturer": "Unknown",
-        "setting_version": 12,
+        "setting_version": 13,
         "file_formats": "text/x-gcode;application/x-stl-ascii;application/x-stl-binary;application/x-wavefront-obj;application/x3g",
         "visible": false,
         "has_materials": true,

--- a/resources/definitions/hms434.def.json
+++ b/resources/definitions/hms434.def.json
@@ -171,7 +171,7 @@
 
         "meshfix_maximum_resolution":       {"value": 0.01 },
         "meshfix_maximum_travel_resolution":{"value": 0.1 },
-        "meshfix_maximum_deviation":        {"value": 0.01 },
+        "meshfix_maximum_deviation":        {"value": 0.005 },
 
         "minimum_polygon_circumference":    {"value": 0.05 },
         "coasting_enable":                  {"value": false},

--- a/resources/definitions/peopoly_moai.def.json
+++ b/resources/definitions/peopoly_moai.def.json
@@ -171,7 +171,7 @@
             "value": "0.1"
         },
         "meshfix_maximum_deviation": {
-            "value": "0.003"
+            "value": "0.0015"
         },
         "skin_outline_count": {
             "value": 0

--- a/resources/definitions/skriware_2.def.json
+++ b/resources/definitions/skriware_2.def.json
@@ -298,7 +298,7 @@
             "default_value": 15
         },
         "meshfix_maximum_deviation": {
-            "default_value": 0.005
+            "default_value": 0.0025
         },
         "wall_0_material_flow": {
             "value": "99"

--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -156,7 +156,7 @@
         "wall_line_width_x": { "value": "round(line_width * 0.3 / 0.35, 2)" },
         "wall_thickness": { "value": "1" },
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 60" },
-        "meshfix_maximum_deviation": { "value": "layer_height / 2" },
+        "meshfix_maximum_deviation": { "value": "layer_height / 4" },
         "optimize_wall_printing_order": { "value": "True" },
         "retraction_combing": { "default_value": "all" },
         "initial_layer_line_width_factor": { "value": "120" },

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -158,7 +158,7 @@
         "wall_line_width_x": { "value": "round(line_width * 0.3 / 0.35, 2)" },
         "wall_thickness": { "value": "1" },
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 60" },
-        "meshfix_maximum_deviation": { "value": "layer_height / 2" },
+        "meshfix_maximum_deviation": { "value": "layer_height / 4" },
         "optimize_wall_printing_order": { "value": "True" },
         "retraction_combing": { "default_value": "all" },
         "initial_layer_line_width_factor": { "value": "120" },

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Draft_Print_Quick.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Draft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = quick
 quality_type = draft

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Fast_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Fast_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = fast
 intent_category = visual

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_High_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_High_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = high
 intent_category = visual

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Normal_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_ABS_Normal_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = normal
 intent_category = visual

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_PC_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_PC_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print_Quick.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = quick
 quality_type = draft

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = fast
 intent_category = visual

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_High_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_High_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = high
 intent_category = visual

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = normal
 intent_category = visual

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Draft_Print_Quick.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Draft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = quick
 quality_type = draft

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = fast
 intent_category = visual

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_High_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_High_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = high
 intent_category = visual

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = normal
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Draft_Print_Quick.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Draft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = quick
 quality_type = draft

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = fast
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_High_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_High_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = high
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = normal
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print_Quick.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = quick
 quality_type = draft

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = fast
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_High_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_High_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = high
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = normal
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print_Quick.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print_Quick.inst.cfg
@@ -4,7 +4,7 @@ name = Quick
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = quick
 quality_type = draft

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = fast

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = fast
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_High_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_High_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = high
 intent_category = visual

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
@@ -4,7 +4,7 @@ name = Accurate
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 intent_category = engineering
 quality_type = normal

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Visual.inst.cfg
@@ -4,7 +4,7 @@ name = Visual
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = intent
 quality_type = normal
 intent_category = visual

--- a/resources/quality/Leapfrog_Bolt_Pro/Leapfrog_Bolt_Pro_global_standard.inst.cfg
+++ b/resources/quality/Leapfrog_Bolt_Pro/Leapfrog_Bolt_Pro_global_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 weight = 0

--- a/resources/quality/Leapfrog_Bolt_Pro/abs/Leapfrog_Bolt_Pro_brass0.4_abs_natural_standard.inst.cfg
+++ b/resources/quality/Leapfrog_Bolt_Pro/abs/Leapfrog_Bolt_Pro_brass0.4_abs_natural_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 weight = 0

--- a/resources/quality/Leapfrog_Bolt_Pro/abs/Leapfrog_Bolt_Pro_nozzlex0.4_abs_natural_standard.inst.cfg
+++ b/resources/quality/Leapfrog_Bolt_Pro/abs/Leapfrog_Bolt_Pro_nozzlex0.4_abs_natural_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 weight = 0

--- a/resources/quality/Leapfrog_Bolt_Pro/epla/Leapfrog_Bolt_Pro_brass0.4_epla_natural_standard.inst.cfg
+++ b/resources/quality/Leapfrog_Bolt_Pro/epla/Leapfrog_Bolt_Pro_brass0.4_epla_natural_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 weight = 0

--- a/resources/quality/Leapfrog_Bolt_Pro/epla/Leapfrog_Bolt_Pro_nozzlex0.4_epla_natural_standard.inst.cfg
+++ b/resources/quality/Leapfrog_Bolt_Pro/epla/Leapfrog_Bolt_Pro_nozzlex0.4_epla_natural_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 weight = 0

--- a/resources/quality/Leapfrog_Bolt_Pro/pva/Leapfrog_Bolt_Pro_brass0.4_pva_natural_standard.inst.cfg
+++ b/resources/quality/Leapfrog_Bolt_Pro/pva/Leapfrog_Bolt_Pro_brass0.4_pva_natural_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 weight = 0

--- a/resources/quality/Leapfrog_Bolt_Pro/pva/Leapfrog_Bolt_Pro_nozzlex0.4_pva_natural_standard.inst.cfg
+++ b/resources/quality/Leapfrog_Bolt_Pro/pva/Leapfrog_Bolt_Pro_nozzlex0.4_pva_natural_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 weight = 0

--- a/resources/quality/abax_pri3/apri3_pla_fast.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = abax_pri3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/abax_pri3/apri3_pla_high.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = abax_pri3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/abax_pri3/apri3_pla_normal.inst.cfg
+++ b/resources/quality/abax_pri3/apri3_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = abax_pri3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/abax_pri5/apri5_pla_fast.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = abax_pri5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/abax_pri5/apri5_pla_high.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = abax_pri5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/abax_pri5/apri5_pla_normal.inst.cfg
+++ b/resources/quality/abax_pri5/apri5_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = abax_pri5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/abax_titan/atitan_pla_fast.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = abax_titan
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/abax_titan/atitan_pla_high.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = abax_titan
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/abax_titan/atitan_pla_normal.inst.cfg
+++ b/resources/quality/abax_titan/atitan_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = abax_titan
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/anycubic_4max/abs/anycubic_4max_abs_draft.inst.cfg
+++ b/resources/quality/anycubic_4max/abs/anycubic_4max_abs_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/anycubic_4max/abs/anycubic_4max_abs_high.inst.cfg
+++ b/resources/quality/anycubic_4max/abs/anycubic_4max_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/anycubic_4max/abs/anycubic_4max_abs_normal.inst.cfg
+++ b/resources/quality/anycubic_4max/abs/anycubic_4max_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/anycubic_4max/anycubic_4max_draft.inst.cfg
+++ b/resources/quality/anycubic_4max/anycubic_4max_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/anycubic_4max/anycubic_4max_high.inst.cfg
+++ b/resources/quality/anycubic_4max/anycubic_4max_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/anycubic_4max/anycubic_4max_normal.inst.cfg
+++ b/resources/quality/anycubic_4max/anycubic_4max_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/anycubic_4max/hips/anycubic_4max_hips_draft.inst.cfg
+++ b/resources/quality/anycubic_4max/hips/anycubic_4max_hips_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/anycubic_4max/hips/anycubic_4max_hips_high.inst.cfg
+++ b/resources/quality/anycubic_4max/hips/anycubic_4max_hips_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/anycubic_4max/hips/anycubic_4max_hips_normal.inst.cfg
+++ b/resources/quality/anycubic_4max/hips/anycubic_4max_hips_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/anycubic_4max/petg/anycubic_4max_petg_draft.inst.cfg
+++ b/resources/quality/anycubic_4max/petg/anycubic_4max_petg_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/anycubic_4max/petg/anycubic_4max_petg_high.inst.cfg
+++ b/resources/quality/anycubic_4max/petg/anycubic_4max_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/anycubic_4max/petg/anycubic_4max_petg_normal.inst.cfg
+++ b/resources/quality/anycubic_4max/petg/anycubic_4max_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/anycubic_4max/pla/anycubic_4max_pla_draft.inst.cfg
+++ b/resources/quality/anycubic_4max/pla/anycubic_4max_pla_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/anycubic_4max/pla/anycubic_4max_pla_high.inst.cfg
+++ b/resources/quality/anycubic_4max/pla/anycubic_4max_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/anycubic_4max/pla/anycubic_4max_pla_normal.inst.cfg
+++ b/resources/quality/anycubic_4max/pla/anycubic_4max_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = anycubic_4max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/anycubic_chiron/anycubic_chiron_draft.inst.cfg
+++ b/resources/quality/anycubic_chiron/anycubic_chiron_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = anycubic_chiron
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/anycubic_chiron/anycubic_chiron_high.inst.cfg
+++ b/resources/quality/anycubic_chiron/anycubic_chiron_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = anycubic_chiron
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/anycubic_chiron/anycubic_chiron_normal.inst.cfg
+++ b/resources/quality/anycubic_chiron/anycubic_chiron_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = anycubic_chiron
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_draft.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = anycubic_i3_mega
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_high.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = anycubic_i3_mega
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_normal.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = anycubic_i3_mega
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/builder_premium/bp_BVOH_Coarse_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_BVOH_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -1

--- a/resources/quality/builder_premium/bp_BVOH_High_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_BVOH_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High Quality
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/builder_premium/bp_BVOH_Normal_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_BVOH_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/builder_premium/bp_Innoflex60_Coarse_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_Innoflex60_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -1

--- a/resources/quality/builder_premium/bp_Innoflex60_High_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_Innoflex60_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High Quality
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/builder_premium/bp_Innoflex60_Normal_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_Innoflex60_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/builder_premium/bp_PET_Coarse_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PET_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -1

--- a/resources/quality/builder_premium/bp_PET_High_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PET_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High Quality
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/builder_premium/bp_PET_Normal_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PET_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/builder_premium/bp_PLA_Coarse_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PLA_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -1

--- a/resources/quality/builder_premium/bp_PLA_High_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High Quality
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/builder_premium/bp_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/builder_premium/bp_PVA_Coarse_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PVA_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -1

--- a/resources/quality/builder_premium/bp_PVA_High_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PVA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High Quality
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/builder_premium/bp_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_PVA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/builder_premium/bp_global_Coarse_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_global_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -1

--- a/resources/quality/builder_premium/bp_global_High_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High Quality
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/builder_premium/bp_global_Normal_Quality.inst.cfg
+++ b/resources/quality/builder_premium/bp_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = builder_premium_small
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/abs/cartesio_0.25_abs_high.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.25_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/abs/cartesio_0.25_abs_normal.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.25_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/abs/cartesio_0.4_abs_high.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.4_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/abs/cartesio_0.4_abs_normal.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.4_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/abs/cartesio_0.8_abs_coarse.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.8_abs_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = 3

--- a/resources/quality/cartesio/abs/cartesio_0.8_abs_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.8_abs_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = 4

--- a/resources/quality/cartesio/abs/cartesio_0.8_abs_high.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.8_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/abs/cartesio_0.8_abs_normal.inst.cfg
+++ b/resources/quality/cartesio/abs/cartesio_0.8_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/arnitel/cartesio_0.4_arnitel2045_high.inst.cfg
+++ b/resources/quality/cartesio/arnitel/cartesio_0.4_arnitel2045_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/arnitel/cartesio_0.4_arnitel2045_normal.inst.cfg
+++ b/resources/quality/cartesio/arnitel/cartesio_0.4_arnitel2045_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/cartesio_global_Coarse_Quality.inst.cfg
+++ b/resources/quality/cartesio/cartesio_global_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/cartesio/cartesio_global_Extra_Coarse_Quality.inst.cfg
+++ b/resources/quality/cartesio/cartesio_global_Extra_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -4

--- a/resources/quality/cartesio/cartesio_global_High_Quality.inst.cfg
+++ b/resources/quality/cartesio/cartesio_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/cartesio_global_Normal_Quality.inst.cfg
+++ b/resources/quality/cartesio/cartesio_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/hips/cartesio_0.25_hips_high.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.25_hips_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/hips/cartesio_0.25_hips_normal.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.25_hips_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/hips/cartesio_0.4_hips_high.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.4_hips_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/hips/cartesio_0.4_hips_normal.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.4_hips_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/hips/cartesio_0.8_hips_coarse.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.8_hips_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = 3

--- a/resources/quality/cartesio/hips/cartesio_0.8_hips_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.8_hips_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = 4

--- a/resources/quality/cartesio/hips/cartesio_0.8_hips_high.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.8_hips_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/hips/cartesio_0.8_hips_normal.inst.cfg
+++ b/resources/quality/cartesio/hips/cartesio_0.8_hips_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/nylon/cartesio_0.25_nylon_high.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.25_nylon_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/nylon/cartesio_0.25_nylon_normal.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.25_nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/nylon/cartesio_0.4_nylon_high.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.4_nylon_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/nylon/cartesio_0.4_nylon_normal.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.4_nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/nylon/cartesio_0.8_nylon_coarse.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.8_nylon_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = 3

--- a/resources/quality/cartesio/nylon/cartesio_0.8_nylon_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.8_nylon_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = 4

--- a/resources/quality/cartesio/nylon/cartesio_0.8_nylon_high.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.8_nylon_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/nylon/cartesio_0.8_nylon_normal.inst.cfg
+++ b/resources/quality/cartesio/nylon/cartesio_0.8_nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pc/cartesio_0.25_pc_high.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.25_pc_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pc/cartesio_0.25_pc_normal.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.25_pc_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pc/cartesio_0.4_pc_high.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.4_pc_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pc/cartesio_0.4_pc_normal.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.4_pc_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pc/cartesio_0.8_pc_coarse.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.8_pc_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = 3

--- a/resources/quality/cartesio/pc/cartesio_0.8_pc_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.8_pc_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = 4

--- a/resources/quality/cartesio/pc/cartesio_0.8_pc_high.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.8_pc_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pc/cartesio_0.8_pc_normal.inst.cfg
+++ b/resources/quality/cartesio/pc/cartesio_0.8_pc_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/petg/cartesio_0.25_petg_high.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.25_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/petg/cartesio_0.25_petg_normal.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.25_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/petg/cartesio_0.4_petg_high.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.4_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/petg/cartesio_0.4_petg_normal.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.4_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/petg/cartesio_0.8_petg_coarse.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.8_petg_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = 3

--- a/resources/quality/cartesio/petg/cartesio_0.8_petg_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.8_petg_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = 4

--- a/resources/quality/cartesio/petg/cartesio_0.8_petg_high.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.8_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/petg/cartesio_0.8_petg_normal.inst.cfg
+++ b/resources/quality/cartesio/petg/cartesio_0.8_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pla/cartesio_0.25_pla_high.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.25_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pla/cartesio_0.25_pla_normal.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.25_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pla/cartesio_0.4_pla_high.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.4_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pla/cartesio_0.4_pla_normal.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.4_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pla/cartesio_0.8_pla_coarse.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.8_pla_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/cartesio/pla/cartesio_0.8_pla_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.8_pla_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -4

--- a/resources/quality/cartesio/pla/cartesio_0.8_pla_high.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.8_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pla/cartesio_0.8_pla_normal.inst.cfg
+++ b/resources/quality/cartesio/pla/cartesio_0.8_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pva/cartesio_0.25_pva_high.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.25_pva_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pva/cartesio_0.25_pva_normal.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.25_pva_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pva/cartesio_0.4_pva_high.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.4_pva_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pva/cartesio_0.4_pva_normal.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.4_pva_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/cartesio/pva/cartesio_0.8_pva_coarse.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.8_pva_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = 3

--- a/resources/quality/cartesio/pva/cartesio_0.8_pva_extra_coarse.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.8_pva_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = 4

--- a/resources/quality/cartesio/pva/cartesio_0.8_pva_high.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.8_pva_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/cartesio/pva/cartesio_0.8_pva_normal.inst.cfg
+++ b/resources/quality/cartesio/pva/cartesio_0.8_pva_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = cartesio
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/coarse.inst.cfg
+++ b/resources/quality/coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = fdmprinter
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/creality/base/base_0.2_ABS_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.2_ABS_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_abs

--- a/resources/quality/creality/base/base_0.2_ABS_ultra.inst.cfg
+++ b/resources/quality/creality/base/base_0.2_ABS_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 material = generic_abs

--- a/resources/quality/creality/base/base_0.2_PETG_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.2_PETG_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_petg

--- a/resources/quality/creality/base/base_0.2_PETG_ultra.inst.cfg
+++ b/resources/quality/creality/base/base_0.2_PETG_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 material = generic_petg

--- a/resources/quality/creality/base/base_0.2_PLA_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.2_PLA_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_pla

--- a/resources/quality/creality/base/base_0.2_PLA_ultra.inst.cfg
+++ b/resources/quality/creality/base/base_0.2_PLA_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 material = generic_pla

--- a/resources/quality/creality/base/base_0.3_ABS_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_ABS_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_abs

--- a/resources/quality/creality/base/base_0.3_ABS_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_ABS_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_abs

--- a/resources/quality/creality/base/base_0.3_ABS_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_ABS_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_abs

--- a/resources/quality/creality/base/base_0.3_ABS_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_ABS_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_abs

--- a/resources/quality/creality/base/base_0.3_PETG_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_PETG_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_petg

--- a/resources/quality/creality/base/base_0.3_PETG_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_PETG_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_petg

--- a/resources/quality/creality/base/base_0.3_PETG_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_PETG_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_petg

--- a/resources/quality/creality/base/base_0.3_PETG_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_PETG_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_petg

--- a/resources/quality/creality/base/base_0.3_PLA_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_PLA_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_pla

--- a/resources/quality/creality/base/base_0.3_PLA_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_PLA_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_pla

--- a/resources/quality/creality/base/base_0.3_PLA_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_PLA_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_pla

--- a/resources/quality/creality/base/base_0.3_PLA_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_PLA_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_pla

--- a/resources/quality/creality/base/base_0.3_TPU_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_TPU_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.3_TPU_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_TPU_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.3_TPU_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.3_TPU_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.4_ABS_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_ABS_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_abs

--- a/resources/quality/creality/base/base_0.4_ABS_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_ABS_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_abs

--- a/resources/quality/creality/base/base_0.4_ABS_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_ABS_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_abs

--- a/resources/quality/creality/base/base_0.4_ABS_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_ABS_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_abs

--- a/resources/quality/creality/base/base_0.4_PETG_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_PETG_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_petg

--- a/resources/quality/creality/base/base_0.4_PETG_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_PETG_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_petg

--- a/resources/quality/creality/base/base_0.4_PETG_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_PETG_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_petg

--- a/resources/quality/creality/base/base_0.4_PETG_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_PETG_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_petg

--- a/resources/quality/creality/base/base_0.4_PLA_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_PLA_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_pla

--- a/resources/quality/creality/base/base_0.4_PLA_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_PLA_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_pla

--- a/resources/quality/creality/base/base_0.4_PLA_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_PLA_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_pla

--- a/resources/quality/creality/base/base_0.4_PLA_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_PLA_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_pla

--- a/resources/quality/creality/base/base_0.4_TPU_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_TPU_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.4_TPU_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_TPU_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.4_TPU_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.4_TPU_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.5_ABS_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_ABS_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_abs

--- a/resources/quality/creality/base/base_0.5_ABS_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_ABS_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_abs

--- a/resources/quality/creality/base/base_0.5_ABS_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_ABS_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_abs

--- a/resources/quality/creality/base/base_0.5_ABS_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_ABS_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_abs

--- a/resources/quality/creality/base/base_0.5_PETG_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_PETG_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_petg

--- a/resources/quality/creality/base/base_0.5_PETG_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_PETG_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_petg

--- a/resources/quality/creality/base/base_0.5_PETG_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_PETG_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_petg

--- a/resources/quality/creality/base/base_0.5_PETG_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_PETG_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_petg

--- a/resources/quality/creality/base/base_0.5_PLA_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_PLA_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_pla

--- a/resources/quality/creality/base/base_0.5_PLA_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_PLA_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_pla

--- a/resources/quality/creality/base/base_0.5_PLA_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_PLA_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_pla

--- a/resources/quality/creality/base/base_0.5_PLA_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_PLA_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_pla

--- a/resources/quality/creality/base/base_0.5_TPU_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_TPU_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.5_TPU_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_TPU_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.5_TPU_super.inst.cfg
+++ b/resources/quality/creality/base/base_0.5_TPU_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.6_ABS_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.6_ABS_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_abs

--- a/resources/quality/creality/base/base_0.6_PETG_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.6_PETG_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_petg

--- a/resources/quality/creality/base/base_0.6_PLA_draft.inst.cfg
+++ b/resources/quality/creality/base/base_0.6_PLA_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_pla

--- a/resources/quality/creality/base/base_0.6_PLA_low.inst.cfg
+++ b/resources/quality/creality/base/base_0.6_PLA_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_pla

--- a/resources/quality/creality/base/base_0.6_PLA_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.6_PLA_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_pla

--- a/resources/quality/creality/base/base_0.6_TPU_standard.inst.cfg
+++ b/resources/quality/creality/base/base_0.6_TPU_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 material = generic_tpu

--- a/resources/quality/creality/base/base_0.8_ABS_draft.inst.cfg
+++ b/resources/quality/creality/base/base_0.8_ABS_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_abs

--- a/resources/quality/creality/base/base_0.8_PETG_draft.inst.cfg
+++ b/resources/quality/creality/base/base_0.8_PETG_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_petg

--- a/resources/quality/creality/base/base_0.8_PLA_draft.inst.cfg
+++ b/resources/quality/creality/base/base_0.8_PLA_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_pla

--- a/resources/quality/creality/base/base_0.8_TPU_draft.inst.cfg
+++ b/resources/quality/creality/base/base_0.8_TPU_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_tpu

--- a/resources/quality/creality/base/base_1.0_ABS_draft.inst.cfg
+++ b/resources/quality/creality/base/base_1.0_ABS_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_abs

--- a/resources/quality/creality/base/base_1.0_PETG_draft.inst.cfg
+++ b/resources/quality/creality/base/base_1.0_PETG_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_petg

--- a/resources/quality/creality/base/base_1.0_PLA_draft.inst.cfg
+++ b/resources/quality/creality/base/base_1.0_PLA_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_pla

--- a/resources/quality/creality/base/base_1.0_TPU_draft.inst.cfg
+++ b/resources/quality/creality/base/base_1.0_TPU_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_tpu

--- a/resources/quality/creality/base/base_global_adaptive.inst.cfg
+++ b/resources/quality/creality/base/base_global_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 weight = -2

--- a/resources/quality/creality/base/base_global_draft.inst.cfg
+++ b/resources/quality/creality/base/base_global_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -5

--- a/resources/quality/creality/base/base_global_low.inst.cfg
+++ b/resources/quality/creality/base/base_global_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 weight = -4

--- a/resources/quality/creality/base/base_global_standard.inst.cfg
+++ b/resources/quality/creality/base/base_global_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = standard
 weight = -3

--- a/resources/quality/creality/base/base_global_super.inst.cfg
+++ b/resources/quality/creality/base/base_global_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 weight = -1

--- a/resources/quality/creality/base/base_global_ultra.inst.cfg
+++ b/resources/quality/creality/base/base_global_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 0

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = dagoma_discoeasy200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = dagoma_discoeasy200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/dagoma/dagoma_discoeasy200_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_pla_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = dagoma_discoeasy200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/dagoma/dagoma_discoultimate_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoultimate_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = dagoma_discoultimate
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/dagoma/dagoma_discoultimate_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoultimate_pla_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = dagoma_discoultimate
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/dagoma/dagoma_discoultimate_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoultimate_pla_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = dagoma_discoultimate
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/dagoma/dagoma_magis_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_magis_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = dagoma_magis
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/dagoma/dagoma_magis_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_magis_pla_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = dagoma_magis
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/dagoma/dagoma_magis_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_magis_pla_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = dagoma_magis
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/dagoma/dagoma_neva_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = dagoma_neva
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/dagoma/dagoma_neva_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = dagoma_neva
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/dagoma/dagoma_neva_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_neva_pla_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard
 definition = dagoma_neva
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/deltacomb/deltacomb_abs_Draft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_abs_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast (beta)
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/deltacomb/deltacomb_abs_Fast_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_abs_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal (beta)
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/deltacomb/deltacomb_abs_High_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_abs_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine (beta)
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_abs_Normal_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_abs_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine (beta)
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_abs_Verydraft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_abs_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast (beta)
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/deltacomb/deltacomb_global_Draft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/deltacomb/deltacomb_global_Fast_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/deltacomb/deltacomb_global_High_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_global_Normal_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_global_Verydraft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_global_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/deltacomb/deltacomb_petg_Draft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_petg_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/deltacomb/deltacomb_petg_Fast_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_petg_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/deltacomb/deltacomb_petg_High_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_petg_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_petg_Normal_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_petg_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_petg_Verydraft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_petg_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/deltacomb/deltacomb_pla_Draft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_pla_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/deltacomb/deltacomb_pla_Fast_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_pla_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/deltacomb/deltacomb_pla_High_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_pla_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_pla_Normal_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_pla_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_pla_Verydraft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_pla_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/deltacomb/deltacomb_tpu_Draft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_tpu_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/deltacomb/deltacomb_tpu_Fast_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_tpu_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/deltacomb/deltacomb_tpu_High_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_tpu_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_tpu_Normal_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_tpu_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/deltacomb/deltacomb_tpu_Verydraft_Quality.inst.cfg
+++ b/resources/quality/deltacomb/deltacomb_tpu_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = deltacomb
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/draft.inst.cfg
+++ b/resources/quality/draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = fdmprinter
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/extra_coarse.inst.cfg
+++ b/resources/quality/extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse
 definition = fdmprinter
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -4

--- a/resources/quality/extra_fast.inst.cfg
+++ b/resources/quality/extra_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = fdmprinter
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/fabtotum/fabtotum_abs_fast.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_abs_fast.inst.cfg
@@ -4,7 +4,7 @@ definition = fabtotum
 name = Fast Quality
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/fabtotum/fabtotum_abs_high.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_abs_high.inst.cfg
@@ -4,7 +4,7 @@ definition = fabtotum
 name = High Quality
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/fabtotum/fabtotum_abs_normal.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ definition = fabtotum
 name = Normal Quality
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/fabtotum/fabtotum_nylon_fast.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast Quality
 definition = fabtotum
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/fabtotum/fabtotum_nylon_high.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_nylon_high.inst.cfg
@@ -4,7 +4,7 @@ name = High Quality
 definition = fabtotum
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/fabtotum/fabtotum_nylon_normal.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal Quality
 definition = fabtotum
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/fabtotum/fabtotum_pla_fast.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ definition = fabtotum
 name = Fast Quality
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/fabtotum/fabtotum_pla_high.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_pla_high.inst.cfg
@@ -4,7 +4,7 @@ definition = fabtotum
 name = High Quality
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/fabtotum/fabtotum_pla_normal.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ definition = fabtotum
 name = Normal Quality
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/fabtotum/fabtotum_tpu_fast.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_tpu_fast.inst.cfg
@@ -5,7 +5,7 @@ name = Fast Quality
 
 [metadata]
 type = quality
-setting_version = 12
+setting_version = 13
 material = generic_tpu
 quality_type = fast
 weight = -1

--- a/resources/quality/fabtotum/fabtotum_tpu_high.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_tpu_high.inst.cfg
@@ -5,7 +5,7 @@ name = High Quality
 
 [metadata]
 type = quality
-setting_version = 12
+setting_version = 13
 material = generic_tpu
 quality_type = high
 weight = 1

--- a/resources/quality/fabtotum/fabtotum_tpu_normal.inst.cfg
+++ b/resources/quality/fabtotum/fabtotum_tpu_normal.inst.cfg
@@ -5,7 +5,7 @@ name = Normal Quality
 
 [metadata]
 type = quality
-setting_version = 12
+setting_version = 13
 material = generic_tpu
 quality_type = normal
 weight = 0

--- a/resources/quality/fabxpro/fabxpro_abs_draft.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_abs_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Draft
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_abs_fine.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_abs_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Fine 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_abs_normal.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Normal 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_asa_draft.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_asa_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Draft 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_asa_fine.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_asa_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Fine 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_asa_normal.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_asa_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Normal 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_hips_draft.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_hips_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Draft 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_hips_fine.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_hips_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Fine 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_hips_normal.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_hips_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Normal 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_nylon_draft.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_nylon_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Draft 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_nylon_fine.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_nylon_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Fine 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_nylon_normal.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Normal 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_petg_draft.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_petg_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Draft 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_petg_fine.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_petg_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Fine 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_petg_normal.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Normal 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_pla_draft.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_pla_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Draft 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_pla_fine.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_pla_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Fine 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_pla_normal.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Normal 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_tpe_draft.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_tpe_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Draft 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_tpe_fine.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_tpe_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Fine 
 weight = -2

--- a/resources/quality/fabxpro/fabxpro_tpe_normal.inst.cfg
+++ b/resources/quality/fabxpro/fabxpro_tpe_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = fabxpro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Normal 
 weight = -2

--- a/resources/quality/fast.inst.cfg
+++ b/resources/quality/fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = fdmprinter
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/flyingbear/abs/flyingbear_0.25_abs_super.inst.cfg
+++ b/resources/quality/flyingbear/abs/flyingbear_0.25_abs_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_abs

--- a/resources/quality/flyingbear/abs/flyingbear_0.25_abs_ultra.inst.cfg
+++ b/resources/quality/flyingbear/abs/flyingbear_0.25_abs_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 material = generic_abs

--- a/resources/quality/flyingbear/abs/flyingbear_0.40_abs_adaptive.inst.cfg
+++ b/resources/quality/flyingbear/abs/flyingbear_0.40_abs_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_abs

--- a/resources/quality/flyingbear/abs/flyingbear_0.40_abs_low.inst.cfg
+++ b/resources/quality/flyingbear/abs/flyingbear_0.40_abs_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_abs

--- a/resources/quality/flyingbear/abs/flyingbear_0.40_abs_standard.inst.cfg
+++ b/resources/quality/flyingbear/abs/flyingbear_0.40_abs_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_abs

--- a/resources/quality/flyingbear/abs/flyingbear_0.40_abs_super.inst.cfg
+++ b/resources/quality/flyingbear/abs/flyingbear_0.40_abs_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_abs

--- a/resources/quality/flyingbear/abs/flyingbear_0.80_abs_draft.inst.cfg
+++ b/resources/quality/flyingbear/abs/flyingbear_0.80_abs_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_abs

--- a/resources/quality/flyingbear/flyingbear_global_0.08_ultra.inst.cfg
+++ b/resources/quality/flyingbear/flyingbear_global_0.08_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 0

--- a/resources/quality/flyingbear/flyingbear_global_0.12_super.inst.cfg
+++ b/resources/quality/flyingbear/flyingbear_global_0.12_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 weight = -1

--- a/resources/quality/flyingbear/flyingbear_global_0.16_adaptive.inst.cfg
+++ b/resources/quality/flyingbear/flyingbear_global_0.16_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 weight = -2

--- a/resources/quality/flyingbear/flyingbear_global_0.20_standard.inst.cfg
+++ b/resources/quality/flyingbear/flyingbear_global_0.20_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = -3

--- a/resources/quality/flyingbear/flyingbear_global_0.28_low.inst.cfg
+++ b/resources/quality/flyingbear/flyingbear_global_0.28_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 weight = -4

--- a/resources/quality/flyingbear/flyingbear_global_0.32_draft.inst.cfg
+++ b/resources/quality/flyingbear/flyingbear_global_0.32_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -5

--- a/resources/quality/flyingbear/hips/flyingbear_0.25_hips_super.inst.cfg
+++ b/resources/quality/flyingbear/hips/flyingbear_0.25_hips_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_hips

--- a/resources/quality/flyingbear/hips/flyingbear_0.25_hips_ultra.inst.cfg
+++ b/resources/quality/flyingbear/hips/flyingbear_0.25_hips_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 material = generic_hips

--- a/resources/quality/flyingbear/hips/flyingbear_0.40_hips_adaptive.inst.cfg
+++ b/resources/quality/flyingbear/hips/flyingbear_0.40_hips_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_hips

--- a/resources/quality/flyingbear/hips/flyingbear_0.40_hips_low.inst.cfg
+++ b/resources/quality/flyingbear/hips/flyingbear_0.40_hips_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_hips

--- a/resources/quality/flyingbear/hips/flyingbear_0.40_hips_standard.inst.cfg
+++ b/resources/quality/flyingbear/hips/flyingbear_0.40_hips_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_hips

--- a/resources/quality/flyingbear/hips/flyingbear_0.40_hips_super.inst.cfg
+++ b/resources/quality/flyingbear/hips/flyingbear_0.40_hips_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_hips

--- a/resources/quality/flyingbear/hips/flyingbear_0.80_hips_draft.inst.cfg
+++ b/resources/quality/flyingbear/hips/flyingbear_0.80_hips_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_hips

--- a/resources/quality/flyingbear/petg/flyingbear_0.25_petg_super.inst.cfg
+++ b/resources/quality/flyingbear/petg/flyingbear_0.25_petg_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_petg

--- a/resources/quality/flyingbear/petg/flyingbear_0.25_petg_ultra.inst.cfg
+++ b/resources/quality/flyingbear/petg/flyingbear_0.25_petg_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 material = generic_petg

--- a/resources/quality/flyingbear/petg/flyingbear_0.40_petg_adaptive.inst.cfg
+++ b/resources/quality/flyingbear/petg/flyingbear_0.40_petg_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_petg

--- a/resources/quality/flyingbear/petg/flyingbear_0.40_petg_low.inst.cfg
+++ b/resources/quality/flyingbear/petg/flyingbear_0.40_petg_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_petg

--- a/resources/quality/flyingbear/petg/flyingbear_0.40_petg_standard.inst.cfg
+++ b/resources/quality/flyingbear/petg/flyingbear_0.40_petg_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_petg

--- a/resources/quality/flyingbear/petg/flyingbear_0.40_petg_super.inst.cfg
+++ b/resources/quality/flyingbear/petg/flyingbear_0.40_petg_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_petg

--- a/resources/quality/flyingbear/petg/flyingbear_0.80_petg_draft.inst.cfg
+++ b/resources/quality/flyingbear/petg/flyingbear_0.80_petg_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_petg

--- a/resources/quality/flyingbear/pla/flyingbear_0.25_pla_super.inst.cfg
+++ b/resources/quality/flyingbear/pla/flyingbear_0.25_pla_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_pla

--- a/resources/quality/flyingbear/pla/flyingbear_0.25_pla_ultra.inst.cfg
+++ b/resources/quality/flyingbear/pla/flyingbear_0.25_pla_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 material = generic_pla

--- a/resources/quality/flyingbear/pla/flyingbear_0.40_pla_adaptive.inst.cfg
+++ b/resources/quality/flyingbear/pla/flyingbear_0.40_pla_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_pla

--- a/resources/quality/flyingbear/pla/flyingbear_0.40_pla_low.inst.cfg
+++ b/resources/quality/flyingbear/pla/flyingbear_0.40_pla_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = generic_pla

--- a/resources/quality/flyingbear/pla/flyingbear_0.40_pla_standard.inst.cfg
+++ b/resources/quality/flyingbear/pla/flyingbear_0.40_pla_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pla

--- a/resources/quality/flyingbear/pla/flyingbear_0.40_pla_super.inst.cfg
+++ b/resources/quality/flyingbear/pla/flyingbear_0.40_pla_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_pla

--- a/resources/quality/flyingbear/pla/flyingbear_0.80_pla_draft.inst.cfg
+++ b/resources/quality/flyingbear/pla/flyingbear_0.80_pla_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_pla

--- a/resources/quality/flyingbear/plapro/flyingbear_0.25_plapro_super.inst.cfg
+++ b/resources/quality/flyingbear/plapro/flyingbear_0.25_plapro_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = eSUN_PLA_PRO_Black

--- a/resources/quality/flyingbear/plapro/flyingbear_0.25_plapro_ultra.inst.cfg
+++ b/resources/quality/flyingbear/plapro/flyingbear_0.25_plapro_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 material = eSUN_PLA_PRO_Black

--- a/resources/quality/flyingbear/plapro/flyingbear_0.40_plapro_adaptive.inst.cfg
+++ b/resources/quality/flyingbear/plapro/flyingbear_0.40_plapro_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = eSUN_PLA_PRO_Black

--- a/resources/quality/flyingbear/plapro/flyingbear_0.40_plapro_low.inst.cfg
+++ b/resources/quality/flyingbear/plapro/flyingbear_0.40_plapro_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = low
 material = eSUN_PLA_PRO_Black

--- a/resources/quality/flyingbear/plapro/flyingbear_0.40_plapro_standard.inst.cfg
+++ b/resources/quality/flyingbear/plapro/flyingbear_0.40_plapro_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = eSUN_PLA_PRO_Black

--- a/resources/quality/flyingbear/plapro/flyingbear_0.40_plapro_super.inst.cfg
+++ b/resources/quality/flyingbear/plapro/flyingbear_0.40_plapro_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = eSUN_PLA_PRO_Black

--- a/resources/quality/flyingbear/plapro/flyingbear_0.80_plapro_draft.inst.cfg
+++ b/resources/quality/flyingbear/plapro/flyingbear_0.80_plapro_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = eSUN_PLA_PRO_Black

--- a/resources/quality/flyingbear/tpu/flyingbear_0.40_tpu_adaptive.inst.cfg
+++ b/resources/quality/flyingbear/tpu/flyingbear_0.40_tpu_adaptive.inst.cfg
@@ -4,7 +4,7 @@ name = Dynamic Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = adaptive
 material = generic_tpu

--- a/resources/quality/flyingbear/tpu/flyingbear_0.40_tpu_standard.inst.cfg
+++ b/resources/quality/flyingbear/tpu/flyingbear_0.40_tpu_standard.inst.cfg
@@ -4,7 +4,7 @@ name = Standard Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_tpu

--- a/resources/quality/flyingbear/tpu/flyingbear_0.40_tpu_super.inst.cfg
+++ b/resources/quality/flyingbear/tpu/flyingbear_0.40_tpu_super.inst.cfg
@@ -4,7 +4,7 @@ name = Super Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = super
 material = generic_tpu

--- a/resources/quality/flyingbear/tpu/flyingbear_0.80_tpu_draft.inst.cfg
+++ b/resources/quality/flyingbear/tpu/flyingbear_0.80_tpu_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 material = generic_tpu

--- a/resources/quality/gmax15plus/gmax15plus_global_dual_normal.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_dual_normal.inst.cfg
@@ -4,7 +4,7 @@ name = gMax 1.5+ Dual Normal Layers
 definition = gmax15plus_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/gmax15plus/gmax15plus_global_dual_thick.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_dual_thick.inst.cfg
@@ -4,7 +4,7 @@ name = gMax 1.5+ Dual Thick Layers
 definition = gmax15plus_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = course
 weight = -2

--- a/resources/quality/gmax15plus/gmax15plus_global_dual_thin.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_dual_thin.inst.cfg
@@ -4,7 +4,7 @@ name = gMax 1.5+ Dual Thin Layers
 definition = gmax15plus_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/gmax15plus/gmax15plus_global_dual_very_thick.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_dual_very_thick.inst.cfg
@@ -4,7 +4,7 @@ name = gMax 1.5+ Dual Very Thick Layers
 definition = gmax15plus_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra_course
 weight = -3

--- a/resources/quality/gmax15plus/gmax15plus_global_normal.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_normal.inst.cfg
@@ -4,7 +4,7 @@ name = gMax 1.5+ Normal Layers
 definition = gmax15plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/gmax15plus/gmax15plus_global_thick.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_thick.inst.cfg
@@ -4,7 +4,7 @@ name = gMax 1.5+ Thick Layers
 definition = gmax15plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = course
 weight = -2

--- a/resources/quality/gmax15plus/gmax15plus_global_thin.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_thin.inst.cfg
@@ -4,7 +4,7 @@ name = gMax 1.5+ Thin Layers
 definition = gmax15plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/gmax15plus/gmax15plus_global_very_thick.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_very_thick.inst.cfg
@@ -4,7 +4,7 @@ name = gMax 1.5+ Very Thick Layers
 definition = gmax15plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra_course
 weight = -3

--- a/resources/quality/high.inst.cfg
+++ b/resources/quality/high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = fdmprinter
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/hms434/hms434_global_Coarse_Quality.inst.cfg
+++ b/resources/quality/hms434/hms434_global_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -1

--- a/resources/quality/hms434/hms434_global_High_Quality.inst.cfg
+++ b/resources/quality/hms434/hms434_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/hms434/hms434_global_Normal_Quality.inst.cfg
+++ b/resources/quality/hms434/hms434_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/hms434/pla/hms434_0.4_pla_high.inst.cfg
+++ b/resources/quality/hms434/pla/hms434_0.4_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/hms434/pla/hms434_0.4_pla_normal.inst.cfg
+++ b/resources/quality/hms434/pla/hms434_0.4_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/hms434/pla/hms434_0.8_pla_coarse.inst.cfg
+++ b/resources/quality/hms434/pla/hms434_0.8_pla_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -1

--- a/resources/quality/hms434/pla/hms434_0.8_pla_normal.inst.cfg
+++ b/resources/quality/hms434/pla/hms434_0.8_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/imade3d_jellybox/PETG/jbo_generic_petg_0.4_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox/PETG/jbo_generic_petg_0.4_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/imade3d_jellybox/PETG/jbo_generic_petg_0.4_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/PETG/jbo_generic_petg_0.4_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/imade3d_jellybox/PETG/jbo_generic_petg_0.4_medium.inst.cfg
+++ b/resources/quality/imade3d_jellybox/PETG/jbo_generic_petg_0.4_medium.inst.cfg
@@ -4,7 +4,7 @@ name = Medium
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/imade3d_jellybox/PLA/jbo_generic_pla_0.4_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox/PLA/jbo_generic_pla_0.4_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/imade3d_jellybox/PLA/jbo_generic_pla_0.4_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/PLA/jbo_generic_pla_0.4_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/imade3d_jellybox/PLA/jbo_generic_pla_0.4_medium.inst.cfg
+++ b/resources/quality/imade3d_jellybox/PLA/jbo_generic_pla_0.4_medium.inst.cfg
@@ -4,7 +4,7 @@ name = Medium
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/imade3d_jellybox/PLA/jbo_generic_pla_0.4_ultrafine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/PLA/jbo_generic_pla_0.4_ultrafine.inst.cfg
@@ -4,7 +4,7 @@ name = UltraFine
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrahigh
 weight = 2

--- a/resources/quality/imade3d_jellybox/imade3d_jellybox_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox/imade3d_jellybox_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/imade3d_jellybox/imade3d_jellybox_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/imade3d_jellybox_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/imade3d_jellybox/imade3d_jellybox_normal.inst.cfg
+++ b/resources/quality/imade3d_jellybox/imade3d_jellybox_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Medium
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/imade3d_jellybox/imade3d_jellybox_ultrafine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/imade3d_jellybox_ultrafine.inst.cfg
@@ -4,7 +4,7 @@ name = UltraFine
 definition = imade3d_jellybox
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrahigh
 weight = 2

--- a/resources/quality/imade3d_jellybox_2/PETG/jb2_generic_petg_0.4_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/PETG/jb2_generic_petg_0.4_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/imade3d_jellybox_2/PETG/jb2_generic_petg_0.4_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/PETG/jb2_generic_petg_0.4_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/imade3d_jellybox_2/PETG/jb2_generic_petg_0.4_medium.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/PETG/jb2_generic_petg_0.4_medium.inst.cfg
@@ -4,7 +4,7 @@ name = Medium
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/imade3d_jellybox_2/PLA/jb2_generic_pla_0.4_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/PLA/jb2_generic_pla_0.4_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/imade3d_jellybox_2/PLA/jb2_generic_pla_0.4_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/PLA/jb2_generic_pla_0.4_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/imade3d_jellybox_2/PLA/jb2_generic_pla_0.4_medium.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/PLA/jb2_generic_pla_0.4_medium.inst.cfg
@@ -4,7 +4,7 @@ name = Medium
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/imade3d_jellybox_2/PLA/jb2_generic_pla_0.4_ultrafine.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/PLA/jb2_generic_pla_0.4_ultrafine.inst.cfg
@@ -4,7 +4,7 @@ name = UltraFine
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrahigh
 weight = 2

--- a/resources/quality/imade3d_jellybox_2/jb2_global_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/jb2_global_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/imade3d_jellybox_2/jb2_global_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/jb2_global_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/imade3d_jellybox_2/jb2_global_normal.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/jb2_global_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Medium
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/imade3d_jellybox_2/jb2_global_ultrafine.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/jb2_global_ultrafine.inst.cfg
@@ -4,7 +4,7 @@ name = UltraFine
 definition = imade3d_jellybox_2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrahigh
 weight = 2

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_draft.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_extra_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_extra_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_low.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_normal.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_draft.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_extra_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_extra_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_low.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_normal.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = kemiq_q2_beta
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_draft.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = kemiq_q2_gama
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_extra_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_extra_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = kemiq_q2_gama
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = kemiq_q2_gama
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_low.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_low.inst.cfg
@@ -4,7 +4,7 @@ name = Low
 definition = kemiq_q2_gama
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_normal.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = kemiq_q2_gama
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/key3d/key3d_tyro_best.inst.cfg
+++ b/resources/quality/key3d/key3d_tyro_best.inst.cfg
@@ -4,7 +4,7 @@ name = Best Quality
 definition = key3d_tyro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = best
 weight = 1

--- a/resources/quality/key3d/key3d_tyro_fast.inst.cfg
+++ b/resources/quality/key3d/key3d_tyro_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast Quality
 definition = key3d_tyro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/key3d/key3d_tyro_normal.inst.cfg
+++ b/resources/quality/key3d/key3d_tyro_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal Quality
 definition = key3d_tyro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/malyan_m200/abs/malyan_m200_abs_draft.inst.cfg
+++ b/resources/quality/malyan_m200/abs/malyan_m200_abs_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/malyan_m200/abs/malyan_m200_abs_fast.inst.cfg
+++ b/resources/quality/malyan_m200/abs/malyan_m200_abs_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/malyan_m200/abs/malyan_m200_abs_high.inst.cfg
+++ b/resources/quality/malyan_m200/abs/malyan_m200_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/malyan_m200/abs/malyan_m200_abs_normal.inst.cfg
+++ b/resources/quality/malyan_m200/abs/malyan_m200_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/malyan_m200/abs/malyan_m200_abs_superdraft.inst.cfg
+++ b/resources/quality/malyan_m200/abs/malyan_m200_abs_superdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/malyan_m200/abs/malyan_m200_abs_thickerdraft.inst.cfg
+++ b/resources/quality/malyan_m200/abs/malyan_m200_abs_thickerdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/malyan_m200/abs/malyan_m200_abs_ultra.inst.cfg
+++ b/resources/quality/malyan_m200/abs/malyan_m200_abs_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/malyan_m200/abs/malyan_m200_abs_verydraft.inst.cfg
+++ b/resources/quality/malyan_m200/abs/malyan_m200_abs_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/malyan_m200/malyan_m200_global_Draft_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/malyan_m200/malyan_m200_global_Fast_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/malyan_m200/malyan_m200_global_High_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/malyan_m200/malyan_m200_global_Normal_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/malyan_m200/malyan_m200_global_SuperDraft_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_SuperDraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/malyan_m200/malyan_m200_global_ThickerDraft_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_ThickerDraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/malyan_m200/malyan_m200_global_Ultra_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_Ultra_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/malyan_m200/malyan_m200_global_VeryDraft_Quality.inst.cfg
+++ b/resources/quality/malyan_m200/malyan_m200_global_VeryDraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/malyan_m200/petg/malyan_m200_petg_draft.inst.cfg
+++ b/resources/quality/malyan_m200/petg/malyan_m200_petg_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/malyan_m200/petg/malyan_m200_petg_fast.inst.cfg
+++ b/resources/quality/malyan_m200/petg/malyan_m200_petg_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/malyan_m200/petg/malyan_m200_petg_high.inst.cfg
+++ b/resources/quality/malyan_m200/petg/malyan_m200_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/malyan_m200/petg/malyan_m200_petg_normal.inst.cfg
+++ b/resources/quality/malyan_m200/petg/malyan_m200_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/malyan_m200/petg/malyan_m200_petg_superdraft.inst.cfg
+++ b/resources/quality/malyan_m200/petg/malyan_m200_petg_superdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/malyan_m200/petg/malyan_m200_petg_thickerdraft.inst.cfg
+++ b/resources/quality/malyan_m200/petg/malyan_m200_petg_thickerdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/malyan_m200/petg/malyan_m200_petg_ultra.inst.cfg
+++ b/resources/quality/malyan_m200/petg/malyan_m200_petg_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/malyan_m200/petg/malyan_m200_petg_verydraft.inst.cfg
+++ b/resources/quality/malyan_m200/petg/malyan_m200_petg_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/malyan_m200/pla/malyan_m200_pla_draft.inst.cfg
+++ b/resources/quality/malyan_m200/pla/malyan_m200_pla_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/malyan_m200/pla/malyan_m200_pla_fast.inst.cfg
+++ b/resources/quality/malyan_m200/pla/malyan_m200_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/malyan_m200/pla/malyan_m200_pla_high.inst.cfg
+++ b/resources/quality/malyan_m200/pla/malyan_m200_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/malyan_m200/pla/malyan_m200_pla_normal.inst.cfg
+++ b/resources/quality/malyan_m200/pla/malyan_m200_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/malyan_m200/pla/malyan_m200_pla_superdraft.inst.cfg
+++ b/resources/quality/malyan_m200/pla/malyan_m200_pla_superdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/malyan_m200/pla/malyan_m200_pla_thickerdraft.inst.cfg
+++ b/resources/quality/malyan_m200/pla/malyan_m200_pla_thickerdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/malyan_m200/pla/malyan_m200_pla_ultra.inst.cfg
+++ b/resources/quality/malyan_m200/pla/malyan_m200_pla_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/malyan_m200/pla/malyan_m200_pla_verydraft.inst.cfg
+++ b/resources/quality/malyan_m200/pla/malyan_m200_pla_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = malyan_m200
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_draft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_fast.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_high.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_normal.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_superdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_superdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_thickerdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_thickerdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_ultra.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = 2

--- a/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_verydraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/abs/monoprice_select_mini_v2_abs_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Draft_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Fast_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_High_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Normal_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_SuperDraft_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_SuperDraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_ThickerDraft_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_ThickerDraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Ultra_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_Ultra_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_VeryDraft_Quality.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/monoprice_select_mini_v2_global_VeryDraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_draft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_fast.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_high.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_high.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_normal.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_superdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_superdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_thickerdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_thickerdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_ultra.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_verydraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/nylon/monoprice_select_mini_v2_nylon_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_draft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_fast.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_high.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_high.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_normal.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_superdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_superdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_thickerdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_thickerdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_ultra.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_verydraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pc/monoprice_select_mini_v2_pc_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_draft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_fast.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_high.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_normal.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_superdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_superdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_thickerdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_thickerdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_ultra.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_verydraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/petg/monoprice_select_mini_v2_petg_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_draft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_fast.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 0

--- a/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_high.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = Finer
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_normal.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_superdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_superdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Lowest Quality Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -5

--- a/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_thickerdraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_thickerdraft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = thickerdraft
 weight = -3

--- a/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_ultra.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_ultra.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Fine
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultra
 weight = 2

--- a/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_verydraft.inst.cfg
+++ b/resources/quality/monoprice_select_mini_v2/pla/monoprice_select_mini_v2_pla_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Low Detail Draft
 definition = monoprice_select_mini_v2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 material = generic_pla
 weight = 0

--- a/resources/quality/normal.inst.cfg
+++ b/resources/quality/normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = fdmprinter
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/nwa3d_a31/nwa3d_a31_best.inst.cfg
+++ b/resources/quality/nwa3d_a31/nwa3d_a31_best.inst.cfg
@@ -5,7 +5,7 @@ name = Best Quality
 definition = nwa3d_a31
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = best
 weight = 1

--- a/resources/quality/nwa3d_a31/nwa3d_a31_e.inst.cfg
+++ b/resources/quality/nwa3d_a31/nwa3d_a31_e.inst.cfg
@@ -4,7 +4,7 @@ name = 0.6 Engineering Quality
 definition = nwa3d_a31
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = Engineering
 weight = -2

--- a/resources/quality/nwa3d_a31/nwa3d_a31_fast.inst.cfg
+++ b/resources/quality/nwa3d_a31/nwa3d_a31_fast.inst.cfg
@@ -5,7 +5,7 @@ name = Fast Quality
 definition = nwa3d_a31
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/nwa3d_a31/nwa3d_a31_normal.inst.cfg
+++ b/resources/quality/nwa3d_a31/nwa3d_a31_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal Quality
 definition = nwa3d_a31
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/nwa3d_a5/nwa3d_a5_best.inst.cfg
+++ b/resources/quality/nwa3d_a5/nwa3d_a5_best.inst.cfg
@@ -4,7 +4,7 @@ name = Best Quality
 definition = nwa3d_a5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = best
 weight = 1

--- a/resources/quality/nwa3d_a5/nwa3d_a5_fast.inst.cfg
+++ b/resources/quality/nwa3d_a5/nwa3d_a5_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast Quality
 definition = nwa3d_a5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/nwa3d_a5/nwa3d_a5_normal.inst.cfg
+++ b/resources/quality/nwa3d_a5/nwa3d_a5_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal Quality
 definition = nwa3d_a5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/peopoly_moai/peopoly_moai_coarse.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = peopoly_moai
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = 3

--- a/resources/quality/peopoly_moai/peopoly_moai_draft.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = peopoly_moai
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/peopoly_moai/peopoly_moai_extra_high.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_extra_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra High
 definition = peopoly_moai
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra_high
 weight = 0

--- a/resources/quality/peopoly_moai/peopoly_moai_high.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = peopoly_moai
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/peopoly_moai/peopoly_moai_normal.inst.cfg
+++ b/resources/quality/peopoly_moai/peopoly_moai_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = peopoly_moai
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ABS_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ABS_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ABS_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ABS_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ABS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ABS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ASA-X_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ASA-X_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ASA-X_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ASA-X_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ASA-X_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_ASA-X_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_HIPS_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_HIPS_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_HIPS_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_HIPS_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_HIPS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_HIPS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PETG_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PETG_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PETG_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PETG_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PETG_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PETG_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PLA_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PLA_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PLA_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PLA_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PLA_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PLA_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-M_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-M_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-M_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-M_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-M_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-M_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-OKS_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-OKS_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-OKS_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-OKS_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-OKS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-OKS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-S_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-S_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-S_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-S_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-S_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_PVA-S_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_TPU98A_A.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_TPU98A_A.inst.cfg
@@ -4,7 +4,7 @@ name = A
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_TPU98A_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_TPU98A_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_TPU98A_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.4/s3d_std0.4_TPU98A_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ABS_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ABS_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ABS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ABS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ABS_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ABS_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ASA-X_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ASA-X_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ASA-X_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ASA-X_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ASA-X_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_ASA-X_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d 
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_HIPS_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_HIPS_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_HIPS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_HIPS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_HIPS_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_HIPS_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_Nylon-1030_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_Nylon-1030_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PETG_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PETG_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PETG_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PETG_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PETG_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PETG_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PLA_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PLA_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PLA_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PLA_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PLA_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PLA_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-M_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-M_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-M_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-M_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-M_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-M_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-OKS_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-OKS_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-OKS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-OKS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-OKS_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-OKS_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-S_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-S_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-S_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-S_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-S_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_PVA-S_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_TPU98A_B.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_TPU98A_B.inst.cfg
@@ -4,7 +4,7 @@ name = B
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_TPU98A_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_TPU98A_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_TPU98A_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.6/s3d_std0.6_TPU98A_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ABS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ABS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ABS_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ABS_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ABS_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ABS_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ASA-X_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ASA-X_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ASA-X_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ASA-X_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ASA-X_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_ASA-X_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_HIPS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_HIPS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_HIPS_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_HIPS_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_HIPS_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_HIPS_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PETG_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PETG_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PETG_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PETG_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PETG_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PETG_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PLA_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PLA_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PLA_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PLA_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PLA_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PLA_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-M_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-M_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-M_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-M_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-M_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-M_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-OKS_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-OKS_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-OKS_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-OKS_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-OKS_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-OKS_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-S_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-S_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-S_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-S_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-S_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_PVA-S_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU98A_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU98A_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU98A_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU98A_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU98A_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU98A_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU_C.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU_C.inst.cfg
@@ -4,7 +4,7 @@ name = C
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 1

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU_D.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU_D.inst.cfg
@@ -4,7 +4,7 @@ name = D
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU_E.inst.cfg
+++ b/resources/quality/strateo3d/Standard_0.8/s3d_std0.8_TPU_E.inst.cfg
@@ -4,7 +4,7 @@ name = E
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = -1

--- a/resources/quality/strateo3d/Standard_1.2/s3d_std1.2_PLA_H.inst.cfg
+++ b/resources/quality/strateo3d/Standard_1.2/s3d_std1.2_PLA_H.inst.cfg
@@ -4,7 +4,7 @@ name = H
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = h
 weight = -1

--- a/resources/quality/strateo3d/s3d_global_A.inst.cfg
+++ b/resources/quality/strateo3d/s3d_global_A.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine Quality
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = a
 weight = 0

--- a/resources/quality/strateo3d/s3d_global_B.inst.cfg
+++ b/resources/quality/strateo3d/s3d_global_B.inst.cfg
@@ -4,7 +4,7 @@ name = Fine Quality
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = b
 weight = 0

--- a/resources/quality/strateo3d/s3d_global_C.inst.cfg
+++ b/resources/quality/strateo3d/s3d_global_C.inst.cfg
@@ -4,7 +4,7 @@ name = High Quality
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = c
 weight = 0

--- a/resources/quality/strateo3d/s3d_global_D.inst.cfg
+++ b/resources/quality/strateo3d/s3d_global_D.inst.cfg
@@ -4,7 +4,7 @@ name = Medium Quality
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = d
 weight = 0

--- a/resources/quality/strateo3d/s3d_global_E.inst.cfg
+++ b/resources/quality/strateo3d/s3d_global_E.inst.cfg
@@ -4,7 +4,7 @@ name = Low Quality
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = e
 weight = 0

--- a/resources/quality/strateo3d/s3d_global_F.inst.cfg
+++ b/resources/quality/strateo3d/s3d_global_F.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse Quality
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = f
 weight = 0

--- a/resources/quality/strateo3d/s3d_global_G.inst.cfg
+++ b/resources/quality/strateo3d/s3d_global_G.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse Quality
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = g
 weight = 0

--- a/resources/quality/strateo3d/s3d_global_H.inst.cfg
+++ b/resources/quality/strateo3d/s3d_global_H.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Coarse Quality
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = h
 weight = 0

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_draft.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tevo_blackwidow
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_high.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tevo_blackwidow
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_normal.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tevo_blackwidow
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.2_abs_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.2_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.3_abs_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.3_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.4_abs_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.4_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.4_abs_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.4_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.5_abs_draft.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.5_abs_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.5_abs_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.5_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.5_abs_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.5_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.6_abs_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.6_abs_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.6_abs_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.6_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.6_abs_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.6_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.8_abs_extra_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.8_abs_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.8_abs_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.8_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.8_abs_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/abs/tizyx_evy_0.8_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.2_flex_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.2_flex_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.3_flex_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.3_flex_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.4_flex_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.4_flex_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.4_flex_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.4_flex_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.5_flex_draft.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.5_flex_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.5_flex_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.5_flex_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.5_flex_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.5_flex_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.6_flex_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.6_flex_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.6_flex_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.6_flex_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.6_flex_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.6_flex_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.8_flex_extra_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.8_flex_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.8_flex_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.8_flex_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.8_flex_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/flex/tizyx_evy_0.8_flex_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.2_petg_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.2_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.3_petg_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.3_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.4_petg_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.4_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.4_petg_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.4_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.5_petg_draft.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.5_petg_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.5_petg_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.5_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.5_petg_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.5_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.6_petg_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.6_petg_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.6_petg_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.6_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.6_petg_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.6_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.8_petg_extra_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.8_petg_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.8_petg_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.8_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.8_petg_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/petg/tizyx_evy_0.8_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.2_pla_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.2_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.3_pla_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.3_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.4_pla_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.4_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.4_pla_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.4_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.5_pla_draft.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.5_pla_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.5_pla_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.5_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.5_pla_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.5_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.6_pla_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.6_pla_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.6_pla_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.6_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.6_pla_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.6_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.8_pla_extra_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.8_pla_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.8_pla_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.8_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.8_pla_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla/tizyx_evy_0.8_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.2_pla_bois_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.2_pla_bois_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.3_pla_bois_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.3_pla_bois_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.4_pla_bois_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.4_pla_bois_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.4_pla_bois_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.4_pla_bois_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.5_pla_bois_draft.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.5_pla_bois_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.5_pla_bois_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.5_pla_bois_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.5_pla_bois_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.5_pla_bois_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.6_pla_bois_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.6_pla_bois_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.6_pla_bois_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.6_pla_bois_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.6_pla_bois_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.6_pla_bois_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.8_pla_bois_extra_coarse.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.8_pla_bois_extra_coarse.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.8_pla_bois_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.8_pla_bois_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.8_pla_bois_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/pla_bois/tizyx_evy_0.8_pla_bois_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Coarse_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Draft_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Extra_Coarse_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Extra_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Normal_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/abs/tizyx_evy_dual_classic_abs_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/abs/tizyx_evy_dual_classic_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/abs/tizyx_evy_dual_classic_abs_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/abs/tizyx_evy_dual_classic_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/abs/tizyx_evy_dual_direct_drive_abs_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/abs/tizyx_evy_dual_direct_drive_abs_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/abs/tizyx_evy_dual_direct_drive_abs_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/abs/tizyx_evy_dual_direct_drive_abs_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/flex/tizyx_evy_dual_classic_flex_flex.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/flex/tizyx_evy_dual_classic_flex_flex.inst.cfg
@@ -4,7 +4,7 @@ name = Flex and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/flex/tizyx_evy_dual_classic_flex_flex_only.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/flex/tizyx_evy_dual_classic_flex_flex_only.inst.cfg
@@ -4,7 +4,7 @@ name = Flex Only
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/tizyx/tizyx_evy_dual/flex/tizyx_evy_dual_direct_drive_flex_flex.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/flex/tizyx_evy_dual_direct_drive_flex_flex.inst.cfg
@@ -4,7 +4,7 @@ name = Flex and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/flex/tizyx_evy_dual_direct_drive_flex_flex_only.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/flex/tizyx_evy_dual_direct_drive_flex_flex_only.inst.cfg
@@ -4,7 +4,7 @@ name = Flex Only
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/tizyx/tizyx_evy_dual/petg/tizyx_evy_dual_classic_petg_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/petg/tizyx_evy_dual_classic_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/petg/tizyx_evy_dual_classic_petg_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/petg/tizyx_evy_dual_classic_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/petg/tizyx_evy_dual_direct_drive_petg_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/petg/tizyx_evy_dual_direct_drive_petg_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/petg/tizyx_evy_dual_direct_drive_petg_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/petg/tizyx_evy_dual_direct_drive_petg_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_flex.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_flex.inst.cfg
@@ -4,7 +4,7 @@ name = Flex and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_flex_only.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_flex_only.inst.cfg
@@ -4,7 +4,7 @@ name = Flex Only
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_pva.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_classic_pla_pva.inst.cfg
@@ -4,7 +4,7 @@ name = PVA and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_flex.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_flex.inst.cfg
@@ -4,7 +4,7 @@ name = Flex and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_flex_only.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_flex_only.inst.cfg
@@ -4,7 +4,7 @@ name = Flex Only
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_pva.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla/tizyx_evy_dual_direct_drive_pla_pva.inst.cfg
@@ -4,7 +4,7 @@ name = PVA and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_classic_pla_bois_flex.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_classic_pla_bois_flex.inst.cfg
@@ -4,7 +4,7 @@ name = Flex and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_classic_pla_bois_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_classic_pla_bois_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_classic_pla_bois_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_classic_pla_bois_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_direct_drive_pla_bois_flex.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_direct_drive_pla_bois_flex.inst.cfg
@@ -4,7 +4,7 @@ name = Flex and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_direct_drive_pla_bois_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_direct_drive_pla_bois_high.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_direct_drive_pla_bois_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pla_bois/tizyx_evy_dual_direct_drive_pla_bois_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/pva/tizyx_evy_dual_classic_pva_pva.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pva/tizyx_evy_dual_classic_pva_pva.inst.cfg
@@ -4,7 +4,7 @@ name = PVA and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/pva/tizyx_evy_dual_direct_drive_pva_pva.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/pva/tizyx_evy_dual_direct_drive_pva_pva.inst.cfg
@@ -4,7 +4,7 @@ name = PVA and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_Flex_Only_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_Flex_Only_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Flex Only
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_Flex_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_Flex_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Flex and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_High_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_Normal_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_PVA_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_PVA_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = PVA and PLA
 definition = tizyx_evy_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/tizyx/tizyx_k25/tizyx_k25_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_k25/tizyx_k25_high.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_k25
 
 [metadata]
 quality_type = draft
-setting_version = 12
+setting_version = 13
 type = quality
 global_quality = True
 

--- a/resources/quality/tizyx/tizyx_k25/tizyx_k25_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_k25/tizyx_k25_normal.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_k25
 
 [metadata]
 quality_type = normal
-setting_version = 12
+setting_version = 13
 type = quality
 global_quality = True
 

--- a/resources/quality/ultimaker2/um2_draft.inst.cfg
+++ b/resources/quality/ultimaker2/um2_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Draft
 definition = ultimaker2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker2/um2_fast.inst.cfg
+++ b/resources/quality/ultimaker2/um2_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker2/um2_high.inst.cfg
+++ b/resources/quality/ultimaker2/um2_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2/um2_normal.inst.cfg
+++ b/resources/quality/ultimaker2/um2_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/pla_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.25_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/pla_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker2_plus/pla_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/pla_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.4_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/pla_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.6_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 0

--- a/resources/quality/ultimaker2_plus/pla_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/pla_0.8_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.25_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.4_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.6_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_abs_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_abs_0.8_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.25_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.4_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.6_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_cpe_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpe_0.8_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.4_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.4_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.4_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.6_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.6_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = slightlycoarse
 weight = -2

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.6_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.8_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = slightlycoarse
 weight = -2

--- a/resources/quality/ultimaker2_plus/um2p_cpep_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_cpep_0.8_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_global_Coarse_Quality.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_global_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse Quality
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -4

--- a/resources/quality/ultimaker2_plus/um2p_global_Draft_Quality.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker2_plus/um2p_global_Extra_Coarse_Quality.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_global_Extra_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse Quality
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extracoarse
 weight = -3

--- a/resources/quality/ultimaker2_plus/um2p_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/um2p_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_global_Slightly_Coarse_Quality.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_global_Slightly_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse Quality
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = slightlycoarse
 weight = -4

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.25_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.25_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.4_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.4_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.6_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = slightlycoarse
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.6_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.8_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = slightlycoarse
 weight = -2

--- a/resources/quality/ultimaker2_plus/um2p_nylon_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_nylon_0.8_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.25_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.25_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.4_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.4_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.6_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = slightlycoarse
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.6_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.8_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extracoarse
 weight = -2

--- a/resources/quality/ultimaker2_plus/um2p_pc_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pc_0.8_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.4_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.4_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.6_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.6_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.6_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.8_draft.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker2_plus/um2p_pp_0.8_verydraft.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_pp_0.8_verydraft.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = slightlycoarse
 weight = -3

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.25_high.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.4_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker2_plus/um2p_tpu_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus/um2p_tpu_0.6_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.25_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.25_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_CPE_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.25_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_Nylon_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.25_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_PC_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine - Experimental
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.25_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_PP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine - Experimental
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.25_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_TPLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker3/um3_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_BAM_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_BAM_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_BAM_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_BAM_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_BAM_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_BAM_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker3/um3_aa0.4_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPEP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker3/um3_aa0.4_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_CPE_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker3/um3_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker3/um3_aa0.4_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PC_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker3/um3_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_PP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_PP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_aa0.8_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_ABS_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_ABS_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_ABS_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_ABS_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_ABS_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_aa0.8_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPEP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast - Experimental
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_CPEP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPEP_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint - Experimental
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_CPEP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPEP_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast - Experimental
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_aa0.8_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_CPE_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPE_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_CPE_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_CPE_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_Nylon_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_Nylon_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_aa0.8_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PC_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast - Experimental
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_PC_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PC_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint - Experimental
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_PC_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PC_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast - Experimental
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_aa0.8_PP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_PP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PP_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_PP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PP_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_aa0.8_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_TPLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPLA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_TPLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPLA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_aa0.8_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPU_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_aa0.8_TPU_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPU_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_aa0.8_TPU_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_TPU_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker3/um3_global_Draft_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker3/um3_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker3/um3_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker3/um3_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker3/um3_global_Superdraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Superdraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker3/um3_global_Verydraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_original/umo_global_Coarse_Quality.inst.cfg
+++ b/resources/quality/ultimaker_original/umo_global_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Coarse Quality
 definition = ultimaker_original
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = coarse
 weight = -3

--- a/resources/quality/ultimaker_original/umo_global_Draft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_original/umo_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Draft Quality
 definition = ultimaker_original
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_original/umo_global_Extra_Coarse_Quality.inst.cfg
+++ b/resources/quality/ultimaker_original/umo_global_Extra_Coarse_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Coarse Quality
 definition = ultimaker_original
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extra coarse
 weight = -4

--- a/resources/quality/ultimaker_original/umo_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker_original/umo_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_original
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_original/umo_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_original/umo_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_original
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_original/umo_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_original/umo_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_original
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_CPE_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_Nylon_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_PC_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine - Experimental
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_PP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine - Experimental
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_TPLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_CPEP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_CPEP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_CPEP_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_CPEP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_CPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_CPE_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_CPE_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_CPE_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PC_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PC_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PC_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PC_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PC_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PC_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_ABS_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_ABS_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_ABS_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_ABS_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_ABS_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_CPEP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast - Experimental
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_CPEP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_CPEP_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint - Experimental
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_CPEP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_CPEP_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast - Experimental
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_CPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_CPE_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_CPE_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_CPE_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_CPE_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_Nylon_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_Nylon_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_Nylon_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_Nylon_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_Nylon_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PC_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast - Experimental
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PC_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PC_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint - Experimental
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PC_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PC_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast - Experimental
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PP_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PP_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPU_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPU_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPU_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPU_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPU_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_bb0.8_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.8_PVA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_bb0.8_PVA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.8_PVA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_bb0.8_PVA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.8_PVA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_CFFCPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_CFFCPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_CFFPA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_CFFPA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_GFFCPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_GFFCPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_GFFPA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_GFFPA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -3

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_global_Draft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s3/um_s3_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s3/um_s3_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s3/um_s3_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s3/um_s3_global_Superdraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_Superdraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s3/um_s3_global_Verydraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_CPE_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_Nylon_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PC_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine - Experimental
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine - Experimental
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_TPLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PP_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_ABS_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_ABS_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_ABS_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_ABS_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_ABS_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast - Experimental
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint - Experimental
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPEP_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast - Experimental
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_CPE_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_Nylon_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_Nylon_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_Nylon_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_Nylon_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_Nylon_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast - Experimental
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint - Experimental
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PC_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast - Experimental
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PP_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PP_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PP_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PP_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PP_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PP_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPU_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPU_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPU_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPU_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPU_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_bb0.8_PVA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.8_PVA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_bb0.8_PVA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.8_PVA_Superdraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_bb0.8_PVA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.8_PVA_Verydraft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_CFFCPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_CFFCPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_CFFPA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_CFFPA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_GFFCPE_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_GFFCPE_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_GFFPA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_GFFPA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Draft_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -3

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Fast_Print.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_global_Draft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_Draft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = draft
 weight = -2

--- a/resources/quality/ultimaker_s5/um_s5_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_Fast_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = -1

--- a/resources/quality/ultimaker_s5/um_s5_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/ultimaker_s5/um_s5_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/ultimaker_s5/um_s5_global_Superdraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_Superdraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = superdraft
 weight = -4

--- a/resources/quality/ultimaker_s5/um_s5_global_Verydraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_Verydraft_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = verydraft
 weight = -3

--- a/resources/quality/vertex_delta_k8800/k8800_ABS_Extreme_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_ABS_Extreme_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extreme
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extreme
 weight = 2

--- a/resources/quality/vertex_delta_k8800/k8800_ABS_High_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_ABS_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/vertex_delta_k8800/k8800_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_ABS_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/vertex_delta_k8800/k8800_Global_Extreme_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_Global_Extreme_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extreme
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extreme
 weight = 2

--- a/resources/quality/vertex_delta_k8800/k8800_Global_High_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_Global_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/vertex_delta_k8800/k8800_Global_Normal_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_Global_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/vertex_delta_k8800/k8800_PET_Extreme_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_PET_Extreme_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extreme
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extreme
 weight = 2

--- a/resources/quality/vertex_delta_k8800/k8800_PET_High_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_PET_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/vertex_delta_k8800/k8800_PET_Normal_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_PET_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/vertex_delta_k8800/k8800_PLA_Extreme_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_PLA_Extreme_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extreme
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extreme
 weight = 2

--- a/resources/quality/vertex_delta_k8800/k8800_PLA_High_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_PLA_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/vertex_delta_k8800/k8800_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_PLA_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/vertex_delta_k8800/k8800_TPU_Extreme_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_TPU_Extreme_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extreme
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extreme
 weight = 2

--- a/resources/quality/vertex_delta_k8800/k8800_TPU_High_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_TPU_High_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = High
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = high
 weight = 1

--- a/resources/quality/vertex_delta_k8800/k8800_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/vertex_delta_k8800/k8800_TPU_Normal_Quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = vertex_delta_k8800
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/voron2/voron2_global_extrafast_quality.inst.cfg
+++ b/resources/quality/voron2/voron2_global_extrafast_quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 global_quality = True

--- a/resources/quality/voron2/voron2_global_extrafine_quality.inst.cfg
+++ b/resources/quality/voron2/voron2_global_extrafine_quality.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 global_quality = True

--- a/resources/quality/voron2/voron2_global_fast_quality.inst.cfg
+++ b/resources/quality/voron2/voron2_global_fast_quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 global_quality = True

--- a/resources/quality/voron2/voron2_global_fine_quality.inst.cfg
+++ b/resources/quality/voron2/voron2_global_fine_quality.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 global_quality = True

--- a/resources/quality/voron2/voron2_global_normal_quality.inst.cfg
+++ b/resources/quality/voron2/voron2_global_normal_quality.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 global_quality = True

--- a/resources/quality/voron2/voron2_global_sprint_quality.inst.cfg
+++ b/resources/quality/voron2/voron2_global_sprint_quality.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 global_quality = True

--- a/resources/quality/voron2/voron2_global_supersprint_quality.inst.cfg
+++ b/resources/quality/voron2/voron2_global_supersprint_quality.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 global_quality = True

--- a/resources/quality/voron2/voron2_global_ultrasprint_quality.inst.cfg
+++ b/resources/quality/voron2/voron2_global_ultrasprint_quality.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 global_quality = True

--- a/resources/quality/voron2/voron2_v6_0.25_ABS_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_ABS_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.25_ABS_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_ABS_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.25_ABS_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_ABS_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.25_ABS_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_ABS_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.25_Nylon_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_Nylon_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.25_Nylon_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_Nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.25_Nylon_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_Nylon_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.25_Nylon_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_Nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.25_PC_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PC_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.25_PC_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PC_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.25_PC_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PC_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.25_PC_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PC_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.25_PETG_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PETG_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.25_PETG_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PETG_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.25_PETG_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PETG_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.25_PETG_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PETG_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.25_PLA_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PLA_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.25_PLA_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PLA_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.25_PLA_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PLA_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.25_PLA_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.25_PLA_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.30_ABS_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_ABS_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.30_ABS_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_ABS_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.30_ABS_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_ABS_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.30_ABS_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_ABS_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.30_Nylon_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_Nylon_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.30_Nylon_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_Nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.30_Nylon_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_Nylon_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.30_Nylon_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_Nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.30_PC_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PC_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.30_PC_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PC_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.30_PC_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PC_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.30_PC_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PC_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.30_PETG_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PETG_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.30_PETG_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PETG_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.30_PETG_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PETG_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.30_PETG_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PETG_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.30_PLA_extrafine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PLA_extrafine.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafine
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.30_PLA_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PLA_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.30_PLA_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PLA_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.30_PLA_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.30_PLA_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.35_ABS_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_ABS_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.35_ABS_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_ABS_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.35_ABS_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_ABS_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.35_Nylon_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_Nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.35_Nylon_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_Nylon_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.35_Nylon_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_Nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.35_PC_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PC_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.35_PC_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PC_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.35_PC_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PC_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.35_PETG_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PETG_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.35_PETG_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PETG_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.35_PETG_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PETG_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.35_PLA_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PLA_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.35_PLA_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PLA_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.35_PLA_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.35_PLA_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.40_ABS_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_ABS_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.40_ABS_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_ABS_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.40_ABS_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_ABS_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.40_ABS_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_ABS_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.40_Nylon_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_Nylon_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.40_Nylon_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_Nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.40_Nylon_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_Nylon_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.40_Nylon_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_Nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.40_PC_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PC_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.40_PC_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PC_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.40_PC_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PC_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.40_PC_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PC_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.40_PETG_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PETG_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.40_PETG_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PETG_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.40_PETG_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PETG_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.40_PETG_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PETG_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.40_PLA_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PLA_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.40_PLA_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PLA_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.40_PLA_fine.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PLA_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.40_PLA_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.40_PLA_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.50_ABS_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_ABS_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.50_ABS_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_ABS_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.50_ABS_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_ABS_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.50_ABS_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_ABS_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.50_Nylon_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_Nylon_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.50_Nylon_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_Nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.50_Nylon_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_Nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.50_Nylon_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_Nylon_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.50_PC_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PC_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.50_PC_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PC_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.50_PC_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PC_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.50_PC_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PC_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.50_PETG_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PETG_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.50_PETG_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PETG_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.50_PETG_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PETG_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.50_PETG_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PETG_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.50_PLA_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PLA_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.50_PLA_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PLA_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.50_PLA_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PLA_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.50_PLA_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.50_PLA_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.60_ABS_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_ABS_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.60_ABS_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_ABS_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.60_ABS_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_ABS_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.60_Nylon_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_Nylon_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.60_Nylon_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_Nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.60_Nylon_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_Nylon_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.60_PC_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PC_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.60_PC_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PC_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.60_PC_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PC_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.60_PETG_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PETG_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.60_PETG_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PETG_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.60_PETG_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PETG_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.60_PLA_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PLA_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.60_PLA_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PLA_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.60_PLA_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.60_PLA_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.80_ABS_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_ABS_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.80_ABS_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_ABS_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.80_ABS_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_ABS_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_v6_0.80_Nylon_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_Nylon_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.80_Nylon_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_Nylon_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.80_Nylon_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_Nylon_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_v6_0.80_PC_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PC_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.80_PC_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PC_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.80_PC_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PC_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_v6_0.80_PETG_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PETG_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.80_PETG_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PETG_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.80_PETG_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PETG_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_v6_0.80_PLA_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PLA_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.80_PLA_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PLA_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_v6_0.80_PLA_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_v6_0.80_PLA_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.40_ABS_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_ABS_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.40_ABS_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_ABS_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.40_ABS_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_ABS_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.40_Nylon_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_Nylon_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.40_Nylon_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_Nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.40_Nylon_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_Nylon_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.40_PC_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PC_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.40_PC_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PC_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.40_PC_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PC_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.40_PETG_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PETG_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.40_PETG_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PETG_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.40_PETG_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PETG_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.40_PLA_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PLA_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.40_PLA_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PLA_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.40_PLA_normal.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.40_PLA_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.60_ABS_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_ABS_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.60_ABS_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_ABS_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.60_ABS_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_ABS_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.60_Nylon_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_Nylon_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.60_Nylon_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_Nylon_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.60_Nylon_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_Nylon_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.60_PC_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PC_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.60_PC_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PC_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.60_PC_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PC_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.60_PETG_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PETG_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.60_PETG_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PETG_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.60_PETG_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PETG_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.60_PLA_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PLA_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.60_PLA_fast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PLA_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.60_PLA_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.60_PLA_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.80_ABS_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_ABS_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.80_ABS_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_ABS_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.80_ABS_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_ABS_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_0.80_Nylon_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_Nylon_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.80_Nylon_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_Nylon_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.80_Nylon_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_Nylon_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_0.80_PC_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PC_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.80_PC_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PC_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.80_PC_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PC_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_0.80_PETG_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PETG_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.80_PETG_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PETG_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.80_PETG_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PETG_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_0.80_PLA_extrafast.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PLA_extrafast.inst.cfg
@@ -4,7 +4,7 @@ name = Extra Fast
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = extrafast
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.80_PLA_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PLA_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_0.80_PLA_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_0.80_PLA_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_1.00_ABS_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_ABS_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_1.00_ABS_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_ABS_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_1.00_ABS_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_ABS_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_1.00_Nylon_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_Nylon_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_1.00_Nylon_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_Nylon_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_1.00_Nylon_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_Nylon_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_1.00_PC_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PC_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_1.00_PC_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PC_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_1.00_PC_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PC_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_1.00_PETG_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PETG_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_1.00_PETG_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PETG_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_1.00_PETG_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PETG_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_1.00_PLA_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PLA_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_1.00_PLA_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PLA_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_1.00_PLA_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.00_PLA_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_1.20_ABS_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_ABS_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_1.20_ABS_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_ABS_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_1.20_ABS_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_ABS_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_abs

--- a/resources/quality/voron2/voron2_volcano_1.20_Nylon_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_Nylon_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_1.20_Nylon_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_Nylon_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_1.20_Nylon_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_Nylon_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_nylon

--- a/resources/quality/voron2/voron2_volcano_1.20_PC_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PC_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_1.20_PC_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PC_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_1.20_PC_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PC_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_pc

--- a/resources/quality/voron2/voron2_volcano_1.20_PETG_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PETG_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_1.20_PETG_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PETG_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_1.20_PETG_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PETG_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_petg

--- a/resources/quality/voron2/voron2_volcano_1.20_PLA_sprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PLA_sprint.inst.cfg
@@ -4,7 +4,7 @@ name = Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = sprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_1.20_PLA_supersprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PLA_supersprint.inst.cfg
@@ -4,7 +4,7 @@ name = Super Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = supersprint
 material = generic_pla

--- a/resources/quality/voron2/voron2_volcano_1.20_PLA_ultrasprint.inst.cfg
+++ b/resources/quality/voron2/voron2_volcano_1.20_PLA_ultrasprint.inst.cfg
@@ -4,7 +4,7 @@ name = Ultra Sprint
 definition = voron2_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = ultrasprint
 material = generic_pla

--- a/resources/quality/zyyx/zyyx_agile_global_fast.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_global_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 1

--- a/resources/quality/zyyx/zyyx_agile_global_fine.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_global_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 weight = 1

--- a/resources/quality/zyyx/zyyx_agile_global_normal.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_global_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/zyyx/zyyx_agile_pro_flex_fast.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_flex_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 1

--- a/resources/quality/zyyx/zyyx_agile_pro_flex_fine.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_flex_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 weight = 1

--- a/resources/quality/zyyx/zyyx_agile_pro_flex_normal.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_flex_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/quality/zyyx/zyyx_agile_pro_pla_fast.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_pla_fast.inst.cfg
@@ -4,7 +4,7 @@ name = Fast
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fast
 weight = 1

--- a/resources/quality/zyyx/zyyx_agile_pro_pla_fine.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_pla_fine.inst.cfg
@@ -4,7 +4,7 @@ name = Fine
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = fine
 weight = 1

--- a/resources/quality/zyyx/zyyx_agile_pro_pla_normal.inst.cfg
+++ b/resources/quality/zyyx/zyyx_agile_pro_pla_normal.inst.cfg
@@ -4,7 +4,7 @@ name = Normal
 definition = zyyx_agile
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = quality
 quality_type = normal
 weight = 0

--- a/resources/variants/Leapfrog_Bolt_Pro_Brass_0.4.inst.cfg
+++ b/resources/variants/Leapfrog_Bolt_Pro_Brass_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/Leapfrog_Bolt_Pro_NozzleX_0.4.inst.cfg
+++ b/resources/variants/Leapfrog_Bolt_Pro_NozzleX_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = leapfrog_bolt_pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/Mark2_for_Ultimaker2_0.25.inst.cfg
+++ b/resources/variants/Mark2_for_Ultimaker2_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = Mark2_for_Ultimaker2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/Mark2_for_Ultimaker2_0.4.inst.cfg
+++ b/resources/variants/Mark2_for_Ultimaker2_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = Mark2_for_Ultimaker2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/Mark2_for_Ultimaker2_0.6.inst.cfg
+++ b/resources/variants/Mark2_for_Ultimaker2_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = Mark2_for_Ultimaker2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/Mark2_for_Ultimaker2_0.8.inst.cfg
+++ b/resources/variants/Mark2_for_Ultimaker2_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = Mark2_for_Ultimaker2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/cartesio_0.25.inst.cfg
+++ b/resources/variants/cartesio_0.25.inst.cfg
@@ -5,7 +5,7 @@ definition = cartesio
 
 [metadata]
 author = Cartesio
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/cartesio_0.4.inst.cfg
+++ b/resources/variants/cartesio_0.4.inst.cfg
@@ -5,7 +5,7 @@ definition = cartesio
 
 [metadata]
 author = Cartesio
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/cartesio_0.8.inst.cfg
+++ b/resources/variants/cartesio_0.8.inst.cfg
@@ -5,7 +5,7 @@ definition = cartesio
 
 [metadata]
 author = Cartesio
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_base_0.2.inst.cfg
+++ b/resources/variants/creality_base_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_base_0.3.inst.cfg
+++ b/resources/variants/creality_base_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_base_0.4.inst.cfg
+++ b/resources/variants/creality_base_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_base_0.5.inst.cfg
+++ b/resources/variants/creality_base_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_base_0.6.inst.cfg
+++ b/resources/variants/creality_base_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_base_0.8.inst.cfg
+++ b/resources/variants/creality_base_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_base_1.0.inst.cfg
+++ b/resources/variants/creality_base_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10_0.2.inst.cfg
+++ b/resources/variants/creality_cr10_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10_0.3.inst.cfg
+++ b/resources/variants/creality_cr10_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10_0.4.inst.cfg
+++ b/resources/variants/creality_cr10_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10_0.5.inst.cfg
+++ b/resources/variants/creality_cr10_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10_0.6.inst.cfg
+++ b/resources/variants/creality_cr10_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10_0.8.inst.cfg
+++ b/resources/variants/creality_cr10_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10_1.0.inst.cfg
+++ b/resources/variants/creality_cr10_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10max_0.2.inst.cfg
+++ b/resources/variants/creality_cr10max_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10max_0.3.inst.cfg
+++ b/resources/variants/creality_cr10max_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10max_0.4.inst.cfg
+++ b/resources/variants/creality_cr10max_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10max_0.5.inst.cfg
+++ b/resources/variants/creality_cr10max_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10max_0.6.inst.cfg
+++ b/resources/variants/creality_cr10max_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10max_0.8.inst.cfg
+++ b/resources/variants/creality_cr10max_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10max_1.0.inst.cfg
+++ b/resources/variants/creality_cr10max_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10max
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10mini_0.2.inst.cfg
+++ b/resources/variants/creality_cr10mini_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10mini
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10mini_0.3.inst.cfg
+++ b/resources/variants/creality_cr10mini_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10mini
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10mini_0.4.inst.cfg
+++ b/resources/variants/creality_cr10mini_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10mini
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10mini_0.5.inst.cfg
+++ b/resources/variants/creality_cr10mini_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10mini
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10mini_0.6.inst.cfg
+++ b/resources/variants/creality_cr10mini_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10mini
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10mini_0.8.inst.cfg
+++ b/resources/variants/creality_cr10mini_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10mini
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10mini_1.0.inst.cfg
+++ b/resources/variants/creality_cr10mini_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10mini
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s4_0.2.inst.cfg
+++ b/resources/variants/creality_cr10s4_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s4_0.3.inst.cfg
+++ b/resources/variants/creality_cr10s4_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s4_0.4.inst.cfg
+++ b/resources/variants/creality_cr10s4_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s4_0.5.inst.cfg
+++ b/resources/variants/creality_cr10s4_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s4_0.6.inst.cfg
+++ b/resources/variants/creality_cr10s4_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s4_0.8.inst.cfg
+++ b/resources/variants/creality_cr10s4_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s4_1.0.inst.cfg
+++ b/resources/variants/creality_cr10s4_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s5_0.2.inst.cfg
+++ b/resources/variants/creality_cr10s5_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s5_0.3.inst.cfg
+++ b/resources/variants/creality_cr10s5_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s5_0.4.inst.cfg
+++ b/resources/variants/creality_cr10s5_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s5_0.5.inst.cfg
+++ b/resources/variants/creality_cr10s5_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s5_0.6.inst.cfg
+++ b/resources/variants/creality_cr10s5_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s5_0.8.inst.cfg
+++ b/resources/variants/creality_cr10s5_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s5_1.0.inst.cfg
+++ b/resources/variants/creality_cr10s5_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s_0.2.inst.cfg
+++ b/resources/variants/creality_cr10s_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s_0.3.inst.cfg
+++ b/resources/variants/creality_cr10s_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s_0.4.inst.cfg
+++ b/resources/variants/creality_cr10s_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s_0.5.inst.cfg
+++ b/resources/variants/creality_cr10s_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s_0.6.inst.cfg
+++ b/resources/variants/creality_cr10s_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s_0.8.inst.cfg
+++ b/resources/variants/creality_cr10s_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10s_1.0.inst.cfg
+++ b/resources/variants/creality_cr10s_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10spro_0.2.inst.cfg
+++ b/resources/variants/creality_cr10spro_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10spro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10spro_0.3.inst.cfg
+++ b/resources/variants/creality_cr10spro_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10spro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10spro_0.4.inst.cfg
+++ b/resources/variants/creality_cr10spro_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10spro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10spro_0.5.inst.cfg
+++ b/resources/variants/creality_cr10spro_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10spro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10spro_0.6.inst.cfg
+++ b/resources/variants/creality_cr10spro_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10spro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10spro_0.8.inst.cfg
+++ b/resources/variants/creality_cr10spro_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10spro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr10spro_1.0.inst.cfg
+++ b/resources/variants/creality_cr10spro_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr10spro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20_0.2.inst.cfg
+++ b/resources/variants/creality_cr20_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20_0.3.inst.cfg
+++ b/resources/variants/creality_cr20_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20_0.4.inst.cfg
+++ b/resources/variants/creality_cr20_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20_0.5.inst.cfg
+++ b/resources/variants/creality_cr20_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20_0.6.inst.cfg
+++ b/resources/variants/creality_cr20_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20_0.8.inst.cfg
+++ b/resources/variants/creality_cr20_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20_1.0.inst.cfg
+++ b/resources/variants/creality_cr20_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20pro_0.2.inst.cfg
+++ b/resources/variants/creality_cr20pro_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20pro_0.3.inst.cfg
+++ b/resources/variants/creality_cr20pro_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20pro_0.4.inst.cfg
+++ b/resources/variants/creality_cr20pro_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20pro_0.5.inst.cfg
+++ b/resources/variants/creality_cr20pro_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20pro_0.6.inst.cfg
+++ b/resources/variants/creality_cr20pro_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20pro_0.8.inst.cfg
+++ b/resources/variants/creality_cr20pro_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_cr20pro_1.0.inst.cfg
+++ b/resources/variants/creality_cr20pro_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_cr20pro
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender2_0.2.inst.cfg
+++ b/resources/variants/creality_ender2_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender2_0.3.inst.cfg
+++ b/resources/variants/creality_ender2_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender2_0.4.inst.cfg
+++ b/resources/variants/creality_ender2_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender2_0.5.inst.cfg
+++ b/resources/variants/creality_ender2_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender2_0.6.inst.cfg
+++ b/resources/variants/creality_ender2_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender2_0.8.inst.cfg
+++ b/resources/variants/creality_ender2_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender2_1.0.inst.cfg
+++ b/resources/variants/creality_ender2_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender2
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender3_0.2.inst.cfg
+++ b/resources/variants/creality_ender3_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender3_0.3.inst.cfg
+++ b/resources/variants/creality_ender3_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender3_0.4.inst.cfg
+++ b/resources/variants/creality_ender3_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender3_0.5.inst.cfg
+++ b/resources/variants/creality_ender3_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender3_0.6.inst.cfg
+++ b/resources/variants/creality_ender3_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender3_0.8.inst.cfg
+++ b/resources/variants/creality_ender3_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender3_1.0.inst.cfg
+++ b/resources/variants/creality_ender3_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender4_0.2.inst.cfg
+++ b/resources/variants/creality_ender4_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender4_0.3.inst.cfg
+++ b/resources/variants/creality_ender4_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender4_0.4.inst.cfg
+++ b/resources/variants/creality_ender4_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender4_0.5.inst.cfg
+++ b/resources/variants/creality_ender4_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender4_0.6.inst.cfg
+++ b/resources/variants/creality_ender4_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender4_0.8.inst.cfg
+++ b/resources/variants/creality_ender4_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender4_1.0.inst.cfg
+++ b/resources/variants/creality_ender4_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender4
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5_0.2.inst.cfg
+++ b/resources/variants/creality_ender5_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5_0.3.inst.cfg
+++ b/resources/variants/creality_ender5_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5_0.4.inst.cfg
+++ b/resources/variants/creality_ender5_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5_0.5.inst.cfg
+++ b/resources/variants/creality_ender5_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5_0.6.inst.cfg
+++ b/resources/variants/creality_ender5_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5_0.8.inst.cfg
+++ b/resources/variants/creality_ender5_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5_1.0.inst.cfg
+++ b/resources/variants/creality_ender5_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5plus_0.2.inst.cfg
+++ b/resources/variants/creality_ender5plus_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5plus_0.3.inst.cfg
+++ b/resources/variants/creality_ender5plus_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5plus_0.4.inst.cfg
+++ b/resources/variants/creality_ender5plus_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5plus_0.5.inst.cfg
+++ b/resources/variants/creality_ender5plus_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5plus_0.6.inst.cfg
+++ b/resources/variants/creality_ender5plus_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5plus_0.8.inst.cfg
+++ b/resources/variants/creality_ender5plus_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/creality_ender5plus_1.0.inst.cfg
+++ b/resources/variants/creality_ender5plus_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = creality_ender5plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/deltacomb_025_e3d.inst.cfg
+++ b/resources/variants/deltacomb_025_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = deltacomb
 
 [metadata]
 author = Deltacomb 3D
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/deltacomb_040_e3d.inst.cfg
+++ b/resources/variants/deltacomb_040_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = deltacomb
 
 [metadata]
 author = Deltacomb 3D
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/deltacomb_080_e3d.inst.cfg
+++ b/resources/variants/deltacomb_080_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = deltacomb
 
 [metadata]
 author = Deltacomb 3D
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/dxu_0.25.inst.cfg
+++ b/resources/variants/dxu_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = dxu
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/dxu_0.4.inst.cfg
+++ b/resources/variants/dxu_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = dxu
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/dxu_0.6.inst.cfg
+++ b/resources/variants/dxu_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = dxu
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/dxu_0.8.inst.cfg
+++ b/resources/variants/dxu_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = dxu
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/dxu_dual_0.25.inst.cfg
+++ b/resources/variants/dxu_dual_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = dxu_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/dxu_dual_0.4.inst.cfg
+++ b/resources/variants/dxu_dual_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = dxu_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/dxu_dual_0.6.inst.cfg
+++ b/resources/variants/dxu_dual_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = dxu_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/dxu_dual_0.8.inst.cfg
+++ b/resources/variants/dxu_dual_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = dxu_dual
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/fabtotum_hyb35.inst.cfg
+++ b/resources/variants/fabtotum_hyb35.inst.cfg
@@ -5,7 +5,7 @@ definition = fabtotum
 
 [metadata]
 author = FABtotum
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/fabtotum_lite04.inst.cfg
+++ b/resources/variants/fabtotum_lite04.inst.cfg
@@ -5,7 +5,7 @@ definition = fabtotum
 
 [metadata]
 author = FABtotum
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/fabtotum_lite06.inst.cfg
+++ b/resources/variants/fabtotum_lite06.inst.cfg
@@ -5,7 +5,7 @@ definition = fabtotum
 
 [metadata]
 author = FABtotum
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/fabtotum_pro02.inst.cfg
+++ b/resources/variants/fabtotum_pro02.inst.cfg
@@ -5,7 +5,7 @@ definition = fabtotum
 
 [metadata]
 author = FABtotum
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/fabtotum_pro04.inst.cfg
+++ b/resources/variants/fabtotum_pro04.inst.cfg
@@ -5,7 +5,7 @@ definition = fabtotum
 
 [metadata]
 author = FABtotum
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/fabtotum_pro06.inst.cfg
+++ b/resources/variants/fabtotum_pro06.inst.cfg
@@ -5,7 +5,7 @@ definition = fabtotum
 
 [metadata]
 author = FABtotum
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/fabtotum_pro08.inst.cfg
+++ b/resources/variants/fabtotum_pro08.inst.cfg
@@ -5,7 +5,7 @@ definition = fabtotum
 
 [metadata]
 author = FABtotum
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/felixpro2_0.25.inst.cfg
+++ b/resources/variants/felixpro2_0.25.inst.cfg
@@ -6,7 +6,7 @@ definition = felixpro2dual
 [metadata]
 author = pnks
 type = variant
-setting_version = 12
+setting_version = 13
 hardware_type = nozzle
 
 [values]

--- a/resources/variants/felixpro2_0.35.inst.cfg
+++ b/resources/variants/felixpro2_0.35.inst.cfg
@@ -6,7 +6,7 @@ definition = felixpro2dual
 [metadata]
 author = pnks
 type = variant
-setting_version = 12
+setting_version = 13
 hardware_type = nozzle
 
 [values]

--- a/resources/variants/felixpro2_0.50.inst.cfg
+++ b/resources/variants/felixpro2_0.50.inst.cfg
@@ -6,7 +6,7 @@ definition = felixpro2dual
 [metadata]
 author = pnks
 type = variant
-setting_version = 12
+setting_version = 13
 hardware_type = nozzle
 
 [values]

--- a/resources/variants/felixpro2_0.70.inst.cfg
+++ b/resources/variants/felixpro2_0.70.inst.cfg
@@ -6,7 +6,7 @@ definition = felixpro2dual
 [metadata]
 author = pnks
 type = variant
-setting_version = 12
+setting_version = 13
 hardware_type = nozzle
 
 [values]

--- a/resources/variants/felixtec4_0.25.inst.cfg
+++ b/resources/variants/felixtec4_0.25.inst.cfg
@@ -6,7 +6,7 @@ definition = felixtec4dual
 [metadata]
 author = kerog777
 type = variant
-setting_version = 12
+setting_version = 13
 hardware_type = nozzle
 
 [values]

--- a/resources/variants/felixtec4_0.35.inst.cfg
+++ b/resources/variants/felixtec4_0.35.inst.cfg
@@ -6,7 +6,7 @@ definition = felixtec4dual
 [metadata]
 author = kerog777
 type = variant
-setting_version = 12
+setting_version = 13
 hardware_type = nozzle
 
 [values]

--- a/resources/variants/felixtec4_0.50.inst.cfg
+++ b/resources/variants/felixtec4_0.50.inst.cfg
@@ -7,7 +7,7 @@ definition = felixtec4dual
 author = kerog777
 type = variant
 hardware_type = nozzle
-setting_version = 12
+setting_version = 13
 
 [values]
 machine_nozzle_size = 0.5

--- a/resources/variants/felixtec4_0.70.inst.cfg
+++ b/resources/variants/felixtec4_0.70.inst.cfg
@@ -7,7 +7,7 @@ definition = felixtec4dual
 author = kerog777
 type = variant
 hardware_type = nozzle
-setting_version = 12
+setting_version = 13
 
 [values]
 machine_nozzle_size = 0.70

--- a/resources/variants/flyingbear_base_0.25.inst.cfg
+++ b/resources/variants/flyingbear_base_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/flyingbear_base_0.40.inst.cfg
+++ b/resources/variants/flyingbear_base_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/flyingbear_base_0.80.inst.cfg
+++ b/resources/variants/flyingbear_base_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = flyingbear_base
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/flyingbear_ghost_4s_0.25.inst.cfg
+++ b/resources/variants/flyingbear_ghost_4s_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = flyingbear_ghost_4s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/flyingbear_ghost_4s_0.40.inst.cfg
+++ b/resources/variants/flyingbear_ghost_4s_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = flyingbear_ghost_4s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/flyingbear_ghost_4s_0.80.inst.cfg
+++ b/resources/variants/flyingbear_ghost_4s_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = flyingbear_ghost_4s
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_025_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_025_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_04_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_04_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_05_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_05_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_05_jhead.inst.cfg
+++ b/resources/variants/gmax15plus_05_jhead.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_06_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_06_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_08_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_08_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_10_jhead.inst.cfg
+++ b/resources/variants/gmax15plus_10_jhead.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_12_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_12_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_dual_025_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_dual_025_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus_dual
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_dual_04_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_dual_04_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus_dual
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_dual_05_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_dual_05_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus_dual
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_dual_05_jhead.inst.cfg
+++ b/resources/variants/gmax15plus_dual_05_jhead.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus_dual
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_dual_06_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_dual_06_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus_dual
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_dual_08_e3d.inst.cfg
+++ b/resources/variants/gmax15plus_dual_08_e3d.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus_dual
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/gmax15plus_dual_10_jhead.inst.cfg
+++ b/resources/variants/gmax15plus_dual_10_jhead.inst.cfg
@@ -5,7 +5,7 @@ definition = gmax15plus_dual
 
 [metadata]
 author = gcreate
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/hms434_0.4tpnozzle.inst.cfg
+++ b/resources/variants/hms434_0.4tpnozzle.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/hms434_0.8tpnozzle.inst.cfg
+++ b/resources/variants/hms434_0.8tpnozzle.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = hms434
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/imade3d_jellybox_0.4.inst.cfg
+++ b/resources/variants/imade3d_jellybox_0.4.inst.cfg
@@ -5,7 +5,7 @@ definition = imade3d_jellybox
 
 [metadata]
 author = IMADE3D
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/imade3d_jellybox_2_0.4.inst.cfg
+++ b/resources/variants/imade3d_jellybox_2_0.4.inst.cfg
@@ -5,7 +5,7 @@ definition = imade3d_jellybox_2
 
 [metadata]
 author = IMADE3D
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/nwa3d_a31_04.inst.cfg
+++ b/resources/variants/nwa3d_a31_04.inst.cfg
@@ -5,7 +5,7 @@ definition = nwa3d_a31
 
 [metadata]
 author = DragonJe
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/nwa3d_a31_06.inst.cfg
+++ b/resources/variants/nwa3d_a31_06.inst.cfg
@@ -5,7 +5,7 @@ definition = nwa3d_a31
 
 [metadata]
 author = DragonJe
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/strateo3d_standard_04.inst.cfg
+++ b/resources/variants/strateo3d_standard_04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/strateo3d_standard_06.inst.cfg
+++ b/resources/variants/strateo3d_standard_06.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/strateo3d_standard_08.inst.cfg
+++ b/resources/variants/strateo3d_standard_08.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = strateo3d
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/structur3d_discov3ry1_complete_um2plus_0.20.inst.cfg
+++ b/resources/variants/structur3d_discov3ry1_complete_um2plus_0.20.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = structur3d_discov3ry1_complete_um2plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/structur3d_discov3ry1_complete_um2plus_0.25.inst.cfg
+++ b/resources/variants/structur3d_discov3ry1_complete_um2plus_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = structur3d_discov3ry1_complete_um2plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/structur3d_discov3ry1_complete_um2plus_0.41.inst.cfg
+++ b/resources/variants/structur3d_discov3ry1_complete_um2plus_0.41.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = structur3d_discov3ry1_complete_um2plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/structur3d_discov3ry1_complete_um2plus_0.58.inst.cfg
+++ b/resources/variants/structur3d_discov3ry1_complete_um2plus_0.58.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = structur3d_discov3ry1_complete_um2plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/structur3d_discov3ry1_complete_um2plus_0.84.inst.cfg
+++ b/resources/variants/structur3d_discov3ry1_complete_um2plus_0.84.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = structur3d_discov3ry1_complete_um2plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/structur3d_discov3ry1_complete_um2plus_1.19.inst.cfg
+++ b/resources/variants/structur3d_discov3ry1_complete_um2plus_1.19.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = structur3d_discov3ry1_complete_um2plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/structur3d_discov3ry1_complete_um2plus_1.60.inst.cfg
+++ b/resources/variants/structur3d_discov3ry1_complete_um2plus_1.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = structur3d_discov3ry1_complete_um2plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_0.2.inst.cfg
+++ b/resources/variants/tizyx_evy_0.2.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_0.3.inst.cfg
+++ b/resources/variants/tizyx_evy_0.3.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_0.4.inst.cfg
+++ b/resources/variants/tizyx_evy_0.4.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_0.5.inst.cfg
+++ b/resources/variants/tizyx_evy_0.5.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_0.6.inst.cfg
+++ b/resources/variants/tizyx_evy_0.6.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_0.8.inst.cfg
+++ b/resources/variants/tizyx_evy_0.8.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_1.0.inst.cfg
+++ b/resources/variants/tizyx_evy_1.0.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_dual_classic.inst.cfg
+++ b/resources/variants/tizyx_evy_dual_classic.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy_dual
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_evy_dual_direct_drive.inst.cfg
+++ b/resources/variants/tizyx_evy_dual_direct_drive.inst.cfg
@@ -5,7 +5,7 @@ definition = tizyx_evy_dual
 
 [metadata]
 author = TiZYX
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_k25_0.2.inst.cfg
+++ b/resources/variants/tizyx_k25_0.2.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = tizyx_k25
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_k25_0.3.inst.cfg
+++ b/resources/variants/tizyx_k25_0.3.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = tizyx_k25
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_k25_0.4.inst.cfg
+++ b/resources/variants/tizyx_k25_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = tizyx_k25
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_k25_0.5.inst.cfg
+++ b/resources/variants/tizyx_k25_0.5.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = tizyx_k25
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_k25_0.6.inst.cfg
+++ b/resources/variants/tizyx_k25_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = tizyx_k25
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_k25_0.8.inst.cfg
+++ b/resources/variants/tizyx_k25_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = tizyx_k25
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/tizyx_k25_1.0.inst.cfg
+++ b/resources/variants/tizyx_k25_1.0.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = tizyx_k25
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_extended_olsson_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_extended_olsson_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_extended_olsson
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_extended_olsson_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_extended_olsson_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_extended_olsson
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_extended_olsson_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_extended_olsson_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_extended_olsson
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_extended_olsson_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_extended_olsson_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_extended_olsson
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_extended_plus_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_extended_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_extended_plus_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_extended_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_extended_plus_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_extended_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_extended_plus_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_extended_plus_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_extended_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_olsson_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_olsson_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_olsson
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_olsson_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_olsson_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_olsson
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_olsson_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_olsson_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_olsson
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_olsson_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_olsson_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_olsson
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_plus_0.25.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_plus_0.4.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.4.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_plus_0.6.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.6.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker2_plus_0.8.inst.cfg
+++ b/resources/variants/ultimaker2_plus_0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker2_plus
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker3_aa0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker3_aa0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_aa04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_bb0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_bb04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_extended_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3_extended
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_extended_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3_extended
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_extended_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3_extended
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3_extended
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker3_extended_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker3_extended
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s3_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker_s3_aa0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s3_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker_s3_aa0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s3_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s3_aa04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s3_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s3_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s3_cc06.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s3
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s5_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s5_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s5_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s5_aluminum.inst.cfg
+++ b/resources/variants/ultimaker_s5_aluminum.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = buildplate
 

--- a/resources/variants/ultimaker_s5_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb0.8.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s5_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb04.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s5_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s5_cc06.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/ultimaker_s5_glass.inst.cfg
+++ b/resources/variants/ultimaker_s5_glass.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = ultimaker_s5
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = buildplate
 

--- a/resources/variants/voron2_250_v6_0.25.inst.cfg
+++ b/resources/variants/voron2_250_v6_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_v6_0.30.inst.cfg
+++ b/resources/variants/voron2_250_v6_0.30.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_v6_0.35.inst.cfg
+++ b/resources/variants/voron2_250_v6_0.35.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_v6_0.40.inst.cfg
+++ b/resources/variants/voron2_250_v6_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_v6_0.50.inst.cfg
+++ b/resources/variants/voron2_250_v6_0.50.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_v6_0.60.inst.cfg
+++ b/resources/variants/voron2_250_v6_0.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_v6_0.80.inst.cfg
+++ b/resources/variants/voron2_250_v6_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_volcano_0.40.inst.cfg
+++ b/resources/variants/voron2_250_volcano_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_volcano_0.60.inst.cfg
+++ b/resources/variants/voron2_250_volcano_0.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_volcano_0.80.inst.cfg
+++ b/resources/variants/voron2_250_volcano_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_volcano_1.00.inst.cfg
+++ b/resources/variants/voron2_250_volcano_1.00.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_250_volcano_1.20.inst.cfg
+++ b/resources/variants/voron2_250_volcano_1.20.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_250
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_v6_0.25.inst.cfg
+++ b/resources/variants/voron2_300_v6_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_v6_0.30.inst.cfg
+++ b/resources/variants/voron2_300_v6_0.30.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_v6_0.35.inst.cfg
+++ b/resources/variants/voron2_300_v6_0.35.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_v6_0.40.inst.cfg
+++ b/resources/variants/voron2_300_v6_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_v6_0.50.inst.cfg
+++ b/resources/variants/voron2_300_v6_0.50.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_v6_0.60.inst.cfg
+++ b/resources/variants/voron2_300_v6_0.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_v6_0.80.inst.cfg
+++ b/resources/variants/voron2_300_v6_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_volcano_0.40.inst.cfg
+++ b/resources/variants/voron2_300_volcano_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_volcano_0.60.inst.cfg
+++ b/resources/variants/voron2_300_volcano_0.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_volcano_0.80.inst.cfg
+++ b/resources/variants/voron2_300_volcano_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_volcano_1.00.inst.cfg
+++ b/resources/variants/voron2_300_volcano_1.00.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_300_volcano_1.20.inst.cfg
+++ b/resources/variants/voron2_300_volcano_1.20.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_300
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_v6_0.25.inst.cfg
+++ b/resources/variants/voron2_350_v6_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_v6_0.30.inst.cfg
+++ b/resources/variants/voron2_350_v6_0.30.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_v6_0.35.inst.cfg
+++ b/resources/variants/voron2_350_v6_0.35.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_v6_0.40.inst.cfg
+++ b/resources/variants/voron2_350_v6_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_v6_0.50.inst.cfg
+++ b/resources/variants/voron2_350_v6_0.50.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_v6_0.60.inst.cfg
+++ b/resources/variants/voron2_350_v6_0.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_v6_0.80.inst.cfg
+++ b/resources/variants/voron2_350_v6_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_volcano_0.40.inst.cfg
+++ b/resources/variants/voron2_350_volcano_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_volcano_0.60.inst.cfg
+++ b/resources/variants/voron2_350_volcano_0.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_volcano_0.80.inst.cfg
+++ b/resources/variants/voron2_350_volcano_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_volcano_1.00.inst.cfg
+++ b/resources/variants/voron2_350_volcano_1.00.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_350_volcano_1.20.inst.cfg
+++ b/resources/variants/voron2_350_volcano_1.20.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_350
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_v6_0.25.inst.cfg
+++ b/resources/variants/voron2_custom_v6_0.25.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_v6_0.30.inst.cfg
+++ b/resources/variants/voron2_custom_v6_0.30.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_v6_0.35.inst.cfg
+++ b/resources/variants/voron2_custom_v6_0.35.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_v6_0.40.inst.cfg
+++ b/resources/variants/voron2_custom_v6_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_v6_0.50.inst.cfg
+++ b/resources/variants/voron2_custom_v6_0.50.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_v6_0.60.inst.cfg
+++ b/resources/variants/voron2_custom_v6_0.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_v6_0.80.inst.cfg
+++ b/resources/variants/voron2_custom_v6_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_volcano_0.40.inst.cfg
+++ b/resources/variants/voron2_custom_volcano_0.40.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_volcano_0.60.inst.cfg
+++ b/resources/variants/voron2_custom_volcano_0.60.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_volcano_0.80.inst.cfg
+++ b/resources/variants/voron2_custom_volcano_0.80.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_volcano_1.00.inst.cfg
+++ b/resources/variants/voron2_custom_volcano_1.00.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 

--- a/resources/variants/voron2_custom_volcano_1.20.inst.cfg
+++ b/resources/variants/voron2_custom_volcano_1.20.inst.cfg
@@ -4,7 +4,7 @@ version = 4
 definition = voron2_custom
 
 [metadata]
-setting_version = 12
+setting_version = 13
 type = variant
 hardware_type = nozzle
 


### PR DESCRIPTION
Previously we had a version upgrade from 4.5 to 4.6 that halves the maximum deviation in concert with this PR in CuraEngine: https://github.com/Ultimaker/CuraEngine/pull/1214
That version upgrade was proposed in a pull request here: https://github.com/Ultimaker/Cura/pull/7247

It seems that this won't make it in 4.6 any more, so we need to apply the same changes during the version upgrade to 4.7 instead.
Some differences with #7247 are:
* Now upgrade to setting version 13 instead of 12.
* Give a new name to the version upgrade plug-in to indicate that it updates to Cura 4.7.