### PR TITLE
Upgrade the ironing inset based on the selected ironing pattern

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade462to47/VersionUpgrade462to47.py
+++ b/plugins/VersionUpgrade/VersionUpgrade462to47/VersionUpgrade462to47.py
@@ -64,7 +64,11 @@ class VersionUpgrade462to47(VersionUpgrade):
                 ironing_inset = parser["values"]["ironing_inset"]
                 if ironing_inset.startswith("="):
                     ironing_inset = ironing_inset[1:]
-                ironing_inset = "=(" + ironing_inset + ") + skin_line_width * (1.0 - ironing_flow) / 2"
+                if "ironing_pattern" in parser["values"] and parser["values"]["ironing_pattern"] == "concentric":
+                    correction = " + ironing_line_spacing - skin_line_width * (1.0 + ironing_flow / 100) / 2"
+                else:  # If ironing_pattern doesn't exist, it means the default (zigzag) is selected
+                    correction = " + skin_line_width * (1.0 - ironing_flow / 100) / 2"
+                ironing_inset = "=(" + ironing_inset + ")" + correction
                 parser["values"]["ironing_inset"] = ironing_inset
 
         result = io.StringIO()

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1575,7 +1575,7 @@
                     "type": "float",
                     "unit": "mm",
                     "default_value": 0.35,
-                    "value": "wall_line_width_0 / 2 + skin_line_width * (1.0 - ironing_flow) / 2",
+                    "value": "wall_line_width_0 / 2 + (ironing_line_spacing - skin_line_width * (1.0 + ironing_flow / 100) / 2 if ironing_pattern == 'concentric' else skin_line_width * (1.0 - ironing_flow / 100) / 2)",
                     "minimum_value_warning": "0",
                     "maximum_value_warning": "wall_line_width_0",
                     "enabled": "ironing_enabled",

--- a/resources/definitions/hms434.def.json
+++ b/resources/definitions/hms434.def.json
@@ -104,7 +104,7 @@
         "skin_outline_count":        {"value": "0"},
         "ironing_line_spacing":      {"value": "line_width / 4 * 3"},
         "ironing_flow":              {"value": "0"},
-        "ironing_inset":             {"value": "ironing_line_spacing + skin_line_width * (1.0 - ironing_flow) / 2"},
+        "ironing_inset":             {"value": "ironing_line_spacing + (ironing_line_spacing - skin_line_width * (1.0 + ironing_flow / 100) / 2 if ironing_pattern == 'concentric' else skin_line_width * (1.0 - ironing_flow / 100) / 2)"},
         "speed_ironing":             {"value": "150"},
  
         "infill_sparse_density": {"value": 30},

--- a/resources/definitions/skriware_2.def.json
+++ b/resources/definitions/skriware_2.def.json
@@ -345,7 +345,7 @@
             "value": "0.8"
         },
         "ironing_inset": {
-            "value": "0.2 + skin_line_width * (1.0 - ironing_flow) / 2"
+            "value": "0.2 + (ironing_line_spacing - skin_line_width * (1.0 + ironing_flow / 100) / 2 if ironing_pattern == 'concentric' else skin_line_width * (1.0 - ironing_flow / 100) / 2)"
         },
         "jerk_travel": {
             "value": "10"


### PR DESCRIPTION
Previously, the ironing_inset was changed in the profiles to reflect
the changes made in the CuraEngine. This inset though was not taking
into account the ironing_pattern (in the CuraEngine, the inset is
compensated differently depending on the pattern).

This PR fixes that in the version upgrader and the printer
definitions in order to maintain the same behavior for the old
profiles.

Merge along with Ultimaker/CuraEngine#1254

CURA-7318