### PR TITLE
Add checkbox to enable/disable Extruder Offsets during Gcode generation

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -338,9 +338,9 @@ Item
 			*/
             Cura.SimpleCheckBox  // "GCode Affected By Extruder Offsets"
             {
-				id: applyExtruderOffsetsCheckbox
+                id: applyExtruderOffsetsCheckbox
                 containerStackId: machineStackId
-				settingKey: "machine_use_extruder_offset_to_offset_coords"
+                settingKey: "machine_use_extruder_offset_to_offset_coords"
                 settingStoreIndex: propertyStoreIndex
                 labelText: catalog.i18nc("@label", "Apply Extruder offsets to GCode")
                 labelFont: base.labelFont
@@ -360,13 +360,13 @@ Item
             Cura.SimpleCheckBox  // "Shared Heater"
             {
                 id: sharedHeaterCheckBox
-                containerStackId: machineStackId
-                settingKey: "machine_extruders_share_heater"
-                settingStoreIndex: propertyStoreIndex
-                labelText: catalog.i18nc("@label", "Shared Heater")
-                labelFont: base.labelFont
-                labelWidth: base.labelWidth
-                forceUpdateOnChangeFunction: forceUpdateFunction
+				containerStackId: machineStackId
+				settingKey: "machine_extruders_share_heater"
+				settingStoreIndex: propertyStoreIndex
+				labelText: catalog.i18nc("@label", "Shared Heater")
+				labelFont: base.labelFont
+				labelWidth: base.labelWidth
+				forceUpdateOnChangeFunction: forceUpdateFunction
             }
             */
         }

--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -330,24 +330,25 @@ Item
                 }
             }
 
-            /* 
-            - Proposed fix for this issue: https://github.com/Ultimaker/Cura/issues/9167 
-            - Allows user to toggle if GCODE coordinates are affected by the extruder offset. 
-            - Machine wide setting. CuraEngine/src/gcodeExport.cpp is not set up to evaluate per extruder currently.
-            - If it is moved to per-extruder (unlikely), then this should be moved to the extruder tab)
-            */
+			/* 
+				- Proposed fix for this issue: https://github.com/Ultimaker/Cura/issues/9167 
+				- Allows user to toggle if GCODE coordinates are affected by the extruder offset. 
+				- Machine wide setting. CuraEngine/src/gcodeExport.cpp is not set up to evaluate per extruder currently.
+				- If it is moved to per-extruder (unlikely), then this should be moved to the extruder tab)
+			*/
             Cura.SimpleCheckBox  // "GCode Affected By Extruder Offsets"
             {
-                id: ApplyExtruderOffsetsToGCodeCheckbox
+				id: applyExtruderOffsetsCheckbox
                 containerStackId: machineStackId
-                settingKey: "machine_use_extruder_offset_to_offset_coords"
+				settingKey: "machine_use_extruder_offset_to_offset_coords"
                 settingStoreIndex: propertyStoreIndex
                 labelText: catalog.i18nc("@label", "Apply Extruder offsets to GCode")
                 labelFont: base.labelFont
                 labelWidth: base.labelWidth
                 forceUpdateOnChangeFunction: forceUpdateFunction
             }
-            
+			
+			
             /* The "Shared Heater" feature is temporarily disabled because its
             implementation is incomplete. Printers with multiple filaments going
             into one nozzle will keep the inactive filaments retracted at the

--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -330,6 +330,24 @@ Item
                 }
             }
 
+            /* 
+            - Proposed fix for this issue: https://github.com/Ultimaker/Cura/issues/9167 
+            - Allows user to toggle if GCODE coordinates are affected by the extruder offset. 
+            - Machine wide setting. CuraEngine/src/gcodeExport.cpp is not set up to evaluate per extruder currently.
+            - If it is moved to per-extruder (unlikely), then this should be moved to the extruder tab)
+            */
+            Cura.SimpleCheckBox  // "GCode Affected By Extruder Offsets"
+            {
+                id: ApplyExtruderOffsetsToGCodeCheckbox
+                containerStackId: machineStackId
+                settingKey: "machine_use_extruder_offset_to_offset_coords"
+                settingStoreIndex: propertyStoreIndex
+                labelText: catalog.i18nc("@label", "Apply Extruder offsets to GCode")
+                labelFont: base.labelFont
+                labelWidth: base.labelWidth
+                forceUpdateOnChangeFunction: forceUpdateFunction
+            }
+            
             /* The "Shared Heater" feature is temporarily disabled because its
             implementation is incomplete. Printers with multiple filaments going
             into one nozzle will keep the inactive filaments retracted at the

--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -360,13 +360,13 @@ Item
             Cura.SimpleCheckBox  // "Shared Heater"
             {
                 id: sharedHeaterCheckBox
-				containerStackId: machineStackId
-				settingKey: "machine_extruders_share_heater"
-				settingStoreIndex: propertyStoreIndex
-				labelText: catalog.i18nc("@label", "Shared Heater")
-				labelFont: base.labelFont
-				labelWidth: base.labelWidth
-				forceUpdateOnChangeFunction: forceUpdateFunction
+                containerStackId: machineStackId
+                settingKey: "machine_extruders_share_heater"
+                settingStoreIndex: propertyStoreIndex
+                labelText: catalog.i18nc("@label", "Shared Heater")
+                labelFont: base.labelFont
+                labelWidth: base.labelWidth
+                forceUpdateOnChangeFunction: forceUpdateFunction
             }
             */
         }

--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -330,12 +330,12 @@ Item
                 }
             }
 
-			/* 
-				- Proposed fix for this issue: https://github.com/Ultimaker/Cura/issues/9167 
-				- Allows user to toggle if GCODE coordinates are affected by the extruder offset. 
-				- Machine wide setting. CuraEngine/src/gcodeExport.cpp is not set up to evaluate per extruder currently.
-				- If it is moved to per-extruder (unlikely), then this should be moved to the extruder tab)
-			*/
+            /* 
+               - Proposed fix for this issue: https://github.com/Ultimaker/Cura/issues/9167 
+               - Allows user to toggle if GCODE coordinates are affected by the extruder offset. 
+               - Machine wide setting. CuraEngine/src/gcodeExport.cpp is not set up to evaluate per extruder currently.
+               - If it is moved to per-extruder (unlikely), then this should be moved to the extruder tab)
+            */
             Cura.SimpleCheckBox  // "GCode Affected By Extruder Offsets"
             {
                 id: applyExtruderOffsetsCheckbox

--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -331,10 +331,10 @@ Item
             }
 
             /* 
-               - Proposed fix for this issue: https://github.com/Ultimaker/Cura/issues/9167 
+               - Fix for this issue: https://github.com/Ultimaker/Cura/issues/9167 
                - Allows user to toggle if GCODE coordinates are affected by the extruder offset. 
                - Machine wide setting. CuraEngine/src/gcodeExport.cpp is not set up to evaluate per extruder currently.
-               - If it is moved to per-extruder (unlikely), then this should be moved to the extruder tab)
+               - If it is moved to per-extruder (unlikely), then this should be moved to the extruder tab.
             */
             Cura.SimpleCheckBox  // "GCode Affected By Extruder Offsets"
             {

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -485,7 +485,7 @@
                 "machine_use_extruder_offset_to_offset_coords":
                 {
                     "label": "Offset with Extruder",
-                    "description": "Apply the extruder offset to the coordinate system.",
+                    "description": "Apply the extruder offset to the coordinate system. Affects all extruders.",
                     "type": "bool",
                     "default_value": true,
                     "settable_per_mesh": false,


### PR DESCRIPTION
This was done as a solution to this issue:  #9167. The original issue can be read for more information, but I'll go over the basics of the change here. 

This change Add a checkbox on the 'Printer' tab of machine settings that allows users to enable/disable the application of extruder offsets to generated gcode. By default this setting is ENABLED for every printer, unless setup in the printer's .def.json file, which is not really accessible unless the user knows what they are doing and want to mess with program files. 

![Cura](https://user-images.githubusercontent.com/20431767/106392587-87e90c80-63c0-11eb-995d-ffc712c55ff0.PNG)

The reason for this change was that my chimera style printer had the offsets defined in firmware. I also defined them in Cura so that I could see the printable area for each nozzle. When it actually went to print, the plastic was off by the distance of the offset. 

This error was due to both the printer shifting to account for the offset, as well as Cura adjusting the gcode for the offset. So instead of printing with nozzle 2 at X100 as expected, cura told the printer to print at X124. Pictures were included in original issue I had posted. 

Below is gcode generated for Nozzle 2 (T1) where offsets are X -24, Y-1

GCODE generated with the offset Enabled (Default / checked)
```
;TYPE:SKIRT
G1 F600 E0
G1 F1200 X124.701 Y109.082 E0.63447
G1 X124.71 Y108.417 E0.65659
G1 X124.76 Y107.681 E0.68113
G1 X124.889 Y106.956 E0.70562
G1 X125.096 Y106.248 E0.73015
G1 X125.378 Y105.567 E0.75467
```

GCODE generated with the offset Disabled (unchecked)  -- nozzle offset will be handled by the firmware:
```
;TYPE:SKIRT
G1 F600 E0
G1 F1200 X100.701 Y108.082 E0.63447
G1 X100.71 Y107.417 E0.65659
G1 X100.76 Y106.681 E0.68113
G1 X100.889 Y105.956 E0.70562
G1 X101.096 Y105.248 E0.73015
G1 X101.378 Y104.567 E0.75467
```

