### PR TITLE
Compatibility for newer python-zeroconf versions

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Network/ZeroConfClient.py
+++ b/plugins/UM3NetworkPrinting/src/Network/ZeroConfClient.py
@@ -155,8 +155,8 @@ class ZeroConfClient:
         return True
 
     @staticmethod
-    def _getAddress(info: ServiceInfo) -> Optional[str]:
-        """Retrieve IPv4 address from the ServiceInfo as string, None if there is no address."""
+    def _getAddress(info: ServiceInfo) -> Optional[bytes]:
+        """Retrieve IPv4 address from the ServiceInfo as bytes, None if there is no address."""
 
         # Check the version of python-zeroconf
         if Version(zeroconf_version) >= Version([0, 24, 0]):

--- a/plugins/UM3NetworkPrinting/src/Network/ZeroConfClient.py
+++ b/plugins/UM3NetworkPrinting/src/Network/ZeroConfClient.py
@@ -155,7 +155,7 @@ class ZeroConfClient:
         return True
 
     @staticmethod
-    def _getAddress(info: ServiceInfo) -> str:
+    def _getAddress(info: ServiceInfo) -> Optional[str]:
         """Retrieve IPv4 address from the ServiceInfo as string, None if there is no address."""
 
         # Check the version of python-zeroconf


### PR DESCRIPTION
python-zeroconf Version 0.24.0 added support for multiple addresses and IPv6 addresses. The attribute ServiceInfo.address (which is still used here) is therefore deprecated and fully removed as of Version 0.27.0. This change makes it compatible with newer versions, while retaining backwards compatibility for Versions <= 0.23.