### PR TITLE
Add silly "ride the nozzle" simulation mode.

### DIFF
--- a/plugins/SimulationView/SimulationPass.py
+++ b/plugins/SimulationView/SimulationPass.py
@@ -100,7 +100,7 @@ class SimulationPass(RenderPass):
         nozzle_node = None
 
         ride_the_nozzle = (self._old_current_path != self._layer_view._current_path_num and
-                            ((QtWidgets.QApplication.queryKeyboardModifiers() & QtCore.Qt.ControlModifier) == QtCore.Qt.ControlModifier))
+                            ((QtWidgets.QApplication.queryKeyboardModifiers() & QtCore.Qt.AltModifier) == QtCore.Qt.AltModifier))
         camera_position = None
         elevation = 1.0 # mm
         trail_by = 5.0 #mm


### PR DESCRIPTION
When running the simulation, press Ctrl (Cmd on MacOS, I think) to "ride the nozzle".

Normal simulation...

![Screenshot_2020-06-06_11-10-59](https://user-images.githubusercontent.com/585618/83941860-a02f6a00-a7e6-11ea-821c-10b12d0bce47.png)

Ride that nozzle!...

![Screenshot_2020-06-06_11-11-42](https://user-images.githubusercontent.com/585618/83941864-a887a500-a7e6-11ea-9887-73e9b8cf0421.png)

Just don't make yourself seasick!
