### PR TITLE
Allow scrolling through setting tooltips

### DIFF
--- a/resources/qml/PrintSetupTooltip.qml
+++ b/resources/qml/PrintSetupTooltip.qml
@@ -11,7 +11,7 @@ UM.PointingRectangle
     id: base
     property real sourceWidth: 0
     width: UM.Theme.getSize("tooltip").width
-    height: label.height + UM.Theme.getSize("tooltip_margins").height * 2
+    height: textScroll.height + UM.Theme.getSize("tooltip_margins").height * 2
     color: UM.Theme.getColor("tooltip")
 
     arrowSize: UM.Theme.getSize("default_arrow").width
@@ -75,23 +75,29 @@ UM.PointingRectangle
             }
         }
 
-        Label
+        ScrollView
         {
-            id: label
-            anchors
-            {
-                top: parent.top;
-                topMargin: UM.Theme.getSize("tooltip_margins").height;
-                left: parent.left;
-                leftMargin: UM.Theme.getSize("tooltip_margins").width;
-                right: parent.right;
-                rightMargin: UM.Theme.getSize("tooltip_margins").width;
+            id: textScroll
+            width: parent.width
+            height: Math.min(label.height, base.parent.height)
+
+            ScrollBar.horizontal: ScrollBar {
+                active: false //Only allow vertical scrolling. We should grow vertically only, but due to how the label is positioned it allocates space in the ScrollView horizontally.
             }
-            wrapMode: Text.Wrap;
-            textFormat: Text.RichText
-            font: UM.Theme.getFont("default");
-            color: UM.Theme.getColor("tooltip_text");
-            renderType: Text.NativeRendering
+
+            Label
+            {
+                id: label
+                x: UM.Theme.getSize("tooltip_margins").width
+                y: UM.Theme.getSize("tooltip_margins").height
+                width: base.width - UM.Theme.getSize("tooltip_margins").width * 2
+
+                wrapMode: Text.Wrap;
+                textFormat: Text.RichText
+                font: UM.Theme.getFont("default");
+                color: UM.Theme.getColor("tooltip_text");
+                renderType: Text.NativeRendering
+            }
         }
     }
 }

--- a/resources/qml/PrintSetupTooltip.qml
+++ b/resources/qml/PrintSetupTooltip.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Ultimaker B.V.
+// Copyright (c) 2020 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.7
@@ -59,22 +59,39 @@ UM.PointingRectangle
         base.opacity = 0;
     }
 
-    Label
+    MouseArea
     {
-        id: label;
-        anchors
+        anchors.fill: parent
+        hoverEnabled: true
+        onHoveredChanged:
         {
-            top: parent.top;
-            topMargin: UM.Theme.getSize("tooltip_margins").height;
-            left: parent.left;
-            leftMargin: UM.Theme.getSize("tooltip_margins").width;
-            right: parent.right;
-            rightMargin: UM.Theme.getSize("tooltip_margins").width;
+            if(containsMouse && base.opacity > 0)
+            {
+                base.show(Qt.point(base.x + base.width, base.y + UM.Theme.getSize("tooltip_arrow_margins").height));
+            }
+            else
+            {
+                base.hide();
+            }
         }
-        wrapMode: Text.Wrap;
-        textFormat: Text.RichText
-        font: UM.Theme.getFont("default");
-        color: UM.Theme.getColor("tooltip_text");
-        renderType: Text.NativeRendering
+
+        Label
+        {
+            id: label
+            anchors
+            {
+                top: parent.top;
+                topMargin: UM.Theme.getSize("tooltip_margins").height;
+                left: parent.left;
+                leftMargin: UM.Theme.getSize("tooltip_margins").width;
+                right: parent.right;
+                rightMargin: UM.Theme.getSize("tooltip_margins").width;
+            }
+            wrapMode: Text.Wrap;
+            textFormat: Text.RichText
+            font: UM.Theme.getFont("default");
+            color: UM.Theme.getColor("tooltip_text");
+            renderType: Text.NativeRendering
+        }
     }
 }

--- a/resources/qml/PrintSetupTooltip.qml
+++ b/resources/qml/PrintSetupTooltip.qml
@@ -67,7 +67,7 @@ UM.PointingRectangle
         {
             if(containsMouse && base.opacity > 0)
             {
-                base.show(Qt.point(base.x + base.width, base.y + UM.Theme.getSize("tooltip_arrow_margins").height));
+                base.show(Qt.point(target.x - 1, target.y - UM.Theme.getSize("tooltip_arrow_margins").height / 2)); //Same arrow position as before.
             }
             else
             {


### PR DESCRIPTION
This is something that will by default probably not make any difference for Cura, unless there are settings with extremely long descriptions and people try to read them on very small screens. I'm implementing this because the Settings Guide has an option to put the articles in the setting tooltips. That option is sometimes useless because the articles are just way too long to display on the screen.

I've made a change that allows the user to interact with the setting tooltips and scroll through the text, if it is too long to display on the screen. To allow this, I've also implemented that hovering over the tooltip makes the tooltip stay visible. You can hover over the tooltip while it is still visible (opacity > 0), so you've got the 0.1s duration of the fade animation to move the cursor from the setting to the tooltip. It's only a dozen pixels or so, so this turns out to be fairly easy.

A video of the action: http://dulek.net/work/setting_tooltip_scroll.webm

A few notes about the requirements of this implementation that I held to:
* It should not affect the design if the tooltip is smaller than the screen.
* It must not cause significant performance reduction, not even in theory. This is not so difficult since the tooltip is only created once, so it will now only have one extra MouseArea and one extra ScrollView to render. Clipping is not necessary since it goes off the screen anyway.

The only difference that you need to consider when deciding on whether to accept this change or not, is that the user may move the mouse on top of the tooltip accidentally, causing the tooltip to be in the way. From what I feel, it behaves sort of like how many applications work with expanding menus and it feels natural that the tooltip stays when you hover, so it is also clear that you must move the cursor to get the tooltip to go away.

A bug that I see in this implementation is that there is somehow a tiny horizontal scrollbar at the bottom. I think this is a bug in Qt 5.14 that doesn't appear 5.10.2. Various other components in the interface have those for me, but they are not in the builds. The scrollbar can be moved but does nothing.