### PR TITLE
Fix loading scripts from all registered resource paths

### DIFF
--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.py
@@ -142,7 +142,9 @@ class PostProcessingPlugin(QObject, Extension):
         # The PostProcessingPlugin path is for built-in scripts.
         # The Resources path is where the user should store custom scripts.
         # The Preferences path is legacy, where the user may previously have stored scripts.
-        for root in [PluginRegistry.getInstance().getPluginPath("PostProcessingPlugin"), Resources.getStoragePath(Resources.Resources), Resources.getStoragePath(Resources.Preferences)]:
+        resource_folders = [PluginRegistry.getInstance().getPluginPath("PostProcessingPlugin"), Resources.getStoragePath(Resources.Preferences)]
+        resource_folders.extend(Resources.getAllPathsForType(Resources.Resources))
+        for root in resource_folders:
             if root is None:
                 continue
             path = os.path.join(root, "scripts")


### PR DESCRIPTION
This PR fixes the PostProcessing plugin to load scripts from all registered resource paths instead of only the main resource folder. With this change, a plugin can include its own `scripts` folder and register it with the following snippet (from its `__init__` implementation):

`Resources.addSearchPath(os.path.dirname(os.path.abspath(__file__)))`

/sa https://github.com/5axes/Calibration-Shapes/issues/1