### PR TITLE
Add local printer improvements

### DIFF
--- a/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
+++ b/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
@@ -29,8 +29,6 @@ Item
         "Custom": -1
     }
 
-    property int maxItemCountAtOnce: 11  // show at max 11 items at once, otherwise you need to scroll.
-
     // User-editable printer name
     property alias printerName: printerNameTextField.text
     property alias isPrinterNameValid: printerNameTextField.acceptableInput

--- a/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
+++ b/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
@@ -29,7 +29,7 @@ Item
         "Custom": -1
     }
 
-    property int maxItemCountAtOnce: 10  // show at max 10 items at once, otherwise you need to scroll.
+    property int maxItemCountAtOnce: 11  // show at max 11 items at once, otherwise you need to scroll.
 
     // User-editable printer name
     property alias printerName: printerNameTextField.text
@@ -54,12 +54,27 @@ Item
         }
     }
 
+    function getMachineName()
+    {
+        return machineList.model.getItem(machineList.currentIndex) != undefined ? machineList.model.getItem(machineList.currentIndex).name : "";
+    }
+
+    function getMachineMetaDataEntry(key)
+    {
+        var metadata = machineList.model.getItem(machineList.currentIndex) != undefined ? machineList.model.getItem(machineList.currentIndex).metadata : undefined;
+        if (metadata)
+        {
+            return metadata[key];
+        }
+        return undefined;
+    }
+
     Component.onCompleted:
     {
         updateCurrentItemUponSectionChange()
     }
 
-    Item
+    Row
     {
         id: localPrinterSelectionItem
         anchors.left: parent.left
@@ -71,16 +86,9 @@ Item
         Cura.ScrollView
         {
             id: scrollView
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
 
             height: (maxItemCountAtOnce * UM.Theme.getSize("action_button").height) - UM.Theme.getSize("default_margin").height
-
-            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-            ScrollBar.vertical.policy: ScrollBar.AsNeeded
-
-            clip: true
+            width: Math.floor(parent.width * 0.4)
 
             ListView
             {
@@ -183,52 +191,94 @@ Item
                 }
             }
         }
-    }
 
-    // Horizontal line
-    Rectangle
-    {
-        id: horizontalLine
-        anchors.top: localPrinterSelectionItem.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
-        height: UM.Theme.getSize("default_lining").height
-        color: UM.Theme.getColor("lining")
-    }
-
-    // User-editable printer name row
-    Row
-    {
-        anchors.top: horizontalLine.bottom
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.topMargin: UM.Theme.getSize("default_lining").height
-        anchors.leftMargin: UM.Theme.getSize("default_margin").width
-
-        spacing: UM.Theme.getSize("default_margin").width
-
-        Label
+        // Vertical line
+        Rectangle
         {
-            text: catalog.i18nc("@label", "Printer name")
-            anchors.verticalCenter: parent.verticalCenter
-            font: UM.Theme.getFont("medium")
-            color: UM.Theme.getColor("text")
-            verticalAlignment: Text.AlignVCenter
-            renderType: Text.NativeRendering
+            id: verticalLine
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: UM.Theme.getSize("default_lining").height
+            color: UM.Theme.getColor("lining")
         }
 
-        Cura.TextField
+        // User-editable printer name row
+        Column
         {
-            id: printerNameTextField
-            anchors.verticalCenter: parent.verticalCenter
-            width: (parent.width / 2) | 0
-            placeholderText: catalog.i18nc("@text", "Please give your printer a name")
-            maximumLength: 40
-            validator: RegExpValidator
+            width: Math.floor(parent.width * 0.6)
+
+            spacing: UM.Theme.getSize("default_margin").width
+            padding: UM.Theme.getSize("default_margin").width
+
+            Label
             {
-                regExp: printerNameTextField.machineNameValidator.machineNameRegex
+                width: parent.width
+                wrapMode: Text.WordWrap
+                text: base.getMachineName()
+                color: UM.Theme.getColor("primary_button")
+                font: UM.Theme.getFont("huge")
+                elide: Text.ElideRight
             }
-            property var machineNameValidator: Cura.MachineNameValidator { }
+            Grid
+            {
+                width: parent.width
+                columns: 2
+                rowSpacing: UM.Theme.getSize("default_lining").height
+                columnSpacing: UM.Theme.getSize("default_margin").width
+
+                verticalItemAlignment: Grid.AlignVCenter
+
+                Label
+                {
+                    text: catalog.i18nc("@label", "Manufacturer")
+                    font: UM.Theme.getFont("default")
+                    color: UM.Theme.getColor("text")
+                    renderType: Text.NativeRendering
+                }
+                Label
+                {
+                    text: base.getMachineMetaDataEntry("manufacturer")
+                    font: UM.Theme.getFont("default")
+                    color: UM.Theme.getColor("text")
+                    renderType: Text.NativeRendering
+                }
+                Label
+                {
+                    text: catalog.i18nc("@label", "Author")
+                    font: UM.Theme.getFont("default")
+                    color: UM.Theme.getColor("text")
+                    renderType: Text.NativeRendering
+                }
+                Label
+                {
+                    text: base.getMachineMetaDataEntry("author")
+                    font: UM.Theme.getFont("default")
+                    color: UM.Theme.getColor("text")
+                    renderType: Text.NativeRendering
+                }
+
+                Label
+                {
+                    text: catalog.i18nc("@label", "Printer name")
+                    font: UM.Theme.getFont("default")
+                    color: UM.Theme.getColor("text")
+                    renderType: Text.NativeRendering
+                }
+
+                Cura.TextField
+                {
+                    id: printerNameTextField
+                    placeholderText: catalog.i18nc("@text", "Please give your printer a name")
+                    maximumLength: 40
+                    validator: RegExpValidator
+                    {
+                        regExp: printerNameTextField.machineNameValidator.machineNameRegex
+                    }
+                    property var machineNameValidator: Cura.MachineNameValidator { }
+                }
+            }
         }
+
+
     }
 }

--- a/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
+++ b/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
@@ -87,7 +87,7 @@ Item
         {
             id: scrollView
 
-            height: (maxItemCountAtOnce * UM.Theme.getSize("action_button").height) - UM.Theme.getSize("default_margin").height
+            height: childrenHeight
             width: Math.floor(parent.width * 0.4)
 
             ListView
@@ -197,7 +197,7 @@ Item
         {
             id: verticalLine
             anchors.top: parent.top
-            anchors.bottom: parent.bottom
+            height: childrenHeight - UM.Theme.getSize("default_lining").height
             width: UM.Theme.getSize("default_lining").height
             color: UM.Theme.getColor("lining")
         }

--- a/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
+++ b/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
@@ -5,7 +5,7 @@ import QtQuick 2.10
 import QtQuick.Controls 2.3
 
 import UM 1.3 as UM
-import Cura 1.0 as Cura
+import Cura 1.1 as Cura
 
 
 //
@@ -68,7 +68,7 @@ Item
         height: childrenRect.height
 
         // ScrollView + ListView for selecting a local printer to add
-        ScrollView
+        Cura.ScrollView
         {
             id: scrollView
             anchors.left: parent.left

--- a/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
+++ b/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
@@ -242,7 +242,7 @@ Item
                 }
                 Label
                 {
-                    text: catalog.i18nc("@label", "Author")
+                    text: catalog.i18nc("@label", "Profile author")
                     font: UM.Theme.getFont("default")
                     color: UM.Theme.getColor("text")
                     renderType: Text.NativeRendering

--- a/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml
+++ b/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml
@@ -108,6 +108,12 @@ Item
             AddLocalPrinterScrollView
             {
                 id: localPrinterView
+                property int childrenHeight: backButton.y - addLocalPrinterDropDown.y - UM.Theme.getSize("expandable_component_content_header").height - UM.Theme.getSize("default_margin").height
+
+                onChildrenHeightChanged:
+                {
+                    addLocalPrinterDropDown.children[1].height = childrenHeight
+                }
             }
         }
     }

--- a/resources/qml/Widgets/ScrollView.qml
+++ b/resources/qml/Widgets/ScrollView.qml
@@ -9,6 +9,7 @@ import UM 1.1 as UM
 ScrollView
 {
     clip: true
+
     // Setting this property to false hides the scrollbar both when the scrollbar is not needed (child height < height)
     // and when the scrollbar is not actively being hovered or pressed
     property bool scrollAlwaysVisible: true

--- a/resources/qml/Widgets/ScrollView.qml
+++ b/resources/qml/Widgets/ScrollView.qml
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Ultimaker B.V.
+// Toolbox is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.10
+import QtQuick.Controls 2.3
+
+import UM 1.1 as UM
+
+ScrollView
+{
+    clip: true
+    // Setting this property to false hides the scrollbar both when the scrollbar is not needed (child height < height)
+    // and when the scrollbar is not actively being hovered or pressed
+    property bool scrollAlwaysVisible: true
+
+    ScrollBar.vertical: ScrollBar
+    {
+        hoverEnabled: true
+        policy: parent.scrollAlwaysVisible ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+
+        contentItem: Rectangle
+        {
+            implicitWidth: UM.Theme.getSize("scrollbar").width
+            opacity: (parent.active || parent.parent.scrollAlwaysVisible) ? 1.0 : 0.0
+            radius: Math.round(width / 2)
+            color:
+            {
+                if (parent.pressed)
+                {
+                    return UM.Theme.getColor("scrollbar_handle_down")
+                }
+                else if (parent.hovered)
+                {
+                    return UM.Theme.getColor("scrollbar_handle_hover")
+                }
+                return UM.Theme.getColor("scrollbar_handle")
+            }
+            Behavior on color { ColorAnimation { duration: 100; } }
+            Behavior on opacity { NumberAnimation { duration: 100 } }
+        }
+    }
+}

--- a/resources/qml/qmldir
+++ b/resources/qml/qmldir
@@ -35,6 +35,7 @@ RadioButton         1.0 RadioButton.qml
 Scrollable          1.0 Scrollable.qml
 TabButton           1.0 TabButton.qml
 TextField           1.0 TextField.qml
+ScrollView          1.0 ScrollView.qml
 
 
 # Cura/MachineSettings


### PR DESCRIPTION
This PR improves the UX of adding a local printer:
* Makes the scrollbar while selecting local printer visible so it doesn't look like only Ultimaker printers are supported
* Makes it more obvious there may be more items in the list by showing at least one more item (Custom)
* Makes the name field look less like a search field by placing it - along with some metadata of the selected printer - to the right of the list
* Makes the list respond to resizing the window

![image](https://user-images.githubusercontent.com/143551/83277015-c2672d80-a1d1-11ea-9354-752c3312e517.png)

Showing the scrollbar is the most important change, and partly based on work by @diegopradogesto here: https://github.com/Ultimaker/Cura/pull/6325

This PR also in part reimplements https://github.com/Ultimaker/Cura/pull/4498

The "Add a networked printer" section remains untouched