### PR TITLE
Change the panelBorder rectangle anchor to the bottom for lower toolbar buttons.

### DIFF
--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -96,6 +96,8 @@ Item
                             {
                                 UM.Controller.setActiveTool(model.id);
                             }
+
+                            base.state = (index < toolsModel.count/2) ? "anchorAtTop" : "anchorAtBottom";
                         }
                     }
                 }
@@ -219,4 +221,33 @@ Item
 
         visible: toolHint.text != ""
     }
+
+    states: [
+        State {
+            name: "anchorAtTop"
+
+            AnchorChanges {
+                target: panelBorder
+                anchors.top: base.top
+                anchors.bottom: undefined
+            }
+            PropertyChanges {
+                target: panelBorder
+                anchors.topMargin: base.activeY
+            }
+        },
+        State {
+            name: "anchorAtBottom"
+
+            AnchorChanges {
+                target: panelBorder
+                anchors.top: undefined
+                anchors.bottom: base.top
+            }
+            PropertyChanges {
+                target: panelBorder
+                anchors.bottomMargin: -(base.activeY + UM.Theme.getSize("button").height)
+            }
+        }
+    ]
 }

--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -246,7 +246,7 @@ Item
             }
             PropertyChanges {
                 target: panelBorder
-                anchors.bottomMargin: -(base.activeY + UM.Theme.getSize("button").height)
+                anchors.bottomMargin: ((base.activeY + UM.Theme.getSize("button").height) > panelBorder.height) ? -(base.activeY + UM.Theme.getSize("button").height) : -panelBorder.height
             }
         }
     ]

--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -246,7 +246,14 @@ Item
             }
             PropertyChanges {
                 target: panelBorder
-                anchors.bottomMargin: ((base.activeY + UM.Theme.getSize("button").height) > panelBorder.height) ? -(base.activeY + UM.Theme.getSize("button").height) : -panelBorder.height
+                anchors.bottomMargin: {
+                    if (panelBorder.height > (base.activeY + UM.Theme.getSize("button").height)) {
+                        // panel is tall, align the top of the panel with the top of the first tool button
+                        return -panelBorder.height
+                    }
+                    // align the bottom of the panel with the bottom of the selected tool button
+                    return -(base.activeY + UM.Theme.getSize("button").height)
+                }
             }
         }
     ]


### PR DESCRIPTION
This makes the panel grow upwards into clear space rather than downwards which is a problem
when the Cura window height is restricted as the bottom of the panel become inaccessible.

![Screenshot_2020-06-03_08-10-27](https://user-images.githubusercontent.com/585618/83607136-98678f80-a572-11ea-9bc5-eaf4b150445b.png)

As discussed in https://community.ultimaker.com/topic/32840-a-problem-in-the-fitting-on-the-screen/.

The panel anchor point for the top toolbar buttons (Move, Scale, Rotate) is not changed.
