### PR TITLE
Included 2 fields on PauseAtHeight script for user to put custom GCODE's before and after the actual pause

### DIFF
--- a/plugins/PostProcessingPlugin/plugin.json
+++ b/plugins/PostProcessingPlugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Post Processing",
     "author": "Ultimaker",
-    "version": "2.3.0",
+    "version": "2.2.1",
     "api": "7.2.0",
     "description": "Extension that allows for user created scripts for post processing",
     "catalog": "cura"

--- a/plugins/PostProcessingPlugin/plugin.json
+++ b/plugins/PostProcessingPlugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Post Processing",
     "author": "Ultimaker",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "api": "7.2.0",
     "description": "Extension that allows for user created scripts for post processing",
     "catalog": "cura"

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -130,20 +130,6 @@ class PauseAtHeight(Script):
                     "description": "Text that should appear on the display while paused. If left empty, there will not be any message.",
                     "type": "str",
                     "default_value": ""
-                },
-                "custom_gcode_before_pause":
-                {
-                    "label": "GCODE Before Pause",
-                    "description": "Any custom GCODE to run before the pause, for example, M300 S440 P200 to beep.",
-                    "type": "str",
-                    "default_value": ""
-                },
-                "custom_gcode_after_pause":
-                {
-                    "label": "GCODE After Pause",
-                    "description": "Any custom GCODE to run after the pause, for example, M300 S440 P200 to beep.",
-                    "type": "str",
-                    "default_value": ""
                 }
             }
         }"""
@@ -180,8 +166,6 @@ class PauseAtHeight(Script):
         control_temperatures = Application.getInstance().getGlobalContainerStack().getProperty("machine_nozzle_temp_enabled", "value")
         initial_layer_height = Application.getInstance().getGlobalContainerStack().getProperty("layer_height_0", "value")
         display_text = self.getSettingValueByKey("display_text")
-        gcode_before = self.getSettingValueByKey("custom_gcode_before_pause")
-        gcode_after = self.getSettingValueByKey("custom_gcode_after_pause")
 
         is_griffin = False
 
@@ -339,16 +323,8 @@ class PauseAtHeight(Script):
                 if disarm_timeout > 0:
                     prepend_gcode += self.putValue(M = 18, S = disarm_timeout) + " ; Set the disarm timeout\n"
 
-                # Set a custom GCODE section before pause
-                if gcode_before:
-                    prepend_gcode += gcode_before + "\n"
-
                 # Wait till the user continues printing
                 prepend_gcode += self.putValue(M = 0) + " ; Do the actual pause\n"
-
-                # Set a custom GCODE section before pause
-                if gcode_after:
-                    prepend_gcode += gcode_after + "\n"
 
                 if not is_griffin:
                     if control_temperatures:

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -130,6 +130,20 @@ class PauseAtHeight(Script):
                     "description": "Text that should appear on the display while paused. If left empty, there will not be any message.",
                     "type": "str",
                     "default_value": ""
+                },
+                "custom_gcode_before_pause":
+                {
+                    "label": "GCODE Before Pause",
+                    "description": "Any custom GCODE to run before the pause, for example, M300 S440 P200 to beep.",
+                    "type": "str",
+                    "default_value": ""
+                },
+                "custom_gcode_after_pause":
+                {
+                    "label": "GCODE After Pause",
+                    "description": "Any custom GCODE to run after the pause, for example, M300 S440 P200 to beep.",
+                    "type": "str",
+                    "default_value": ""
                 }
             }
         }"""
@@ -166,6 +180,8 @@ class PauseAtHeight(Script):
         control_temperatures = Application.getInstance().getGlobalContainerStack().getProperty("machine_nozzle_temp_enabled", "value")
         initial_layer_height = Application.getInstance().getGlobalContainerStack().getProperty("layer_height_0", "value")
         display_text = self.getSettingValueByKey("display_text")
+        gcode_before = self.getSettingValueByKey("custom_gcode_before_pause")
+        gcode_after = self.getSettingValueByKey("custom_gcode_after_pause")
 
         is_griffin = False
 
@@ -323,8 +339,16 @@ class PauseAtHeight(Script):
                 if disarm_timeout > 0:
                     prepend_gcode += self.putValue(M = 18, S = disarm_timeout) + " ; Set the disarm timeout\n"
 
+                # Set a custom GCODE section before pause
+                if gcode_before:
+                    prepend_gcode += gcode_before + "\n"
+
                 # Wait till the user continues printing
                 prepend_gcode += self.putValue(M = 0) + " ; Do the actual pause\n"
+
+                # Set a custom GCODE section before pause
+                if gcode_after:
+                    prepend_gcode += gcode_after + "\n"
 
                 if not is_griffin:
                     if control_temperatures:

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -130,6 +130,20 @@ class PauseAtHeight(Script):
                     "description": "Text that should appear on the display while paused. If left empty, there will not be any message.",
                     "type": "str",
                     "default_value": ""
+                },
+                "custom_gcode_before_pause":
+                {
+                    "label": "GCODE Before Pause",
+                    "description": "Any custom GCODE to run before the pause, for example, M300 S440 P200 to beep.",
+                    "type": "str",
+                    "default_value": "M300 S440 P200; M300 S660 P250; M300 S880 P300;"
+                },
+                "custom_gcode_after_pause":
+                {
+                    "label": "GCODE After Pause",
+                    "description": "Any custom GCODE to run after the pause, for example, M300 S440 P200 to beep.",
+                    "type": "str",
+                    "default_value": ""
                 }
             }
         }"""
@@ -166,6 +180,8 @@ class PauseAtHeight(Script):
         control_temperatures = Application.getInstance().getGlobalContainerStack().getProperty("machine_nozzle_temp_enabled", "value")
         initial_layer_height = Application.getInstance().getGlobalContainerStack().getProperty("layer_height_0", "value")
         display_text = self.getSettingValueByKey("display_text")
+        gcode_before = self.getSettingValueByKey("custom_gcode_before_pause")
+        gcode_after = self.getSettingValueByKey("custom_gcode_after_pause")
 
         is_griffin = False
 
@@ -323,8 +339,16 @@ class PauseAtHeight(Script):
                 if disarm_timeout > 0:
                     prepend_gcode += self.putValue(M = 18, S = disarm_timeout) + " ; Set the disarm timeout\n"
 
+                # Set a custom GCODE section before pause
+                if gcode_before:
+                    prepend_gcode += gcode_before + "\n"
+
                 # Wait till the user continues printing
                 prepend_gcode += self.putValue(M = 0) + " ; Do the actual pause\n"
+
+                # Set a custom GCODE section before pause
+                if gcode_after:
+                    prepend_gcode += gcode_after + "\n"
 
                 if not is_griffin:
                     if control_temperatures:

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
@@ -67,21 +67,6 @@ class PauseAtHeightforRepetier(Script):
                     "unit": "layers",
                     "type": "int",
                     "default_value": 0
-                },
-                ,
-                "custom_gcode_before_pause":
-                {
-                    "label": "GCODE Before Pause",
-                    "description": "Any custom GCODE to run before the pause, for example, M300 S300 P1000 to beep.",
-                    "type": "str",
-                    "default_value": ""
-                },
-                "custom_gcode_after_pause":
-                {
-                    "label": "GCODE After Pause",
-                    "description": "Any custom GCODE to run after the pause, for example, M300 S300 P1000 to beep.",
-                    "type": "str",
-                    "default_value": ""
                 }
             }
         }"""
@@ -99,9 +84,6 @@ class PauseAtHeightforRepetier(Script):
         move_Z = self.getSettingValueByKey("head_move_Z")
         layers_started = False
         redo_layers = self.getSettingValueByKey("redo_layers")
-        gcode_before = self.getSettingValueByKey("custom_gcode_before_pause")
-        gcode_after = self.getSettingValueByKey("custom_gcode_after_pause")
-
         for layer in data:
             lines = layer.split("\n")
             for line in lines:
@@ -150,17 +132,8 @@ class PauseAtHeightforRepetier(Script):
 
                             #Disable the E steppers
                             prepend_gcode += "M84 E0\n"
-
-                            # Set a custom GCODE section before pause
-                            if gcode_before:
-                                prepend_gcode += gcode_before + "\n"
-
                             #Wait till the user continues printing
                             prepend_gcode += "@pause now change filament and press continue printing ;Do the actual pause\n"
-
-                            # Set a custom GCODE section before pause
-                            if gcode_after:
-                                prepend_gcode += gcode_after + "\n"
 
                             #Push the filament back,
                             if retraction_amount != 0:

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
@@ -67,6 +67,21 @@ class PauseAtHeightforRepetier(Script):
                     "unit": "layers",
                     "type": "int",
                     "default_value": 0
+                },
+                ,
+                "custom_gcode_before_pause":
+                {
+                    "label": "GCODE Before Pause",
+                    "description": "Any custom GCODE to run before the pause, for example, M300 S300 P1000 to beep.",
+                    "type": "str",
+                    "default_value": ""
+                },
+                "custom_gcode_after_pause":
+                {
+                    "label": "GCODE After Pause",
+                    "description": "Any custom GCODE to run after the pause, for example, M300 S300 P1000 to beep.",
+                    "type": "str",
+                    "default_value": ""
                 }
             }
         }"""
@@ -84,6 +99,9 @@ class PauseAtHeightforRepetier(Script):
         move_Z = self.getSettingValueByKey("head_move_Z")
         layers_started = False
         redo_layers = self.getSettingValueByKey("redo_layers")
+        gcode_before = self.getSettingValueByKey("custom_gcode_before_pause")
+        gcode_after = self.getSettingValueByKey("custom_gcode_after_pause")
+
         for layer in data:
             lines = layer.split("\n")
             for line in lines:
@@ -132,8 +150,17 @@ class PauseAtHeightforRepetier(Script):
 
                             #Disable the E steppers
                             prepend_gcode += "M84 E0\n"
+
+                            # Set a custom GCODE section before pause
+                            if gcode_before:
+                                prepend_gcode += gcode_before + "\n"
+
                             #Wait till the user continues printing
                             prepend_gcode += "@pause now change filament and press continue printing ;Do the actual pause\n"
+
+                            # Set a custom GCODE section before pause
+                            if gcode_after:
+                                prepend_gcode += gcode_after + "\n"
 
                             #Push the filament back,
                             if retraction_amount != 0:

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeightforRepetier.py
@@ -67,6 +67,21 @@ class PauseAtHeightforRepetier(Script):
                     "unit": "layers",
                     "type": "int",
                     "default_value": 0
+                },
+                ,
+                "custom_gcode_before_pause":
+                {
+                    "label": "GCODE Before Pause",
+                    "description": "Any custom GCODE to run before the pause, for example, M300 S300 P1000 to beep.",
+                    "type": "str",
+                    "default_value": "M300 S440 P200; M300 S660 P250; M300 S880 P300;"
+                },
+                "custom_gcode_after_pause":
+                {
+                    "label": "GCODE After Pause",
+                    "description": "Any custom GCODE to run after the pause, for example, M300 S300 P1000 to beep.",
+                    "type": "str",
+                    "default_value": ""
                 }
             }
         }"""
@@ -84,6 +99,9 @@ class PauseAtHeightforRepetier(Script):
         move_Z = self.getSettingValueByKey("head_move_Z")
         layers_started = False
         redo_layers = self.getSettingValueByKey("redo_layers")
+        gcode_before = self.getSettingValueByKey("custom_gcode_before_pause")
+        gcode_after = self.getSettingValueByKey("custom_gcode_after_pause")
+
         for layer in data:
             lines = layer.split("\n")
             for line in lines:
@@ -132,8 +150,17 @@ class PauseAtHeightforRepetier(Script):
 
                             #Disable the E steppers
                             prepend_gcode += "M84 E0\n"
+
+                            # Set a custom GCODE section before pause
+                            if gcode_before:
+                                prepend_gcode += gcode_before + "\n"
+
                             #Wait till the user continues printing
                             prepend_gcode += "@pause now change filament and press continue printing ;Do the actual pause\n"
+
+                            # Set a custom GCODE section before pause
+                            if gcode_after:
+                                prepend_gcode += gcode_after + "\n"
 
                             #Push the filament back,
                             if retraction_amount != 0:


### PR DESCRIPTION
I've opened a Feature Request, but made this change.

So, I've tested with my Cura 4.6 on Windows and it worked like a charm. 

Example:

;TYPE:CUSTOM
;added code by post processing
;script: PauseAtHeight.py
;current layer: 87
M83 ; switch to relative E values for any needed retraction
G1 F2400 E-30
G1 F300 Z18.64 ; move up a millimeter to get out of the way
G1 F9000 X30 Y30
M104 S240 ; standby temperature
M18 S900 ; Set the disarm timeout
**M300 S440 P200;
M300 S660 P250;
M300 S880 P300;**
M0 ; Do the actual pause
**M300 S440 P200;
M300 S660 P250;
M300 S880 P300;**
M109 S240 ; resume temperature
G1 F2400 E30
G1 F2400 E-30

I've putted some beep code to alert me when it's time to change the filament.