### PR TITLE
CURA-7646: Settings not applied when creating new CFFF from project file

### DIFF
--- a/cura/Settings/CuraStackBuilder.py
+++ b/cura/Settings/CuraStackBuilder.py
@@ -68,7 +68,7 @@ class CuraStackBuilder:
 
         # If given, set the machine_extruder_count when creating the machine, or else the extruderList used bellow will
         # not return the correct extruder list (since by default, the machine_extruder_count is 1) in machines with
-        # settable number of extruders. See CURA-7646.
+        # settable number of extruders.
         if machine_extruder_count and 0 <= machine_extruder_count <= len(extruder_dict):
             new_global_stack.setProperty("machine_extruder_count", "value", machine_extruder_count)
 

--- a/cura/Settings/CuraStackBuilder.py
+++ b/cura/Settings/CuraStackBuilder.py
@@ -16,13 +16,13 @@ from .ExtruderStack import ExtruderStack
 class CuraStackBuilder:
     """Contains helper functions to create new machines."""
 
-
     @classmethod
-    def createMachine(cls, name: str, definition_id: str) -> Optional[GlobalStack]:
+    def createMachine(cls, name: str, definition_id: str, machine_extruder_count: Optional[int] = None) -> Optional[GlobalStack]:
         """Create a new instance of a machine.
 
         :param name: The name of the new machine.
         :param definition_id: The ID of the machine definition to use.
+        :param machine_extruder_count: The number of extruders in the machine.
 
         :return: The new global stack or None if an error occurred.
         """
@@ -66,7 +66,14 @@ class CuraStackBuilder:
                 Logger.logException("e", "Failed to create an extruder stack for position {pos}: {err}".format(pos = position, err = str(e)))
                 return None
 
-        for new_extruder in new_global_stack.extruderList:  # Only register the extruders if we're sure that all of them are correct.
+        # If given, set the machine_extruder_count when creating the machine, or else the extruderList used bellow will
+        # not return the correct extruder list (since by default, the machine_extruder_count is 1) in machines with
+        # settable number of extruders. See CURA-7646.
+        if machine_extruder_count and 0 <= machine_extruder_count <= len(extruder_dict):
+            new_global_stack.setProperty("machine_extruder_count", "value", machine_extruder_count)
+
+        # Only register the extruders if we're sure that all of them are correct.
+        for new_extruder in new_global_stack.extruderList:
             registry.addContainer(new_extruder)
 
         # Register the global stack after the extruder stacks are created. This prevents the registry from adding another

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -939,6 +939,10 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
                 and "values" in self._machine_info.definition_changes_info.parser \
                 and "machine_extruder_count" in self._machine_info.definition_changes_info.parser["values"]:
             try:
+                # Theoretically, if the machine_extruder_count is a setting formula (e.g. "=3"), this will produce a
+                # value error and the project file loading will load the settings in the first extruder only.
+                # This is not expected to happen though, since all machine definitions define the machine_extruder_count
+                # as an integer.
                 machine_extruder_count = int(self._machine_info.definition_changes_info.parser["values"]["machine_extruder_count"])
             except ValueError:
                 Logger.log("w", "'machine_extruder_count' in file '{file_name}' is not a number."

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -934,7 +934,8 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
         :return: The count of the machine's extruders
         """
         machine_extruder_count = None
-        if self._machine_info.definition_changes_info \
+        if self._machine_info \
+                and self._machine_info.definition_changes_info \
                 and "values" in self._machine_info.definition_changes_info.parser \
                 and "machine_extruder_count" in self._machine_info.definition_changes_info.parser["values"]:
             try:

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -663,7 +663,12 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
             # We need to create a new machine
             machine_name = self._container_registry.uniqueName(self._machine_info.name)
 
-            global_stack = CuraStackBuilder.createMachine(machine_name, self._machine_info.definition_id)
+            # Printers with modifiable number of extruders (such as CFFF) will specify a machine_extruder_count in their
+            # quality_changes file. If that's the case, take the extruder count into account when creating the machine
+            # or else the extruderList will return only the first extruder, leading to missing non-global settings in
+            # the other extruders. See CURA-7646
+            machine_extruder_count = self._getMachineExtruderCount()  # type: Optional[int]
+            global_stack = CuraStackBuilder.createMachine(machine_name, self._machine_info.definition_id, machine_extruder_count)
             if global_stack:  # Only switch if creating the machine was successful.
                 extruder_stack_dict = {str(position): extruder for position, extruder in enumerate(global_stack.extruderList)}
 
@@ -917,6 +922,24 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
                     container_info.container.setProperty(key, "value", value)
 
         self._machine_info.quality_changes_info.name = quality_changes_name
+
+    def _getMachineExtruderCount(self) -> Optional[int]:
+        """
+        Extracts the machine extruder count from the definition_changes file of the printer. If it is not specified in
+        the file, None is returned instead.
+
+        :return: The count of the machine's extruders
+        """
+        machine_extruder_count = None
+        if self._machine_info.definition_changes_info \
+                and "values" in self._machine_info.definition_changes_info.parser \
+                and "machine_extruder_count" in self._machine_info.definition_changes_info.parser["values"]:
+            try:
+                machine_extruder_count = int(self._machine_info.definition_changes_info.parser["values"]["machine_extruder_count"])
+            except ValueError:
+                Logger.log("w", "'machine_extruder_count' in file '{file_name}' is not a number."
+                           .format(file_name = self._machine_info.definition_changes_info.file_name))
+        return machine_extruder_count
 
     def _createNewQualityChanges(self, quality_type: str, intent_category: Optional[str], name: str, global_stack: GlobalStack, extruder_stack: Optional[ExtruderStack]) -> InstanceContainer:
         """Helper class to create a new quality changes profile.

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -502,6 +502,9 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
         # Now we know which material is in which extruder. Let's use that to sort the material_labels according to
         # their extruder position
         material_labels = [material_name for pos, material_name in sorted(materials_in_extruders_dict.items())]
+        machine_extruder_count = self._getMachineExtruderCount()
+        if machine_extruder_count:
+            material_labels = material_labels[:machine_extruder_count]
 
         num_visible_settings = 0
         try:

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -666,7 +666,7 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
             # Printers with modifiable number of extruders (such as CFFF) will specify a machine_extruder_count in their
             # quality_changes file. If that's the case, take the extruder count into account when creating the machine
             # or else the extruderList will return only the first extruder, leading to missing non-global settings in
-            # the other extruders. See CURA-7646
+            # the other extruders.
             machine_extruder_count = self._getMachineExtruderCount()  # type: Optional[int]
             global_stack = CuraStackBuilder.createMachine(machine_name, self._machine_info.definition_id, machine_extruder_count)
             if global_stack:  # Only switch if creating the machine was successful.


### PR DESCRIPTION
The non-global settings of only the first extruder are applied, while the rest of the extruders are ignored. This happens because of the fact that the machine_extruder_count is not taken into consideration when creating a machine, which leads to the extruderList thinking that there is only 1 extruder (since machine_extruder_count == 1 by default). The problem is observed in project files with printers that have a settable number of extruders (through their machine settings).

This PR fixes that by accounting for the amount of extruders specified in the definition_changes of the printer when creating the machine.

In addition, this PR fixes the issue of displaying the materials of multiple extruders in the open project dialog, even if the printer has only 1 extruder.
