### PR TITLE
Fix cluster print job constraints typing and optionality

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrintJobConstraints.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrintJobConstraints.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 from typing import Optional
 

--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrintJobStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrintJobStatus.py
@@ -74,10 +74,9 @@ class ClusterPrintJobStatus(BaseModel):
         printer
         :param preview_url: URL to the preview image (same as wou;d've been included in the ufp).
         """
-
         self.assigned_to = assigned_to
         self.configuration = self.parseModels(ClusterPrintCoreConfiguration, configuration)
-        self.constraints = self.parseModel(ClusterPrintJobConstraints, constraints)
+        self.constraints = self.parseModel(ClusterPrintJobConstraints, constraints) if constraints else None
         self.created_at = created_at
         self.force = force
         self.last_seen = last_seen
@@ -94,7 +93,6 @@ class ClusterPrintJobStatus(BaseModel):
         self.deleted_at = deleted_at
         self.printed_on_uuid = printed_on_uuid
         self.preview_url = preview_url
-
         self.configuration_changes_required = self.parseModels(ClusterPrintJobConfigurationChange,
                                                                configuration_changes_required) \
             if configuration_changes_required else []

--- a/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrintJobStatus.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/ClusterPrintJobStatus.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 from typing import List, Optional, Union, Dict, Any
 
@@ -8,7 +8,7 @@ from .ClusterBuildPlate import ClusterBuildPlate
 from .ClusterPrintJobConfigurationChange import ClusterPrintJobConfigurationChange
 from .ClusterPrintJobImpediment import ClusterPrintJobImpediment
 from .ClusterPrintCoreConfiguration import ClusterPrintCoreConfiguration
-from .ClusterPrintJobConstraint import ClusterPrintJobConstraints
+from .ClusterPrintJobConstraints import ClusterPrintJobConstraints
 from ..UM3PrintJobOutputModel import UM3PrintJobOutputModel
 from ..ConfigurationChangeModel import ConfigurationChangeModel
 from ..BaseModel import BaseModel
@@ -18,13 +18,24 @@ from ...ClusterOutputController import ClusterOutputController
 class ClusterPrintJobStatus(BaseModel):
     """Model for the status of a single print job in a cluster."""
 
-    def __init__(self, created_at: str, force: bool, machine_variant: str, name: str, started: bool, status: str,
-                 time_total: int, uuid: str,
+    def __init__(self,
+                 created_at: str,
+                 force: bool,
+                 machine_variant: str,
+                 name: str,
+                 started: bool,
+                 status: str,
+                 time_total: int,
+                 uuid: str,
                  configuration: List[Union[Dict[str, Any], ClusterPrintCoreConfiguration]],
-                 constraints: List[Union[Dict[str, Any], ClusterPrintJobConstraints]],
-                 last_seen: Optional[float] = None, network_error_count: Optional[int] = None,
-                 owner: Optional[str] = None, printer_uuid: Optional[str] = None, time_elapsed: Optional[int] = None,
-                 assigned_to: Optional[str] = None, deleted_at: Optional[str] = None,
+                 constraints: Optional[Union[Dict[str, Any], ClusterPrintJobConstraints]] = None,
+                 last_seen: Optional[float] = None,
+                 network_error_count: Optional[int] = None,
+                 owner: Optional[str] = None,
+                 printer_uuid: Optional[str] = None,
+                 time_elapsed: Optional[int] = None,
+                 assigned_to: Optional[str] = None,
+                 deleted_at: Optional[str] = None,
                  printed_on_uuid: Optional[str] = None,
                  configuration_changes_required: List[
                      Union[Dict[str, Any], ClusterPrintJobConfigurationChange]] = None,
@@ -66,7 +77,7 @@ class ClusterPrintJobStatus(BaseModel):
 
         self.assigned_to = assigned_to
         self.configuration = self.parseModels(ClusterPrintCoreConfiguration, configuration)
-        self.constraints = self.parseModels(ClusterPrintJobConstraints, constraints)
+        self.constraints = self.parseModel(ClusterPrintJobConstraints, constraints)
         self.created_at = created_at
         self.force = force
         self.last_seen = last_seen


### PR DESCRIPTION
During Digital Factory implementation of the UM2+C this bug was discovered. For now we'll also make sure that printers always send at least an empty object, but this bug should be fixed here nonetheless. Also fixed the typing for the constraints (was typed a list, but is actually just a single object with known key `require_printer_name`, which is already optional).

The original stack trace:

```
Traceback (most recent call last):
  File "/build/4.8/build/inst/lib/python3.5/site-packages/UM/TaskManagement/TaskManager.py", line 143, in event
  File "/build/4.8/build/inst/lib/python3.5/site-packages/UM/TaskManagement/TaskManager.py", line 33, in callFunction
  File "/tmp/.mount_UltimaPsBReR/usr/bin/plugins/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py", line 245, in parse
    self._parseModels(response, on_finished, model)
  File "/tmp/.mount_UltimaPsBReR/usr/bin/plugins/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py", line 208, in _parseModels
    result = model_class(**data)  # type: CloudApiClientModel
  File "/tmp/.mount_UltimaPsBReR/usr/bin/plugins/plugins/UM3NetworkPrinting/src/Models/Http/CloudClusterStatus.py", line 27, in __init__
    self.print_jobs = self.parseModels(ClusterPrintJobStatus, print_jobs)
  File "/tmp/.mount_UltimaPsBReR/usr/bin/plugins/plugins/UM3NetworkPrinting/src/Models/BaseModel.py", line 62, in parseModels
    return [cls.parseModel(model_class, value) for value in values]
  File "/tmp/.mount_UltimaPsBReR/usr/bin/plugins/plugins/UM3NetworkPrinting/src/Models/BaseModel.py", line 62, in <listcomp>
    return [cls.parseModel(model_class, value) for value in values]
  File "/tmp/.mount_UltimaPsBReR/usr/bin/plugins/plugins/UM3NetworkPrinting/src/Models/BaseModel.py", line 51, in parseModel
    return model_class(**values)
TypeError: __init__() missing 1 required positional argument: 'constraints'
```