### PR TITLE
Prevent duplicate adding of extruders

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -336,7 +336,8 @@ class MachineManager(QObject):
             return  # We're done here
 
         self._global_container_stack = global_stack
-        extruder_manager.addMachineExtruders(global_stack)
+        if not global_stack.extruderList:  # First time we're activating this, there are no extruders yet.
+            extruder_manager.addMachineExtruders(global_stack)
         self._application.setGlobalContainerStack(global_stack)
 
         # Switch to the first enabled extruder


### PR DESCRIPTION
The addMachineExtruders function assumes that this is a new printer (first time the printer is activated since a restart of Cura) and it needs to add the extruder stacks to it. However most of the time when we're switching, it's not to a new printer. If it's not a new printer, this function would get called anyway and we'd be adding the extruders multiple times. This then does a lot of unnecessary work and eventually fails a couple of calls deep when it sees the extruders are already there.
This change prevents it from adding the extruders if there are already extruders associated with the printer, thus preventing this unnecessary work (switch is faster) and preventing the error from happening.

Discovered during work on CURA-7501.