### PR TITLE
CURA-7728: Recalculate the number of user settings after setting the quality group

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -1153,6 +1153,7 @@ class MachineManager(QObject):
             extruder.qualityChanges = quality_changes_container
 
         self.setIntentByCategory(quality_changes_group.intent_category)
+        self._reCalculateNumUserSettings()
 
         self.activeQualityGroupChanged.emit()
         self.activeQualityChangesGroupChanged.emit()


### PR DESCRIPTION
So that the dialog ensures actually knows that there are no changed settings and will not show up.

CURA-7728