### PR TITLE
Move the getCfgVersion to base version upgrade

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade21to22/VersionUpgrade21to22.py
+++ b/plugins/VersionUpgrade/VersionUpgrade21to22/VersionUpgrade21to22.py
@@ -236,23 +236,11 @@ _variant_translations_materials = {
     }
 } # type: Dict[str, Dict[str, str]]
 
+
 ##  Converts configuration from Cura 2.1's file formats to Cura 2.2's.
 #
 #   It converts the machine instances and profiles.
 class VersionUpgrade21to22(VersionUpgrade):
-    ##  Gets the version number from a config file.
-    #
-    #   In all config files that concern this version upgrade, the version
-    #   number is stored in general/version, so get the data from that key.
-    #
-    #   \param serialised The contents of a config file.
-    #   \return The version number of that config file.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
 
     ##  Gets the fallback quality to use for a specific machine-variant-material
     #   combination.

--- a/plugins/VersionUpgrade/VersionUpgrade25to26/VersionUpgrade25to26.py
+++ b/plugins/VersionUpgrade/VersionUpgrade25to26/VersionUpgrade25to26.py
@@ -19,6 +19,7 @@ _split_settings = { #These settings should be copied to all settings it was spli
     "support_interface_line_distance": {"support_roof_line_distance", "support_bottom_line_distance"}
 } # type: Dict[str, Set[str]]
 
+
 ##  A collection of functions that convert the configuration of the user in Cura
 #   2.5 to a configuration for Cura 2.6.
 #
@@ -27,24 +28,6 @@ class VersionUpgrade25to26(VersionUpgrade):
     def __init__(self) -> None:
         super().__init__()
         self._current_fdm_printer_count = 2
-
-    ##  Gets the version number from a CFG file in Uranium's 2.5 format.
-    #
-    #   Since the format may change, this is implemented for the 2.5 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
 
     ##  Upgrades the preferences file from version 2.5 to 2.6.
     #

--- a/plugins/VersionUpgrade/VersionUpgrade26to27/VersionUpgrade26to27.py
+++ b/plugins/VersionUpgrade/VersionUpgrade26to27/VersionUpgrade26to27.py
@@ -64,29 +64,12 @@ _renamed_quality_profiles = {
     "um3_bb0.8_TPU_Not_Supported_Superdraft_Quality": "um3_bb0.8_TPU_Superdraft_Print",
 } # type: Dict[str, str]
 
+
 ##  A collection of functions that convert the configuration of the user in Cura
 #   2.6 to a configuration for Cura 2.7.
 #
 #   All of these methods are essentially stateless.
 class VersionUpgrade26to27(VersionUpgrade):
-    ##  Gets the version number from a CFG file in Uranium's 2.6 format.
-    #
-    #   Since the format may change, this is implemented for the 2.6 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades a preferences file from version 2.6 to 2.7.
     #
     #   \param serialised The serialised form of a preferences file.

--- a/plugins/VersionUpgrade/VersionUpgrade30to31/VersionUpgrade30to31.py
+++ b/plugins/VersionUpgrade/VersionUpgrade30to31/VersionUpgrade30to31.py
@@ -62,24 +62,6 @@ _RENAMED_DEFINITION_DICT = {
 
 
 class VersionUpgrade30to31(VersionUpgrade):
-    ##  Gets the version number from a CFG file in Uranium's 3.0 format.
-    #
-    #   Since the format may change, this is implemented for the 3.0 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades a preferences file from version 3.0 to 3.1.
     #
     #   \param serialised The serialised form of a preferences file.

--- a/plugins/VersionUpgrade/VersionUpgrade32to33/VersionUpgrade32to33.py
+++ b/plugins/VersionUpgrade/VersionUpgrade32to33/VersionUpgrade32to33.py
@@ -68,24 +68,6 @@ _RENAMED_QUALITY_TYPES = {
 class VersionUpgrade32to33(VersionUpgrade):
     temporary_group_name_counter = 1
 
-    ##  Gets the version number from a CFG file in Uranium's 3.2 format.
-    #
-    #   Since the format may change, this is implemented for the 3.2 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades a preferences file from version 3.2 to 3.3.
     #
     #   \param serialised The serialised form of a preferences file.

--- a/plugins/VersionUpgrade/VersionUpgrade33to34/VersionUpgrade33to34.py
+++ b/plugins/VersionUpgrade/VersionUpgrade33to34/VersionUpgrade33to34.py
@@ -14,24 +14,6 @@ _renamed_settings = {
 ##  Upgrades configurations from the state they were in at version 3.3 to the
 #   state they should be in at version 3.4.
 class VersionUpgrade33to34(VersionUpgrade):
-    ##  Gets the version number from a CFG file in Uranium's 3.3 format.
-    #
-    #   Since the format may change, this is implemented for the 3.3 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades instance containers to have the new version
     #   number.
     def upgradeInstanceContainer(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:

--- a/plugins/VersionUpgrade/VersionUpgrade34to35/VersionUpgrade34to35.py
+++ b/plugins/VersionUpgrade/VersionUpgrade34to35/VersionUpgrade34to35.py
@@ -63,24 +63,6 @@ _RENAMED_MATERIAL_PROFILES = {
 ##  Upgrades configurations from the state they were in at version 3.4 to the
 #   state they should be in at version 3.5.
 class VersionUpgrade34to35(VersionUpgrade):
-    ##  Gets the version number from a CFG file in Uranium's 3.4 format.
-    #
-    #   Since the format may change, this is implemented for the 3.4 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades Preferences to have the new version number.
     def upgradePreferences(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
         parser = configparser.ConfigParser(interpolation = None)

--- a/plugins/VersionUpgrade/VersionUpgrade35to40/VersionUpgrade35to40.py
+++ b/plugins/VersionUpgrade/VersionUpgrade35to40/VersionUpgrade35to40.py
@@ -34,13 +34,6 @@ class VersionUpgrade35to40(VersionUpgrade):
         parser.write(result)
         return [filename], [result.getvalue()]
 
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades Preferences to have the new version number.
     def upgradePreferences(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
         parser = configparser.ConfigParser(interpolation=None)

--- a/plugins/VersionUpgrade/VersionUpgrade40to41/VersionUpgrade40to41.py
+++ b/plugins/VersionUpgrade/VersionUpgrade40to41/VersionUpgrade40to41.py
@@ -23,24 +23,6 @@ _renamed_quality_profiles = {
 ##  Upgrades configurations from the state they were in at version 4.0 to the
 #   state they should be in at version 4.1.
 class VersionUpgrade40to41(VersionUpgrade):
-    ##  Gets the version number from a CFG file in Uranium's 4.0 format.
-    #
-    #   Since the format may change, this is implemented for the 4.0 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades instance containers to have the new version
     #   number.
     def upgradeInstanceContainer(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:

--- a/plugins/VersionUpgrade/VersionUpgrade41to42/VersionUpgrade41to42.py
+++ b/plugins/VersionUpgrade/VersionUpgrade41to42/VersionUpgrade41to42.py
@@ -213,27 +213,10 @@ _creality_limited_quality_type = {
     "extra_coarse": "draft"
 }
 
+
 ##  Upgrades configurations from the state they were in at version 4.1 to the
 #   state they should be in at version 4.2.
 class VersionUpgrade41to42(VersionUpgrade):
-    ##  Gets the version number from a CFG file in Uranium's 4.1 format.
-    #
-    #   Since the format may change, this is implemented for the 4.1 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version"))  # Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades instance containers to have the new version
     #   number.
     #

--- a/plugins/VersionUpgrade/VersionUpgrade42to43/VersionUpgrade42to43.py
+++ b/plugins/VersionUpgrade/VersionUpgrade42to43/VersionUpgrade42to43.py
@@ -56,27 +56,10 @@ _renamed_settings = {
     "support_infill_angle": "support_infill_angles"
 }  # type: Dict[str, str]
 
+
 ##  Upgrades configurations from the state they were in at version 4.2 to the
 #   state they should be in at version 4.3.
 class VersionUpgrade42to43(VersionUpgrade):
-    ##  Gets the version number from a CFG file in Uranium's 4.2 format.
-    #
-    #   Since the format may change, this is implemented for the 4.2 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version"))  # Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     def upgradePreferences(self, serialized: str, filename: str):
         parser = configparser.ConfigParser(interpolation = None)
         parser.read_string(serialized)

--- a/plugins/VersionUpgrade/VersionUpgrade43to44/VersionUpgrade43to44.py
+++ b/plugins/VersionUpgrade/VersionUpgrade43to44/VersionUpgrade43to44.py
@@ -26,12 +26,6 @@ _renamed_container_id_map = {
 
 
 class VersionUpgrade43to44(VersionUpgrade):
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version"))  # Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
 
     ##  Upgrades Preferences to have the new version number.
     #

--- a/plugins/VersionUpgrade/VersionUpgrade44to45/VersionUpgrade44to45.py
+++ b/plugins/VersionUpgrade/VersionUpgrade44to45/VersionUpgrade44to45.py
@@ -122,13 +122,6 @@ class VersionUpgrade44to45(VersionUpgrade):
                     except OSError:  # Is a directory, file not found, or insufficient rights.
                         continue
 
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version"))  # Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
-
     ##  Upgrades Preferences to have the new version number.
     #
     #   This renames the renamed settings in the list of visible settings.

--- a/plugins/VersionUpgrade/VersionUpgrade45to46/VersionUpgrade45to46.py
+++ b/plugins/VersionUpgrade/VersionUpgrade45to46/VersionUpgrade45to46.py
@@ -10,14 +10,8 @@ _removed_settings = {
     "machine_filament_park_distance",
 }
 
-class VersionUpgrade45to46(VersionUpgrade):
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version"))  # Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
 
+class VersionUpgrade45to46(VersionUpgrade):
     def upgradePreferences(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
         """
         Upgrades preferences to have the new version number.

--- a/plugins/VersionUpgrade/VersionUpgrade46to47/VersionUpgrade46to47.py
+++ b/plugins/VersionUpgrade/VersionUpgrade46to47/VersionUpgrade46to47.py
@@ -6,14 +6,8 @@ from typing import Tuple, List
 import io
 from UM.VersionUpgrade import VersionUpgrade
 
-class VersionUpgrade46to47(VersionUpgrade):
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version"))  # Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
 
+class VersionUpgrade46to47(VersionUpgrade):
     def upgradePreferences(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
         """
         Upgrades preferences to have the new version number.


### PR DESCRIPTION
They can still be overridden, but in the current situation they were
all the same.