### PR TITLE
CURA-7751: Simplify arachne toolpaths

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6130,11 +6130,11 @@
                 "meshfix_maximum_extrusion_area_deviation":
                 {
                     "label": "Maximum Extrusion Area Deviation",
-                    "description": "The maximum deviation allowed when reducing the resolution for the Maximum Resolution setting. If you increase this, the print will be less accurate, but the g-code will be smaller. Maximum Deviation is a limit for Maximum Resolution, so if the two conflict the Maximum Deviation will always be held true.",
+                    "description": "The maximum extrusion area deviation allowed when removing intermediate points from a straight line. An intermediate point may serve as width-changing point in a long straight line. Therefore, if it is removed, it will cause the line to have a uniform width and, as a result, lose (or gain) a bit of extrusion area. If you increase this you may notice slight under- (or over-) extrusion in between straight parallel walls, as more intermediate width-changing points will be allowed to be removed. Your print will be less accurate, but the g-code will be smaller.",
                     "type": "float",
                     "unit": "mm²",
                     "default_value": 2,
-                    "minimum_value": "0.001",
+                    "minimum_value": "0",
                     "minimum_value_warning": "0.01",
                     "maximum_value_warning": "10",
                     "settable_per_mesh": true

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6132,11 +6132,11 @@
                     "label": "Maximum Extrusion Area Deviation",
                     "description": "The maximum extrusion area deviation allowed when removing intermediate points from a straight line. An intermediate point may serve as width-changing point in a long straight line. Therefore, if it is removed, it will cause the line to have a uniform width and, as a result, lose (or gain) a bit of extrusion area. If you increase this you may notice slight under- (or over-) extrusion in between straight parallel walls, as more intermediate width-changing points will be allowed to be removed. Your print will be less accurate, but the g-code will be smaller.",
                     "type": "float",
-                    "unit": "mm²",
-                    "default_value": 2,
+                    "unit": "μm²",
+                    "default_value": 2000,
                     "minimum_value": "0",
-                    "minimum_value_warning": "0.01",
-                    "maximum_value_warning": "10",
+                    "minimum_value_warning": "500",
+                    "maximum_value_warning": "100000",
                     "settable_per_mesh": true
                 }
             }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6126,6 +6126,18 @@
                     "minimum_value_warning": "0.01",
                     "maximum_value_warning": "0.3",
                     "settable_per_mesh": true
+                },
+                "meshfix_maximum_extrusion_area_deviation":
+                {
+                    "label": "Maximum Extrusion Area Deviation",
+                    "description": "The maximum deviation allowed when reducing the resolution for the Maximum Resolution setting. If you increase this, the print will be less accurate, but the g-code will be smaller. Maximum Deviation is a limit for Maximum Resolution, so if the two conflict the Maximum Deviation will always be held true.",
+                    "type": "float",
+                    "unit": "mm²",
+                    "default_value": 2,
+                    "minimum_value": "0.001",
+                    "minimum_value_warning": "0.01",
+                    "maximum_value_warning": "10",
+                    "settable_per_mesh": true
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6136,7 +6136,7 @@
                     "default_value": 2000,
                     "minimum_value": "0",
                     "minimum_value_warning": "500",
-                    "maximum_value_warning": "100000",
+                    "maximum_value_warning": "5000",
                     "settable_per_mesh": true
                 }
             }

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -330,6 +330,7 @@ meshfix_keep_open_polygons
 meshfix_maximum_resolution
 meshfix_maximum_travel_resolution
 meshfix_maximum_deviation
+meshfix_maximum_extrusion_area_deviation
 multiple_mesh_overlap
 carve_multiple_volumes
 alternate_carve_order


### PR DESCRIPTION
Adds a new setting called "Maximum Extrusion Area Deviation", which tells the simplification algorithm what is the maximum allowed extrusion area error when removing intermediate junctions from a straight ExtrusionLine.

![image](https://user-images.githubusercontent.com/19388042/99815857-2ea46780-2b4b-11eb-9d65-a964969cc86b.png)

A few bench(y)marks and statistics of the simplification of colinear segments:

|    | Benchy |
| ------------- | ------------- |
| Total candidate points checked  | 445834 |
| Area deviation Error == 0μm²  | 382422  |
| Area deviation Error in range (0mm², 500μm²]  | 41977 |
| Area deviation Error in range (500mm², 1000μm²]  | 11910 |
| Area deviation Error in range (1000μm², 2000μm²] | 5657 |
| Area deviation Error in range (2000μm², 3000μm²] | 1390 |
| Area deviation Error in range (3000μm², 4000μm²] | 1017 |
| Area deviation Error in range (4000μm², 5000μm²] | 624 |
| Area deviation Error in range (5000μm², 10000μm²] | 589 |
| Area deviation Error in range (10000μm², 50000μm²] | 232 |
| Area deviation Error in range (50000μm², ] | 16 |


"Area deviation Error" distribution of colinear segments in the range (0, 10000]
![image](https://user-images.githubusercontent.com/19388042/99819641-ffdcc000-2b4f-11eb-924c-be12c4a8a5e3.png)

As an example, if an area error of ~2500μm² is allowed, it will lead to the following difference after removing the middle point(left, unsimplified, right simplified). 
 
![image](https://user-images.githubusercontent.com/19388042/99825834-d889f100-2b57-11eb-8a58-169b0dedb437.png)

The difference is barely noticeable when zooming that far.

On the other hand, when an area error of ~5000μm² is allowed by the setting, the difference is way more noticeable:
![6_0benchy_area_error5000_289_comparison](https://user-images.githubusercontent.com/19388042/99826339-84cbd780-2b58-11eb-9605-a156159f4857.png)

As a result, the default value for the setting is selected at 2000μm², while the maximum value warning is set to 5000μm².

| Benchy GCode file size without simplification | Benchy GCode file size with simplification (error = 2000μm²)  |
| ------------- | ------------- |
| 26MB  | 13MB |

Requires https://github.com/Ultimaker/CuraEngine/pull/1360.

CURA-7751