### PR TITLE
CURA-7340_fix_simulation_slider_layout

### DIFF
--- a/resources/qml/ActionButton.qml
+++ b/resources/qml/ActionButton.qml
@@ -49,15 +49,6 @@ Button
     height: UM.Theme.getSize("action_button").height
     hoverEnabled: true
 
-    Component.onCompleted: {
-        if(fixedWidthMode){
-            buttonText.width = width - leftPadding - rightPadding
-        } else {
-            buttonText.width = (maximumWidth != 0 && contentWidth > maximumWidth) ? maximumWidth : undefined
-        }
-    }
-
-
     contentItem: Row
     {
         spacing: UM.Theme.getSize("narrow_margin").width
@@ -93,12 +84,22 @@ Button
             font: UM.Theme.getFont("medium")
             visible: text != ""
             renderType: Text.NativeRendering
-            // width is set by parent because it depends on button.fixedWidthMode
             height: parent.height
             anchors.verticalCenter: parent.verticalCenter
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             elide: Text.ElideRight
+
+            Binding
+            {
+                // When settting width directly, an unjust binding loop warning would be triggered,
+                // because button.width is part of this expression.
+                // Using parent.width is fine in fixedWidthMode.
+                target: buttonText
+                property: "width"
+                value: button.fixedWidthMode ? button.width - button.leftPadding - button.rightPadding
+                                             : ((maximumWidth != 0 && contentWidth > maximumWidth) ? maximumWidth : undefined)
+            }
         }
 
         //Right side icon. Only displayed if isIconOnRightSide.

--- a/resources/qml/ActionButton.qml
+++ b/resources/qml/ActionButton.qml
@@ -49,6 +49,15 @@ Button
     height: UM.Theme.getSize("action_button").height
     hoverEnabled: true
 
+    Component.onCompleted: {
+        if(fixedWidthMode){
+            buttonText.width = width - leftPadding - rightPadding
+        } else {
+            buttonText.width = (maximumWidth != 0 && contentWidth > maximumWidth) ? maximumWidth : undefined
+        }
+    }
+
+
     contentItem: Row
     {
         spacing: UM.Theme.getSize("narrow_margin").width
@@ -84,9 +93,9 @@ Button
             font: UM.Theme.getFont("medium")
             visible: text != ""
             renderType: Text.NativeRendering
+            // width is set by parent because it depends on button.fixedWidthMode
             height: parent.height
             anchors.verticalCenter: parent.verticalCenter
-            width: fixedWidthMode ? button.width - button.leftPadding - button.rightPadding : ((maximumWidth != 0 && contentWidth > maximumWidth) ? maximumWidth : undefined)
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             elide: Text.ElideRight

--- a/resources/qml/ActionPanel/ActionPanelWidget.qml
+++ b/resources/qml/ActionPanel/ActionPanelWidget.qml
@@ -15,6 +15,7 @@ import Cura 1.0 as Cura
 Item
 {
     id: base
+    width: actionPanelWidget.width + additionalComponents.width
     height: childrenRect.height
     visible: CuraApplication.platformActivity
 


### PR DESCRIPTION
Fixed: ActionPanelWidget's width was removed, 
which prevented a safe area from being layed out.
This in turn caused misalignment of the simulation slider