### PR TITLE
Fix layer view being greyed out after reslicing gives same current layer

### DIFF
--- a/plugins/SimulationView/SimulationPass.py
+++ b/plugins/SimulationView/SimulationPass.py
@@ -36,13 +36,15 @@ class SimulationPass(RenderPass):
         self._disabled_shader = None
         self._old_current_layer = 0
         self._old_current_path = 0
-        self._switching_layers = True # It tracks when the user is moving the layers' slider
+        self._switching_layers = True  # Tracking whether the user is moving across layers (True) or across paths (False). If false, lower layers render as shadowy.
         self._gl = OpenGL.getInstance().getBindingsObject()
         self._scene = Application.getInstance().getController().getScene()
         self._extruder_manager = ExtruderManager.getInstance()
 
         self._layer_view = None
         self._compatibility_mode = None
+
+        self._scene.sceneChanged.connect(self._onSceneChanged)
 
     def setSimulationView(self, layerview):
         self._layer_view = layerview
@@ -219,3 +221,9 @@ class SimulationPass(RenderPass):
             tool_handle_batch.render(self._scene.getActiveCamera())
 
         self.release()
+
+    def _onSceneChanged(self, changed_object: SceneNode):
+        if changed_object.callDecoration("getLayerData"):  # Any layer data has changed.
+            self._switching_layers = True
+            self._old_current_layer = 0
+            self._old_current_path = 0


### PR DESCRIPTION
This fixes a very old bug in Cura where sometimes after re-slicing it would display the layer as if you've been going horizontal through the path slider, even if you never touched the horizontal path slider.

This was caused by a tracking flag in the `SimulationPass`, `_switching_layers`. This bit of state in the `SimulationPass` was tracking whether the user is going through the vertical layer slider (`True`) or the horizontal path slider (`False`). If `False`, the nozzle mesh is drawn and lower layers get drawn in a shadowy shader. The state of this flag was being updated on every render by looking at whether the previous render has the same current layer number but a different path index. If so, it changed to `False`, meaning that it assumes you're going through the paths on a layer and things get shadowy.
However if you slice a different object such that the number of layers stay the same (or at least the current layer) but the number of paths on a layer change (e.g. by reducing Maximum Resolution, or by loading a different model that happens to be equally tall) then it would falsely think you were going through the horizontal path slider.

This change effectively resets this state flag when any layer data is changed in the scene. So if you re-slice, it always goes back to `_switching_layers = True`.

The side effect is that if you were going through the paths of a layer and you re-slice, you won't end up on the same path even if the number of paths on your current layer didn't change due to the reslice. But I think that is more towards what the user would accept a re-slice to do anyway.

I decided to take a look into this bug because I'm making a script to automatically refresh the screenshots of the Settings Guide plug-in. This script frequently hits cases like this, and it's easier to fix this bug than to work around it in my script.