### PR TITLE
Fix error log spam.

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Network/ZeroConfClient.py
+++ b/plugins/UM3NetworkPrinting/src/Network/ZeroConfClient.py
@@ -129,16 +129,16 @@ class ZeroConfClient:
 
         for record in zero_conf.cache.entries_with_name(info.server):
             info.update_record(zero_conf, time(), record)
-            if info.addresses:
+            if hasattr(info, "addresses") and info.addresses:
                 break
 
         # Request more data if info is not complete
-        if not info.addresses:
+        if not hasattr(info, "addresses") or not info.addresses:
             new_info = zero_conf.get_service_info(service_type, name)
             if new_info is not None:
                 info = new_info
 
-        if info and info.addresses:
+        if info and hasattr(info, "addresses") and info.addresses:
             type_of_device = info.properties.get(b"type", None)
             if type_of_device:
                 if type_of_device == b"printer":


### PR DESCRIPTION
The code is clearly written to take into account that 'addresses' may be null. But not that the whole 'addresses' attribute may not exist. And then instead of printing one warning (Could not get information about XX) it instead printed a stacktrace and retried and printed a stacktrace and retried and printed a stacktrace and.... It ended up driving me a bit nuts when looking at the logs for unrelated reasons. So Ifinallay fixed it. Could end up as a speedup in some cases as well I suppose?