### PR TITLE
Fix ExtruderConfigurationModel.__eq__

### DIFF
--- a/cura/PrinterOutput/Models/ExtruderConfigurationModel.py
+++ b/cura/PrinterOutput/Models/ExtruderConfigurationModel.py
@@ -74,11 +74,11 @@ class ExtruderConfigurationModel(QObject):
         # Empty materials should be ignored for comparison
         if self.activeMaterial is not None and other.activeMaterial is not None:
             if self.activeMaterial.guid != other.activeMaterial.guid:
-                if self.activeMaterial.guid != "" and other.activeMaterial.guid != "":
-                    return False
-                else:
+                if self.activeMaterial.guid == "" and other.activeMaterial.guid == "":
                     # At this point there is no material, so it doesn't matter what the hotend is.
                     return True
+                else:
+                    return False
 
         if self.hotendID != other.hotendID:
             return False


### PR DESCRIPTION
Fixes an issue where 2 configurations
(empty, empty) and (pla, empty) were considered
equal

CURA-7248