### PR TITLE
Adding note about unexpected behavior caused by USB Printing plugin t…

### DIFF
--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -113,6 +113,23 @@ UM.ManagementPage
                     }
                 }
             }
+
+            Text
+            {
+                textFormat: Text.RichText
+                text: "<i>Note: The USB Printing plugin can cause unexpected serial port behavior in third-party software such as Arduino IDE and PlatformIO. The USB Printing plugin can be disabled in the <a href=\"marketplace\">Marketplace</a> as a workaround. (GitHub Issue <a href=\"https://github.com/Ultimaker/Cura/issues/5207#issuecomment-570139859\">#5207</a>)</i>"
+                width: parent.width
+                wrapMode: Text.Wrap
+                topPadding: UM.Theme.getSize("default_margin").height
+                onLinkActivated:
+                {
+                    if (link == "marketplace") {
+                        Cura.Actions.browsePackages.trigger()
+                    } else {
+                        Qt.openUrlExternally(link)
+                    }
+                }
+            }
         }
 
         UM.Dialog


### PR DESCRIPTION
…o the Printers section of the Preferences.

This PR is intended to help address #5207 where the USB Printing plugin can cause unexpected behavior in third-party software due to how it enumerates USB serial devices while looking for available printers.

I've added two clickable links. One to @fieldOfView's comment on #5207 describing the work around and another that opens the Marketplace panel itself.

![Imgur](https://i.imgur.com/QuMoeZn.png)