### PR TITLE
feat: add snapmaker 2.0 definitions

### DIFF
--- a/resources/definitions/snapmaker2.def.json
+++ b/resources/definitions/snapmaker2.def.json
@@ -1,0 +1,77 @@
+{
+    "version": 2,
+    "name": "Snapmaker 2",
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": false,
+        "manufacturer": "Snapmaker",
+        "file_formats": "text/x-gcode",
+        "machine_extruder_trains": {
+            "0": "snapmaker_extruder_0"
+        },
+        "has_materials": true,
+        "has_machine_quality": true,
+        "preferred_quality_type": "normal",
+        "preferred_material": "generic_pla",
+        "exclude_materials": [ ]
+    },
+    "overrides": {
+        "machine_name": {
+            "default_value": "Snapmaker"
+        },
+        "machine_buildplate_type": {
+            "default_value": "aluminum"
+        },
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "machine_start_gcode": {
+            "default_value": "M104 S{material_print_temperature} ;Set Hotend Temperature\nM140 S{material_bed_temperature} ;Set Bed Temperature\nG28 ;home\nG90 ;absolute positioning\nG1 X-10 Y-10 F3000 ;Move to corner \nG1 Z0 F1800 ;Go to zero offset\nM109 S{material_print_temperature} ;Wait for Hotend Temperature\nM190 S{material_bed_temperature} ;Wait for Bed Temperature\nG92 E0 ;Zero set extruder position\nG1 E20 F200 ;Feed filament to clear nozzle\nG92 E0 ;Zero set extruder position"
+        },
+        "machine_end_gcode": {
+            "default_value": "M104 S0 ;Extruder heater off\nM140 S0 ;Heated bed heater off\nG90 ;absolute positioning\nG92 E0 ;Retract the filament\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z{machine_width} E-1 F3000 ;move Z up a bit and retract filament even more\nG1 X0 F3000 ;move X to min endstops, so the head is out of the way\nG1 Y{machine_depth} F3000 ;so the head is out of the way and Plate is moved forward"
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        },
+        "machine_max_acceleration_x": {
+            "default_value": 1000
+        },
+        "machine_max_acceleration_y": {
+            "default_value": 1000
+        },
+        "machine_max_acceleration_z": {
+            "default_value": 1000
+        },
+        "machine_max_acceleration_e": {
+            "default_value": 1000
+        },
+        "machine_acceleration": {
+            "default_value": 1000
+        },
+        "material_print_temp_prepend": {
+            "default_value": false
+        },
+        "material_bed_temp_prepend": {
+            "default_value": false
+        },
+        "default_material_print_temperature": {
+            "default_value": 205
+        },
+        "retraction_enable": {
+            "default_value": true
+        },
+        "retraction_amount": {
+            "default_value": 5
+        },
+        "retraction_speed": {
+            "default_value": 60
+        },
+        "retract_at_layer_change": {
+            "default_value": false
+        }
+    }
+}

--- a/resources/definitions/snapmaker2_A150.def.json
+++ b/resources/definitions/snapmaker2_A150.def.json
@@ -1,0 +1,39 @@
+{
+    "version": 2,
+    "name": "Snapmaker 2 A150",
+    "inherits": "snapmaker2",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Snapmaker",
+        "file_formats": "text/x-gcode",
+        "machine_extruder_trains": {
+            "0": "snapmaker_extruder_0"
+        },
+        "quality_definition": "snapmaker2"
+    },
+    "overrides": {
+        "machine_name": {
+            "default_value": "Snapmaker A150"
+        },
+        "machine_width": {
+            "default_value": 160
+        },
+        "machine_depth": {
+            "default_value": 160
+        },
+        "machine_height": {
+            "default_value": 145
+        },
+        "machine_head_with_fans_polygon": {
+            "default_value": [
+                [-67, 22],
+                [-67, -25],
+                [25.5, 22],
+                [25.5, -25]
+            ]
+        },
+        "gantry_height": {
+            "value": 27
+        }
+    }
+}

--- a/resources/definitions/snapmaker2_A250.def.json
+++ b/resources/definitions/snapmaker2_A250.def.json
@@ -1,0 +1,39 @@
+{
+    "version": 2,
+    "name": "Snapmaker 2 A250",
+    "inherits": "snapmaker2",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Snapmaker",
+        "file_formats": "text/x-gcode",
+        "machine_extruder_trains": {
+            "0": "snapmaker_extruder_0"
+        },
+        "quality_definition": "snapmaker2"
+    },
+    "overrides": {
+        "machine_name": {
+            "default_value": "Snapmaker A250"
+        },
+        "machine_width": {
+            "default_value": 230
+        },
+        "machine_depth": {
+            "default_value": 250
+        },
+        "machine_height": {
+            "default_value": 235
+        },
+        "machine_head_with_fans_polygon": {
+            "default_value": [
+                [-67, 22],
+                [-67, -25],
+                [25.5, 22],
+                [25.5, -25]
+            ]
+        },
+        "gantry_height": {
+            "value": 27
+        }
+    }
+}

--- a/resources/definitions/snapmaker2_A350.def.json
+++ b/resources/definitions/snapmaker2_A350.def.json
@@ -1,0 +1,39 @@
+{
+    "version": 2,
+    "name": "Snapmaker 2 A350",
+    "inherits": "snapmaker2",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Snapmaker",
+        "file_formats": "text/x-gcode",
+        "machine_extruder_trains": {
+            "0": "snapmaker_extruder_0"
+        },
+        "quality_definition": "snapmaker2"
+    },
+    "overrides": {
+        "machine_name": {
+            "default_value": "Snapmaker A350"
+        },
+        "machine_width": {
+            "default_value": 320
+        },
+        "machine_depth": {
+            "default_value": 350
+        },
+        "machine_height": {
+            "default_value": 330
+        },
+        "machine_head_with_fans_polygon": {
+            "default_value": [
+                [-67, 22],
+                [-67, -25],
+                [25.5, 22],
+                [25.5, -25]
+            ]
+        },
+        "gantry_height": {
+            "value": 27
+        }
+    }
+}

--- a/resources/extruders/snapmaker_extruder_0.def.json
+++ b/resources/extruders/snapmaker_extruder_0.def.json
@@ -1,0 +1,20 @@
+{
+    "name": "Extruder 1",
+    "version": 2,
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "snapmaker2",
+        "position": "0"
+    },
+    "overrides": {
+        "extruder_nr": {
+            "default_value": 0
+        },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        }
+    }
+}

--- a/resources/quality/snapmaker2/snapmaker2_fast.inst.cfg
+++ b/resources/quality/snapmaker2/snapmaker2_fast.inst.cfg
@@ -1,0 +1,66 @@
+[general]
+version = 4
+name = Fast
+definition = snapmaker2
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = fast
+weight = -2
+global_quality = True
+
+[values]
+layer_height = 0.24
+layer_height_0 = 0.2
+initial_layer_line_width_factor = 100
+
+wall_thickness = 0.8
+wall_line_count = 2
+top_thickness = 0.8
+top_layers = 4
+bottom_thickness = 0.8
+bottom_layers = 4
+outer_inset_first = False
+skin_outline_count = 0
+
+; infill_line_distance = 8
+infill_sparse_density = 15
+infill_sparse_thickness = 0.24
+skin_preshrink = 0.8
+top_skin_preshrink = 0.8
+bottom_skin_preshrink = 0.8
+expand_skins_expand_distance = 0.8
+top_skin_expand_distance = 0.8
+bottom_skin_expand_distance = 0.8
+
+speed_travel = 80
+speed_topbottom = 30
+speed_wall_x = 25
+speed_wall_0 = 20
+speed_wall = 40
+speed_infill = 60
+speed_print = 60
+speed_print_layer_0 = 18
+speed_travel_layer_0 = 24
+skirt_brim_speed = 18
+
+retraction_hop = 1
+retraction_hop_enabled = False
+
+magic_spiralize = False
+magic_mesh_surface_mode = normal
+
+adhesion_type = skirt
+skirt_line_count = 1
+brim_width = 8
+brim_line_count = 20
+raft_margin = 15
+
+support_enable = False
+support_type = everywhere
+support_pattern = zigzag
+support_angle = 50
+support_infill_rate = 15
+support_line_distance = 2.66
+support_initial_layer_line_distance = 2.66

--- a/resources/quality/snapmaker2/snapmaker2_high.inst.cfg
+++ b/resources/quality/snapmaker2/snapmaker2_high.inst.cfg
@@ -1,0 +1,65 @@
+[general]
+version = 4
+name = High
+definition = snapmaker2
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+weight = 1
+global_quality = True
+
+[values]
+layer_height = 0.08
+layer_height_0 = 0.15
+initial_layer_line_width_factor = 100
+
+wall_thickness = 1.2
+wall_line_count = 3
+top_thickness = 0.8
+top_layers = 10
+bottom_thickness = 0.8
+bottom_layers = 10
+outer_inset_first = False
+skin_outline_count = 1
+
+; infill_line_distance = 8
+infill_sparse_density = 15
+infill_sparse_thickness = 0.08
+skin_preshrink = 1.2
+top_skin_preshrink = 1.2
+bottom_skin_preshrink = 1.2
+expand_skins_expand_distance = 1.2
+top_skin_expand_distance = 1.2
+bottom_skin_expand_distance = 1.2
+
+speed_travel = 60
+speed_topbottom = 20
+speed_wall_x = 15
+speed_wall_0 = 10
+speed_wall = 30
+speed_infill = 40
+speed_print = 40
+speed_print_layer_0 = 18
+speed_travel_layer_0 = 24
+skirt_brim_speed = 18
+
+retraction_hop = 1
+retraction_hop_enabled = False
+
+magic_spiralize = False
+magic_mesh_surface_mode = normal
+
+adhesion_type = skirt
+skirt_line_count = 1
+brim_width = 8
+brim_line_count = 20
+raft_margin = 15
+
+support_enable = False
+support_type = everywhere
+support_pattern = zigzag
+support_angle = 50
+support_infill_rate = 15
+support_line_distance = 2.66

--- a/resources/quality/snapmaker2/snapmaker2_normal.inst.cfg
+++ b/resources/quality/snapmaker2/snapmaker2_normal.inst.cfg
@@ -1,0 +1,66 @@
+[general]
+version = 4
+name = Normal
+definition = snapmaker2
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+weight = 0
+global_quality = True
+
+[values]
+layer_height = 0.16
+layer_height_0 = 0.2
+initial_layer_line_width_factor = 100
+
+wall_thickness = 1.2
+wall_line_count = 3
+top_thickness = 0.8
+top_layers = 5
+bottom_thickness = 0.8
+bottom_layers = 5
+outer_inset_first = False
+skin_outline_count = 0
+
+; infill_line_distance = 8
+infill_sparse_density = 15
+infill_sparse_thickness = 0.16
+skin_preshrink = 1.2
+top_skin_preshrink = 1.2
+bottom_skin_preshrink = 1.2
+expand_skins_expand_distance = 1.2
+top_skin_expand_distance = 1.2
+bottom_skin_expand_distance = 1.2
+
+speed_travel = 70
+speed_topbottom = 25
+speed_wall_x = 20
+speed_wall_0 = 15
+speed_wall = 30
+speed_infill = 50
+speed_print = 50
+speed_print_layer_0 = 18
+speed_travel_layer_0 = 24
+skirt_brim_speed = 18
+
+retraction_hop = 1
+retraction_hop_enabled = False
+
+magic_spiralize = False
+magic_mesh_surface_mode = normal
+
+adhesion_type = skirt
+skirt_line_count = 1
+brim_width = 8
+brim_line_count = 20
+raft_margin = 15
+
+support_enable = False
+support_type = everywhere
+support_pattern = zigzag
+support_angle = 50
+support_infill_rate = 15
+support_line_distance = 2.66
+support_initial_layer_line_distance = 2.66


### PR DESCRIPTION
This PR adds Snapmaker 2.0 definitions as an available printer within Cura.

The intention is to generally mimic the Luban settings (i.e. the default Snapmaker Profiles).  These settings are generally found in: https://github.com/Snapmaker/Luban/tree/master/resources/CuraEngine/Config.

I have tested these with the A350 for about a month now without issue.

The A250 and A150 profiles were added for completeness but, lacking those models, I cannot test them myself.