### PR TITLE
Fix default filament diameter for custom printers

### DIFF
--- a/resources/definitions/fdmextruder.def.json
+++ b/resources/definitions/fdmextruder.def.json
@@ -243,7 +243,7 @@
                     "description": "Adjusts the diameter of the filament used. Match this value with the diameter of the used filament.",
                     "unit": "mm",
                     "type": "float",
-                    "default_value": 2.85,
+                    "default_value": 1.75,
                     "minimum_value": "0.0001",
                     "minimum_value_warning": "0.4",
                     "maximum_value_warning": "3.5",


### PR DESCRIPTION
Almost all new consumer-grade printers have switched to 1.75 mm filament.
Reflecting this change in the default printer profile for Cura reduces the chance of extrusion issues when newcomers set up their own machine in Cura.