### PR TITLE
Limit platform meshes to 1MB

### DIFF
--- a/tests/Machines/TestPlatformMeshes.py
+++ b/tests/Machines/TestPlatformMeshes.py
@@ -11,7 +11,7 @@ def collecAllPlatformMeshes():
     result = []
     for root, directories, filenames in os.walk(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "resources", "meshes"))):
         for filename in filenames:
-            if os.path.basename(filename) not in __exclude_filenames:
+            if filename not in __exclude_filenames:
                 result.append(os.path.join(root, filename))
     return result
 

--- a/tests/Machines/TestPlatformMeshes.py
+++ b/tests/Machines/TestPlatformMeshes.py
@@ -1,0 +1,31 @@
+import pytest
+
+import os
+import os.path
+
+
+__exclude_filenames = ["UltimakerRobot_support.stl"]
+
+
+def collecAllPlatformMeshes():
+    result = []
+    for root, directories, filenames in os.walk(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "resources", "meshes"))):
+        for filename in filenames:
+            if os.path.basename(filename) not in __exclude_filenames:
+                result.append(os.path.join(root, filename))
+    return result
+
+
+platform_mesh_filepaths = collecAllPlatformMeshes()
+MAX_MESH_FILE_SIZE = 1 * 1024 * 1024  # 1MB
+
+
+# Check if the platform meshes adhere to the maximum file size (1MB)
+@pytest.mark.parametrize("file_name", platform_mesh_filepaths)
+def test_validatePlatformMeshSizes(file_name):
+    assert os.path.getsize(file_name) <= MAX_MESH_FILE_SIZE, \
+        "Platform mesh {} should be less than {}KB. Current file size: {}KB.".format(
+            file_name,
+            round(MAX_MESH_FILE_SIZE / 1024),
+            round(os.path.getsize(file_name) / 1024, 2)
+        )


### PR DESCRIPTION
As a result of Cura and Cookies discussion, we decided to limit the
sizes of platform meshes to less than 1MB. This test checks that
during the CI/CD process and displays an assertion error when a
mesh excludes this limit.