### PR TITLE
Don't take snapshot if no main window present.

### DIFF
--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -250,6 +250,9 @@ class CuraEngineBackend(QObject, Backend):
     @call_on_qt_thread  # must be called from the main thread because of OpenGL
     def _createSnapshot(self) -> None:
         self._snapshot = None
+        if not CuraApplication.getInstance().isVisible:
+            Logger.log("w", "Can't create snapshot when renderer not initialized.")
+            return
         Logger.log("i", "Creating thumbnail image (just before slice)...")
         try:
             self._snapshot = Snapshot.snapshot(width = 300, height = 300)


### PR DESCRIPTION
When autoslicing is enabled, it was trying to create a snapshot before the main window is present.

You'll need the Uranium branch of the same (fix_is_visible) name if you don't want this to crash on slicing!