### PR TITLE
Remove the reset of one_at_a_time on extruder switch

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -162,7 +162,8 @@ class BuildVolume(SceneNode):
             self.rebuild()
 
             self._scene_objects = new_scene_objects
-            self._onSettingPropertyChanged("print_sequence", "value")  # Create fake event, so right settings are triggered.
+            self._onSettingPropertyChanged("print_sequence", "value")
+            self._onSettingPropertyChanged("extruders_enabled_count", "value")  # Create fake event, so right settings are triggered.
 
     def _updateNodeListeners(self, node: SceneNode):
         """Updates the listeners that listen for changes in per-mesh stacks.
@@ -627,7 +628,7 @@ class BuildVolume(SceneNode):
 
             self._width = self._global_container_stack.getProperty("machine_width", "value")
             machine_height = self._global_container_stack.getProperty("machine_height", "value")
-            if self._global_container_stack.getProperty("print_sequence", "value") == "one_at_a_time" and len(self._scene_objects) > 1:
+            if self._global_container_stack.isInOneAtATimeMode() and len(self._scene_objects) > 1:
                 self._height = min(self._global_container_stack.getProperty("gantry_height", "value"), machine_height)
                 if self._height < machine_height:
                     self._build_volume_message.show()
@@ -667,9 +668,9 @@ class BuildVolume(SceneNode):
         update_extra_z_clearance = True
 
         for setting_key in self._changed_settings_since_last_rebuild:
-            if setting_key == "print_sequence":
+            if setting_key == "print_sequence" or setting_key == "extruders_enabled_count":
                 machine_height = self._global_container_stack.getProperty("machine_height", "value")
-                if self._application.getGlobalContainerStack().getProperty("print_sequence", "value") == "one_at_a_time" and len(self._scene_objects) > 1:
+                if self._application.getGlobalContainerStack().isInOneAtATimeMode() and len(self._scene_objects) > 1:
                     self._height = min(self._global_container_stack.getProperty("gantry_height", "value"), machine_height)
                     if self._height < machine_height:
                         self._build_volume_message.show()
@@ -1151,7 +1152,7 @@ class BuildVolume(SceneNode):
         used_extruders = ExtruderManager.getInstance().getUsedExtruderStacks()
 
         # If we are printing one at a time, we need to add the bed adhesion size to the disallowed areas of the objects
-        if container_stack.getProperty("print_sequence", "value") == "one_at_a_time":
+        if container_stack.isInOneAtATimeMode():
             return 0.1
 
         bed_adhesion_size = self._calculateBedAdhesionSize(used_extruders)

--- a/cura/Scene/ConvexHullDecorator.py
+++ b/cura/Scene/ConvexHullDecorator.py
@@ -387,7 +387,7 @@ class ConvexHullDecorator(SceneNodeDecorator):
         result = convex_hull
         if scale_factor != 1.0 and not self.getNode().callDecoration("isGroup"):
             center = None
-            if self._global_stack.getProperty("print_sequence", "value") == "one_at_a_time":
+            if self._global_stack.isInOneAtATimeMode():
                 # Find the root node that's placed in the scene; the root of the mesh group.
                 ancestor = self.getNode()
                 while ancestor.getParent() != self._root:
@@ -491,11 +491,11 @@ class ConvexHullDecorator(SceneNodeDecorator):
         if self._node is None:
             return False
         return self._global_stack is not None \
-            and self._global_stack.getProperty("print_sequence", "value") == "one_at_a_time" \
+            and self._global_stack.isInOneAtATimeMode() \
             and not self.hasGroupAsParent(self._node)
 
     _affected_settings = [
-        "adhesion_type", "raft_margin", "print_sequence",
+        "adhesion_type", "raft_margin", "print_sequence", "extruders_enabled_count",
         "skirt_gap", "skirt_line_count", "skirt_brim_line_width", "skirt_distance", "brim_line_count"]
 
     _influencing_settings = {"xy_offset", "xy_offset_layer_0", "mold_enabled", "mold_width", "anti_overhang_mesh", "infill_mesh", "cutting_mesh", "material_shrinkage_percentage"}

--- a/cura/Settings/GlobalStack.py
+++ b/cura/Settings/GlobalStack.py
@@ -301,6 +301,16 @@ class GlobalStack(CuraContainerStack):
                 return False
         return True
 
+    def isInOneAtATimeMode(self) -> bool:
+        """
+        Gets whether the one-at-a-time mode is activated, provided that there is only one active extruder
+        """
+        one_at_a_time_mode_is_active = self.getProperty("print_sequence", "value") == "one_at_a_time"
+        extruders_enabled_count = self.definitionChanges.getProperty("extruders_enabled_count", "value")
+        if extruders_enabled_count:
+            one_at_a_time_mode_is_active &= extruders_enabled_count == 1
+        return one_at_a_time_mode_is_active
+
     def getHeadAndFansCoordinates(self):
         return self.getProperty("machine_head_with_fans_polygon", "value")
 

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -823,14 +823,10 @@ class MachineManager(QObject):
         if self._global_container_stack is None:
             return []
         extruder_count = self._global_container_stack.getProperty("machine_extruder_count", "value")
+
         result = []  # type: List[str]
         for setting_instance in container.findInstances():
             setting_key = setting_instance.definition.key
-            if setting_key == "print_sequence":
-                old_value = container.getProperty(setting_key, "value")
-                Logger.log("d", "Reset setting [%s] in [%s] because its old value [%s] is no longer valid", setting_key, container, old_value)
-                result.append(setting_key)
-                continue
             if not self._global_container_stack.getProperty(setting_key, "type") in ("extruder", "optional_extruder"):
                 continue
 

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -201,7 +201,7 @@ class StartSliceJob(Job):
 
         # Get the objects in their groups to print.
         object_groups = []
-        if stack.getProperty("print_sequence", "value") == "one_at_a_time" and stack.getProperty("print_sequence", "enabled"):
+        if stack.isInOneAtATimeMode():
             for node in OneAtATimeIterator(self._scene.getRoot()):
                 temp_list = []
 

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -201,7 +201,7 @@ class StartSliceJob(Job):
 
         # Get the objects in their groups to print.
         object_groups = []
-        if stack.getProperty("print_sequence", "value") == "one_at_a_time":
+        if stack.getProperty("print_sequence", "value") == "one_at_a_time" and stack.getProperty("print_sequence", "enabled"):
             for node in OneAtATimeIterator(self._scene.getRoot()):
                 temp_list = []
 


### PR DESCRIPTION
Instead solve it by ensuring that the order of the models isn't
changed if the setting is disabled

Fixes #8682

CURA-7827