### PR TITLE
Cura 7813 simple exit

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -603,6 +603,15 @@ class CuraApplication(QtApplication):
     @pyqtSlot()
     def closeApplication(self) -> None:
         Logger.log("i", "Close application")
+
+        # Workaround: Before closing the window, remove the global stack.
+        # This is necessary because as the main window gets closed, hundreds of QML elements get updated which often
+        # request the global stack. However as the Qt-side of the Machine Manager is being dismantled, the conversion of
+        # the Global Stack to a QObject fails.
+        # If instead we first take down the global stack, PyQt will just convert `None` to `null` which succeeds, and
+        # the QML code then gets `null` as the global stack and can deal with that as it deems fit.
+        self.getMachineManager().setActiveMachine(None)
+
         main_window = self.getMainWindow()
         if main_window is not None:
             main_window.close()

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -603,20 +603,7 @@ class CuraApplication(QtApplication):
     @pyqtSlot()
     def closeApplication(self) -> None:
         Logger.log("i", "Close application")
-
-        # Workaround: Before closing the window, remove the global stack.
-        # This is necessary because as the main window gets closed, hundreds of QML elements get updated which often
-        # request the global stack. However as the Qt-side of the Machine Manager is being dismantled, the conversion of
-        # the Global Stack to a QObject fails.
-        # If instead we first take down the global stack, PyQt will just convert `None` to `null` which succeeds, and
-        # the QML code then gets `null` as the global stack and can deal with that as it deems fit.
-        self.getMachineManager().setActiveMachine(None)
-
-        main_window = self.getMainWindow()
-        if main_window is not None:
-            main_window.close()
-        else:
-            self.exit(0)
+        os._exit(0)
 
     # This function first performs all upon-exit checks such as USB printing that is in progress.
     # Use this to close the application.


### PR DESCRIPTION
As the comments for this method already state, anything of value should already have been saved when calling this. It may not be the prettiest workaround, but why bother cleaning things up before they go in the fires of /dev/null anyway? Now the question is ... will it work in the build?