### PR TITLE
Add ConsoleLogger as pre-loaded plug-in

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -756,7 +756,7 @@ class CuraApplication(QtApplication):
             self._plugin_registry.addPluginLocation(os.path.join(QtApplication.getInstallPrefix(), "lib" + suffix, "cura"))
         if not hasattr(sys, "frozen"):
             self._plugin_registry.addPluginLocation(os.path.join(os.path.abspath(os.path.dirname(__file__)), "..", "plugins"))
-            self._plugin_registry.loadPlugin("ConsoleLogger")
+            self._plugin_registry.preloaded_plugins.append("ConsoleLogger")
 
         self._plugin_registry.loadPlugins()
 


### PR DESCRIPTION
This way it gets loaded only once on start-up, which prevents errors that the plug-in was already loaded.

This PR depends on https://github.com/Ultimaker/Uranium/pull/648 . Please merge at the same time.
Contributes to issue CURA-7501.