### PR TITLE
Make ActionButtons render.

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -230,5 +230,8 @@ if ApplicationMetadata.CuraDebugMode:
     ssl_conf.setPeerVerifyMode(QSslSocket.VerifyNone)
     QSslConfiguration.setDefaultConfiguration(ssl_conf)
 
+if "QT_QUICK_CONTROLS_STYLE" not in os.environ:
+    os.environ["QT_QUICK_CONTROLS_STYLE"] = "Default"
+
 app = CuraApplication()
 app.run()

--- a/resources/qml/ActionButton.qml
+++ b/resources/qml/ActionButton.qml
@@ -120,6 +120,7 @@ Button
     background: Cura.RoundedRectangle
     {
         id: backgroundRect
+        implicitWidth: contentItem.implicitWidth+contentItem.spacing*4
         cornerSide: Cura.RoundedRectangle.Direction.All
         color: button.enabled ? (button.hovered ? button.hoverColor : button.color) : button.disabledColor
         radius: UM.Theme.getSize("action_button_radius").width

--- a/resources/qml/ActionButton.qml
+++ b/resources/qml/ActionButton.qml
@@ -120,7 +120,6 @@ Button
     background: Cura.RoundedRectangle
     {
         id: backgroundRect
-        implicitWidth: contentItem.implicitWidth+contentItem.spacing*4
         cornerSide: Cura.RoundedRectangle.Direction.All
         color: button.enabled ? (button.hovered ? button.hoverColor : button.color) : button.disabledColor
         radius: UM.Theme.getSize("action_button_radius").width


### PR DESCRIPTION
The background implicitly got a zero width, making the buttons unusable
and near invisible.
This appears to be this bug:
https://community.ultimaker.com/topic/28928-cura-41-stuck-at-welcome-screen-buttons-are-missing/

I am uncertain if the particular implicitWidth I set is perfectly
correct, but usable buttons beat unusable ones.