### PR TITLE
Initial layer Horizontal Expansion for AA0.4 and AA0.25 print core

### DIFF
--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print_Accurate.inst.cfg
@@ -32,3 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality_Accurate.inst.cfg
@@ -32,3 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Fast_Print_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPEP_Normal_Quality_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Fast_Print_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_CPE_Normal_Quality_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Fast_Print_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PC_Normal_Quality_Accurate.inst.cfg
@@ -32,5 +32,5 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print_Accurate.inst.cfg
@@ -32,3 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality_Accurate.inst.cfg
@@ -32,3 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print_Accurate.inst.cfg
@@ -32,3 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
@@ -32,4 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
-xy_offset_layer_0 = =((-0.2 - layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =((-0.2 + layer_height * 0.2) if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality_Accurate.inst.cfg
@@ -32,3 +32,4 @@ top_bottom_thickness = =wall_thickness
 wall_line_width_x = =line_width
 wall_thickness = =line_width * 3
 xy_offset = =-layer_height * 0.2
+xy_offset_layer_0  = = ((-0.2 - layer_height * 0.2)  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/variants/ultimaker3_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker3_aa0.25.inst.cfg
@@ -48,4 +48,4 @@ switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_line_width_x = 0.23
 wall_thickness = 1.3
-xy_offset_layer_0 = =(-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =(-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/variants/ultimaker3_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker3_aa0.25.inst.cfg
@@ -48,3 +48,4 @@ switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_line_width_x = 0.23
 wall_thickness = 1.3
+xy_offset_layer_0  = = (-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/variants/ultimaker3_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker3_aa0.25.inst.cfg
@@ -48,4 +48,4 @@ switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_line_width_x = 0.23
 wall_thickness = 1.3
-xy_offset_layer_0  = = (-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =(-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/variants/ultimaker3_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_aa04.inst.cfg
@@ -40,3 +40,4 @@ switch_extruder_prime_speed = =switch_extruder_retraction_speeds
 switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_thickness = 1.3
+xy_offset_layer_0  = = (-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/variants/ultimaker3_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_aa04.inst.cfg
@@ -40,4 +40,4 @@ switch_extruder_prime_speed = =switch_extruder_retraction_speeds
 switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_thickness = 1.3
-xy_offset_layer_0 = =(-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =(-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/variants/ultimaker3_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_aa04.inst.cfg
@@ -40,4 +40,4 @@ switch_extruder_prime_speed = =switch_extruder_retraction_speeds
 switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_thickness = 1.3
-xy_offset_layer_0  = = (-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =(-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/variants/ultimaker3_extended_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa0.25.inst.cfg
@@ -48,3 +48,4 @@ switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_line_width_x = 0.23
 wall_thickness = 1.3
+xy_offset_layer_0 = =(-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/variants/ultimaker3_extended_aa04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_aa04.inst.cfg
@@ -40,3 +40,4 @@ switch_extruder_prime_speed = =switch_extruder_retraction_speeds
 switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_thickness = 1.3
+xy_offset_layer_0 = =(-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/variants/ultimaker_s5_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa0.25.inst.cfg
@@ -48,4 +48,4 @@ switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_line_width_x = 0.23
 wall_thickness = 1.3
-xy_offset_layer_0 = =(-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+xy_offset_layer_0 = =(-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset

--- a/resources/variants/ultimaker_s5_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa0.25.inst.cfg
@@ -48,3 +48,4 @@ switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_line_width_x = 0.23
 wall_thickness = 1.3
+xy_offset_layer_0  = = (-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 

--- a/resources/variants/ultimaker_s5_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa0.25.inst.cfg
@@ -48,4 +48,4 @@ switch_extruder_retraction_amount = =machine_heat_zone_length
 top_bottom_thickness = 1.2
 wall_line_width_x = 0.23
 wall_thickness = 1.3
-xy_offset_layer_0  = = (-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset 
+xy_offset_layer_0 = =(-0.2  if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset


### PR DESCRIPTION
To compensate elephant foot -> initial layer horizontal expansion setting is modeified for engineering and AA0.25 core profile for UMS5 and for UM3  for AA0.4 and AA0.25 cores.