### PR TITLE
Post Processing Plugin | Pause at height | Repetier (@pause) 1mm to high

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -455,7 +455,7 @@ class PauseAtHeight(Script):
                         prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = 6000) + "\n"
 
                     #Move the head back
-                    prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + "\n"
+                    prepend_gcode += self.putValue(G = 1, Z = current_z, F = 300) + "\n"
                     prepend_gcode += self.putValue(G = 1, X = x, Y = y, F = 9000) + "\n"
                     if retraction_amount != 0:
                         prepend_gcode += self.putValue(G = 1, E = retraction_amount, F = 6000) + "\n"


### PR DESCRIPTION
Bug:
The Post Processing Plugin "Pause at height" has a bug with the Repetier Method where the Z-height is 1mm to high after continue.
Discuss: https://github.com/Ultimaker/Cura/issues/8575

The wrong line starts here:
458: prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + "\n"
The correct line:
458: prepend_gcode += self.putValue(G = 1, Z = current_z, F = 300) + "\n"