### PR TITLE
Add the offline cloud printers in Cura when they are discovered

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -98,9 +98,10 @@ class CloudOutputDeviceManager:
         """Callback for when the request for getting the clusters is finished."""
 
         new_clusters = []
+        all_clusters = {c.cluster_id: c for c in clusters}  # type: Dict[str, CloudClusterResponse]
         online_clusters = {c.cluster_id: c for c in clusters if c.is_online}  # type: Dict[str, CloudClusterResponse]
 
-        for device_id, cluster_data in online_clusters.items():
+        for device_id, cluster_data in all_clusters.items():
             if device_id not in self._remote_clusters:
                 new_clusters.append(cluster_data)
 


### PR DESCRIPTION
This PR corrects the current cloud printer discovering process to also add printers that are offline.
The fix was much simpler than we expected.

CURA-7458