### PR TITLE
Fix prime tower overlap

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -791,7 +791,9 @@ class BuildVolume(SceneNode):
                         break
                     if self._global_container_stack.getProperty("prime_tower_brim_enable", "value") and self._global_container_stack.getProperty("adhesion_type", "value") != "raft":
                         brim_size = self._calculateBedAdhesionSize(used_extruders, "brim")
-                        prime_tower_areas[extruder_id][area_index] = prime_tower_area.getMinkowskiHull(Polygon.approximatedCircle(brim_size))
+                        # Use 2x the brim size, since we need 1x brim size distance due to the object brim and another
+                        # times the brim due to the brim of the prime tower
+                        prime_tower_areas[extruder_id][area_index] = prime_tower_area.getMinkowskiHull(Polygon.approximatedCircle(2 * brim_size, num_segments = 24))
                 if not prime_tower_collision:
                     result_areas[extruder_id].extend(prime_tower_areas[extruder_id])
                     result_areas_no_brim[extruder_id].extend(prime_tower_areas[extruder_id])
@@ -843,7 +845,7 @@ class BuildVolume(SceneNode):
                 prime_tower_y += brim_size
 
             radius = prime_tower_size / 2
-            prime_tower_area = Polygon.approximatedCircle(radius)
+            prime_tower_area = Polygon.approximatedCircle(radius, num_segments = 24)
             prime_tower_area = prime_tower_area.translate(prime_tower_x - radius, prime_tower_y - radius)
 
             prime_tower_area = prime_tower_area.getMinkowskiHull(Polygon.approximatedCircle(0))


### PR DESCRIPTION
CURA-7643 

There could still be some cases where the prime tower brim was overlapping with the brim of the object.

needs: https://github.com/Ultimaker/Uranium/pull/649