### PR TITLE
Add a preference to use a single instance for loading files

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -304,7 +304,9 @@ class CuraApplication(QtApplication):
 
         super().initialize()
 
-        self._checkEarlyPreferences()
+        self._preferences.addPreference("cura/single_instance", False)
+        self._use_single_instance = self._preferences.getValue("cura/single_instance")
+
         self.__sendCommandToSingleInstance()
         self._initializeSettingDefinitions()
         self._initializeSettingFunctions()
@@ -314,20 +316,6 @@ class CuraApplication(QtApplication):
 
         self._machine_action_manager = MachineActionManager.MachineActionManager(self)
         self._machine_action_manager.initialize()
-
-    def _checkEarlyPreferences(self) -> None:
-        # Check for specific preferences early in the bootstrap process, without spinning up the full Preference singleton yet
-        if self._use_single_instance:
-            return
-
-        preferences_file = Resources.getPath(Resources.Preferences, "{}.cfg".format(self.getApplicationName()))
-        if not os.path.exists(preferences_file):
-            return
-
-        with open(preferences_file) as preferences:
-            if "single_instance = True" in preferences.read():
-                Logger.log("i", "Preference to use a single instance detected")
-                self._use_single_instance = True
 
     def __sendCommandToSingleInstance(self):
         self._single_instance = SingleInstance(self, self._files_to_open)
@@ -523,7 +511,7 @@ class CuraApplication(QtApplication):
         preferences.setValue("metadata/setting_version", self.SettingVersion) #Don't make it equal to the default so that the setting version always gets written to the file.
 
         preferences.addPreference("cura/active_mode", "simple")
-        preferences.addPreference("cura/single_instance", False)
+
         preferences.addPreference("cura/categories_expanded", "")
         preferences.addPreference("cura/jobname_prefix", True)
         preferences.addPreference("cura/select_models_on_load", False)

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -304,6 +304,7 @@ class CuraApplication(QtApplication):
 
         super().initialize()
 
+        self._checkEarlyPreferences()
         self.__sendCommandToSingleInstance()
         self._initializeSettingDefinitions()
         self._initializeSettingFunctions()
@@ -313,6 +314,20 @@ class CuraApplication(QtApplication):
 
         self._machine_action_manager = MachineActionManager.MachineActionManager(self)
         self._machine_action_manager.initialize()
+
+    def _checkEarlyPreferences(self) -> None:
+        # Check for specific preferences early in the bootstrap process, without spinning up the full Preference singleton yet
+        if self._use_single_instance:
+            return
+
+        preferences_file = Resources.getPath(Resources.Preferences, "{}.cfg".format(self.getApplicationName()))
+        if not os.path.exists(preferences_file):
+            return
+
+        with open(preferences_file) as preferences:
+            if "single_instance = True" in preferences.read():
+                Logger.log("i", "Preference to use a single instance detected")
+                self._use_single_instance = True
 
     def __sendCommandToSingleInstance(self):
         self._single_instance = SingleInstance(self, self._files_to_open)
@@ -508,7 +523,7 @@ class CuraApplication(QtApplication):
         preferences.setValue("metadata/setting_version", self.SettingVersion) #Don't make it equal to the default so that the setting version always gets written to the file.
 
         preferences.addPreference("cura/active_mode", "simple")
-
+        preferences.addPreference("cura/single_instance", False)
         preferences.addPreference("cura/categories_expanded", "")
         preferences.addPreference("cura/jobname_prefix", True)
         preferences.addPreference("cura/select_models_on_load", False)

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -72,6 +72,9 @@ UM.PreferencesPage
         var defaultTheme = UM.Preferences.getValue("general/theme")
         setDefaultTheme(defaultTheme)
 
+        UM.Preferences.resetPreference("cura/single_instance")
+        scaleToFitCheckbox.checked = boolCheck(UM.Preferences.getValue("cura/single_instance"))
+
         UM.Preferences.resetPreference("physics/automatic_push_free")
         pushFreeCheckbox.checked = boolCheck(UM.Preferences.getValue("physics/automatic_push_free"))
         UM.Preferences.resetPreference("physics/automatic_drop_down")
@@ -558,6 +561,21 @@ UM.PreferencesPage
             {
                 font.bold: true
                 text: catalog.i18nc("@label","Opening and saving files")
+            }
+
+            UM.TooltipArea
+            {
+                width: childrenRect.width
+                height: childrenRect.height
+                text: catalog.i18nc("@info:tooltip","Should opening files from the desktop or external applications open in the same instance of Cura?")
+
+                CheckBox
+                {
+                    id: singleInstanceCheckbox
+                    text: catalog.i18nc("@option:check","Use a single instance of Cura")
+                    checked: boolCheck(UM.Preferences.getValue("cura/single_instance"))
+                    onCheckedChanged: UM.Preferences.setValue("cura/single_instance", checked)
+                }
             }
 
             UM.TooltipArea


### PR DESCRIPTION
This PR adds a preference to use a single instance for loading files which has the same functionality as the --single_instance command line argument. ~It adds a very minimal preference parser that specifically looks for this particular preference instead of spinning up the full preference singleton, so the early boot is not delayed by much for this feature.~ Edit: the preferences are already available at that point, so I can use them as is.

The "single instance" feature is commonly used by users of CAD applications that launch Cura from their CAD application, and who may prefer to sequentially load objects into a single instance of Cura instead of starting up a new Cura for each iteration of the design.

This PR fixes #7664