### PR TITLE
CURA-7678: Remove inset usage

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6674,7 +6674,7 @@
                     "description": "Jitter only the parts' outlines and not the parts' holes.",
                     "type": "bool",
                     "default_value": false,
-                    "enabled": "magic_fuzzy_skin_enabled and false" ,
+                    "enabled": "magic_fuzzy_skin_enabled and False" ,
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
                 },
@@ -6687,7 +6687,7 @@
                     "default_value": 0.3,
                     "minimum_value": "0.001",
                     "maximum_value_warning": "wall_line_width_0",
-                    "enabled": "magic_fuzzy_skin_enabled and false",
+                    "enabled": "magic_fuzzy_skin_enabled and False",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
                 },
@@ -6702,7 +6702,7 @@
                     "minimum_value_warning": "0.1",
                     "maximum_value_warning": "10",
                     "maximum_value": "2 / magic_fuzzy_skin_thickness",
-                    "enabled": "magic_fuzzy_skin_enabled and false",
+                    "enabled": "magic_fuzzy_skin_enabled and False",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true,
                     "children":
@@ -6718,7 +6718,7 @@
                             "minimum_value_warning": "0.1",
                             "maximum_value_warning": "10",
                             "value": "10000 if magic_fuzzy_skin_point_density == 0 else 1 / magic_fuzzy_skin_point_density",
-                            "enabled": "magic_fuzzy_skin_enabled and false",
+                            "enabled": "magic_fuzzy_skin_enabled and False",
                             "limit_to_extruder": "wall_0_extruder_nr",
                             "settable_per_mesh": true
                         }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6665,6 +6665,7 @@
                     "type": "bool",
                     "default_value": false,
                     "limit_to_extruder": "wall_0_extruder_nr",
+                    "enabled": false,
                     "settable_per_mesh": true
                 },
                 "magic_fuzzy_skin_outside_only":
@@ -6673,7 +6674,7 @@
                     "description": "Jitter only the parts' outlines and not the parts' holes.",
                     "type": "bool",
                     "default_value": false,
-                    "enabled": "magic_fuzzy_skin_enabled",
+                    "enabled": "magic_fuzzy_skin_enabled and false" ,
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
                 },
@@ -6686,7 +6687,7 @@
                     "default_value": 0.3,
                     "minimum_value": "0.001",
                     "maximum_value_warning": "wall_line_width_0",
-                    "enabled": "magic_fuzzy_skin_enabled",
+                    "enabled": "magic_fuzzy_skin_enabled and false",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
                 },
@@ -6701,7 +6702,7 @@
                     "minimum_value_warning": "0.1",
                     "maximum_value_warning": "10",
                     "maximum_value": "2 / magic_fuzzy_skin_thickness",
-                    "enabled": "magic_fuzzy_skin_enabled",
+                    "enabled": "magic_fuzzy_skin_enabled and false",
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true,
                     "children":
@@ -6717,7 +6718,7 @@
                             "minimum_value_warning": "0.1",
                             "maximum_value_warning": "10",
                             "value": "10000 if magic_fuzzy_skin_point_density == 0 else 1 / magic_fuzzy_skin_point_density",
-                            "enabled": "magic_fuzzy_skin_enabled",
+                            "enabled": "magic_fuzzy_skin_enabled and false",
                             "limit_to_extruder": "wall_0_extruder_nr",
                             "settable_per_mesh": true
                         }


### PR DESCRIPTION
Since the insets are going to be removed from CuraEngine, some settings will no longer work until they are adapted to use the libArachne toolpaths. At the moment the following settings are disabled:

- Fuzzy Skin
- Fuzzy Skin Outside Only
- Fuzzy Skin Thickness
- Fuzzy Skin Density
- Fuzzy Skin Point Distance

Merge along with https://github.com/Ultimaker/CuraEngine/pull/1364.

CURA-7678