### PR TITLE
Skip running the tests for the old arrange algorithm

### DIFF
--- a/tests/TestArrange.py
+++ b/tests/TestArrange.py
@@ -2,9 +2,12 @@
 # Cura is released under the terms of the LGPLv3 or higher.
 
 import numpy
+import pytest
 
 from cura.Arranging.Arrange import Arrange
 from cura.Arranging.ShapeArray import ShapeArray
+
+pytestmark = pytest.mark.skip()
 
 def gimmeTriangle():
     """Triangle of area 12"""


### PR DESCRIPTION
So that the output of the CI/CD testing step is not cluttered with deprecation warnings.

Done during TTT