### PR TITLE
Set padding to 0 to remove vertical shift on Linux builds.

### DIFF
--- a/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
+++ b/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
@@ -77,6 +77,7 @@ UM.TooltipArea
         anchors.left: fieldLabel.right
         anchors.leftMargin: UM.Theme.getSize("default_margin").width
         verticalAlignment: Text.AlignVCenter
+        padding: 0
         width: numericTextFieldWithUnit.controlWidth
         height: numericTextFieldWithUnit.controlHeight
 


### PR DESCRIPTION
This problem has been seen before but I don't think it was ever fixed and one of the users of my builds reported it again so here's a fix for the bad valign issue that you can get in the machine settings dialog (at least on Linux).

Before...

![Screenshot_2020-06-05_07-56-36](https://user-images.githubusercontent.com/585618/83888704-1f1e9700-a742-11ea-8274-8b0c0b0511f1.png)

After...

![Screenshot_2020-06-05_15-35-27](https://user-images.githubusercontent.com/585618/83888789-38bfde80-a742-11ea-9297-5a22713a0cd5.png)

FYI I'm using Qt 5.13.2.