### PR TITLE
Fix connecting to printer via USB

### DIFF
--- a/plugins/USBPrinting/AutoDetectBaudJob.py
+++ b/plugins/USBPrinting/AutoDetectBaudJob.py
@@ -71,7 +71,9 @@ class AutoDetectBaudJob(Job):
                 timeout_time = time() + wait_response_timeout
 
                 while timeout_time > time():
-                    # If baudrate is wrong, then readline() might never return, even with timeouts set. Using read_until with size limit seems to fix this.
+                    # If baudrate is wrong, then readline() might never
+                    # return, even with timeouts set. Using read_until
+                    # with size limit seems to fix this.
                     line = serial.read_until(size = 100)
                     if b"ok" in line and b"T:" in line:
                         successful_responses += 1

--- a/plugins/USBPrinting/AutoDetectBaudJob.py
+++ b/plugins/USBPrinting/AutoDetectBaudJob.py
@@ -71,7 +71,8 @@ class AutoDetectBaudJob(Job):
                 timeout_time = time() + wait_response_timeout
 
                 while timeout_time > time():
-                    line = serial.readline()
+                    # If baudrate is wrong, then readline() might never return, even with timeouts set. Using read_until with size limit seems to fix this.
+                    line = serial.read_until(size = 100)
                     if b"ok" in line and b"T:" in line:
                         successful_responses += 1
                         if successful_responses >= 1:


### PR DESCRIPTION
If the baudrate was anything else than 115200, detection of baudrate could fail
because readline() with a wrong baudrate would never return, even if timeouts
were set.

Update: Sometimes detection would succeed anyway if restarting Cura enough times, or pulling the USB cable out and in enough times. The problem may be that readline() would read an infinite stream of random data that usually, but not always, would happen to have an EOF character by coincidence.

The fix in the PR still applies