### PR TITLE
Correctly select the color mode from GUI - this fixes bug #8040

### DIFF
--- a/plugins/ImageReader/ImageReaderUI.py
+++ b/plugins/ImageReader/ImageReaderUI.py
@@ -172,7 +172,7 @@ class ImageReaderUI(QObject):
 
     @pyqtSlot(int)
     def onColorModelChanged(self, value):
-        self.use_transparency_model = (value == 0)
+        self.use_transparency_model = (value == 1)
 
     @pyqtSlot(int)
     def onTransmittanceChanged(self, value):


### PR DESCRIPTION
This fix selects transparency model according to the UI. There index 0 is Linear mode and index 1 is Translucency mode. In the python code it was interpreted the other way round.