### PR TITLE
Objectlist additions

### DIFF
--- a/cura/Settings/SettingOverrideDecorator.py
+++ b/cura/Settings/SettingOverrideDecorator.py
@@ -94,6 +94,12 @@ class SettingOverrideDecorator(SceneNodeDecorator):
     #
     #   \return An extruder's position, or None if no position info is available.
     def getActiveExtruderPosition(self):
+        # for support_meshes, always use the support_extruder
+        if self.getStack().getProperty("support_mesh", "value"):
+            global_container_stack = Application.getInstance().getGlobalContainerStack()
+            if global_container_stack:
+                return str(global_container_stack.getProperty("support_extruder_nr", "value"))
+
         containers = ContainerRegistry.getInstance().findContainers(id = self.getActiveExtruder())
         if containers:
             container_stack = containers[0]

--- a/cura/UI/ObjectsModel.py
+++ b/cura/UI/ObjectsModel.py
@@ -191,6 +191,17 @@ class ObjectsModel(ListModel):
                         per_object_settings_count -= 1 # do not count this mesh type setting
                         break
 
+                if per_object_settings_count > 0:
+                    if node_mesh_type == "support_mesh":
+                        # support meshes only allow support settings
+                        per_object_settings_count = 0
+                        for key in per_object_stack.getTop().getAllKeys():
+                            if per_object_stack.getTop().getInstance(key).definition.isAncestor("support"):
+                                per_object_settings_count += 1
+                    elif node_mesh_type == "anti_overhang_mesh":
+                        # anti overhang meshes ignore per model settings
+                        per_object_settings_count = 0
+
             extruder_position = node.callDecoration("getActiveExtruderPosition")
             if extruder_position is None:
                 extruder_number = -1

--- a/cura/UI/ObjectsModel.py
+++ b/cura/UI/ObjectsModel.py
@@ -191,7 +191,11 @@ class ObjectsModel(ListModel):
                         per_object_settings_count -= 1 # do not count this mesh type setting
                         break
 
-            extruder_number = int(node.callDecoration("getActiveExtruderPosition"))
+            extruder_position = node.callDecoration("getActiveExtruderPosition")
+            if extruder_position is None:
+                extruder_number = -1
+            else:
+                extruder_number = int(extruder_position)
             if node_mesh_type == "anti_overhang_mesh" or node.callDecoration("isGroup"):
                 # for anti overhang meshes and groups the extruder nr is irrelevant
                 extruder_number = -1

--- a/cura/UI/ObjectsModel.py
+++ b/cura/UI/ObjectsModel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 from UM.Logger import Logger
 import re

--- a/cura/UI/ObjectsModel.py
+++ b/cura/UI/ObjectsModel.py
@@ -40,6 +40,7 @@ class ObjectsModel(ListModel):
     NodeRole = Qt.UserRole + 5
     PerObjectSettingsCountRole = Qt.UserRole + 6
     MeshTypeRole = Qt.UserRole + 7
+    ExtruderNumberRole = Qt.UserRole + 8
 
     def __init__(self, parent = None) -> None:
         super().__init__(parent)
@@ -48,6 +49,7 @@ class ObjectsModel(ListModel):
         self.addRoleName(self.SelectedRole, "selected")
         self.addRoleName(self.OutsideAreaRole, "outside_build_area")
         self.addRoleName(self.BuilplateNumberRole, "buildplate_number")
+        self.addRoleName(self.ExtruderNumberRole, "extruder_number")
         self.addRoleName(self.PerObjectSettingsCountRole, "per_object_settings_count")
         self.addRoleName(self.MeshTypeRole, "mesh_type")
         self.addRoleName(self.NodeRole, "node")
@@ -189,11 +191,17 @@ class ObjectsModel(ListModel):
                         per_object_settings_count -= 1 # do not count this mesh type setting
                         break
 
+            extruder_number = int(node.callDecoration("getActiveExtruderPosition"))
+            if node_mesh_type == "anti_overhang_mesh":
+                # for anti overhang meshes, the extruder nr is irrelevant
+                extruder_number = -1
+
             nodes.append({
                 "name": node.getName(),
                 "selected": Selection.isSelected(node),
                 "outside_build_area": is_outside_build_area,
                 "buildplate_number": node_build_plate_number,
+                "extruder_number": extruder_number,
                 "per_object_settings_count": per_object_settings_count,
                 "mesh_type": node_mesh_type,
                 "node": node

--- a/cura/UI/ObjectsModel.py
+++ b/cura/UI/ObjectsModel.py
@@ -192,8 +192,8 @@ class ObjectsModel(ListModel):
                         break
 
             extruder_number = int(node.callDecoration("getActiveExtruderPosition"))
-            if node_mesh_type == "anti_overhang_mesh":
-                # for anti overhang meshes, the extruder nr is irrelevant
+            if node_mesh_type == "anti_overhang_mesh" or node.callDecoration("isGroup"):
+                # for anti overhang meshes and groups the extruder nr is irrelevant
                 extruder_number = -1
 
             nodes.append({

--- a/resources/qml/ObjectItemButton.qml
+++ b/resources/qml/ObjectItemButton.qml
@@ -23,13 +23,26 @@ Button
         width: objectItemButton.width - objectItemButton.leftPadding
         height: UM.Theme.getSize("action_button").height
 
+        UM.RecolorImage
+        {
+            id: swatch
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            width: height
+            height: parent.height - UM.Theme.getSize("narrow_margin").height
+            source: UM.Theme.getIcon("extruder_button")
+            color: extruderColor
+            visible: showExtruderSwatches && extruderColor != ""
+        }
+
         Label
         {
             id: buttonText
             anchors
             {
-                left: parent.left
-                right: perObjectSettingsInfo.left
+                left: showExtruderSwatches ? swatch.right : parent.left
+                leftMargin: showExtruderSwatches ? UM.Theme.getSize("narrow_margin").width : 0
+                right: perObjectSettingsInfo.visible ? perObjectSettingsInfo.left : parent.right
                 verticalCenter: parent.verticalCenter
             }
             text: objectItemButton.text

--- a/resources/qml/ObjectItemButton.qml
+++ b/resources/qml/ObjectItemButton.qml
@@ -14,7 +14,7 @@ Button
     width: parent.width
     height: UM.Theme.getSize("action_button").height
     leftPadding: UM.Theme.getSize("thin_margin").width
-    rightPadding: UM.Theme.getSize("default_lining").width
+    rightPadding: perObjectSettingsInfo.visible ? UM.Theme.getSize("default_lining").width : UM.Theme.getSize("thin_margin").width
     checkable: true
     hoverEnabled: true
 
@@ -87,10 +87,44 @@ Button
                 UM.Controller.setActiveTool("PerObjectSettingsTool")
             }
 
+            property string tooltipText:
+            {
+                var result = "";
+                if (!visible)
+                {
+                    return result;
+                }
+                if (meshType != "")
+                {
+                    result += "<br>";
+                    switch (meshType) {
+                        case "support_mesh":
+                            result += catalog.i18nc("@label", "Is printed as support.");
+                            break;
+                        case "cutting_mesh":
+                            result += catalog.i18nc("@label", "Other models overlapping with this model are modified.");
+                            break;
+                        case "infill_mesh":
+                            result += catalog.i18nc("@label", "Infill overlapping with this model is modified.");
+                            break;
+                        case "anti_overhang_mesh":
+                            result += catalog.i18nc("@label", "Overlaps with this model are not supported.");
+                            break;
+                    }
+                }
+                if (perObjectSettingsCount != "")
+                {
+                    result += "<br>" + catalog.i18ncp(
+                        "@label", "Overrides %1 setting.", "Overrides %1 settings.", perObjectSettingsCount
+                    ).arg(perObjectSettingsCount);
+                }
+                return result;
+            }
+
             contentItem: Item
             {
                 height: parent.height
-                width: childrenRect.width
+                width: meshTypeIcon.width + perObjectSettingsCountLabel.width + UM.Theme.getSize("narrow_margin").width
 
                 Cura.NotificationIcon
                 {
@@ -107,6 +141,7 @@ Button
 
                 UM.RecolorImage
                 {
+                    id: meshTypeIcon
                     anchors
                     {
                         right: perObjectSettingsCountLabel.left
@@ -121,12 +156,12 @@ Button
                     {
                         switch (meshType) {
                             case "support_mesh":
-                                return UM.Theme.getIcon("pos_print_as_support")
+                                return UM.Theme.getIcon("pos_print_as_support");
                             case "cutting_mesh":
                             case "infill_mesh":
-                                return UM.Theme.getIcon("pos_modify_overlaps")
+                                return UM.Theme.getIcon("pos_modify_overlaps");
                             case "anti_overhang_mesh":
-                                return UM.Theme.getIcon("pos_modify_dont_support_overlap")
+                                return UM.Theme.getIcon("pos_modify_dont_support_overlap");
                         }
                         return "";
                     }
@@ -149,8 +184,13 @@ Button
     Cura.ToolTip
     {
         id: tooltip
-        tooltipText: objectItemButton.text
-        visible: objectItemButton.hovered && buttonTextMetrics.elidedText != buttonText.text
+        tooltipText: objectItemButton.text + perObjectSettingsInfo.tooltipText
+        visible: objectItemButton.hovered && (buttonTextMetrics.elidedText != buttonText.text || perObjectSettingsInfo.visible)
     }
 
+    UM.I18nCatalog
+    {
+        id: catalog
+        name: "cura"
+    }
 }

--- a/resources/qml/ObjectItemButton.qml
+++ b/resources/qml/ObjectItemButton.qml
@@ -14,7 +14,7 @@ Button
     width: parent.width
     height: UM.Theme.getSize("action_button").height
     leftPadding: UM.Theme.getSize("thin_margin").width
-    rightPadding: UM.Theme.getSize("thin_margin").width
+    rightPadding: UM.Theme.getSize("default_lining").width
     checkable: true
     hoverEnabled: true
 
@@ -29,7 +29,7 @@ Button
             anchors
             {
                 left: parent.left
-                right: parent.right
+                right: perObjectSettingsInfo.left
                 verticalCenter: parent.verticalCenter
             }
             text: objectItemButton.text
@@ -40,6 +40,75 @@ Button
             renderType: Text.NativeRendering
             verticalAlignment: Text.AlignVCenter
             elide: Text.ElideRight
+        }
+
+        Button
+        {
+            id: perObjectSettingsInfo
+
+            anchors
+            {
+                right: parent.right
+                rightMargin: 0
+            }
+            width: childrenRect.width
+            height: parent.height
+            padding: 0
+            leftPadding: UM.Theme.getSize("thin_margin").width
+
+            onClicked:
+            {
+                Cura.SceneController.changeSelection(index)
+                UM.Controller.setActiveTool("PerObjectSettingsTool")
+            }
+
+            contentItem: Item
+            {
+                height: parent.height
+                width: childrenRect.width
+
+                Cura.NotificationIcon
+                {
+                    id: perObjectSettingsCountLabel
+                    anchors
+                    {
+                        right: parent.right
+                        rightMargin: 0
+                    }
+                    visible: perObjectSettingsCount > 0
+                    color: UM.Theme.getColor("text_scene")
+                    labelText: perObjectSettingsCount.toString()
+                }
+
+                UM.RecolorImage
+                {
+                    anchors
+                    {
+                        right: perObjectSettingsCountLabel.left
+                        rightMargin: UM.Theme.getSize("narrow_margin").width
+                    }
+
+                    width: parent.height
+                    height: parent.height
+                    color: UM.Theme.getColor("text_scene")
+                    visible: meshType != ""
+                    source:
+                    {
+                        switch (meshType) {
+                            case "support_mesh":
+                                return UM.Theme.getIcon("pos_print_as_support")
+                            case "cutting_mesh":
+                            case "infill_mesh":
+                                return UM.Theme.getIcon("pos_modify_overlaps")
+                            case "anti_overhang_mesh":
+                                return UM.Theme.getIcon("pos_modify_dont_support_overlap")
+                        }
+                        return "";
+                    }
+                }
+            }
+
+            background: Item {}
         }
     }
 

--- a/resources/qml/ObjectItemButton.qml
+++ b/resources/qml/ObjectItemButton.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Ultimaker B.V.
+// Copyright (c) 2020 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.10
@@ -17,6 +17,17 @@ Button
     rightPadding: UM.Theme.getSize("default_lining").width
     checkable: true
     hoverEnabled: true
+
+    onClicked: Cura.SceneController.changeSelection(index)
+
+    background: Rectangle
+    {
+        id: backgroundRect
+        color: objectItemButton.hovered ? UM.Theme.getColor("action_button_hovered") : "transparent"
+        radius: UM.Theme.getSize("action_button_radius").width
+        border.width: UM.Theme.getSize("default_lining").width
+        border.color: objectItemButton.checked ? UM.Theme.getColor("primary") : "transparent"
+    }
 
     contentItem: Item
     {
@@ -126,15 +137,6 @@ Button
         }
     }
 
-    background: Rectangle
-    {
-        id: backgroundRect
-        color: objectItemButton.hovered ? UM.Theme.getColor("action_button_hovered") : "transparent"
-        radius: UM.Theme.getSize("action_button_radius").width
-        border.width: UM.Theme.getSize("default_lining").width
-        border.color: objectItemButton.checked ? UM.Theme.getColor("primary") : "transparent"
-    }
-
     TextMetrics
     {
         id: buttonTextMetrics
@@ -151,5 +153,4 @@ Button
         visible: objectItemButton.hovered && buttonTextMetrics.elidedText != buttonText.text
     }
 
-    onClicked: Cura.SceneController.changeSelection(index)
 }

--- a/resources/qml/ObjectItemButton.qml
+++ b/resources/qml/ObjectItemButton.qml
@@ -68,6 +68,7 @@ Button
             height: parent.height
             padding: 0
             leftPadding: UM.Theme.getSize("thin_margin").width
+            visible: meshType != "" || perObjectSettingsCount > 0
 
             onClicked:
             {

--- a/resources/qml/ObjectItemButton.qml
+++ b/resources/qml/ObjectItemButton.qml
@@ -35,6 +35,7 @@ Button
             text: objectItemButton.text
             font: UM.Theme.getFont("default")
             color: UM.Theme.getColor("text_scene")
+            opacity: (outsideBuildArea) ? 0.5 : 1.0
             visible: text != ""
             renderType: Text.NativeRendering
             verticalAlignment: Text.AlignVCenter

--- a/resources/qml/ObjectSelector.qml
+++ b/resources/qml/ObjectSelector.qml
@@ -87,6 +87,17 @@ Item
 
         anchors.bottom: parent.bottom
 
+        property var extrudersModel: CuraApplication.getExtrudersModel()
+        UM.SettingPropertyProvider
+        {
+            id: machineExtruderCount
+
+            containerStack: Cura.MachineManager.activeMachine
+            key: "machine_extruder_count"
+            watchedProperties: [ "value" ]
+            storeIndex: 0
+        }
+
         ListView
         {
             id: listView
@@ -123,6 +134,16 @@ Item
                 property bool outsideBuildArea: model.outside_build_area
                 property int perObjectSettingsCount: model.per_object_settings_count
                 property string meshType: model.mesh_type
+                property int extruderNumber: model.extruder_number
+                property string extruderColor:
+                {
+                    if (model.extruder_number == -1)
+                    {
+                        return "";
+                    }
+                    return contents.extrudersModel.getItem(model.extruder_number).color;
+                }
+                property bool showExtruderSwatches: machineExtruderCount.properties.value > 1
             }
         }
     }

--- a/resources/qml/ObjectSelector.qml
+++ b/resources/qml/ObjectSelector.qml
@@ -121,6 +121,8 @@ Item
                 text: model.name
                 width: listView.width
                 property bool outsideBuildArea: model.outside_build_area
+                property int perObjectSettingsCount: model.per_object_settings_count
+                property string meshType: model.mesh_type
             }
         }
     }

--- a/resources/qml/ObjectSelector.qml
+++ b/resources/qml/ObjectSelector.qml
@@ -120,6 +120,7 @@ Item
                 }
                 text: model.name
                 width: listView.width
+                property bool outsideBuildArea: model.outside_build_area
             }
         }
     }

--- a/resources/qml/ObjectSelector.qml
+++ b/resources/qml/ObjectSelector.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Ultimaker B.V.
+// Copyright (c) 2020 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.10

--- a/tests/TestObjectsModel.py
+++ b/tests/TestObjectsModel.py
@@ -125,7 +125,16 @@ class Test_Update:
         application_with_mocked_scene.getController().getScene().getRoot = MagicMock(return_value = group_scene_node)
         with patch("UM.Application.Application.getInstance", MagicMock(return_value=application_with_mocked_scene)):
             objects_model._update()
-            assert objects_model.items == [{'name': 'Group #1', 'selected': False, 'outside_build_area': False, 'buildplate_number': None, 'node': group_scene_node}]
+            assert objects_model.items == [{
+                'name': 'Group #1',
+                'selected': False,
+                'outside_build_area': False,
+                'buildplate_number': None,
+                'node': group_scene_node,
+                "extruder_number": -1,
+                "per_object_settings_count": 0,
+                "mesh_type": ""
+            }]
 
     def test_updateWithNonGroup(self, objects_model, application_with_mocked_scene, slicable_scene_node):
         objects_model._shouldNodeBeHandled = MagicMock(return_value=True)
@@ -133,7 +142,16 @@ class Test_Update:
         application_with_mocked_scene.getController().getScene().getRoot = MagicMock(return_value=slicable_scene_node)
         with patch("UM.Application.Application.getInstance", MagicMock(return_value=application_with_mocked_scene)):
             objects_model._update()
-            assert objects_model.items == [{'name': 'YAY(1)', 'selected': False, 'outside_build_area': False, 'buildplate_number': None, 'node': slicable_scene_node}]
+            assert objects_model.items == [{
+                'name': 'YAY(1)',
+                'selected': False,
+                'outside_build_area': False,
+                'buildplate_number': None,
+                'node': slicable_scene_node,
+                "extruder_number": -1,
+                "per_object_settings_count": 0,
+                "mesh_type": ""
+            }]
 
     def test_updateWithNonTwoNodes(self, objects_model, application_with_mocked_scene, slicable_scene_node):
         objects_model._shouldNodeBeHandled = MagicMock(return_value=True)
@@ -143,7 +161,25 @@ class Test_Update:
         application_with_mocked_scene.getController().getScene().getRoot = MagicMock(return_value=slicable_scene_node)
         with patch("UM.Application.Application.getInstance", MagicMock(return_value=application_with_mocked_scene)):
             objects_model._update()
-            assert objects_model.items == [{'name': 'YAY', 'selected': False, 'outside_build_area': False, 'buildplate_number': None, 'node': slicable_scene_node}, {'name': 'YAY(1)', 'selected': False, 'outside_build_area': False, 'buildplate_number': None, 'node': copied_node}]
+            assert objects_model.items == [{
+                'name': 'YAY',
+                'selected': False,
+                'outside_build_area': False,
+                'buildplate_number': None,
+                'node': slicable_scene_node,
+                "extruder_number": -1,
+                "per_object_settings_count": 0,
+                "mesh_type": ""
+            }, {
+                'name': 'YAY(1)',
+                'selected': False,
+                'outside_build_area': False,
+                'buildplate_number': None,
+                'node': copied_node,
+                "extruder_number": -1,
+                "per_object_settings_count": 0,
+                "mesh_type": ""
+            }]
 
     def test_updateWithNonTwoGroups(self, objects_model, application_with_mocked_scene, group_scene_node):
         objects_model._shouldNodeBeHandled = MagicMock(return_value=True)
@@ -153,7 +189,25 @@ class Test_Update:
         application_with_mocked_scene.getController().getScene().getRoot = MagicMock(return_value=group_scene_node)
         with patch("UM.Application.Application.getInstance", MagicMock(return_value=application_with_mocked_scene)):
             objects_model._update()
-            assert objects_model.items == [{'name': 'Group #1', 'selected': False, 'outside_build_area': False, 'buildplate_number': None, 'node': group_scene_node}, {'name': 'Group #2', 'selected': False, 'outside_build_area': False, 'buildplate_number': None, 'node': copied_node}]
+            assert objects_model.items == [{
+                'name': 'Group #1',
+                'selected': False,
+                'outside_build_area': False,
+                'buildplate_number': None,
+                'node': group_scene_node,
+                "extruder_number": -1,
+                "per_object_settings_count": 0,
+                "mesh_type": ""
+            }, {
+                'name': 'Group #2',
+                'selected': False,
+                'outside_build_area': False,
+                'buildplate_number': None,
+                'node': copied_node,
+                "extruder_number": -1,
+                "per_object_settings_count": 0,
+                "mesh_type": ""
+            }]
 
     def test_updateOutsideBuildplate(self, objects_model, application_with_mocked_scene, group_scene_node):
         objects_model._shouldNodeBeHandled = MagicMock(return_value=True)
@@ -162,5 +216,14 @@ class Test_Update:
         application_with_mocked_scene.getController().getScene().getRoot = MagicMock(return_value=group_scene_node)
         with patch("UM.Application.Application.getInstance", MagicMock(return_value=application_with_mocked_scene)):
             objects_model._update()
-            assert objects_model.items == [{'name': 'Group #1', 'selected': False, 'outside_build_area': True, 'buildplate_number': None, 'node': group_scene_node}]
+            assert objects_model.items == [{
+                'name': 'Group #1',
+                'selected': False,
+                'outside_build_area': True,
+                'buildplate_number': None,
+                'node': group_scene_node,
+                "extruder_number": -1,
+                "per_object_settings_count": 0,
+                "mesh_type": ""
+            }]
 


### PR DESCRIPTION
This PR adds some information to the object list:
* indicates the extruder(-color) used for the model (for multi-extrusion printers only)
* shows the meshtype if the model is not a normal mesh
* shows the number of per model setting overrides
* indicates models that are outside the build volume

![which box is which?](https://user-images.githubusercontent.com/143551/79070378-c0a2e280-7cd5-11ea-9392-c0bce58cfbe7.png)
Clicking the mesh-type or per-model-settings-count will open the Per Model Settings tool panel.

The PR also adds a small fix to ensure that support_mesh models are rendered using the color of the support_extruder.