### PR TITLE
When running from AppImage, chdir to os.environ["OWD"] if it exists and is a directory.

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -118,7 +118,10 @@ if Platform.isWindows() and hasattr(sys, "frozen"):
 # otherwise it doesn't work. This is a workaround on Linux that before we call QDesktopServices.openUrl(), we
 # switch to a directory where the user has the ownership.
 if Platform.isLinux() and hasattr(sys, "frozen"):
-    os.chdir(os.path.expanduser("~"))
+    if "OWD" in os.environ and os.path.isdir(os.environ["OWD"]):
+        os.chdir(os.environ["OWD"])
+    else:
+        os.chdir(os.path.expanduser("~"))
 
 # WORKAROUND: GITHUB-704 GITHUB-708
 # It looks like setuptools creates a .pth file in


### PR DESCRIPTION
The AppImage runtime should set OWD to the original current working directory.

Solution for https://github.com/Ultimaker/Cura/issues/7665.