### PR TITLE
Add new specialised settings for variable line width

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1092,6 +1092,18 @@
                     "maximum_value_warning": "50",
                     "maximum_value": "59"
                 },
+                "wall_transition_filter_distance":
+                {
+                    "label": "Wall Transition Distance Filter",
+                    "description": "If it would be transitioning back and forth between different numbers of walls in quick succession, don't transition at all. Remove transitions if they are closer together than this distance.",
+                    "type": "float",
+                    "unit": "mm",
+                    "default_value": 0.7,
+                    "value": "2 * math.cos(wall_transition_angle / 180 * math.pi) * wall_line_width_x",
+                    "minimum_value": "wall_transition_length",
+                    "minimum_value_warning": "math.cos(wall_transition_angle / 180 * math.pi) * wall_line_width_x",
+                    "maximum_value_warning": "8 * math.cos(wall_transition_angle / 180 * math.pi) * wall_line_width_x"
+                },
                 "wall_0_wipe_dist":
                 {
                     "label": "Outer Wall Wipe Distance",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1067,6 +1067,18 @@
                     "default_value": "inward_distributed",
                     "limit_to_extruder": "wall_0_extruder_nr"
                 },
+                "wall_transition_threshold":
+                {
+                    "label": "Minimum Variable Line Width",
+                    "description": "The smallest line width, as a factor of the normal line width, beyond which it will choose to use fewer, but wider lines to fill the available space. Reduce this threshold to use more, thinner lines. Increase to use fewer, wider lines.",
+                    "type": "float",
+                    "unit": "%",
+                    "default_value": 50,
+                    "minimum_value": "1",
+                    "minimum_value_warning": "min_bead_width / line_width * 100",
+                    "maximum_value_warning": "75",
+                    "maximum_value": "100"
+                },
                 "wall_transition_length":
                 {
                     "label": "Wall Transition Length",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1056,7 +1056,7 @@
                 "beading_strategy_type":
                 {
                     "label": "Variable Line Strategy",
-                    "description": "Beading strategy used by libArachne to generate walls.",
+                    "description": "Strategy to use to print the width of a part with a number of walls. This determines how many walls it will use for a certain total width, and how wide each of these lines are. \"Center Deviation\" will print all walls at the nominal line width except the central one(s), causing big variations in the center but very consistent outsides. \"Distributed\" distributes the width equally over all walls. \"Inward Distributed\" is a balance between the other two, distributing the changes in width over all walls but keeping the walls on the outside slightly more consistent.",
                     "type": "enum",
                     "options":
                     {

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1067,6 +1067,19 @@
                     "default_value": "inward_distributed",
                     "limit_to_extruder": "wall_0_extruder_nr"
                 },
+                "wall_transition_length":
+                {
+                    "label": "Wall Transition Length",
+                    "description": "When transitioning between different numbers of walls as the part becomes thinner, a certain amount of space is allotted to split or join the wall lines.",
+                    "type": "float",
+                    "unit": "mm",
+                    "default_value": 0.4,
+                    "value": "line_width",
+                    "minimum_value": "0.001",
+                    "minimum_value_warning": "0.5 * line_width",
+                    "maximum_value_warning": "2 * line_width",
+                    "maximum_value": "min_bead_width * 3 * math.pi"
+                },
                 "wall_0_wipe_dist":
                 {
                     "label": "Outer Wall Wipe Distance",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1080,6 +1080,18 @@
                     "maximum_value_warning": "2 * line_width",
                     "maximum_value": "min_bead_width * 3 * math.pi"
                 },
+                "wall_transition_angle":
+                {
+                    "label": "Wall Transition Angle",
+                    "description": "When transitioning between different numbers of walls as the part becomes thinner, two adjacent walls will join together at this angle. This can make the walls come together faster than what the Wall Transition Length indicates, filling the space better.",
+                    "type": "float",
+                    "unit": "°",
+                    "default_value": 30,
+                    "minimum_value": "1",
+                    "minimum_value_warning": "15",
+                    "maximum_value_warning": "50",
+                    "maximum_value": "59"
+                },
                 "wall_0_wipe_dist":
                 {
                     "label": "Outer Wall Wipe Distance",


### PR DESCRIPTION
This change adds a number of settings for things that were initially hard-coded in the variable line width code. In some cases the value is still hard-coded but updated to a more sensible value.

These are the variables that have been considered for this change:
* Wall Transition Length: This is a new setting that determines how much space is used to transition from one bead count to another. Instead of the previously suggested % of nozzle size, the default and warning values are now % of line width. The maximum is chosen based on what could theoretically result in loops within one transition. Experimentally though this doesn't seem to be a problem. What is a problem is that we get all sorts of assertion failures at extreme values of this setting. This causes some lines to be missing. These bugs will be handled in a different ticket.
* Wall Transition Angle: This is a new setting that determines the angle at which lines come together around a transition. The suggested default of 30 degrees has been used. The lower warning value is set to 5 degrees less than the lower bound suggested for the default ("20 - 30"). The upper warning value is set to what was suggested for a "perfect" printer.
* discretization_step_size: I opted to keep this hard-coded but just update the hard-coded value (so no change in this PR). The effect on the resulting print is very minimal and can only be found on some models if you know where to look.
* Wall Transition Filter Distance: This is a new setting that determines when two transitions are merged together to reduce the oscillating transitions effect. Instead of the suggested "cosine of transition length" I've used twice that amount, theorising that this is what you'd need to transition completely to one less bead size and then one more bead size. The minimum is exactly what was suggested, which turns out to also be what about originally the suggested default was. For my extreme test model it was desirable to turn this way up, but that might have a negative effect on other prints I didn't test with so I think this is a reasonable default. Definitely a setting that our print engineers should pay attention to.
* beading_propagation_transition_dist: I've made this previously hard-coded value scale along with the transition length, as suggested.
* Minimum Variable Line Width: This is a completely new feature for something that was previously hard-coded. It was explicitly hard-coded for the Center Deviation strategy, and sort of implicitly hard-coded for the other two strategies. It serves as a threshold of line width, as to when it chooses to reduce the number of lines rather than reduce the line width further. I don't think the actual value of this setting is great, but it feels like something you should be able to tune so the psychological value is great. It's not that hard to understand as far as settings go.
* Hardcoded `Point(50, 0)` in `generateLocalMaximaSingleBeads`: Not considered to be within scope.

Implements CURA-7686.

This PR belongs to a PR in CuraEngine that implements these settings: https://github.com/Ultimaker/CuraEngine/pull/1372