### PR TITLE
Add "preparing" printer status in the monitor page

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
@@ -359,6 +359,10 @@ Item
                     {
                         return catalog.i18nc("@label:status", "Idle")
                     }
+                    if (!printer.activePrintJob && printer.state == "pre_print")
+                    {
+                        return catalog.i18nc("@label:status", "Preparing...")
+                    }
                     if (!printer.activePrintJob && printer.state == "printing")
                     {
                         // The print job isn't quite updated yet.


### PR DESCRIPTION
To make sure that the printer status reflected in Cura is the same as the one in the Digital Factory when the printer is preparing for the print.

Contributes to CURA-7745