### PR TITLE
Modified raft settings: raft air gap, raft surface speed, speed layer 0

### DIFF
--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_Nylon_Normal_Quality.inst.cfg
@@ -33,3 +33,6 @@ switch_extruder_prime_speed = 30
 switch_extruder_retraction_amount = 30
 switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Draft_Print.inst.cfg
@@ -29,3 +29,5 @@ wall_thickness = 1
 infill_line_width = =round(line_width * 0.4 / 0.35, 2)
 speed_infill = =math.ceil(speed_print * 50 / 60)
 
+raft_airgap = 0.15
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Fast_Print.inst.cfg
@@ -28,3 +28,5 @@ speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
 infill_line_width = =round(line_width * 0.4 / 0.35, 2)
 speed_infill = =math.ceil(speed_print * 45 / 60)
 
+raft_airgap = 0.15
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_High_Quality.inst.cfg
@@ -27,3 +27,5 @@ speed_wall = =math.ceil(speed_print * 30 / 50)
 infill_line_width = =round(line_width * 0.4 / 0.35, 2)
 speed_infill = =math.ceil(speed_print * 40 / 50)
 
+raft_airgap = 0.15
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -25,3 +25,6 @@ speed_wall = =math.ceil(speed_print * 30 / 55)
 
 infill_line_width = =round(line_width * 0.4 / 0.35, 2)
 speed_infill = =math.ceil(speed_print * 40 / 55)
+
+raft_airgap = 0.15
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -36,3 +36,7 @@ switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
 
 jerk_travel = 50
+
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -36,3 +36,7 @@ switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
 
 jerk_travel = 50
+
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_High_Quality.inst.cfg
@@ -35,3 +35,7 @@ switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
 
 jerk_travel = 50
+
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -35,3 +35,7 @@ switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
 
 jerk_travel = 50
+
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print.inst.cfg
@@ -33,3 +33,6 @@ infill_sparse_density = 15
 layer_height_0 = 0.2
 acceleration_wall = 2000
 acceleration_wall_0 = 2000
+
+raft_airgap = 0.25
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print.inst.cfg
@@ -29,3 +29,6 @@ wall_thickness = 1
 jerk_travel = 50
 infill_line_width = =round(line_width * 0.42 / 0.35, 2)
 layer_height_0 = 0.2
+
+raft_airgap = 0.25
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_High_Quality.inst.cfg
@@ -31,3 +31,6 @@ wall_thickness = 1
 jerk_travel = 50
 infill_line_width = =round(line_width * 0.42 / 0.35, 2)
 layer_height_0 = 0.2
+
+raft_airgap = 0.25
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -27,3 +27,6 @@ wall_thickness = 1
 jerk_travel = 50
 infill_line_width = =round(line_width * 0.42 / 0.35, 2)
 layer_height_0 = 0.2
+
+raft_airgap = 0.25
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Draft_Print.inst.cfg
@@ -29,3 +29,5 @@ wall_thickness = 1
 infill_line_width = =round(line_width * 0.4 / 0.35, 2)
 speed_infill = =math.ceil(speed_print * 50 / 60)
 
+raft_airgap = 0.15
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Fast_Print.inst.cfg
@@ -28,3 +28,5 @@ speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
 infill_line_width = =round(line_width * 0.4 / 0.35, 2)
 speed_infill = =math.ceil(speed_print * 45 / 60)
 
+raft_airgap = 0.15
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_High_Quality.inst.cfg
@@ -27,3 +27,5 @@ speed_wall = =math.ceil(speed_print * 30 / 50)
 infill_line_width = =round(line_width * 0.4 / 0.35, 2)
 speed_infill = =math.ceil(speed_print * 40 / 50)
 
+raft_airgap = 0.15
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_ABS_Normal_Quality.inst.cfg
@@ -25,3 +25,5 @@ speed_wall = =math.ceil(speed_print * 30 / 55)
 
 infill_line_width = =round(line_width * 0.4 / 0.35, 2)
 speed_infill = =math.ceil(speed_print * 40 / 55)
+raft_airgap = 0.15
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Draft_Print.inst.cfg
@@ -36,3 +36,6 @@ switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
 
 jerk_travel = 50
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Fast_Print.inst.cfg
@@ -36,3 +36,6 @@ switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
 
 jerk_travel = 50
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_High_Quality.inst.cfg
@@ -35,3 +35,6 @@ switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
 
 jerk_travel = 50
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_Nylon_Normal_Quality.inst.cfg
@@ -35,3 +35,6 @@ switch_extruder_retraction_speeds = 40
 wall_line_width_x = =wall_line_width
 
 jerk_travel = 50
+raft_airgap = 0.4
+raft_surface_speed = 45
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
@@ -34,3 +34,5 @@ infill_sparse_density = 15
 layer_height_0 = 0.2
 acceleration_wall = 2000
 acceleration_wall_0 = 2000
+raft_airgap = 0.25
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
@@ -29,3 +29,5 @@ wall_thickness = 1
 jerk_travel = 50
 infill_line_width = =round(line_width * 0.42 / 0.35, 2)
 layer_height_0 = 0.2
+raft_airgap = 0.25
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
@@ -31,3 +31,5 @@ wall_thickness = 1
 jerk_travel = 50
 infill_line_width = =round(line_width * 0.42 / 0.35, 2)
 layer_height_0 = 0.2
+raft_airgap = 0.25
+speed_layer_0 = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -27,3 +27,5 @@ wall_thickness = 1
 jerk_travel = 50
 infill_line_width = =round(line_width * 0.42 / 0.35, 2)
 layer_height_0 = 0.2
+raft_airgap = 0.25
+speed_layer_0 = 10


### PR DESCRIPTION
These settings are optimized by Coen who was doing his internship project on raft release strategy for PLA, Nylon and ABS for AA0.4 print core for UMS3 and UMS5 printers.

![image](https://user-images.githubusercontent.com/58853962/98000984-65f5e300-1ded-11eb-9651-50c18deec40b.png)


