### PR TITLE
UM3NetworkPrinting: remove duplicate updates for model properties

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrintJobStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrintJobStatus.py
@@ -125,9 +125,6 @@ class ClusterPrintJobStatus(BaseModel):
         model.updateOwner(self.owner)
         model.updateState(self.status)
         model.setCompatibleMachineFamilies(self.compatible_machine_families)
-        model.updateTimeTotal(self.time_total)
-        model.updateTimeElapsed(self.time_elapsed)
-        model.updateOwner(self.owner)
 
         status_set_by_impediment = False
         for impediment in self.impediments_to_printing:


### PR DESCRIPTION
time_total, time_elapsed and owner were updated twice for the ClusterPrintJobStatus Model. 

(Also 1000th fork)