### PR TITLE
Get property speed improvements

### DIFF
--- a/cura/Settings/CuraContainerStack.py
+++ b/cura/Settings/CuraContainerStack.py
@@ -393,9 +393,11 @@ class CuraContainerStack(ContainerStack):
         if property_name == "settable_per_extruder":
             # Setable per extruder isn't a value that can ever change. So once we requested it once, we can just keep
             # that in memory.
-            if key not in self._settable_per_extruder_cache:
+            try:
+                return self._settable_per_extruder_cache[key]
+            except KeyError:
                 self._settable_per_extruder_cache[key] = super().getProperty(key, property_name, context)
-            return self._settable_per_extruder_cache[key]
+                return self._settable_per_extruder_cache[key]
 
         return super().getProperty(key, property_name, context)
 

--- a/cura/Settings/CuraContainerStack.py
+++ b/cura/Settings/CuraContainerStack.py
@@ -60,6 +60,8 @@ class CuraContainerStack(ContainerStack):
         import cura.CuraApplication #Here to prevent circular imports.
         self.setMetaDataEntry("setting_version", cura.CuraApplication.CuraApplication.SettingVersion)
 
+        self._settable_per_extruder_cache = {}
+
         self.setDirty(False)
 
     # This is emitted whenever the containersChanged signal from the ContainerStack base class is emitted.
@@ -386,6 +388,16 @@ class CuraContainerStack(ContainerStack):
         if value == -1:
             value = int(Application.getInstance().getMachineManager().defaultExtruderPosition)
         return value
+
+    def getProperty(self, key: str, property_name: str, context = None) -> Any:
+        if property_name == "settable_per_extruder":
+            # Setable per extruder isn't a value that can ever change. So once we requested it once, we can just keep
+            # that in memory.
+            if key not in self._settable_per_extruder_cache:
+                self._settable_per_extruder_cache[key] = super().getProperty(key, property_name, context)
+            return self._settable_per_extruder_cache[key]
+
+        return super().getProperty(key, property_name, context)
 
 
 class _ContainerIndexes:

--- a/cura/Settings/CuraContainerStack.py
+++ b/cura/Settings/CuraContainerStack.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
-from typing import Any, cast, List, Optional
+from typing import Any, cast, List, Optional, Dict
 from PyQt5.QtCore import pyqtProperty, pyqtSignal, QObject
 
 from UM.Application import Application
@@ -60,7 +60,7 @@ class CuraContainerStack(ContainerStack):
         import cura.CuraApplication #Here to prevent circular imports.
         self.setMetaDataEntry("setting_version", cura.CuraApplication.CuraApplication.SettingVersion)
 
-        self._settable_per_extruder_cache = {}
+        self._settable_per_extruder_cache = {}  # type: Dict[str, Any]
 
         self.setDirty(False)
 

--- a/cura/Settings/ExtruderStack.py
+++ b/cura/Settings/ExtruderStack.py
@@ -131,13 +131,13 @@ class ExtruderStack(CuraContainerStack):
         if not self._next_stack:
             raise Exceptions.NoGlobalStackError("Extruder {id} is missing the next stack!".format(id = self.id))
 
-        if context is None:
-            context = PropertyEvaluationContext()
-        context.pushContainer(self)
+        if context:
+            context.pushContainer(self)
 
         if not super().getProperty(key, "settable_per_extruder", context):
             result = self.getNextStack().getProperty(key, property_name, context)
-            context.popContainer()
+            if context:
+                context.popContainer()
             return result
 
         limit_to_extruder = super().getProperty(key, "limit_to_extruder", context)
@@ -150,13 +150,15 @@ class ExtruderStack(CuraContainerStack):
             try:
                 result = self.getNextStack().extruderList[int(limit_to_extruder)].getProperty(key, property_name, context)
                 if result is not None:
-                    context.popContainer()
+                    if context:
+                        context.popContainer()
                     return result
             except IndexError:
                 pass
 
         result = super().getProperty(key, property_name, context)
-        context.popContainer()
+        if context:
+            context.popContainer()
         return result
 
     @override(CuraContainerStack)

--- a/cura/Settings/GlobalStack.py
+++ b/cura/Settings/GlobalStack.py
@@ -192,7 +192,7 @@ class GlobalStack(CuraContainerStack):
         self._extruders[position] = extruder
         self.extrudersChanged.emit()
         Logger.log("i", "Extruder[%s] added to [%s] at position [%s]", extruder.id, self.id, position)
-
+    
     @override(ContainerStack)
     def getProperty(self, key: str, property_name: str, context: Optional[PropertyEvaluationContext] = None) -> Any:
         """Overridden from ContainerStack
@@ -211,9 +211,8 @@ class GlobalStack(CuraContainerStack):
         if not self.definition.findDefinitions(key = key):
             return None
 
-        if context is None:
-            context = PropertyEvaluationContext()
-        context.pushContainer(self)
+        if context:
+            context.pushContainer(self)
 
         # Handle the "resolve" property.
         #TODO: Why the hell does this involve threading?
@@ -238,13 +237,15 @@ class GlobalStack(CuraContainerStack):
             if super().getProperty(key, "settable_per_extruder", context):
                 result = self._extruders[str(limit_to_extruder)].getProperty(key, property_name, context)
                 if result is not None:
-                    context.popContainer()
+                    if context:
+                        context.popContainer()
                     return result
             else:
                 Logger.log("e", "Setting {setting} has limit_to_extruder but is not settable per extruder!", setting = key)
 
         result = super().getProperty(key, property_name, context)
-        context.popContainer()
+        if context:
+            context.popContainer()
         return result
 
     @override(ContainerStack)

--- a/cura/Settings/GlobalStack.py
+++ b/cura/Settings/GlobalStack.py
@@ -263,6 +263,10 @@ class GlobalStack(CuraContainerStack):
             # Do not try to resolve anything but the "value" property
             return False
 
+        if not self.definition.getProperty(key, "resolve"):
+            # If there isn't a resolve set for this setting, there isn't anything to do here.
+            return False
+
         current_thread = threading.current_thread()
         if key in self._resolving_settings[current_thread.name]:
             # To prevent infinite recursion, if getProperty is called with the same key as

--- a/cura/Settings/GlobalStack.py
+++ b/cura/Settings/GlobalStack.py
@@ -192,7 +192,7 @@ class GlobalStack(CuraContainerStack):
         self._extruders[position] = extruder
         self.extrudersChanged.emit()
         Logger.log("i", "Extruder[%s] added to [%s] at position [%s]", extruder.id, self.id, position)
-    
+
     @override(ContainerStack)
     def getProperty(self, key: str, property_name: str, context: Optional[PropertyEvaluationContext] = None) -> Any:
         """Overridden from ContainerStack

--- a/cura/Settings/GlobalStack.py
+++ b/cura/Settings/GlobalStack.py
@@ -256,8 +256,6 @@ class GlobalStack(CuraContainerStack):
 
         raise Exceptions.InvalidOperationError("Global stack cannot have a next stack!")
 
-    # protected:
-
     # Determine whether or not we should try to get the "resolve" property instead of the
     # requested property.
     def _shouldResolve(self, key: str, property_name: str, context: Optional[PropertyEvaluationContext] = None) -> bool:
@@ -273,10 +271,8 @@ class GlobalStack(CuraContainerStack):
             # track all settings that are being resolved.
             return False
 
-        setting_state = super().getProperty(key, "state", context = context)
-        if setting_state is not None and setting_state != InstanceState.Default:
-            # When the user has explicitly set a value, we should ignore any resolve and
-            # just return that value.
+        if self.hasUserValue(key):
+            # When the user has explicitly set a value, we should ignore any resolve and just return that value.
             return False
 
         return True

--- a/tests/Settings/TestGlobalStack.py
+++ b/tests/Settings/TestGlobalStack.py
@@ -410,13 +410,13 @@ def test_getPropertyInstancesBeforeResolve(global_stack):
 
     value = unittest.mock.MagicMock() #Sets just the value.
     value.getProperty = unittest.mock.MagicMock(side_effect = getValueProperty)
-    value.getMetaDataEntry = unittest.mock.MagicMock(return_value = "quality")
+    value.getMetaDataEntry = unittest.mock.MagicMock(return_value = "quality_changes")
     resolve = unittest.mock.MagicMock() #Sets just the resolve.
     resolve.getProperty = unittest.mock.MagicMock(side_effect = getResolveProperty)
 
     with unittest.mock.patch("cura.Settings.CuraContainerStack.DefinitionContainer", unittest.mock.MagicMock): #To guard against the type checking.
         global_stack.definition = resolve
-    global_stack.quality = value
+    global_stack.qualityChanges = value
 
     assert global_stack.getProperty("material_bed_temperature", "value") == 10
 


### PR DESCRIPTION
I was doing some research on finding a way to create a fundamentally different way to handle properties. But during that time I again found some things that were being rather inefficient about it.

This PR should improve the speed of setting loading & value changes.

The one that is easiest to measure it the speed by which the slice message sending is handled. 
Before: 0.65s
After: 0.36s