### PR TITLE
Support serial connections with 76800 baud rate 

### DIFF
--- a/plugins/USBPrinting/AutoDetectBaudJob.py
+++ b/plugins/USBPrinting/AutoDetectBaudJob.py
@@ -18,7 +18,7 @@ class AutoDetectBaudJob(Job):
     def __init__(self, serial_port: int) -> None:
         super().__init__()
         self._serial_port = serial_port
-        self._all_baud_rates = [115200, 250000, 500000, 230400, 57600, 38400, 19200, 9600]
+        self._all_baud_rates = [115200, 250000, 500000, 230400, 76800, 57600, 38400, 19200, 9600]
 
     def run(self) -> None:
         Logger.log("d", "Auto detect baud rate started.")

--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -58,7 +58,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
 
         self._baud_rate = baud_rate
 
-        self._all_baud_rates = [115200, 250000, 500000, 230400, 57600, 38400, 19200, 9600]
+        self._all_baud_rates = [115200, 250000, 500000, 230400, 76800, 57600, 38400, 19200, 9600]
 
         # Instead of using a timer, we really need the update to be as a thread, as reading from serial can block.
         self._update_thread = Thread(target = self._update, daemon = True, name = "USBPrinterUpdate")


### PR DESCRIPTION
Some printers are using 76800baud, and cura is not able to detect them.

Why?

Running a 16Mhz ATmega2560 at the more common _115200 baud_ is not recommended as the error rate of 3% would be above what the spec tolerates, because of the clock mismatch 16Mhz is not divisible by 300.
So the next more appropriate rate is `76800 baud` with a much cleaner transmission with an error rate of about 0.2%.

76800 is also referred as 38400 double rate, and some ESP-12 also use 76.8K baud.

Sources:
https://www.robotroom.com/Asynchronous-Serial-Communication-2.html
https://trolsoft.ru/en/uart-calc
