### PR TITLE
CURA-6711: Fix preferences.cfg not being updated in project files

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade34to35/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade34to35/__init__.py
@@ -14,6 +14,7 @@ def getMetaData() -> Dict[str, Any]:
     return {
         "version_upgrade": {
             # From                           To                              Upgrade function
+            ("preferences", 6000000):        ("preferences", 6000005,        upgrade.upgradePreferences),
             ("preferences", 6000004):        ("preferences", 6000005,        upgrade.upgradePreferences),
 
             ("definition_changes", 4000004): ("definition_changes", 4000005, upgrade.upgradeInstanceContainer),


### PR DESCRIPTION
Since the metadata/setting_version field was not written in project files from the 3MF writer,
the preferences were never really updated, because their preferences version was marked as 6000000
(basically omitting the setting_version). Now, if any project file is found without a metadata
setting_version tag, it will default to preference version 6000000 and thus it will start calling
the updatedPreferences() functions starting from VersionUpgrade34to35, properly updating the
preferences and adding the metadata/setting_version field in the preferences.cfg of the project
file.

CURA-6711