### PR TITLE
Premultiplied alpha blending

### DIFF
--- a/plugins/SimulationView/layers3d.shader
+++ b/plugins/SimulationView/layers3d.shader
@@ -342,7 +342,7 @@ fragment41core =
     void main()
     {
         mediump vec4 finalColor = vec4(0.0);
-        float alpha = f_color.a;
+        finalColor.a = f_color.a;
 
         finalColor.rgb += f_color.rgb * 0.2 + u_minimumAlbedo.rgb;
 
@@ -351,8 +351,10 @@ fragment41core =
 
         // Diffuse Component
         highp float NdotL = clamp(dot(normal, light_dir), 0.0, 1.0);
-        finalColor += (NdotL * f_color);
-        finalColor.a = alpha;  // Do not change alpha in any way
+        finalColor.rgb += (NdotL * f_color).rgb;
+        //Premultiply the alpha component into the colour. Combine this with additive blending.
+        //See https://apoorvaj.io/alpha-compositing-opengl-blending-and-premultiplied-alpha/ for a layout of theory.
+        finalColor *= f_color.a;
 
         frag_color = finalColor;
     }

--- a/plugins/SimulationView/layers3d.shader
+++ b/plugins/SimulationView/layers3d.shader
@@ -136,6 +136,7 @@ geometry41core =
     uniform int u_show_skin;
     uniform int u_show_infill;
     uniform int u_show_starts;
+    uniform int u_transparent_pass;
 
     layout(lines) in;
     layout(triangle_strip, max_vertices = 40) out;
@@ -192,6 +193,14 @@ geometry41core =
         }
         if ((u_show_infill == 0) && (v_line_type[0] == 6)) {
             return;
+        }
+        if ((u_transparent_pass == 0) && (v_color[0][3] < 1.0))
+        {
+            return; //Skip transparent bits if it's not the transparent pass.
+        }
+        if ((u_transparent_pass == 1) && (v_color[0][3] >= 1.0))
+        {
+            return; //Skip opaque bits if it is the transparent pass.
         }
 
         if ((v_line_type[0] == 8) || (v_line_type[0] == 9)) {

--- a/resources/shaders/transparent_object.shader
+++ b/resources/shaders/transparent_object.shader
@@ -46,7 +46,9 @@ fragment =
         highp float NdotL = clamp(abs(dot(normal, lightDir)), 0.0, 1.0);
         finalColor += (NdotL * u_diffuseColor);
 
-        gl_FragColor = finalColor;
+        //Premultiply the alpha component into the colour. Combine this with additive blending.
+        //See https://apoorvaj.io/alpha-compositing-opengl-blending-and-premultiplied-alpha/ for a layout of theory.
+        gl_FragColor = finalColor * u_opacity;
         gl_FragColor.a = u_opacity;
     }
 
@@ -101,7 +103,9 @@ fragment41core =
         highp float NdotL = clamp(abs(dot(normal, lightDir)), 0.0, 1.0);
         finalColor += (NdotL * u_diffuseColor);
 
-        frag_color = finalColor;
+        //Premultiply the alpha component into the colour. Combine this with additive blending.
+        //See https://apoorvaj.io/alpha-compositing-opengl-blending-and-premultiplied-alpha/ for a layout of theory.
+        frag_color = finalColor * u_opacity;
         frag_color.a = u_opacity;
     }
 


### PR DESCRIPTION
This implements a change to our rendering system. It is a good change under water, I think, but it has some unexpected consequences, so I'm asking for your opinions on this. Because the final result is better in some ways but worse in others.

Current/old situation
----
A while ago I [changed the opacity of support to 50%](https://github.com/Ultimaker/Cura/pull/7251). I saw this as an "easy win", low-hanging fruit, which wasn't implemented perfectly but it was such a simple change to make and provided a marginal improvement so it was okay. My colleagues agreed and it was merged.

However this implementation had some problems. You could indeed see the shape of the solid model through the support, but what you were really looking at is the "shadowy" silhouette of the input 3D mesh being rendered behind the layer view.
![image](https://user-images.githubusercontent.com/2448634/112077738-62d17880-8b7d-11eb-8e7a-9e58e0c9b61c.png)
This looks weird for two main reasons:
* If the solid parts of layer view differs significantly from the input 3D mesh, you'd see the difference. This is very easy to see in the brim which is not shown at all behind the support.
* The shadowy silhouette of the input mesh still had transparency by itself, and so the pass over layer view actually made the solid part of layer view transparent. You could faintly see the build plate grid through the solid parts of layer view.

This fix
----
In this branch, and an accompanying branch in Uranium, I implemented pre-multiplied alpha blending.

![image](https://user-images.githubusercontent.com/2448634/112077315-87792080-8b7c-11eb-9b7a-b656447a1547.png)

For a theory behind pre-multiplied alpha blending, see https://apoorvaj.io/alpha-compositing-opengl-blending-and-premultiplied-alpha/
In my own words: Pre-multiplied alpha blending multiplies the colour of the image with the alpha channel, which would make the image darker for translucent objects. It then changes the blend function in OpenGL accordingly to restore the brightness of the original colour. (The blend function is essentially the formula that OpenGL will use to blend multiple rendered images together with alpha channels, usually something like `L_out = L1 * alpha + L2 * (1 - alpha)`.) The default blend function of OpenGL is intended for when the output is always fully opaque, but doesn't work well if this is not the case. Because we were rendering with Uranium's composite passes feature, our render results weren't completely opaque if support was transparent. This pre-multiplied alpha technique does work if the output is translucent.

However this then does require a change to the shaders: All output needs to be pre-multiplied with the alpha channel. As far as I could see there are three shaders in Cura and Uranium that may render translucent objects. So this pull request changes all of those. If we add more shaders in the future we'll need to do that too. You'll quickly see that the image becomes white or too bright if you don't.

The result looks impressive and pretty accurate as far as I can tell. Pre-multiplied alpha is in theory not accurate if there are multiple layers on top of each other with different opacities. In practice, since only our support is transparent in layer view, and only the modifier meshes are transparent in solid view, this hardly occurs. Other parts such as the aforementioned shadowy silhouette are drawn on a completely different layer and then blended later so they don't affect it.

One thing that I did notice is that the nozzle mesh gets rendered with incorrect colour if it's in front of the semi-transparent lower layers: 
![image](https://user-images.githubusercontent.com/2448634/112079198-058af680-8b80-11eb-8ea5-8fa2699bc29f.png)
This is because the nozzle mesh is very transparent but the lower layers are almost-but-not-quite-100% opaque. I don't consider this to be a huge issue since nobody really needs to see a lot of detail in the nozzle mesh.

Performance
----
I could really only theorise about the performance impact of this change. My GPU is modern-ish (NVidia RTX2070) so I noticed no change in performance even with very heavy models. Cura also doesn't keep rendering as fast as it can; it only updates if the scene changes, so just measuring frame rate is also not feasible.

The pre-multiplied alpha itself hardly has a performance impact at all. It is one extra colour multiplication per pixel, which is not significant.

However when rendering solid objects, we tell OpenGL to mask pixels behind other pixels. It calculates the colour (since it calculates all fragments in parallel), but then masks it since it needs to be behind another object. This doesn't result in more fragments needing to render, but it does mean that the render batch needs to be split up into a translucent bit and a non-translucent bit even though it is one mesh.
I implemented this in the geometry shader. The geometry shader doesn't emit any vertices for translucent bits when rendering the solid bits, and doesn't emit any vertices for solid bits when rendering the translucent bits. This means that the vertex shader and this check for translucency gets calculated twice (=an extra matrix multiplication and a few if checks for each vertex). And the number of render batches increases by 2. We already have a dozen or so in each frame, but this now increases by 2, so there is more to blend in the composite. All in all, the performance impact shouldn't be huge compared to rendering a full frame, but it could have a measurable impact.

Problems with the result
----
However this change does come with some unforeseen consequences which is why I'd really like to hear your opinions about it.

As it turns out, a normal print really does have a LOT of layers. And all of these layers add up to become pretty much 100% opaque if you look at it from the wrong angle. This is what it really means to have transparent layer view. It should not come at a surprise. But looking at it in person is something else entirely of course.
![image](https://user-images.githubusercontent.com/2448634/112080488-63204280-8b82-11eb-8e63-dd52755ff246.png)

Secondly, having all this transparency also makes the layer view quite "blurry" from some angles. It's sometimes harder to make out how the support is structured without looking at it from multiple angles. I think this can be fixed by doing something with the shaders but I'm currently not really sure how, so I'd like to get your opinions first.

![image](https://user-images.githubusercontent.com/2448634/112080713-c0b48f00-8b82-11eb-9853-2e3b75f91e9c.png)

This PR is accompanied by a PR in Uranium: https://github.com/Ultimaker/Uranium/pull/677