### PR TITLE
Remove shrinkage percentage setting alias

### DIFF
--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -1112,7 +1112,6 @@ class XmlMaterialProfile(InstanceContainer):
         "retraction speed": "retraction_speed",
         "adhesion tendency": "material_adhesion_tendency",
         "surface energy": "material_surface_energy",
-        "shrinkage percentage": "material_shrinkage_percentage",
         "build volume temperature": "build_volume_temperature",
         "anti ooze retract position": "material_anti_ooze_retracted_position",
         "anti ooze retract speed": "material_anti_ooze_retraction_speed",


### PR DESCRIPTION
This alias shouldn't be written any more since the firmware misinterprets the setting value and errors when it's more than 100%.

Contributes to issue CURA-7724.