### PR TITLE
Remove use of `support_tree_enable` setting in UM 2+ Connect profiles

### DIFF
--- a/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.4_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.4_draft.inst.cfg
@@ -34,7 +34,7 @@ speed_wall_0 = =math.ceil(speed_print * 20 / 25)
 speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.26
 top_bottom_thickness = 1.5

--- a/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.4_normal.inst.cfg
@@ -34,7 +34,7 @@ speed_wall_0 = =math.ceil(speed_print * 20 / 35)
 speed_wall_x = =math.ceil(speed_print * 30 / 35)
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.26
 top_bottom_thickness = 1.5

--- a/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.6_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.6_draft.inst.cfg
@@ -36,7 +36,7 @@ speed_wall_0 = =math.ceil(speed_print * 20 / 25)
 speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_line_distance = 2.85
 support_pattern = lines
 support_xy_distance = 0.6

--- a/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.6_normal.inst.cfg
@@ -36,7 +36,7 @@ speed_wall_0 = =math.ceil(speed_print * 30 / 35)
 speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_line_distance = 2.85
 support_pattern = lines
 support_xy_distance = 0.6

--- a/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.8_draft.inst.cfg
@@ -33,7 +33,7 @@ speed_wall_0 = =math.ceil(speed_print * 20 / 25)
 speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.26
 top_bottom_thickness = 1.2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_cpep_0.8_normal.inst.cfg
@@ -33,7 +33,7 @@ speed_wall_0 = =math.ceil(speed_print * 20 / 30)
 speed_wall_x = =speed_print
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.26
 top_bottom_thickness = 1.2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.25_high.inst.cfg
@@ -34,7 +34,7 @@ speed_travel = 150
 speed_wall_0 = =math.ceil(speed_print * 20 / 40)
 speed_wall_x = =speed_print
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_xy_distance = 0.6
 support_z_distance = =layer_height * 2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.25_normal.inst.cfg
@@ -34,7 +34,7 @@ speed_travel = 150
 speed_wall_0 = =math.ceil(speed_print * 20 / 40)
 speed_wall_x = =speed_print
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_xy_distance = 0.6
 support_z_distance = =layer_height * 2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.4_fast.inst.cfg
@@ -33,7 +33,7 @@ speed_travel = 150
 speed_wall = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
-support_infill_rate = =25 if support_enable else 0 if support_tree_enable else 25
+support_infill_rate = =25 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_xy_distance = 0.6
 support_z_distance = =layer_height * 2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.4_normal.inst.cfg
@@ -32,7 +32,7 @@ speed_travel = 150
 speed_wall = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
-support_infill_rate = =25 if support_enable else 0 if support_tree_enable else 25
+support_infill_rate = =25 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_xy_distance = 0.6
 support_z_distance = =layer_height * 2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.6_fast.inst.cfg
@@ -37,7 +37,7 @@ speed_wall_x = =math.ceil(speed_print * 40 / 55)
 support_angle = 45
 support_bottom_distance = 0.55
 support_enable = True
-support_infill_rate = =25 if support_enable else 0 if support_tree_enable else 25
+support_infill_rate = =25 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_top_distance = 0.55
 support_xy_distance = 0.7

--- a/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.6_normal.inst.cfg
@@ -36,7 +36,7 @@ speed_wall_0 = =math.ceil(speed_print * 15 / 55)
 speed_wall_x = =math.ceil(speed_print * 40 / 55)
 support_angle = 45
 support_enable = True
-support_infill_rate = =25 if support_enable else 0 if support_tree_enable else 25
+support_infill_rate = =25 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_xy_distance = 0.7
 support_z_distance = =layer_height * 2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.8_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.8_draft.inst.cfg
@@ -36,7 +36,7 @@ speed_wall_x = =math.ceil(speed_print * 40 / 55)
 support_angle = 45
 support_bottom_distance = 0.65
 support_enable = True
-support_infill_rate = =25 if support_enable else 0 if support_tree_enable else 25
+support_infill_rate = =25 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_top_distance = 0.5
 support_xy_distance = 0.75

--- a/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_nylon_0.8_normal.inst.cfg
@@ -36,7 +36,7 @@ speed_wall_x = =math.ceil(speed_print * 40 / 55)
 support_angle = 45
 support_bottom_distance = 0.65
 support_enable = True
-support_infill_rate = =25 if support_enable else 0 if support_tree_enable else 25
+support_infill_rate = =25 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_top_distance = 0.5
 support_xy_distance = 0.75

--- a/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.25_high.inst.cfg
@@ -30,7 +30,7 @@ raft_surface_line_width = 0.2
 speed_layer_0 = =round(speed_print * 30 / 30)
 speed_print = 30
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.19
 wall_thickness = 0.88

--- a/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.25_normal.inst.cfg
@@ -30,7 +30,7 @@ raft_surface_line_width = 0.2
 speed_layer_0 = =round(speed_print * 30 / 30)
 speed_print = 30
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.19
 wall_thickness = 0.88

--- a/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.4_fast.inst.cfg
@@ -31,7 +31,7 @@ speed_wall_0 = =math.ceil(speed_print * 20 / 45)
 speed_wall_x = =math.ceil(speed_print * 30 / 45)
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.19
 wall_thickness = 1.2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.4_normal.inst.cfg
@@ -31,7 +31,7 @@ speed_wall_0 = =math.ceil(speed_print * 20 / 45)
 speed_wall_x = =math.ceil(speed_print * 30 / 45)
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.19
 wall_thickness = 1.2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.6_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.6_fast.inst.cfg
@@ -35,7 +35,7 @@ speed_wall_0 = =math.ceil(speed_print * 30 / 45)
 speed_wall_x = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_line_distance = 3.5333
 support_pattern = lines
 support_z_distance = 0.21

--- a/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.6_normal.inst.cfg
@@ -35,7 +35,7 @@ speed_wall_0 = =math.ceil(speed_print * 30 / 45)
 speed_wall_x = =math.ceil(speed_print * 40 / 45)
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_line_distance = 3.5333
 support_pattern = lines
 support_z_distance = 0.21

--- a/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_pc_0.8_normal.inst.cfg
@@ -30,7 +30,7 @@ speed_layer_0 = =round(speed_print * 30 / 40)
 speed_print = 40
 support_angle = 45
 support_enable = True
-support_infill_rate = =20 if support_enable else 0 if support_tree_enable else 20
+support_infill_rate = =20 if support_enable and support_structure != "tree" else 0
 support_pattern = lines
 support_z_distance = 0.26
 top_bottom_thickness = 1.2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_tpu_0.25_high.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_tpu_0.25_high.inst.cfg
@@ -35,7 +35,7 @@ speed_wall_0 = =math.ceil(speed_print * 15 / 40)
 speed_wall_x = =math.ceil(speed_print * 38 / 40)
 support_angle = 45
 support_enable = True
-support_infill_rate = =25 if support_enable else 0 if support_tree_enable else 25
+support_infill_rate = =25 if support_enable and support_structure != "tree" else 0
 support_xy_distance = 0.6
 support_z_distance = =layer_height * 2
 top_bottom_thickness = 1.2

--- a/resources/quality/ultimaker2_plus_connect/um2pc_tpu_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_tpu_0.4_normal.inst.cfg
@@ -33,7 +33,7 @@ speed_wall_0 = =math.ceil(speed_print * 20 / 40)
 speed_wall_x = =math.ceil(speed_print * 35 / 40)
 support_angle = 45
 support_enable = True
-support_infill_rate = =25 if support_enable else 0 if support_tree_enable else 25
+support_infill_rate = =25 if support_enable and support_structure != "tree" else 0
 support_xy_distance = 0.65
 support_z_distance = =layer_height * 2
 top_bottom_thickness = 1.2


### PR DESCRIPTION
This PR fixes the UM 2+ Connect profiles that were published in 1927f78d5a1124f3a3dda8a90e170c1714ac70c1 containing references to a setting that no longer exists. The `support_tree_enable` setting was removed in Cura 4.7, and instead uses the `support_enable` and `support_structure` settings.