### PR TITLE
CURA-7522: Removing printer created by project file also removes the original printer

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -745,7 +745,7 @@ class MachineManager(QObject):
         # If the printer that is being removed is a network printer, the hidden printers have to be also removed
         group_id = metadata.get("group_id", None)
         if group_id:
-            metadata_filter = {"group_id": group_id}
+            metadata_filter = {"group_id": group_id, "hidden": True}
             hidden_containers = CuraContainerRegistry.getInstance().findContainerStacks(type = "machine", **metadata_filter)
             if hidden_containers:
                 # This reuses the method and remove all printers recursively


### PR DESCRIPTION
When printers share the same group_id, they are removed, regardless if they are hidden or not. This was resulting in sometimes removing multiple printers when removing a printer that was created by a project file.
This PR fixes that by actually checking whether the printer-to-be-removed is hidden.

CURA-7522