### PR TITLE
Cura 7427 add option to sign in with different account while waiting for printers

### DIFF
--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -90,23 +90,23 @@ class Account(QObject):
             self.loginStateChanged.emit(logged_in)
 
     @pyqtSlot()
-    def login(self) -> None:
-        if self._logged_in:
-            # Nothing to do, user already logged in.
-            return
-        self._authorization_service.startAuthorizationFlow()
-
-    @pyqtSlot()
-    def loginWithForcedLogout(self) -> None:
+    @pyqtSlot(bool)
+    def login(self, force_logout_before_login: bool = False) -> None:
         """
-        Forces a logout from Cura and then initiates the authorization flow with the force_browser_logout variable
-        as true, to sync the accounts in Cura and in the browser.
+        Initializes the login process. If the user is logged in already and force_logout_before_login is true, Cura will
+        logout from the account before initiating the authorization flow. If the user is logged in and
+        force_logout_before_login is false, the function will return, as there is nothing to do.
 
+        :param force_logout_before_login: Optional boolean parameter
         :return: None
         """
         if self._logged_in:
-            self.logout()
-        self._authorization_service.startAuthorizationFlow(True)
+            if force_logout_before_login:
+                self.logout()
+            else:
+                # Nothing to do, user already logged in.
+                return
+        self._authorization_service.startAuthorizationFlow(force_logout_before_login)
 
     @pyqtProperty(str, notify=loginStateChanged)
     def userName(self):

--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -99,7 +99,7 @@ class Account(QObject):
     @pyqtSlot()
     def loginWithForcedLogout(self) -> None:
         """
-        Forces a logout from Cura and then initiates the authorization flow with the force_logout_from_mycloud variable
+        Forces a logout from Cura and then initiates the authorization flow with the force_browser_logout variable
         as true, to sync the accounts in Cura and in the browser.
 
         :return: None

--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -96,6 +96,18 @@ class Account(QObject):
             return
         self._authorization_service.startAuthorizationFlow()
 
+    @pyqtSlot()
+    def loginWithForcedLogout(self) -> None:
+        """
+        Forces a logout from Cura and then initiates the authorization flow with the force_logout_from_mycloud variable
+        as true, to sync the accounts in Cura and in the browser.
+
+        :return: None
+        """
+        if self._logged_in:
+            self.logout()
+        self._authorization_service.startAuthorizationFlow(True)
+
     @pyqtProperty(str, notify=loginStateChanged)
     def userName(self):
         user_profile = self._authorization_service.getUserProfile()

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -178,7 +178,7 @@ class AuthorizationService:
         # Open the authorization page in a new browser window.
         QDesktopServices.openUrl(QUrl(auth_url))
 
-    def _generate_auth_url(self, query_parameters_dict: Dict[str, str], force_browser_logout: bool) -> str:
+    def _generate_auth_url(self, query_parameters_dict: Dict[str, Optional[str]], force_browser_logout: bool) -> str:
         """
         Generates the authentications url based on the original auth_url and the query_parameters_dict to be included.
         If there is a request to force logging out of mycloud in the browser, the link to logoff from mycloud is

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from cura.OAuth2.Models import UserProfile, OAuth2Settings
     from UM.Preferences import Preferences
 
-MYCLOUD_LOGOFF = "https://mycloud.ultimaker.com/logoff"
+MYCLOUD_LOGOFF_URL = "https://mycloud.ultimaker.com/logoff"
 
 ##  The authorization service is responsible for handling the login flow,
 #   storing user credentials and providing account information.
@@ -184,14 +184,17 @@ class AuthorizationService:
         If there is a request to force logging out of mycloud in the browser, the link to logoff from mycloud is
         prepended in order to force the browser to logoff from mycloud and then redirect to the authentication url to
         login again. This case is used to sync the accounts between Cura and the browser.
-        :param query_parameters_dict:
-        :param force_browser_logout:
-        :return:
+
+        :param query_parameters_dict: A dictionary with the query parameters to be url encoded and added to the
+                                      authentication link
+        :param force_browser_logout: If True, Cura will prepend the MYCLOUD_LOGOFF_URL link before the authentication
+                                     link to force the a browser logout from mycloud.ultimaker.com
+        :return: The authentication URL, properly formatted and encoded
         """
         auth_url = "{}?{}".format(self._auth_url, urlencode(query_parameters_dict))
         if force_browser_logout:
             # The url after '?next=' should be urlencoded
-            auth_url = "{}?next={}".format(MYCLOUD_LOGOFF, quote_plus(auth_url))
+            auth_url = "{}?next={}".format(MYCLOUD_LOGOFF_URL, quote_plus(auth_url))
         return auth_url
 
     ##  Callback method for the authentication flow.

--- a/resources/qml/WelcomePages/AddCloudPrintersView.qml
+++ b/resources/qml/WelcomePages/AddCloudPrintersView.qml
@@ -51,11 +51,11 @@ Item
         }
 
         // Component that contains a busy indicator and a message, while it waits for Cura to discover a cloud printer
-        Rectangle
+        Item
         {
             id: waitingContent
             width: parent.width
-            height: waitingIndicator.height + waitingLabel.height
+            height: childrenRect.height
             anchors.verticalCenter: parent.verticalCenter
             anchors.horizontalCenter: parent.horizontalCenter
             BusyIndicator
@@ -73,6 +73,37 @@ Item
                 text: catalog.i18nc("@label", "Waiting for Cloud response")
                 font: UM.Theme.getFont("large")
                 renderType: Text.NativeRendering
+            }
+            Label
+            {
+                id: noPrintersFoundLabel
+                anchors.top: waitingLabel.bottom
+                anchors.topMargin: 2 * UM.Theme.getSize("wide_margin").height
+                anchors.horizontalCenter: parent.horizontalCenter
+                horizontalAlignment: Text.AlignHCenter
+                text: catalog.i18nc("@label", "No printers found in your account?")
+                font: UM.Theme.getFont("medium")
+            }
+            Label
+            {
+                text: "Sign in with a different account"
+                anchors.top: noPrintersFoundLabel.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
+                font: UM.Theme.getFont("medium")
+                color: UM.Theme.getColor("text_link")
+                MouseArea {
+                    anchors.fill: parent;
+                    onClicked: Cura.API.account.loginWithForcedLogout()
+                    hoverEnabled: true
+                    onEntered:
+                    {
+                        parent.font.underline = true
+                    }
+                    onExited:
+                    {
+                        parent.font.underline = false
+                    }
+                }
             }
             visible: discoveredCloudPrintersModel.count == 0
         }

--- a/resources/qml/WelcomePages/AddCloudPrintersView.qml
+++ b/resources/qml/WelcomePages/AddCloudPrintersView.qml
@@ -93,7 +93,7 @@ Item
                 color: UM.Theme.getColor("text_link")
                 MouseArea {
                     anchors.fill: parent;
-                    onClicked: Cura.API.account.loginWithForcedLogout()
+                    onClicked: Cura.API.account.login(true)
                     hoverEnabled: true
                     onEntered:
                     {

--- a/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml
+++ b/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml
@@ -75,7 +75,7 @@ Item
                     }
                     else
                     {
-                        Qt.openUrlExternally("https://mycloud.ultimaker.com/app/manage/printers")
+                        Qt.openUrlExternally("https://mycloud.ultimaker.com/")
                     }
 
                 }

--- a/tests/API/TestAccount.py
+++ b/tests/API/TestAccount.py
@@ -19,35 +19,23 @@ def test_login():
     account = Account(MagicMock())
     mocked_auth_service = MagicMock()
     account._authorization_service = mocked_auth_service
+    account.logout = MagicMock()
 
     account.login()
-    mocked_auth_service.startAuthorizationFlow.assert_called_once_with()
+    mocked_auth_service.startAuthorizationFlow.assert_called_once_with(False)
 
     # Fake a successful login
     account._onLoginStateChanged(True)
 
     # Attempting to log in again shouldn't change anything.
     account.login()
-    mocked_auth_service.startAuthorizationFlow.assert_called_once_with()
+    mocked_auth_service.startAuthorizationFlow.assert_called_once_with(False)
 
-
-def test_loginWithForcedLogout():
-    account = Account(MagicMock())
-    mocked_auth_service = MagicMock()
-    account._authorization_service = mocked_auth_service
-    account.logout = MagicMock()
-
-    # Fake a successful login
-    account._onLoginStateChanged(True)
-    account.loginWithForcedLogout()
-    # Make sure logout is called once
+    # Attempting to log in with force_logout_before_login as True should call the logout before calling the
+    # startAuthorizationFlow(True).
+    account.login(force_logout_before_login=True)
     account.logout.assert_called_once_with()
-    mocked_auth_service.startAuthorizationFlow.assert_called_once_with(True)
-
-    account._onLoginStateChanged(False)
-    account.loginWithForcedLogout()
-    # If we are not logged in previously, logout shouldn't be called again
-    account.logout.assert_called_once_with()
+    mocked_auth_service.startAuthorizationFlow.assert_called_with(True)
     assert mocked_auth_service.startAuthorizationFlow.call_count == 2
 
 

--- a/tests/API/TestAccount.py
+++ b/tests/API/TestAccount.py
@@ -23,12 +23,32 @@ def test_login():
     account.login()
     mocked_auth_service.startAuthorizationFlow.assert_called_once_with()
 
-    # Fake a sucesfull login
+    # Fake a successful login
     account._onLoginStateChanged(True)
 
     # Attempting to log in again shouldn't change anything.
     account.login()
     mocked_auth_service.startAuthorizationFlow.assert_called_once_with()
+
+
+def test_loginWithForcedLogout():
+    account = Account(MagicMock())
+    mocked_auth_service = MagicMock()
+    account._authorization_service = mocked_auth_service
+    account.logout = MagicMock()
+
+    # Fake a successful login
+    account._onLoginStateChanged(True)
+    account.loginWithForcedLogout()
+    # Make sure logout is called once
+    account.logout.assert_called_once_with()
+    mocked_auth_service.startAuthorizationFlow.assert_called_once_with(True)
+
+    account._onLoginStateChanged(False)
+    account.loginWithForcedLogout()
+    # If we are not logged in previously, logout shouldn't be called again
+    account.logout.assert_called_once_with()
+    assert mocked_auth_service.startAuthorizationFlow.call_count == 2
 
 
 def test_initialize():

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -7,7 +7,7 @@ from PyQt5.QtGui import QDesktopServices
 
 from UM.Preferences import Preferences
 from cura.OAuth2.AuthorizationHelpers import AuthorizationHelpers, TOKEN_TIMESTAMP_FORMAT
-from cura.OAuth2.AuthorizationService import AuthorizationService, MYCLOUD_LOGOFF
+from cura.OAuth2.AuthorizationService import AuthorizationService, MYCLOUD_LOGOFF_URL
 from cura.OAuth2.LocalAuthorizationServer import LocalAuthorizationServer
 from cura.OAuth2.Models import OAuth2Settings, AuthenticationResponse, UserProfile
 
@@ -238,7 +238,7 @@ def test__generate_auth_url() -> None:
         "response_type": "code"
     }
     auth_url = authorization_service._generate_auth_url(query_parameters_dict, force_browser_logout = False)
-    assert MYCLOUD_LOGOFF + "?next=" not in auth_url
+    assert MYCLOUD_LOGOFF_URL + "?next=" not in auth_url
 
     auth_url = authorization_service._generate_auth_url(query_parameters_dict, force_browser_logout = True)
-    assert MYCLOUD_LOGOFF + "?next=" in auth_url
+    assert MYCLOUD_LOGOFF_URL + "?next=" in auth_url

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -7,7 +7,7 @@ from PyQt5.QtGui import QDesktopServices
 
 from UM.Preferences import Preferences
 from cura.OAuth2.AuthorizationHelpers import AuthorizationHelpers, TOKEN_TIMESTAMP_FORMAT
-from cura.OAuth2.AuthorizationService import AuthorizationService
+from cura.OAuth2.AuthorizationService import AuthorizationService, MYCLOUD_LOGOFF
 from cura.OAuth2.LocalAuthorizationServer import LocalAuthorizationServer
 from cura.OAuth2.Models import OAuth2Settings, AuthenticationResponse, UserProfile
 
@@ -226,3 +226,19 @@ def test_wrongServerResponses() -> None:
     with patch.object(AuthorizationHelpers, "parseJWT", return_value=UserProfile()):
         authorization_service._onAuthStateChanged(MALFORMED_AUTH_RESPONSE)
     assert authorization_service.getUserProfile() is None
+
+
+def test__generate_auth_url() -> None:
+    preferences = Preferences()
+    authorization_service = AuthorizationService(OAUTH_SETTINGS, preferences)
+    query_parameters_dict = {
+        "client_id": "",
+        "redirect_uri": OAUTH_SETTINGS.CALLBACK_URL,
+        "scope": OAUTH_SETTINGS.CLIENT_SCOPES,
+        "response_type": "code"
+    }
+    auth_url = authorization_service._generate_auth_url(query_parameters_dict, force_browser_logout = False)
+    assert MYCLOUD_LOGOFF + "?next=" not in auth_url
+
+    auth_url = authorization_service._generate_auth_url(query_parameters_dict, force_browser_logout = True)
+    assert MYCLOUD_LOGOFF + "?next=" in auth_url


### PR DESCRIPTION
Adds a button in the "Waiting for cloud response" page, which will allow the user to force logout from Cura and from mycloud.ultimaker.com in the browser, in order to login again and sync the accounts between Cura and the browser. 