### PR TITLE
Fix definition of machine_gcode_flavor setting in PauseAtHeight

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -182,8 +182,7 @@ class PauseAtHeight(Script):
                         "Repetier": "Repetier"
                     },
                     "default_value": "RepRap (Marlin/Sprinter)",
-                    "enabled": false,
-                    "default_value": ""
+                    "enabled": false
                 },
                 "custom_gcode_before_pause":
                 {


### PR DESCRIPTION
This PR fixes the json definition of the PauseAtHeight script, which contained a double declaration of the default value for the machine_gcode_flavor setting.