### PR TITLE
Add preference to enable loading multiple objects into a single instance

### DIFF
--- a/cura/SingleInstance.py
+++ b/cura/SingleInstance.py
@@ -18,6 +18,8 @@ class SingleInstance:
 
         self._single_instance_server = None
 
+        self._application.getPreferences().addPreference("cura/single_instance_clear_before_load", True)
+
     # Starts a client that checks for a single instance server and sends the files that need to opened if the server
     # exists. Returns True if the single instance server is found, otherwise False.
     def startClient(self) -> bool:
@@ -42,8 +44,9 @@ class SingleInstance:
             # "command" field is required and holds the name of the command to execute.
             # Other fields depend on the command.
 
-            payload = {"command": "clear-all"}
-            single_instance_socket.write(bytes(json.dumps(payload) + "\n", encoding = "ascii"))
+            if self._application.getPreferences().getValue("cura/single_instance_clear_before_load"):
+                payload = {"command": "clear-all"}
+                single_instance_socket.write(bytes(json.dumps(payload) + "\n", encoding = "ascii"))
 
             payload = {"command": "focus"}
             single_instance_socket.write(bytes(json.dumps(payload) + "\n", encoding = "ascii"))

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -74,6 +74,8 @@ UM.PreferencesPage
 
         UM.Preferences.resetPreference("cura/single_instance")
         singleInstanceCheckbox.checked = boolCheck(UM.Preferences.getValue("cura/single_instance"))
+        UM.Preferences.resetPreference("cura/single_instance_clear_before_load")
+        singleInstanceClearBeforeLoadCheckbox.checked = boolCheck(UM.Preferences.getValue("cura/single_instance_clear_before_load"))
 
         UM.Preferences.resetPreference("physics/automatic_push_free")
         pushFreeCheckbox.checked = boolCheck(UM.Preferences.getValue("physics/automatic_push_free"))
@@ -575,6 +577,22 @@ UM.PreferencesPage
                     text: catalog.i18nc("@option:check","Use a single instance of Cura")
                     checked: boolCheck(UM.Preferences.getValue("cura/single_instance"))
                     onCheckedChanged: UM.Preferences.setValue("cura/single_instance", checked)
+                }
+            }
+
+            UM.TooltipArea
+            {
+                width: childrenRect.width
+                height: childrenRect.height
+                text: catalog.i18nc("@info:tooltip","Should the build plate be cleared before loading a new model in the single instance of Cura?")
+                enabled: singleInstanceCheckbox.checked
+
+                CheckBox
+                {
+                    id: singleInstanceClearBeforeLoadCheckbox
+                    text: catalog.i18nc("@option:check","Clear buildplate before loading model into the single instance")
+                    checked: boolCheck(UM.Preferences.getValue("cura/single_instance_clear_before_load"))
+                    onCheckedChanged: UM.Preferences.setValue("cura/single_instance_clear_before_load", checked)
                 }
             }
 


### PR DESCRIPTION
This PR adds a preference to the General pane of the preferences to clear the buildplate before loading a model via the "single instance" method. This way a user can choose to iterate on a single model (the current behavior, and still the default option) or to load multiple models into the single instance.

See https://community.ultimaker.com/topic/35858-command-line-to-open-an-stl-model-while-keeping-existing-ones/?tab=comments#comment-282714 and https://www.reddit.com/r/Cura/comments/mbkw2j/cant_open_multiple_models_at_the_same_time/
