### PR TITLE
Adapt to Python 3.9 API changes

### DIFF
--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -151,7 +151,7 @@ class XmlMaterialProfile(InstanceContainer):
                               "version": self.CurrentFdmMaterialVersion})
 
         ## Begin Metadata Block
-        builder.start("metadata") # type: ignore
+        builder.start("metadata", {}) # type: ignore
 
         metadata = copy.deepcopy(self.getMetaData())
         # setting_version is derived from the "version" tag in the schema, so don't serialize it into a file
@@ -165,21 +165,21 @@ class XmlMaterialProfile(InstanceContainer):
         properties = metadata.pop("properties", {})
 
         ## Begin Name Block
-        builder.start("name") # type: ignore
+        builder.start("name", {}) # type: ignore
 
-        builder.start("brand") # type: ignore
+        builder.start("brand", {}) # type: ignore
         builder.data(metadata.pop("brand", ""))
         builder.end("brand")
 
-        builder.start("material") # type: ignore
+        builder.start("material", {}) # type: ignore
         builder.data(metadata.pop("material", ""))
         builder.end("material")
 
-        builder.start("color") # type: ignore
+        builder.start("color", {}) # type: ignore
         builder.data(metadata.pop("color_name", ""))
         builder.end("color")
 
-        builder.start("label") # type: ignore
+        builder.start("label", {}) # type: ignore
         builder.data(self.getName())
         builder.end("label")
 
@@ -190,7 +190,7 @@ class XmlMaterialProfile(InstanceContainer):
             key_to_use = key
             if key in self._metadata_tags_that_have_cura_namespace:
                 key_to_use = "cura:" + key_to_use
-            builder.start(key_to_use) # type: ignore
+            builder.start(key_to_use, {}) # type: ignore
             if value is not None: #Nones get handled well by the builder.
                 #Otherwise the builder always expects a string.
                 #Deserialize expects the stringified version.
@@ -202,10 +202,10 @@ class XmlMaterialProfile(InstanceContainer):
         ## End Metadata Block
 
         ## Begin Properties Block
-        builder.start("properties") # type: ignore
+        builder.start("properties", {}) # type: ignore
 
         for key, value in properties.items():
-            builder.start(key) # type: ignore
+            builder.start(key, {}) # type: ignore
             builder.data(value)
             builder.end(key)
 
@@ -213,7 +213,7 @@ class XmlMaterialProfile(InstanceContainer):
         ## End Properties Block
 
         ## Begin Settings Block
-        builder.start("settings") # type: ignore
+        builder.start("settings", {}) # type: ignore
 
         if self.getMetaDataEntry("definition") == "fdmprinter":
             for instance in self.findInstances():
@@ -258,7 +258,7 @@ class XmlMaterialProfile(InstanceContainer):
                     product = product_name
                     break
 
-            builder.start("machine") # type: ignore
+            builder.start("machine", {}) # type: ignore
             builder.start("machine_identifier", {
                 "manufacturer": container.getMetaDataEntry("machine_manufacturer",
                                                            definition_metadata.get("manufacturer", "Unknown")),


### PR DESCRIPTION
While attempting to save a project on my machine using Python 3.9 I ran into the following traceback.

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/cura/CuraApplication.py", line 1063, in event
    return super().event(event)
  File "/usr/lib/python3.9/site-packages/UM/Qt/QtApplication.py", line 464, in event
    event._function_event.call()
  File "/usr/lib/python3.9/site-packages/UM/Event.py", line 218, in call
    self._function(*self._args, **self._kwargs)
  File "/usr/lib/python3.9/site-packages/cura/Utils/Threading.py", line 34, in _handle_call
    ico.result = func(*args, **kwargs)
  File "/usr/lib/cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py", line 57, in write
    self._writeContainerToArchive(container, archive)
  File "/usr/lib/cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py", line 154, in _writeContainerToArchive
    serialized_data = container.serialize(ignored_metadata_keys = ignore_keys)
  File "/usr/lib/cura/plugins/XmlMaterialProfile/XmlMaterialProfile.py", line 154, in serialize
    builder.start("metadata") # type: ignore
TypeError: start expected 2 arguments, got 1
```
This was introduced by a [fix](https://bugs.python.org/issue39495) in Python 3.9 which aligns the C implementation of TreeBuilder with the Python implementation.
