### PR TITLE
CURA-7780: Fix arrange message not closing when arrange crashes

### DIFF
--- a/cura/Arranging/ArrangeObjectsJob.py
+++ b/cura/Arranging/ArrangeObjectsJob.py
@@ -4,6 +4,7 @@ from typing import List
 
 from UM.Application import Application
 from UM.Job import Job
+from UM.Logger import Logger
 from UM.Message import Message
 from UM.Scene.SceneNode import SceneNode
 from UM.i18n import i18nCatalog
@@ -27,10 +28,14 @@ class ArrangeObjectsJob(Job):
                                  title = i18n_catalog.i18nc("@info:title", "Finding Location"))
         status_message.show()
 
-        found_solution_for_all = arrange(self._nodes, Application.getInstance().getBuildVolume(), self._fixed_nodes)
+        found_solution_for_all = None
+        try:
+            found_solution_for_all = arrange(self._nodes, Application.getInstance().getBuildVolume(), self._fixed_nodes)
+        except:  # If the thread crashes, the message should still close
+            Logger.logException("e", "Unable to arrange the objects on the buildplate. The arrange algorithm has crashed.")
 
         status_message.hide()
-        if not found_solution_for_all:
+        if found_solution_for_all is not None and not found_solution_for_all:
             no_full_solution_message = Message(
                     i18n_catalog.i18nc("@info:status",
                                        "Unable to find a location within the build volume for all objects"),

--- a/cura/Arranging/Nest2DArrange.py
+++ b/cura/Arranging/Nest2DArrange.py
@@ -3,6 +3,7 @@ from pynest2d import Point, Box, Item, NfpConfig, nest
 from typing import List, TYPE_CHECKING, Optional, Tuple
 
 from UM.Application import Application
+from UM.Logger import Logger
 from UM.Math.Matrix import Matrix
 from UM.Math.Polygon import Polygon
 from UM.Math.Quaternion import Quaternion
@@ -44,6 +45,9 @@ def findNodePlacement(nodes_to_arrange: List["SceneNode"], build_volume: "BuildV
     node_items = []
     for node in nodes_to_arrange:
         hull_polygon = node.callDecoration("getConvexHull")
+        if not hull_polygon or hull_polygon.getPoints is None:
+            Logger.log("w", "Object {} cannot be arranged because it has no convex hull.".format(node.getName()))
+            continue
         converted_points = []
         for point in hull_polygon.getPoints():
             converted_points.append(Point(point[0] * factor, point[1] * factor))

--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -19,6 +19,7 @@ from UM.Scene.SceneNode import SceneNode  # For typing.
 from cura.CuraApplication import CuraApplication
 from cura.Machines.ContainerTree import ContainerTree
 from cura.Scene.BuildPlateDecorator import BuildPlateDecorator
+from cura.Scene.ConvexHullDecorator import ConvexHullDecorator
 from cura.Scene.CuraSceneNode import CuraSceneNode
 from cura.Scene.SliceableObjectDecorator import SliceableObjectDecorator
 from cura.Scene.ZOffsetDecorator import ZOffsetDecorator
@@ -108,6 +109,7 @@ class ThreeMFReader(MeshReader):
 
         um_node = CuraSceneNode() # This adds a SettingOverrideDecorator
         um_node.addDecorator(BuildPlateDecorator(active_build_plate))
+        um_node.addDecorator(ConvexHullDecorator())
         um_node.setName(node_name)
         um_node.setId(node_id)
         transformation = self._createMatrixFromTransformationString(savitar_node.getTransformation())


### PR DESCRIPTION
This PR fixes three things:

- The "Finding Location" message would remain open without an option to be closed, if for any reason arrange would crash. This is fixed by surrounding arrange with try-except.
- If for some reason an objects has no convex hull, then it will be skipped from being arranged.
- Previously, objects loaded from 3mf and are outside of the buildplate would have no ConvexHullDecorator. This is now fixed by adding it on 3mf loading.

CURA-7780