### PR TITLE
Fix validator for floats in Machine Settings dialog

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml
@@ -137,6 +137,7 @@ Item
                 labelWidth: base.labelWidth
                 controlWidth: base.controlWidth
                 unitText: ""
+                decimals: 0
                 forceUpdateOnChangeFunction: forceUpdateFunction
             }
         }

--- a/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
+++ b/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
@@ -156,12 +156,24 @@ UM.TooltipArea
             const value = propertyProvider.properties.value
             return value ? value : ""
         }
-        validator: DoubleValidator
+        property string validatorString:
         {
-            bottom: numericTextFieldWithUnit.minimum
-            top: numericTextFieldWithUnit.maximum
-            decimals: numericTextFieldWithUnit.decimals
-            notation: DoubleValidator.StandardNotation
+            var digits = Math.min(8, 1 + Math.floor(
+                Math.log(Math.max(Math.abs(numericTextFieldWithUnit.maximum), Math.abs(numericTextFieldWithUnit.minimum)))/Math.log(10)
+            ))
+            var minus = numericTextFieldWithUnit.minimum < 0 ? "-?" : ""
+            if (numericTextFieldWithUnit.decimals == 0)
+            {
+                return "^%0\\d{1,%1}$".arg(minus).arg(digits)
+            }
+            else
+            {
+                return "^%0\\d{0,%1}[.,]?\\d{0,%2}$".arg(minus).arg(digits).arg(numericTextFieldWithUnit.decimals)
+            }
+        }
+        validator: RegExpValidator
+        {
+            regExp: new RegExp(textFieldWithUnit.validatorString)
         }
 
         //Enforce actual minimum and maximum values.


### PR DESCRIPTION
This PR fixes the issue that users of some system locales have to enter nozzle and material diameters with a comma instead of a decimal dot.

The DoubleValidator depends on the system locale, requiring users with certain locales to enter floats with a comma instead of a dot (though confusingly floats are always represented with a decimal a dot). Instead of configuring the DoubleValidator with a locale that only accepts decimal dots, this commit uses a RegExpValidator, like other numeric fields in Cura does.

Fixes #6546