### PR TITLE
Separate mono/dual extruders Dagoma printers profiles

### DIFF
--- a/resources/definitions/dagoma_discoeasy200.def.json
+++ b/resources/definitions/dagoma_discoeasy200.def.json
@@ -14,13 +14,12 @@
         "preferred_material": "chromatik_pla",
         "machine_extruder_trains":
         {
-            "0": "dagoma_discoeasy200_extruder_0",
-            "1": "dagoma_discoeasy200_extruder_1"
+            "0": "dagoma_discoeasy200_extruder"
         }
     },
     "overrides": {
         "machine_extruder_count": {
-            "default_value": 2
+            "default_value": 1
         },
         "machine_extruders_share_heater": {
             "default_value": true
@@ -49,10 +48,10 @@
             "value": "10"
         },
         "machine_start_gcode": {
-            "default_value": ";Gcode by Cura\nG90\nM106 S255\nG28 X Y\nG1 X50\nM109 R90\nG28\nM104 S{material_print_temperature_layer_0}\nG29\nM107\nG1 X100 Y20 F3000\nG1 Z0.5\nM109 S{material_print_temperature_layer_0}\nM82\nG92 E0\nG1 F200 E10\nG92 E0\nG1 Z3\nG1 F6000\n"
+            "default_value": "\nG90\nM106 S255\nG28 X Y\nG1 X50\nM109 R90\nG28\nG29\nM104 S{material_print_temperature_layer_0}\nM107\nG1 X100 Y20 0.5 F3000\nM109 S{material_print_temperature_layer_0}\nM83\nG1 E10 F200\nG1 E-3 F5000\nG1 Z3 F240\nM82\nG92 E0\n"
         },
         "machine_end_gcode": {
-            "default_value": "\nM104 S0\nM106 S255\nM140 S0\nG91\nG1 E-1 F300\nG1 Z+3 F3000\nG90\nG28 X Y\nM107\nM84\n"
+            "default_value": "\nM106 S255\nM104 S0\nM140 S0\nG91\nG1 E-3 F5000\nG1 Z2 F3000\nG90\nG28 X Y\nM107\nM84\n"
         },
         "default_material_print_temperature": {
             "default_value": 205

--- a/resources/definitions/dagoma_discoeasy200_bicolor.def.json
+++ b/resources/definitions/dagoma_discoeasy200_bicolor.def.json
@@ -1,5 +1,5 @@
 {
-    "name": "Dagoma Magis",
+    "name": "Dagoma DiscoEasy200 Bicolor",
     "version": 2,
     "inherits": "fdmprinter",
     "metadata": {
@@ -7,60 +7,64 @@
         "author": "Dagoma",
         "manufacturer": "Dagoma",
         "file_formats": "text/x-gcode",
-        "platform": "dagoma_magis.3mf",
-        "platform_offset": [0, -28, -35],
+        "platform": "dagoma_discoeasy200.3mf",
+        "platform_offset": [0, -57.3, -11],
         "has_machine_quality": true,
         "has_materials": true,
         "preferred_material": "chromatik_pla",
         "machine_extruder_trains":
         {
-            "0": "dagoma_magis_extruder"
+            "0": "dagoma_discoeasy200_extruder_0",
+            "1": "dagoma_discoeasy200_extruder_1"
         }
     },
     "overrides": {
+        "machine_extruder_count": {
+            "default_value": 2
+        },
+        "machine_extruders_share_heater": {
+            "default_value": true
+        },
         "machine_width": {
-            "default_value": 195.55
+            "default_value": 205
         },
         "machine_height": {
             "default_value": 205
         },
         "machine_depth": {
-            "default_value": 195.55
+            "default_value": 205
         },
         "machine_center_is_zero": {
-            "default_value": true
+            "default_value": false
         },
         "machine_head_with_fans_polygon": {
             "default_value": [
-                [-36, -42],
-                [-36, 42],
-                [36, 42],
-                [36, -42]
+                [-17, -70],
+                [-17, 40],
+                [17, 40],
+                [17, -70]
             ]
         },
         "gantry_height": {
-          "value": "0"
-        },
-        "machine_shape": {
-            "default_value": "elliptic"
+            "value": "10"
         },
         "machine_start_gcode": {
-            "default_value": ";Gcode by Cura\nG90\nG28\nM107\nM109 R100\nG29\nM109 S{material_print_temperature_layer_0} U-55 X55 V-85 Y-85 W0.26 Z0.26\nM82\nG92 E0\nG1 F200 E6\nG92 E0\nG1 F200 E-3.5\nG0 Z0.15\nG0 X10\nG0 Z3\nG1 F6000\n"
+            "default_value": "\nG90\nM106 S255\nG28 X Y\nG1 X50\nM109 R90\nG28\nG29\nM104 S{material_print_temperature_layer_0}\nM107\nG1 X100 Y20 Z0.5 F3000\nM109 S{material_print_temperature_layer_0}\nM83\nG1 E60 F3000\nG1 E10 F200\nG1 E-3 F5000\nG1 Z3 F240\nM82\nG92 E0\n"
         },
         "machine_end_gcode": {
-            "default_value": "\nM104 S0\nM106 S255\nM140 S0\nG91\nG1 E-1 F300\nG1 Z+3 E-2 F9000\nG90\nG28\n"
+            "default_value": "\nM106 S255\nM104 S0\nM140 S0\nG91\nG1 E3 F3000\nG1 E-60 F10000\nG1 Z2 F3000\nG90\nG28 X Y\nM107\nM84\n"
         },
         "default_material_print_temperature": {
             "default_value": 205
         },
         "speed_print": {
-            "default_value": 40
+            "default_value": 60
         },
         "retraction_amount": {
-            "default_value": 3.8
+            "default_value": 3.5
         },
         "retraction_speed": {
-            "default_value": 60
+            "default_value": 50
         },
         "adhesion_type": {
             "default_value": "skirt"

--- a/resources/definitions/dagoma_discoultimate.def.json
+++ b/resources/definitions/dagoma_discoultimate.def.json
@@ -14,13 +14,12 @@
         "preferred_material": "chromatik_pla",
         "machine_extruder_trains":
         {
-            "0": "dagoma_discoultimate_extruder_0",
-            "1": "dagoma_discoultimate_extruder_1"
+            "0": "dagoma_discoultimate_extruder"
         }
     },
     "overrides": {
         "machine_extruder_count": {
-            "default_value": 2
+            "default_value": 1
         },
         "machine_extruders_share_heater": {
             "default_value": true
@@ -49,10 +48,10 @@
             "value": "10"
         },
         "machine_start_gcode": {
-            "default_value": ";Gcode by Cura\nG90\nM106 S255\nG28 X Y\nG1 X50\nM109 R90\nG28\nM104 S{material_print_temperature_layer_0}\nG29\nM107\nG1 X100 Y20 F3000\nG1 Z0.5\nM109 S{material_print_temperature_layer_0}\nM82\nG92 E0\nG1 F200 E10\nG92 E0\nG1 Z3\nG1 F6000\n"
+            "default_value": "\nG90\nM106 S255\nG28 X Y\nG1 X50\nM109 R90\nG28\nG29\nM104 S{material_print_temperature_layer_0}\nM107\nG1 X100 Y20 0.5 F3000\nM109 S{material_print_temperature_layer_0}\nM83\nG1 E10 F200\nG1 E-3 F5000\nG1 Z3 F240\nM82\nG92 E0\n"
         },
         "machine_end_gcode": {
-            "default_value": "\nM104 S0\nM106 S255\nM140 S0\nG91\nG1 E-1 F300\nG1 Z+3 F3000\nG90\nG28 X Y\nM107\nM84\n"
+            "default_value": "\nM106 S255\nM104 S0\nM140 S0\nG91\nG1 E-3 F5000\nG1 Z2 F3000\nG90\nG28 X Y\nM107\nM84\n"
         },
         "default_material_print_temperature": {
             "default_value": 205

--- a/resources/definitions/dagoma_discoultimate_bicolor.def.json
+++ b/resources/definitions/dagoma_discoultimate_bicolor.def.json
@@ -1,5 +1,5 @@
 {
-    "name": "Dagoma Magis",
+    "name": "Dagoma DiscoUltimate Bicolor",
     "version": 2,
     "inherits": "fdmprinter",
     "metadata": {
@@ -7,60 +7,64 @@
         "author": "Dagoma",
         "manufacturer": "Dagoma",
         "file_formats": "text/x-gcode",
-        "platform": "dagoma_magis.3mf",
-        "platform_offset": [0, -28, -35],
+        "platform": "dagoma_discoultimate.3mf",
+        "platform_offset": [0, -58.5, -11],
         "has_machine_quality": true,
         "has_materials": true,
         "preferred_material": "chromatik_pla",
         "machine_extruder_trains":
         {
-            "0": "dagoma_magis_extruder"
+            "0": "dagoma_discoultimate_extruder_0",
+            "1": "dagoma_discoultimate_extruder_1"
         }
     },
     "overrides": {
+        "machine_extruder_count": {
+            "default_value": 2
+        },
+        "machine_extruders_share_heater": {
+            "default_value": true
+        },
         "machine_width": {
-            "default_value": 195.55
+            "default_value": 205
         },
         "machine_height": {
             "default_value": 205
         },
         "machine_depth": {
-            "default_value": 195.55
+            "default_value": 205
         },
         "machine_center_is_zero": {
-            "default_value": true
+            "default_value": false
         },
         "machine_head_with_fans_polygon": {
             "default_value": [
-                [-36, -42],
-                [-36, 42],
-                [36, 42],
-                [36, -42]
+                [-17, -70],
+                [-17, 40],
+                [17, 40],
+                [17, -70]
             ]
         },
         "gantry_height": {
-          "value": "0"
-        },
-        "machine_shape": {
-            "default_value": "elliptic"
+            "value": "10"
         },
         "machine_start_gcode": {
-            "default_value": ";Gcode by Cura\nG90\nG28\nM107\nM109 R100\nG29\nM109 S{material_print_temperature_layer_0} U-55 X55 V-85 Y-85 W0.26 Z0.26\nM82\nG92 E0\nG1 F200 E6\nG92 E0\nG1 F200 E-3.5\nG0 Z0.15\nG0 X10\nG0 Z3\nG1 F6000\n"
+            "default_value": "\nG90\nM106 S255\nG28 X Y\nG1 X50\nM109 R90\nG28\nG29\nM104 S{material_print_temperature_layer_0}\nM107\nG1 X100 Y20 Z0.5 F3000\nM109 S{material_print_temperature_layer_0}\nM83\nG1 E60 F3000\nG1 E10 F200\nG1 E-3 F5000\nG1 Z3 F240\nM82\nG92 E0\n"
         },
         "machine_end_gcode": {
-            "default_value": "\nM104 S0\nM106 S255\nM140 S0\nG91\nG1 E-1 F300\nG1 Z+3 E-2 F9000\nG90\nG28\n"
+            "default_value": "\nM106 S255\nM104 S0\nM140 S0\nG91\nG1 E3 F3000\nG1 E-60 F10000\nG1 Z2 F3000\nG90\nG28 X Y\nM107\nM84\n"
         },
         "default_material_print_temperature": {
             "default_value": 205
         },
         "speed_print": {
-            "default_value": 40
+            "default_value": 60
         },
         "retraction_amount": {
-            "default_value": 3.8
+            "default_value": 3.5
         },
         "retraction_speed": {
-            "default_value": 60
+            "default_value": 50
         },
         "adhesion_type": {
             "default_value": "skirt"

--- a/resources/definitions/dagoma_neva.def.json
+++ b/resources/definitions/dagoma_neva.def.json
@@ -14,7 +14,7 @@
         "preferred_material": "chromatik_pla",
         "machine_extruder_trains":
         {
-            "0": "dagoma_neva_extruder_0"
+            "0": "dagoma_neva_extruder"
         }
     },
     "overrides": {

--- a/resources/extruders/dagoma_discoeasy200_extruder.def.json
+++ b/resources/extruders/dagoma_discoeasy200_extruder.def.json
@@ -1,0 +1,21 @@
+{
+    "version": 2,
+    "name": "Extruder",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "dagoma_discoeasy200",
+        "position": "0"
+    },
+
+    "overrides": {
+        "extruder_nr": {
+            "default_value": 0
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        }
+    }
+}

--- a/resources/extruders/dagoma_discoeasy200_extruder_0.def.json
+++ b/resources/extruders/dagoma_discoeasy200_extruder_0.def.json
@@ -3,7 +3,7 @@
     "name": "Extruder 1",
     "inherits": "fdmextruder",
     "metadata": {
-        "machine": "dagoma_discoeasy200",
+        "machine": "dagoma_discoeasy200_bicolor",
         "position": "0"
     },
 
@@ -18,10 +18,10 @@
             "default_value": 1.75
         },
         "machine_extruder_start_code": {
-            "default_value": "\n;Start T0\nG92 E0\nG1 E-{retraction_amount} F10000\nG92 E0G1 E1.5 F3000\nG1 E-60 F10000\nG92 E0\n"         
+            "default_value": "\n;This start extruder gcode comes from CuraByDagoma\n;Commented for now as there is discussion regarding its usage in Ultimaker Cura\n;Start T0\n;G92 E0\n;G1 E-{retraction_amount} F10000\n;G92 E0\n;G1 E1.5 F3000\n;G1 E-60 F10000\n;G92 E0\n"         
         },
         "machine_extruder_end_code": {
-            "default_value": "\nG92 E0\nG1 E{retraction_amount} F3000\nG92 E0\nG1 E60 F3000\nG92 E0\nG1 E-{retraction_amount} F5000\n;End T0\n\n"
+            "default_value": "\n;This end extruder gcode comes from CuraByDagoma\n;Commented for now as there is discussion regarding its usage in Ultimaker Cura\n;G92 E0\n;G1 E{retraction_amount} F3000\n;G92 E0\n;G1 E60 F3000\n;G92 E0\n;G1 E-{retraction_amount} F5000\n;End T0\n\n"
         }
     }
 }

--- a/resources/extruders/dagoma_discoeasy200_extruder_1.def.json
+++ b/resources/extruders/dagoma_discoeasy200_extruder_1.def.json
@@ -3,7 +3,7 @@
     "name": "Extruder 2",
     "inherits": "fdmextruder",
     "metadata": {
-        "machine": "dagoma_discoeasy200",
+        "machine": "dagoma_discoeasy200_bicolor",
         "position": "1"
     },
 
@@ -18,10 +18,10 @@
             "default_value": 1.75
         },
         "machine_extruder_start_code": {
-            "default_value": "\n;Start T1\nG92 E0\nG1 E-{retraction_amount} F10000\nG92 E0G1 E1.5 F3000\nG1 E-60 F10000\nG92 E0\n"         
+            "default_value": "\n;This start extruder gcode comes from CuraByDagoma\n;Commented for now as there is discussion regarding its usage in Ultimaker Cura\n;Start T1\n;G92 E0\n;G1 E-{retraction_amount} F10000\n;G92 E0\n;G1 E1.5 F3000\n;G1 E-60 F10000\n;G92 E0\n"         
         },
         "machine_extruder_end_code": {
-            "default_value": "\nG92 E0\nG1 E{retraction_amount} F3000\nG92 E0\nG1 E60 F3000\nG92 E0\nG1 E-{retraction_amount} F5000\n;End T1\n\n"
+            "default_value": "\n;This end extruder gcode comes from CuraByDagoma\n;Commented for now as there is discussion regarding its usage in Ultimaker Cura\n;G92 E0\n;G1 E{retraction_amount} F3000\n;G92 E0\n;G1 E60 F3000\n;G92 E0\n;G1 E-{retraction_amount} F5000\n;End T1\n\n"
         }
     }
 }

--- a/resources/extruders/dagoma_discoultimate_extruder.def.json
+++ b/resources/extruders/dagoma_discoultimate_extruder.def.json
@@ -1,0 +1,21 @@
+{
+    "version": 2,
+    "name": "Extruder",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "dagoma_discoultimate",
+        "position": "0"
+    },
+
+    "overrides": {
+        "extruder_nr": {
+            "default_value": 0
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        }
+    }
+}

--- a/resources/extruders/dagoma_discoultimate_extruder_0.def.json
+++ b/resources/extruders/dagoma_discoultimate_extruder_0.def.json
@@ -3,7 +3,7 @@
     "name": "Extruder 1",
     "inherits": "fdmextruder",
     "metadata": {
-        "machine": "dagoma_discoultimate",
+        "machine": "dagoma_discoultimate_bicolor",
         "position": "0"
     },
 
@@ -18,10 +18,10 @@
             "default_value": 1.75
         },
         "machine_extruder_start_code": {
-            "default_value": "\n;Start T0\nG92 E0\nG1 E-{retraction_amount} F10000\nG92 E0G1 E1.5 F3000\nG1 E-60 F10000\nG92 E0\n"         
+            "default_value": "\n;This start extruder gcode comes from CuraByDagoma\n;Commented for now as there is discussion regarding its usage in Ultimaker Cura\n;Start T0\n;G92 E0\n;G1 E-{retraction_amount} F10000\n;G92 E0\n;G1 E1.5 F3000\n;G1 E-60 F10000\n;G92 E0\n"         
         },
         "machine_extruder_end_code": {
-            "default_value": "\nG92 E0\nG1 E{retraction_amount} F3000\nG92 E0\nG1 E60 F3000\nG92 E0\nG1 E-{retraction_amount} F5000\n;End T0\n\n"
+            "default_value": "\n;This end extruder gcode comes from CuraByDagoma\n;Commented for now as there is discussion regarding its usage in Ultimaker Cura\n;G92 E0\n;G1 E{retraction_amount} F3000\n;G92 E0\n;G1 E60 F3000\n;G92 E0\n;G1 E-{retraction_amount} F5000\n;End T0\n\n"
         }
     }
 }

--- a/resources/extruders/dagoma_discoultimate_extruder_1.def.json
+++ b/resources/extruders/dagoma_discoultimate_extruder_1.def.json
@@ -3,7 +3,7 @@
     "name": "Extruder 2",
     "inherits": "fdmextruder",
     "metadata": {
-        "machine": "dagoma_discoultimate",
+        "machine": "dagoma_discoultimate_bicolor",
         "position": "1"
     },
 
@@ -18,10 +18,10 @@
             "default_value": 1.75
         },
         "machine_extruder_start_code": {
-            "default_value": "\n;Start T1\nG92 E0\nG1 E-{retraction_amount} F10000\nG92 E0G1 E1.5 F3000\nG1 E-60 F10000\nG92 E0\n"         
+            "default_value": "\n;This start extruder gcode comes from CuraByDagoma\n;Commented for now as there is discussion regarding its usage in Ultimaker Cura\n;Start T1\n;G92 E0\n;G1 E-{retraction_amount} F10000\n;G92 E0\n;G1 E1.5 F3000\n;G1 E-60 F10000\n;G92 E0\n"         
         },
         "machine_extruder_end_code": {
-            "default_value": "\nG92 E0\nG1 E{retraction_amount} F3000\nG92 E0\nG1 E60 F3000\nG92 E0\nG1 E-{retraction_amount} F5000\n;End T1\n\n"
+            "default_value": "\n;This end extruder gcode comes from CuraByDagoma\n;Commented for now as there is discussion regarding its usage in Ultimaker Cura\n;G92 E0\n;G1 E{retraction_amount} F3000\n;G92 E0\n;G1 E60 F3000\n;G92 E0\n;G1 E-{retraction_amount} F5000\n;End T1\n\n"
         }
     }
 }

--- a/resources/extruders/dagoma_magis_extruder.def.json
+++ b/resources/extruders/dagoma_magis_extruder.def.json
@@ -1,6 +1,6 @@
 {
     "version": 2,
-    "name": "Extruder 1",
+    "name": "Extruder",
     "inherits": "fdmextruder",
     "metadata": {
         "machine": "dagoma_magis",

--- a/resources/extruders/dagoma_neva_extruder.def.json
+++ b/resources/extruders/dagoma_neva_extruder.def.json
@@ -1,6 +1,6 @@
 {
     "version": 2,
-    "name": "Extruder 1",
+    "name": "Extruder",
     "inherits": "fdmextruder",
     "metadata": {
         "machine": "dagoma_neva",

--- a/resources/quality/dagoma/dagoma_discoeasy200_bicolor_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_bicolor_pla_fast.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+version = 4
+name = Fast
+definition = dagoma_discoeasy200_bicolor
+
+[metadata]
+setting_version = 15
+type = quality
+quality_type = draft
+weight = -2
+material = chromatik_pla
+
+[values]
+layer_height = 0.2
+line_width = =machine_nozzle_size * 0.875
+
+material_print_temperature = =default_material_print_temperature + 10
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 10
+
+speed_print = 60
+speed_travel = 75
+speed_layer_0 = 17
+speed_infill = 60
+speed_wall_0 = 50
+speed_wall_x = 60
+speed_topbottom = 60

--- a/resources/quality/dagoma/dagoma_discoeasy200_bicolor_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_bicolor_pla_fine.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+version = 4
+name = Fine
+definition = dagoma_discoeasy200_bicolor
+
+[metadata]
+setting_version = 15
+type = quality
+quality_type = normal
+weight = 0
+material = chromatik_pla
+
+[values]
+layer_height = 0.1
+line_width = =machine_nozzle_size * 0.875
+
+speed_print = 35
+speed_travel = 50
+speed_layer_0 = 15
+speed_infill = 40
+speed_wall_0 = 25
+speed_wall_x = 35
+speed_topbottom = 35

--- a/resources/quality/dagoma/dagoma_discoeasy200_bicolor_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoeasy200_bicolor_pla_standard.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+version = 4
+name = Standard
+definition = dagoma_discoeasy200_bicolor
+
+[metadata]
+setting_version = 15
+type = quality
+quality_type = fast
+weight = -1
+material = chromatik_pla
+
+[values]
+layer_height = 0.15
+line_width = =machine_nozzle_size * 0.875
+
+material_print_temperature = =default_material_print_temperature + 5
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 5
+
+speed_print = 50
+speed_travel = 60
+speed_layer_0 = 17
+speed_infill = 50
+speed_wall_0 = 40
+speed_wall_x = 45
+speed_topbottom = 50

--- a/resources/quality/dagoma/dagoma_discoultimate_bicolor_pla_fast.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoultimate_bicolor_pla_fast.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+version = 4
+name = Fast
+definition = dagoma_discoultimate_bicolor
+
+[metadata]
+setting_version = 15
+type = quality
+quality_type = draft
+weight = -2
+material = chromatik_pla
+
+[values]
+layer_height = 0.2
+line_width = =machine_nozzle_size * 0.875
+
+material_print_temperature = =default_material_print_temperature + 10
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 10
+
+speed_print = 60
+speed_travel = 75
+speed_layer_0 = 17
+speed_infill = 60
+speed_wall_0 = 50
+speed_wall_x = 60
+speed_topbottom = 60

--- a/resources/quality/dagoma/dagoma_discoultimate_bicolor_pla_fine.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoultimate_bicolor_pla_fine.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+version = 4
+name = Fine
+definition = dagoma_discoultimate_bicolor
+
+[metadata]
+setting_version = 15
+type = quality
+quality_type = normal
+weight = 0
+material = chromatik_pla
+
+[values]
+layer_height = 0.1
+line_width = =machine_nozzle_size * 0.875
+
+speed_print = 35
+speed_travel = 50
+speed_layer_0 = 15
+speed_infill = 40
+speed_wall_0 = 25
+speed_wall_x = 35
+speed_topbottom = 35

--- a/resources/quality/dagoma/dagoma_discoultimate_bicolor_pla_standard.inst.cfg
+++ b/resources/quality/dagoma/dagoma_discoultimate_bicolor_pla_standard.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+version = 4
+name = Standard
+definition = dagoma_discoultimate_bicolor
+
+[metadata]
+setting_version = 15
+type = quality
+quality_type = fast
+weight = -1
+material = chromatik_pla
+
+[values]
+layer_height = 0.15
+line_width = =machine_nozzle_size * 0.875
+
+material_print_temperature = =default_material_print_temperature + 5
+material_bed_temperature_layer_0 = =default_material_bed_temperature + 5
+
+speed_print = 50
+speed_travel = 60
+speed_layer_0 = 17
+speed_infill = 50
+speed_wall_0 = 40
+speed_wall_x = 45
+speed_topbottom = 50


### PR DESCRIPTION
Hi,

The goal of this PR is to separate the Dagoma printers profiles for which the bicolor option is available.
Some discussions around start/end extruder gcodes usage in both CuraEngine and Cura (see #7564 and #6160) lead to this change.

@Sophist-UK, @Bigsmooth68, @kirax999 : Does it seem fair enough for your needs?

Regards,
Orel