### PR TITLE
fix: remove disallowed areas on ender 3

### DIFF
--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -12,11 +12,6 @@
         "machine_width": { "default_value": 235 },
         "machine_depth": { "default_value": 235 },
         "machine_height": { "default_value": 250 },
-        "machine_disallowed_areas": {
-            "default_value": [
-              [[-117.5, 117.5], [-117.5, 108], [117.5, 108], [117.5, 117.5]],
-              [[-117.5, -108], [-117.5, -117.5], [117.5, -117.5], [117.5, -108]]
-        ]},
         "machine_head_with_fans_polygon": { "default_value": [
                 [-26, 34],
                 [-26, -32],


### PR DESCRIPTION
The Ender 3's bed is properly set to 235 x 235. However, the `machine_disallowed_areas` does not allow users to use the entire area. Strangely, the disallowed areas are also only set on the y axis.

The Ender 3 is capable of printing in the entire 235 x 235 area, so in my opinion, having disallowed areas does not make sense.

This change removes the disallowed areas, allowing users to choose for themselves how closely to the edge of the bed they would like to place models.