### PR TITLE
CURA-7454: Add "remove printers" button in removed printers from account message

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -648,7 +648,7 @@ class CuraApplication(QtApplication):
         return self._global_container_stack
 
     @override(Application)
-    def setGlobalContainerStack(self, stack: Optional[GlobalStack]) -> None:
+    def setGlobalContainerStack(self, stack: Optional["GlobalStack"]) -> None:
         self._setLoadingHint(self._i18n_catalog.i18nc("@info:progress", "Initializing Active Machine..."))
         super().setGlobalContainerStack(stack)
 

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1948,11 +1948,6 @@ class CuraApplication(QtApplication):
         return self._machine_manager.activeMachine is None
 
     @pyqtSlot(result = bool)
-    def shouldShowAddPrintersUncancellableDialog(self) -> bool:
-        # If there is no printer and the user is logged in, show only the add printers flow in the welcome dialog.
-        return self._machine_manager.activeMachine is None and self.getCuraAPI().account.isLoggedIn
-
-    @pyqtSlot(result = bool)
     def shouldShowWhatsNewDialog(self) -> bool:
         has_active_machine = self._machine_manager.activeMachine is not None
         has_app_just_upgraded = self.hasJustUpdatedFromOldVersion()

--- a/cura/Machines/Models/BaseMaterialsModel.py
+++ b/cura/Machines/Models/BaseMaterialsModel.py
@@ -154,7 +154,7 @@ class BaseMaterialsModel(ListModel):
 
         # Update the available materials (ContainerNode) for the current active machine and extruder setup.
         global_stack = cura.CuraApplication.CuraApplication.getInstance().getGlobalContainerStack()
-        if not global_stack.hasMaterials:
+        if not global_stack or not global_stack.hasMaterials:
             return  # There are no materials for this machine, so nothing to do.
         extruder_list = global_stack.extruderList
         if self._extruder_position > len(extruder_list):

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -290,8 +290,14 @@ class MachineManager(QObject):
             self.activeStackValueChanged.emit()
 
     @pyqtSlot(str)
-    def setActiveMachine(self, stack_id: str) -> None:
+    def setActiveMachine(self, stack_id: Optional[str]) -> None:
         self.blurSettings.emit()  # Ensure no-one has focus.
+
+        if not stack_id:
+            self._application.setGlobalContainerStack(None)
+            self.globalContainerChanged.emit()
+            self._application.showAddPrintersUncancellableDialog.emit()
+            return
 
         container_registry = CuraContainerRegistry.getInstance()
         containers = container_registry.findContainerStacks(id = stack_id)
@@ -717,6 +723,8 @@ class MachineManager(QObject):
             other_machine_stacks = [s for s in machine_stacks if s["id"] != machine_id]
             if other_machine_stacks:
                 self.setActiveMachine(other_machine_stacks[0]["id"])
+            else:
+                self.setActiveMachine(None)
 
         metadatas = CuraContainerRegistry.getInstance().findContainerStacksMetadata(id = machine_id)
         if not metadatas:

--- a/cura/UI/AddPrinterPagesModel.py
+++ b/cura/UI/AddPrinterPagesModel.py
@@ -10,12 +10,11 @@ from .WelcomePagesModel import WelcomePagesModel
 #
 class AddPrinterPagesModel(WelcomePagesModel):
 
-    def initialize(self) -> None:
+    def initialize(self, cancellable: bool = True) -> None:
         self._pages.append({"id": "add_network_or_local_printer",
                             "page_url": self._getBuiltinWelcomePagePath("AddNetworkOrLocalPrinterContent.qml"),
                             "next_page_id": "machine_actions",
                             "next_page_button_text": self._catalog.i18nc("@action:button", "Add"),
-                            "previous_page_button_text": self._catalog.i18nc("@action:button", "Cancel"),
                             })
         self._pages.append({"id": "add_printer_by_ip",
                             "page_url": self._getBuiltinWelcomePagePath("AddPrinterByIpContent.qml"),
@@ -30,6 +29,9 @@ class AddPrinterPagesModel(WelcomePagesModel):
                             "page_url": self._getBuiltinWelcomePagePath("FirstStartMachineActionsContent.qml"),
                             "should_show_function": self.shouldShowMachineActions,
                             })
+        if cancellable:
+            self._pages[0]["previous_page_button_text"] = self._catalog.i18nc("@action:button", "Cancel")
+
         self.setItems(self._pages)
 
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -412,7 +412,7 @@ class CloudOutputDeviceManager:
 
     def _onRemovedPrintersMessageActionTriggered(self, removed_printers_message: Message, action: str) -> None:
         if action == "keep_printer_configurations_action":
-            self.removed_printers_message.hide()
+            removed_printers_message.hide()
         elif action == "remove_printers_action":
             machine_manager = CuraApplication.getInstance().getMachineManager()
             remove_printers_ids = {self._um_cloud_printers[i].getId() for i in self.reported_device_ids}
@@ -429,4 +429,4 @@ class CloudOutputDeviceManager:
             for machine_cloud_id in self.reported_device_ids:
                 machine_manager.setActiveMachine(self._um_cloud_printers[machine_cloud_id].getId())
                 machine_manager.removeMachine(self._um_cloud_printers[machine_cloud_id].getId())
-            self.removed_printers_message.hide()
+            removed_printers_message.hide()

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -51,6 +51,7 @@ class CloudOutputDeviceManager:
         self._account = CuraApplication.getInstance().getCuraAPI().account  # type: Account
         self._api = CloudApiClient(CuraApplication.getInstance(), on_error = lambda error: Logger.log("e", str(error)))
         self._account.loginStateChanged.connect(self._onLoginStateChanged)
+        self.removed_printers_message = None  # type: Optional[Message]
 
         # Ensure we don't start twice.
         self._running = False
@@ -120,6 +121,11 @@ class CloudOutputDeviceManager:
             if device_id in self._um_cloud_printers and not parseBool(self._um_cloud_printers[device_id].getMetaDataEntry(META_UM_LINKED_TO_ACCOUNT, "true")):
                 self._um_cloud_printers[device_id].setMetaDataEntry(META_UM_LINKED_TO_ACCOUNT, True)
         self._onDevicesDiscovered(new_clusters)
+
+        # Hide the current removed_printers_message, if there is any
+        if self.removed_printers_message:
+            self.removed_printers_message.actionTriggered.disconnect(self._onRemovedPrintersMessageActionTriggered)
+            self.removed_printers_message.hide()
 
         # Remove the CloudOutput device for offline printers
         offline_device_keys = set(self._remote_clusters.keys()) - set(online_clusters.keys())
@@ -266,7 +272,7 @@ class CloudOutputDeviceManager:
             return
 
         # Generate message
-        removed_printers_message = Message(
+        self.removed_printers_message = Message(
                 title = self.I18N_CATALOG.i18ncp(
                         "info:status",
                         "Cloud connection is not available for a printer",
@@ -288,19 +294,19 @@ class CloudOutputDeviceManager:
                 "<a href='https://mycloud.ultimaker.com/'>Ultimaker Digital Factory</a>.",
                 device_names
         )
-        removed_printers_message.setText(message_text)
-        removed_printers_message.addAction("keep_printer_configurations_action",
+        self.removed_printers_message.setText(message_text)
+        self.removed_printers_message.addAction("keep_printer_configurations_action",
                                name = self.I18N_CATALOG.i18nc("@action:button", "Keep printer configurations"),
                                icon = "",
                                description = "Keep the configuration of the cloud printer(s) synced with Cura which are not linked to your account.",
                                button_align = Message.ActionButtonAlignment.ALIGN_RIGHT)
-        removed_printers_message.addAction("remove_printers_action",
+        self.removed_printers_message.addAction("remove_printers_action",
                                name = self.I18N_CATALOG.i18nc("@action:button", "Remove printers"),
                                icon = "",
                                description = "Remove the cloud printer(s) which are not linked to your account.",
                                button_style = Message.ActionButtonStyle.SECONDARY,
                                button_align = Message.ActionButtonAlignment.ALIGN_LEFT)
-        removed_printers_message.actionTriggered.connect(self._onRemovedPrintersMessageActionTriggered)
+        self.removed_printers_message.actionTriggered.connect(self._onRemovedPrintersMessageActionTriggered)
 
         output_device_manager = CuraApplication.getInstance().getOutputDeviceManager()
 
@@ -317,7 +323,7 @@ class CloudOutputDeviceManager:
             # Update the printer's metadata to mark it as not linked to the account
             device.setMetaDataEntry(META_UM_LINKED_TO_ACCOUNT, False)
 
-        removed_printers_message.show()
+        self.removed_printers_message.show()
 
     def _onDiscoveredDeviceRemoved(self, device_id: str) -> None:
         device = self._remote_clusters.pop(device_id, None)  # type: Optional[CloudOutputDevice]
@@ -406,7 +412,7 @@ class CloudOutputDeviceManager:
 
     def _onRemovedPrintersMessageActionTriggered(self, removed_printers_message: Message, action: str) -> None:
         if action == "keep_printer_configurations_action":
-            removed_printers_message.hide()
+            self.removed_printers_message.hide()
         elif action == "remove_printers_action":
             machine_manager = CuraApplication.getInstance().getMachineManager()
             remove_printers_ids = {self._um_cloud_printers[i].getId() for i in self.reported_device_ids}
@@ -423,4 +429,4 @@ class CloudOutputDeviceManager:
             for machine_cloud_id in self.reported_device_ids:
                 machine_manager.setActiveMachine(self._um_cloud_printers[machine_cloud_id].getId())
                 machine_manager.removeMachine(self._um_cloud_printers[machine_cloud_id].getId())
-            removed_printers_message.hide()
+            self.removed_printers_message.hide()

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -273,7 +273,7 @@ class CloudOutputDeviceManager:
                         "Cloud connection is not available for some printers",
                         len(self.reported_device_ids)
                 ),
-                lifetime = 0
+                lifetime = 30
         )
         device_names = "\n".join(["<li>{} ({})</li>".format(self._um_cloud_printers[device].name, self._um_cloud_printers[device].definition.name) for device in self.reported_device_ids])
         message_text = self.I18N_CATALOG.i18ncp(

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -51,7 +51,7 @@ class CloudOutputDeviceManager:
         self._account = CuraApplication.getInstance().getCuraAPI().account  # type: Account
         self._api = CloudApiClient(CuraApplication.getInstance(), on_error = lambda error: Logger.log("e", str(error)))
         self._account.loginStateChanged.connect(self._onLoginStateChanged)
-        self.removed_printers_message = None  # type: Optional[Message]
+        self._removed_printers_message = None  # type: Optional[Message]
 
         # Ensure we don't start twice.
         self._running = False
@@ -123,9 +123,9 @@ class CloudOutputDeviceManager:
         self._onDevicesDiscovered(new_clusters)
 
         # Hide the current removed_printers_message, if there is any
-        if self.removed_printers_message:
-            self.removed_printers_message.actionTriggered.disconnect(self._onRemovedPrintersMessageActionTriggered)
-            self.removed_printers_message.hide()
+        if self._removed_printers_message:
+            self._removed_printers_message.actionTriggered.disconnect(self._onRemovedPrintersMessageActionTriggered)
+            self._removed_printers_message.hide()
 
         # Remove the CloudOutput device for offline printers
         offline_device_keys = set(self._remote_clusters.keys()) - set(online_clusters.keys())
@@ -276,7 +276,7 @@ class CloudOutputDeviceManager:
             return
 
         # Generate message
-        self.removed_printers_message = Message(
+        self._removed_printers_message = Message(
                 title = self.I18N_CATALOG.i18ncp(
                         "info:status",
                         "Cloud connection is not available for a printer",
@@ -298,19 +298,19 @@ class CloudOutputDeviceManager:
                 "<a href='https://mycloud.ultimaker.com/'>Ultimaker Digital Factory</a>.",
                 device_names
         )
-        self.removed_printers_message.setText(message_text)
-        self.removed_printers_message.addAction("keep_printer_configurations_action",
-                               name = self.I18N_CATALOG.i18nc("@action:button", "Keep printer configurations"),
-                               icon = "",
-                               description = "Keep the configuration of the cloud printer(s) synced with Cura which are not linked to your account.",
-                               button_align = Message.ActionButtonAlignment.ALIGN_RIGHT)
-        self.removed_printers_message.addAction("remove_printers_action",
-                               name = self.I18N_CATALOG.i18nc("@action:button", "Remove printers"),
-                               icon = "",
-                               description = "Remove the cloud printer(s) which are not linked to your account.",
-                               button_style = Message.ActionButtonStyle.SECONDARY,
-                               button_align = Message.ActionButtonAlignment.ALIGN_LEFT)
-        self.removed_printers_message.actionTriggered.connect(self._onRemovedPrintersMessageActionTriggered)
+        self._removed_printers_message.setText(message_text)
+        self._removed_printers_message.addAction("keep_printer_configurations_action",
+                                                 name = self.I18N_CATALOG.i18nc("@action:button", "Keep printer configurations"),
+                                                 icon = "",
+                                                 description = "Keep the configuration of the cloud printer(s) synced with Cura which are not linked to your account.",
+                                                 button_align = Message.ActionButtonAlignment.ALIGN_RIGHT)
+        self._removed_printers_message.addAction("remove_printers_action",
+                                                 name = self.I18N_CATALOG.i18nc("@action:button", "Remove printers"),
+                                                 icon = "",
+                                                 description = "Remove the cloud printer(s) which are not linked to your account.",
+                                                 button_style = Message.ActionButtonStyle.SECONDARY,
+                                                 button_align = Message.ActionButtonAlignment.ALIGN_LEFT)
+        self._removed_printers_message.actionTriggered.connect(self._onRemovedPrintersMessageActionTriggered)
 
         output_device_manager = CuraApplication.getInstance().getOutputDeviceManager()
 
@@ -327,7 +327,7 @@ class CloudOutputDeviceManager:
             # Update the printer's metadata to mark it as not linked to the account
             device.setMetaDataEntry(META_UM_LINKED_TO_ACCOUNT, False)
 
-        self.removed_printers_message.show()
+        self._removed_printers_message.show()
 
     def _onDiscoveredDeviceRemoved(self, device_id: str) -> None:
         device = self._remote_clusters.pop(device_id, None)  # type: Optional[CloudOutputDevice]

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py
@@ -282,8 +282,7 @@ class CloudOutputDeviceManager:
                         "Cloud connection is not available for a printer",
                         "Cloud connection is not available for some printers",
                         len(self.reported_device_ids)
-                ),
-                lifetime = 30
+                )
         )
         device_names = "\n".join(["<li>{} ({})</li>".format(self._um_cloud_printers[device].name, self._um_cloud_printers[device].definition.name) for device in self.reported_device_ids])
         message_text = self.I18N_CATALOG.i18ncp(

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -135,7 +135,7 @@ UM.MainWindow
 
             // Reuse the welcome dialog item to show the "Add printers" dialog. Triggered when there is no active
             // machine and the user is logged in.
-            if (CuraApplication.shouldShowAddPrintersUncancellableDialog())
+            if (!Cura.MachineManager.activeMachine && Cura.API.account.isLoggedIn)
             {
                 welcomeDialogItem.model = CuraApplication.getAddPrinterPagesModelWithoutCancel()
                 welcomeDialogItem.progressBarVisible = false

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -86,6 +86,21 @@ UM.MainWindow
 
     Connections
     {
+        // This connection is used when there is no ActiveMachine and the user is logged in
+        target: CuraApplication
+        onShowAddPrintersUncancellableDialog:
+        {
+            Cura.Actions.parent = backgroundItem
+
+            // Reuse the welcome dialog item to show "Add a printer" only.
+            welcomeDialogItem.model = CuraApplication.getAddPrinterPagesModelWithoutCancel()
+            welcomeDialogItem.progressBarVisible = false
+            welcomeDialogItem.visible = true
+        }
+    }
+
+    Connections
+    {
         target: CuraApplication
         onInitializationFinished:
         {
@@ -114,6 +129,15 @@ UM.MainWindow
             if (CuraApplication.shouldShowWhatsNewDialog())
             {
                 welcomeDialogItem.model = CuraApplication.getWhatsNewPagesModel()
+                welcomeDialogItem.progressBarVisible = false
+                welcomeDialogItem.visible = true
+            }
+
+            // Reuse the welcome dialog item to show the "Add printers" dialog. Triggered when there is no active
+            // machine and the user is logged in.
+            if (CuraApplication.shouldShowAddPrintersUncancellableDialog())
+            {
+                welcomeDialogItem.model = CuraApplication.getAddPrinterPagesModelWithoutCancel()
                 welcomeDialogItem.progressBarVisible = false
                 welcomeDialogItem.visible = true
             }

--- a/resources/qml/Dialogs/WorkspaceSummaryDialog.qml
+++ b/resources/qml/Dialogs/WorkspaceSummaryDialog.qml
@@ -143,7 +143,7 @@ UM.Dialog
                 {
                     width: parent.width
                     height: childrenRect.height
-                    model: Cura.MachineManager.activeMachine.extruderList
+                    model: Cura.MachineManager.activeMachine ? Cura.MachineManager.activeMachine.extruderList : null
                     delegate: Column
                     {
                         height: childrenRect.height

--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -33,7 +33,7 @@ Cura.ExpandablePopup
     }
 
     contentPadding: UM.Theme.getSize("default_lining").width
-    enabled: Cura.MachineManager.activeMachine.hasMaterials || Cura.MachineManager.activeMachine.hasVariants || Cura.MachineManager.activeMachine.hasVariantBuildplates; //Only let it drop down if there is any configuration that you could change.
+    enabled: Cura.MachineManager.activeMachine ? Cura.MachineManager.activeMachine.hasMaterials || Cura.MachineManager.activeMachine.hasVariants || Cura.MachineManager.activeMachine.hasVariantBuildplates : false; //Only let it drop down if there is any configuration that you could change.
 
     headerItem: Item
     {
@@ -84,7 +84,7 @@ Cura.ExpandablePopup
                     {
                         id: variantLabel
 
-                        visible: Cura.MachineManager.activeMachine.hasVariants
+                        visible: Cura.MachineManager.activeMachine ? Cura.MachineManager.activeMachine.hasVariants : false
 
                         text: model.variant
                         elide: Text.ElideRight
@@ -114,7 +114,7 @@ Cura.ExpandablePopup
             color: UM.Theme.getColor("text")
             renderType: Text.NativeRendering
 
-            visible: !Cura.MachineManager.activeMachine.hasMaterials && (Cura.MachineManager.activeMachine.hasVariants || Cura.MachineManager.activeMachine.hasVariantBuildplates)
+            visible: Cura.MachineManager.activeMachine ? !Cura.MachineManager.activeMachine.hasMaterials && (Cura.MachineManager.activeMachine.hasVariants || Cura.MachineManager.activeMachine.hasVariantBuildplates) : false
 
             anchors
             {

--- a/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml
+++ b/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml
@@ -244,7 +244,7 @@ Item
             Row
             {
                 height: visible ? UM.Theme.getSize("print_setup_big_item").height : 0
-                visible: Cura.MachineManager.activeMachine.hasMaterials
+                visible: Cura.MachineManager.activeMachine ? Cura.MachineManager.activeMachine.hasMaterials : false
 
                 Label
                 {
@@ -305,7 +305,7 @@ Item
             Row
             {
                 height: visible ? UM.Theme.getSize("print_setup_big_item").height : 0
-                visible: Cura.MachineManager.activeMachine.hasVariants
+                visible: Cura.MachineManager.activeMachine ? Cura.MachineManager.activeMachine.hasVariants : false
 
                 Label
                 {

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
@@ -130,7 +130,11 @@ Item
                 target: extruderModel
                 onModelChanged:
                 {
-                    supportExtruderCombobox.color = supportExtruderCombobox.model.getItem(supportExtruderCombobox.currentIndex).color
+                    var maybeColor = supportExtruderCombobox.model.getItem(supportExtruderCombobox.currentIndex).color
+                    if (maybeColor)
+                    {
+                        supportExtruderCombobox.color = maybeColor
+                    }
                 }
             }
             onCurrentIndexChanged:

--- a/resources/qml/PrinterSelector/MachineSelectorList.qml
+++ b/resources/qml/PrinterSelector/MachineSelectorList.qml
@@ -28,11 +28,11 @@ ListView
 
     delegate: MachineSelectorButton
     {
-        text: model.name
+        text: model.name ? model.name : ""
         width: listView.width
         outputDevice: Cura.MachineManager.printerOutputDevices.length >= 1 ? Cura.MachineManager.printerOutputDevices[0] : null
 
-        checked: Cura.MachineManager.activeMachine.id == model.id
+        checked: Cura.MachineManager.activeMachine ? Cura.MachineManager.activeMachine.id == model.id : false
 
         onClicked:
         {


### PR DESCRIPTION
This PR adds an additional button in the "removed printers from account" message that allows the user to completely remove these printers from Cura. 
![Removed printers message](https://user-images.githubusercontent.com/19388042/84164591-fc0e2300-aa72-11ea-8c71-5bfa0acd169a.png)
For that to happen, the user is asked through a question box to confirm the action.
![image](https://user-images.githubusercontent.com/19388042/84164935-658e3180-aa73-11ea-9716-1a1b3409dbc6.png)

To achieve the requirements of this ticket, the following had to be done in Cura:

- Add another "AddPrintersPagesModel" that is exactly the same as the other one with the exception that it does not display a "Cancel" button
- Allow Cura to set an empty active machine, if all machines are removed (when pressing the "Remove printers" button)
- Gracefully handle in the front-end the case where the last active machine is removed 
- Popup the "Add printers" wizard without the option to be cancelled when the last printer is removed

**Note 1**: Tests are failing because it requires the Uranium PR https://github.com/Ultimaker/Uranium/pull/621.

**Note 2**: Before reviewing and component testing this PR, make sure that the tickets that follow
 are merged in the right order.

1. CURA-7438:
    - https://github.com/Ultimaker/Cura/pull/7873 (Cura)
    - https://github.com/Ultimaker/Uranium/pull/617 (Uranium)
2. CURA-7455:
    - https://github.com/Ultimaker/Cura/pull/7880 (Cura)
3. CURA-7454