### PR TITLE
Upload to cloud printer in a single chunk

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/ToolPathUploader.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/ToolPathUploader.py
@@ -62,8 +62,9 @@ class ToolPathUploader:
     def stop(self):
         """Stops uploading the mesh, marking it as finished."""
 
-        Logger.log("i", "Stopped uploading")
-        self._finished = True
+        Logger.log("i", "Finished uploading")
+        self._finished = True  # Signal to any ongoing retries that we should stop retrying.
+        self._on_finished()
 
     def _upload(self) -> None:
         """
@@ -88,7 +89,7 @@ class ToolPathUploader:
         :param bytes_sent: The amount of bytes sent in the current request.
         :param bytes_total: The amount of bytes to send in the current request.
         """
-        Logger.log("i", "Progress callback %s / %s", bytes_sent, bytes_total)
+        Logger.debug("Cloud upload progress %s / %s", bytes_sent, bytes_total)
         if bytes_total:
             self._on_progress(int(bytes_sent / len(self._data) * 100))
 
@@ -128,4 +129,3 @@ class ToolPathUploader:
                    [bytes(header).decode() for header in reply.rawHeaderList()], bytes(reply.readAll()).decode())
 
         self.stop()
-        self._on_finished()


### PR DESCRIPTION
Previously the print job was sent with multiple PUT requests. This was necessary since the request was made with the Python Requests library, which freezes the interface while it's running. By breaking the upload up in chunks, it would at least periodically keep updating the interface (4 times per second or so, depending on your internet speed and Ultimaker's). Later on, this was replaced by a `QNetworkRequest` which doesn't freeze the interface in a refactor, but it was still broken up in chunks.

Recently that was again refactored to use Uranium's `HttpRequestManager`, which under the covers also uses `QNetworkRequest`. This also doesn't freeze while uploading, which is good. However for some reason the second chunk would always give a `QNetworkReply::ProtocolUnknownError`, which is a bit of a catch-all error for any HTTP status codes not supported by Qt. I was not able to figure out what was really going wrong there, but it has something to do with the content-range header and making multiple requests.

Instead of fixing that, I've removed the chunking. This simplifies the code a lot and doesn't have any implications for the user, since it still doesn't freeze the interface while the network request is ongoing. It should be slightly faster to upload, and reduce load on the server too.

However the two disadvantages of this are that:
* If the original bug is in the `HttpRequestManager`, it will still be there. If it was a bug here in the `ToolPathUploader` I probably deleted that bug in this PR.
* If internet connection is spotty but restores quickly, the previous code would only try to resend the last chunk. This code will start again from the beginning.

To test, upload UFP files larger than 256kB. This was the chunk size originally.

Fixes CURA-7488.