### PR TITLE
setting for support_tree_max_diameter

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4508,6 +4508,20 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
+                "support_tree_max_diameter":
+                {
+                    "label": "Tree Support Trunk Diameter",
+                    "description": "The diameter of the widest branches of tree support. A thicker trunk is more sturdy; a thinner trunk takes up less space on the build plate.",
+                    "unit": "mm",
+                    "type": "float",
+                    "minimum_value": "support_tree_branch_diameter",
+                    "minimum_value_warning": "support_line_width * 5",
+                    "default_value": 15,
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "enabled": "support_enable and support_structure=='tree'",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true
+                },
                 "support_tree_branch_diameter_angle":
                 {
                     "label": "Tree Support Branch Diameter Angle",


### PR DESCRIPTION
New setting to limit the width of the base of tree support.

I was trying to optimize the hell out of one print and I figured that this setting might help.