### PR TITLE
Force reloading the VariantNode if it exists

### DIFF
--- a/cura/Machines/MachineNode.py
+++ b/cura/Machines/MachineNode.py
@@ -171,6 +171,10 @@ class MachineNode(ContainerNode):
                 if variant_name not in self.variants:
                     self.variants[variant_name] = VariantNode(variant["id"], machine = self)
                     self.variants[variant_name].materialsChanged.connect(self.materialsChanged)
+                else:
+                    # Force reloading the materials if the variant already exists or else materals won't be loaded
+                    # when the G-Code flavor changes --> CURA-7354
+                    self.variants[variant_name]._loadAll()
             if not self.variants:
                 self.variants["empty"] = VariantNode("empty_variant", machine = self)
 


### PR DESCRIPTION
When the MachineNode is updated through _loadAll, it was not updating
its VariantNodes when they already existed. This caused an issue to
UM2+Olsson block printers, where changing the G-Code flavor to Marlin
was not updating the VariantNodes to search for materials (since the
variants already existed).

This commit fixes that by forcing an update to the existing Variant
nodes.

Related GitHub issue: https://github.com/Ultimaker/Cura/issues/7347

CURA-7354