### PR TITLE
Fix tooltips on actionbuttons

### DIFF
--- a/resources/qml/ToolTip.qml
+++ b/resources/qml/ToolTip.qml
@@ -34,6 +34,9 @@ ToolTip
         NumberAnimation { duration: 100; }
     }
 
+    onAboutToShow: show()
+    onAboutToHide: hide()
+
     // If the text is not set, just set the height to 0 to prevent it from showing
     height: text != "" ? label.contentHeight + 2 * UM.Theme.getSize("thin_margin").width: 0
 


### PR DESCRIPTION
This PR fixes tooltips on ActionButtons such as the buttons that constitute the toolbar and buttons in the ActionPanel etc. The tooltips were broken in 5f574d4b64ab0114b19b843acbc70e006bbe69d1, and this PR applies a fix on top of that. I am not entirely sure what the original commit was meant to fix, so there may be a more direct way to fix the tooltips than this roundabout fix.