### PR TITLE
CURA-7691: Unclear why imported profile is not immediately visible

### DIFF
--- a/cura/Settings/CuraContainerRegistry.py
+++ b/cura/Settings/CuraContainerRegistry.py
@@ -179,7 +179,7 @@ class CuraContainerRegistry(ContainerRegistry):
         """Imports a profile from a file
 
         :param file_name: The full path and filename of the profile to import.
-        :return: Dict with a 'status' key containing the string 'ok' or 'error',
+        :return: Dict with a 'status' key containing the string 'ok', 'warning' or 'error',
             and a 'message' key containing a message for the user.
         """
 
@@ -338,10 +338,12 @@ class CuraContainerRegistry(ContainerRegistry):
                                 "Failed to import profile from <filename>{0}</filename>:",
                                 file_name) + " " + message}
                     profile_ids_added.append(profile.getId())
+                result_status = "ok"
                 success_message = catalog.i18nc("@info:status", "Successfully imported profile {0}.", profile_or_list[0].getName())
                 if additional_message:
+                    result_status = "warning"
                     success_message += additional_message
-                return {"status": "ok", "message": success_message}
+                return {"status": result_status, "message": success_message}
 
             # This message is throw when the profile reader doesn't find any profile in the file
             return {"status": "error", "message": catalog.i18nc("@info:status", "File {0} does not contain any valid profile.", file_name)}

--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -313,7 +313,7 @@ Item
             {
                 messageDialog.icon = StandardIcon.Information;
             }
-            else if (result.status == "duplicate")
+            else if (result.status == "warning" || result.status == "duplicate")
             {
                 messageDialog.icon = StandardIcon.Warning;
             }


### PR DESCRIPTION
Warn when importing quality profiles that don't match the current configuration

When importing a profile that doesn't much the current nozzle combination (e.g. importing a 'high'
quality when we have AA0.8 and AA0.4 nozzles), the profile was being accepted and a success message
was shown to the user, but the quality did not show up in the profile list.

This commit fixes that by accepting the quality profile and informing the user that the profile is
not visible due to the current configuration.

CURA-7691