### PR TITLE
Fabtotum profiles fix

### DIFF
--- a/resources/definitions/fabtotum.def.json
+++ b/resources/definitions/fabtotum.def.json
@@ -8,7 +8,7 @@
         "manufacturer": "FABtotum",
         "file_formats": "text/x-gcode",
         "platform": "fabtotum_platform.3mf",
-        "has_machine_quality": true,
+        "has_machine_quality": false,
         "has_variants": true,
         "variants_name": "Head",
         "preferred_variant_name": "Lite 0.4 mm",
@@ -22,7 +22,7 @@
     "overrides": {
         "machine_name": { "default_value": "FABtotum Personal Fabricator" },
         "machine_start_gcode": {
-            "default_value": ";Layer height: {layer_height}\n;Walls: {wall_thickness}\n;Fill: {infill_sparse_density}\n;Top\\Bottom Thickness: {top_bottom_thickness}\nG90 ;absolute positioning\nM82 ;set extruder to absolute mode\nG4 S1 ;1 millisecond pause to buffer the bep bep \nM300 S2 ;FAB bep bep (start the print, go check the oozing and skirt lines adesion) \nG4 S1 ;1 second pause to reach the printer (run fast)\nG92 E0 ;zero the extruded length \nG1 F200 E35    ;slowly extrude 35mm of filament to clean the nozzle and build up extrusion pressure \nG92 E0 ;zero the extruded length again \n;print"
+            "default_value": ";Layer height: {layer_height}\n;Walls: {wall_thickness}\n;Fill: {infill_sparse_density}\n;Top\\Bottom Thickness: {top_bottom_thickness}\nG90 ;absolute positioning\nM82 ;set extruder to absolute mode\nG4 S1 ;1 second pause to buffer the bep bep \nM300 S2 ;FAB bep bep (start the print, go check the oozing and skirt lines adesion) \nG4 S1 ;1 second pause to reach the printer (run fast)\nG92 E0 ;zero the extruded length \nG1 F200 E35    ;slowly extrude 35mm of filament to clean the nozzle and build up extrusion pressure \nG92 E0 ;zero the extruded length again \n;print"
         },
         "machine_end_gcode": {
             "default_value": "M104 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300    ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-3 X+5 Y+5 F5000 ;move Z up a bit and retract filament even more\n;end of the print\nM84 ;steppers off\nG90 ;absolute positioning\nM300 S2 ;FAB bep bep (end print)"
@@ -45,25 +45,6 @@
         "machine_acceleration": { "default_value": 4000 },
         "machine_max_jerk_xy": { "default_value": 25.0 },
         "machine_max_jerk_z": { "default_value": 0.4 },
-        "machine_max_jerk_e": { "default_value": 1.0 },
-        "retraction_hop_enabled": { "default_value": false },
-        "material_final_print_temperature": { "value": "material_print_temperature - 5" },
-        "material_initial_print_temperature": { "value": "material_print_temperature" },
-        "travel_avoid_distance": { "value": 1 },
-        "speed_travel": { "value": 200 },
-        "speed_infill": { "value": "round(speed_print * 1.05, 0)" },
-        "speed_topbottom": { "value": "round(speed_print * 0.95, 0)" },
-        "speed_wall": { "value": "speed_print" },
-        "speed_wall_0": { "value": "round(speed_print * 0.9, 0)" },
-        "speed_wall_x": { "value": "speed_wall" },
-        "speed_layer_0": { "value": "min(round(speed_print * 0.75, 0), 45.0)" },
-        "speed_travel_layer_0": { "value": "round(speed_travel * 0.7, 0)" },
-        "skirt_brim_speed": { "value": "speed_layer_0" },
-        "skirt_line_count": { "default_value": 3 },
-        "skirt_brim_minimal_length": { "default_value": 150 },
-        "infill_sparse_density": { "default_value": 24 },
-        "top_bottom_thickness": { "default_value": 0.6 },
-        "support_z_distance": { "default_value": 0.2, "value": "min(2 * layer_height, machine_nozzle_size * 0.75)" },
-        "support_interface_enable": { "default_value": true }
+        "machine_max_jerk_e": { "default_value": 1.0 }
     }
 }

--- a/resources/variants/fabtotum_hyb35.inst.cfg
+++ b/resources/variants/fabtotum_hyb35.inst.cfg
@@ -14,4 +14,3 @@ machine_nozzle_size = 0.35
 retraction_speed = 23
 retraction_amount = 2.5
 retraction_count_max = 25
-retraction_min_travel = 0.1

--- a/resources/variants/fabtotum_lite04.inst.cfg
+++ b/resources/variants/fabtotum_lite04.inst.cfg
@@ -14,4 +14,3 @@ machine_nozzle_size = 0.4
 retraction_speed = 23
 retraction_amount = 2.5
 retraction_count_max = 25
-retraction_min_travel = 0.1

--- a/resources/variants/fabtotum_lite06.inst.cfg
+++ b/resources/variants/fabtotum_lite06.inst.cfg
@@ -14,4 +14,3 @@ machine_nozzle_size = 0.6
 retraction_speed = 23
 retraction_amount = 2.5
 retraction_count_max = 25
-retraction_min_travel = 0.1

--- a/resources/variants/fabtotum_pro02.inst.cfg
+++ b/resources/variants/fabtotum_pro02.inst.cfg
@@ -14,4 +14,3 @@ machine_nozzle_size = 0.2
 retraction_speed = 48
 retraction_amount = 1.0
 retraction_count_max = 50
-retraction_min_travel = 0.1

--- a/resources/variants/fabtotum_pro04.inst.cfg
+++ b/resources/variants/fabtotum_pro04.inst.cfg
@@ -14,4 +14,3 @@ machine_nozzle_size = 0.4
 retraction_speed = 48
 retraction_amount = 1.0
 retraction_count_max = 50
-retraction_min_travel = 0.1

--- a/resources/variants/fabtotum_pro06.inst.cfg
+++ b/resources/variants/fabtotum_pro06.inst.cfg
@@ -14,4 +14,3 @@ machine_nozzle_size = 0.6
 retraction_speed = 48
 retraction_amount = 1.0
 retraction_count_max = 50
-retraction_min_travel = 0.1

--- a/resources/variants/fabtotum_pro08.inst.cfg
+++ b/resources/variants/fabtotum_pro08.inst.cfg
@@ -14,4 +14,3 @@ machine_nozzle_size = 0.8
 retraction_speed = 48
 retraction_amount = 1.0
 retraction_count_max = 50
-retraction_min_travel = 0.1


### PR DESCRIPTION
This PR temporarily disables the quality profiles of the Fabtotum printer until they are corrected.
Since version 4.3 of Cura the profiles are not loaded correctly. Pending a correction I propose that they be disabled.
I have removed the non-machine related settings from the printer definition and removed the minimum retraction distance that Cura will calculate from the profiles.