### PR TITLE
Add Ender-3 Pro without clip boundaries for magnetic bed

### DIFF
--- a/resources/definitions/creality_ender3pro.def.json
+++ b/resources/definitions/creality_ender3pro.def.json
@@ -1,0 +1,28 @@
+{
+    "name": "Creality Ender-3 Pro",
+    "version": 2,
+    "inherits": "creality_base",
+    "metadata": {
+        "quality_definition": "creality_base",
+        "visible": true,
+        "platform": "creality_ender3.stl"
+    },
+    "overrides": {
+        "machine_name": { "default_value": "Creality Ender-3 Pro" },
+        "machine_width": { "default_value": 235 },
+        "machine_depth": { "default_value": 235 },
+        "machine_height": { "default_value": 250 },
+        "machine_head_with_fans_polygon": { "default_value": [
+                [-26, 34],
+                [-26, -32],
+                [32, -32],
+                [32, 34]
+            ]
+        },
+        "machine_start_gcode": {
+            "default_value": "; Ender 3 Custom Start G-code\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z0.3 F5000.0 ; Move to start position\nG1 X0.1 Y200.0 Z0.3 F1500.0 E15 ; Draw the first line\nG1 X0.4 Y200.0 Z0.3 F5000.0 ; Move to side a little\nG1 X0.4 Y20 Z0.3 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.3 F5000.0 ; Move over to prevent blob squish"
+        },
+
+        "gantry_height": { "value": 25 }
+    }
+}


### PR DESCRIPTION
In this discussion: https://github.com/Ultimaker/Cura/issues/7252

Some were pointing out the Ender-3 Pro comes with a magnetic bed without clips making the entire surface of the bed printable. The disallowed areas in the standard Ender-3 are not easily removed. @Ghostkeeper seemed to indicate a new "Pro" profile is an acceptable solution. So, here it is.

P.S. I'm still very new to GitHub. I made this change in the 4.6 branch instead of master this time. Is this correct? (preferred by you?) 