### PR TITLE
Fix QML warnings produced due to signal calls in Connections

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsAction.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsAction.qml
@@ -27,7 +27,7 @@ Cura.MachineAction
     Connections
     {
         target: extrudersModel
-        onItemsChanged: tabNameModel.update()
+        function onItemsChanged() { tabNameModel.update() }
     }
 
     ListModel

--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -326,7 +326,7 @@ Item
                 Connections
                 {
                     target: Cura.MachineManager
-                    onGlobalContainerChanged: extruderCountModel.update()
+                    function onGlobalContainerChanged() { extruderCountModel.update() }
                 }
             }
 

--- a/plugins/PerObjectSettingsTool/PerObjectItem.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectItem.qml
@@ -35,7 +35,7 @@ UM.TooltipArea
     Connections
     {
         target: addedSettingsModel
-        onVisibleCountChanged:
+        function onVisibleCountChanged()
         {
             check.checked = addedSettingsModel.getVisible(model.key)
         }

--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -334,13 +334,13 @@ Item
                         Connections
                         {
                             target: inheritStackProvider
-                            onPropertiesChanged: provider.forcePropertiesChanged()
+                            function onPropertiesChanged() { provider.forcePropertiesChanged() }
                         }
 
                         Connections
                         {
                             target: UM.ActiveTool
-                            onPropertiesChanged:
+                            function onPropertiesChanged()
                             {
                                 // the values cannot be bound with UM.ActiveTool.properties.getValue() calls,
                                 // so here we connect to the signal and update the those values.

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -414,7 +414,7 @@ UM.Dialog
                         {
                             target: item
 
-                            onShowTooltip:
+                            function onShowTooltip(text)
                             {
                                 tooltip.text = text
                                 var position = settingLoader.mapToItem(settingsPanel, settingsPanel.x, 0)

--- a/plugins/SimulationView/SimulationViewMainComponent.qml
+++ b/plugins/SimulationView/SimulationViewMainComponent.qml
@@ -55,8 +55,8 @@ Item
         Connections
         {
             target: UM.SimulationView
-            onMaxPathsChanged: pathSlider.setHandleValue(UM.SimulationView.currentPath)
-            onCurrentPathChanged:
+            function onMaxPathsChanged() { pathSlider.setHandleValue(UM.SimulationView.currentPath) }
+            function onCurrentPathChanged()
             {
                 // Only pause the simulation when the layer was changed manually, not when the simulation is running
                 if (pathSlider.manuallyChanged)
@@ -89,7 +89,7 @@ Item
         Connections
         {
             target: UM.Preferences
-            onPreferenceChanged:
+            function onPreferenceChanged(preference)
             {
                 if (preference !== "view/only_show_top_layers" && preference !== "view/top_layer_count" && ! preference.match("layerview/"))
                 {
@@ -221,9 +221,9 @@ Item
         Connections
         {
             target: UM.SimulationView
-            onMaxLayersChanged: layerSlider.setUpperValue(UM.SimulationView.currentLayer)
-            onMinimumLayerChanged: layerSlider.setLowerValue(UM.SimulationView.minimumLayer)
-            onCurrentLayerChanged:
+            function onMaxLayersChanged() { layerSlider.setUpperValue(UM.SimulationView.currentLayer) }
+            function onMinimumLayerChanged() { layerSlider.setLowerValue(UM.SimulationView.minimumLayer) }
+            function onCurrentLayerChanged()
             {
                 // Only pause the simulation when the layer was changed manually, not when the simulation is running
                 if (layerSlider.manuallyChanged)

--- a/plugins/SimulationView/SimulationViewMenuComponent.qml
+++ b/plugins/SimulationView/SimulationViewMenuComponent.qml
@@ -22,7 +22,7 @@ Cura.ExpandableComponent
     Connections
     {
         target: UM.Preferences
-        onPreferenceChanged:
+        function onPreferenceChanged(preference)
         {
             if (preference !== "view/only_show_top_layers" && preference !== "view/top_layer_count" && ! preference.match("layerview/"))
             {

--- a/plugins/Toolbox/resources/qml/Toolbox.qml
+++ b/plugins/Toolbox/resources/qml/Toolbox.qml
@@ -100,8 +100,8 @@ Window
         Connections
         {
             target: toolbox
-            onShowLicenseDialog: { licenseDialog.show() }
-            onCloseLicenseDialog: { licenseDialog.close() }
+            function onShowLicenseDialog() { licenseDialog.show() }
+            function onCloseLicenseDialog() { licenseDialog.close() }
         }
         
         ToolboxLicenseDialog

--- a/plugins/Toolbox/resources/qml/components/ToolboxDetailTileActions.qml
+++ b/plugins/Toolbox/resources/qml/components/ToolboxDetailTileActions.qml
@@ -112,8 +112,8 @@ Column
     Connections
     {
         target: toolbox
-        onInstallChanged: installed = toolbox.isInstalled(model.id)
-        onFilterChanged:
+        function onInstallChanged() { installed = toolbox.isInstalled(model.id) }
+        function onFilterChanged()
         {
             installed = toolbox.isInstalled(model.id)
         }

--- a/plugins/Toolbox/resources/qml/components/ToolboxInstalledTile.qml
+++ b/plugins/Toolbox/resources/qml/components/ToolboxInstalledTile.qml
@@ -117,7 +117,7 @@ Item
         Connections
         {
             target: toolbox
-            onEnabledChanged: isEnabled = toolbox.isEnabled(model.id)
+            function onEnabledChanged() { isEnabled = toolbox.isEnabled(model.id) }
         }
     }
 }

--- a/plugins/Toolbox/resources/qml/components/ToolboxInstalledTile.qml
+++ b/plugins/Toolbox/resources/qml/components/ToolboxInstalledTile.qml
@@ -117,7 +117,7 @@ Item
         Connections
         {
             target: toolbox
-            function onEnabledChanged() { isEnabled = toolbox.isEnabled(model.id) }
+            function onToolboxEnabledChanged() { isEnabled = toolbox.isEnabled(model.id) }
         }
     }
 }

--- a/plugins/Toolbox/resources/qml/components/ToolboxInstalledTileActions.qml
+++ b/plugins/Toolbox/resources/qml/components/ToolboxInstalledTileActions.qml
@@ -81,7 +81,7 @@ Column
         Connections
         {
             target: toolbox
-            onMetadataChanged:
+            function onMetadataChanged()
             {
                 canDowngrade = toolbox.canDowngrade(model.id)
             }

--- a/plugins/Toolbox/src/Toolbox.py
+++ b/plugins/Toolbox/src/Toolbox.py
@@ -122,7 +122,7 @@ class Toolbox(QObject, Extension):
     onIsDownloadingChanged = pyqtSignal()
     restartRequiredChanged = pyqtSignal()
     installChanged = pyqtSignal()
-    enabledChanged = pyqtSignal()
+    toolboxEnabledChanged = pyqtSignal()
 
     # UI changes
     viewChanged = pyqtSignal()
@@ -208,7 +208,7 @@ class Toolbox(QObject, Extension):
 
         self._dialog.show()
         # Apply enabled/disabled state to installed plugins
-        self.enabledChanged.emit()
+        self.toolboxEnabledChanged.emit()
 
     def _createDialog(self, qml_name: str) -> Optional[QObject]:
         Logger.log("d", "Marketplace: Creating dialog [%s].", qml_name)
@@ -442,7 +442,7 @@ class Toolbox(QObject, Extension):
     @pyqtSlot(str)
     def enable(self, plugin_id: str) -> None:
         self._plugin_registry.enablePlugin(plugin_id)
-        self.enabledChanged.emit()
+        self.toolboxEnabledChanged.emit()
         Logger.log("i", "%s was set as 'active'.", plugin_id)
         self._restart_required = True
         self.restartRequiredChanged.emit()
@@ -450,7 +450,7 @@ class Toolbox(QObject, Extension):
     @pyqtSlot(str)
     def disable(self, plugin_id: str) -> None:
         self._plugin_registry.disablePlugin(plugin_id)
-        self.enabledChanged.emit()
+        self.toolboxEnabledChanged.emit()
         Logger.log("i", "%s was set as 'deactive'.", plugin_id)
         self._restart_required = True
         self.restartRequiredChanged.emit()

--- a/resources/qml/ActionPanel/ActionPanelWidget.qml
+++ b/resources/qml/ActionPanel/ActionPanelWidget.qml
@@ -93,7 +93,7 @@ Item
     Connections
     {
         target: CuraApplication
-        onAdditionalComponentsChanged: base.addAdditionalComponents()
+        function onAdditionalComponentsChanged(areaId) { base.addAdditionalComponents() }
     }
 
     function addAdditionalComponents()

--- a/resources/qml/ActionPanel/SliceProcessWidget.qml
+++ b/resources/qml/ActionPanel/SliceProcessWidget.qml
@@ -127,7 +127,7 @@ Column
     Connections
     {
         target: UM.Preferences
-        onPreferenceChanged:
+        function onPreferenceChanged(preference)
         {
             if (preference !== "general/auto_slice")
             {

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -88,7 +88,7 @@ UM.MainWindow
     {
         // This connection is used when there is no ActiveMachine and the user is logged in
         target: CuraApplication
-        onShowAddPrintersUncancellableDialog:
+        function onShowAddPrintersUncancellableDialog()
         {
             Cura.Actions.parent = backgroundItem
 
@@ -102,7 +102,7 @@ UM.MainWindow
     Connections
     {
         target: CuraApplication
-        onInitializationFinished:
+        function onInitializationFinished()
         {
             // Workaround silly issues with QML Action's shortcut property.
             //
@@ -471,19 +471,19 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.preferences
-        onTriggered: preferences.visible = true
+        function onTriggered() { preferences.visible = true }
     }
 
     Connections
     {
         target: CuraApplication
-        onShowPreferencesWindow: preferences.visible = true
+        function onShowPreferencesWindow() { preferences.visible = true }
     }
 
     Connections
     {
         target: Cura.Actions.addProfile
-        onTriggered:
+        function onTriggered()
         {
             preferences.show();
             preferences.setPage(4);
@@ -495,7 +495,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.configureMachines
-        onTriggered:
+        function onTriggered()
         {
             preferences.visible = true;
             preferences.setPage(2);
@@ -505,7 +505,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.manageProfiles
-        onTriggered:
+        function onTriggered()
         {
             preferences.visible = true;
             preferences.setPage(4);
@@ -515,7 +515,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.manageMaterials
-        onTriggered:
+        function onTriggered()
         {
             preferences.visible = true;
             preferences.setPage(3)
@@ -525,7 +525,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.configureSettingVisibility
-        onTriggered:
+        function onTriggered()
         {
             preferences.visible = true;
             preferences.setPage(1);
@@ -550,7 +550,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.MachineManager
-        onBlurSettings:
+        function onBlurSettings()
         {
             contentItem.forceActiveFocus()
         }
@@ -594,7 +594,7 @@ UM.MainWindow
     Connections
     {
         target: CuraApplication
-        onShowConfirmExitDialog:
+        function onShowConfirmExitDialog(message)
         {
             exitConfirmationDialog.text = message;
             exitConfirmationDialog.open();
@@ -604,19 +604,19 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.quit
-        onTriggered: CuraApplication.checkAndExitApplication();
+        function onTriggered() { CuraApplication.checkAndExitApplication(); }
     }
 
     Connections
     {
         target: Cura.Actions.toggleFullScreen
-        onTriggered: base.toggleFullscreen()
+        function onTriggered() { base.toggleFullscreen() }
     }
 
     Connections
     {
         target: Cura.Actions.exitFullScreen
-        onTriggered: base.exitFullscreen()
+        function onTriggered() { base.exitFullscreen() }
     }
 
     FileDialog
@@ -761,7 +761,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.open
-        onTriggered: openDialog.open()
+        function onTriggered() { openDialog.open() }
     }
 
     OpenFilesIncludingProjectsDialog
@@ -777,7 +777,7 @@ UM.MainWindow
     Connections
     {
         target: CuraApplication
-        onOpenProjectFile:
+        function onOpenProjectFile(project_file, add_to_recent_files)
         {
             askOpenAsProjectOrModelsDialog.fileUrl = project_file;
             askOpenAsProjectOrModelsDialog.addToRecent = add_to_recent_files;
@@ -788,7 +788,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.showProfileFolder
-        onTriggered:
+        function onTriggered()
         {
             var path = UM.Resources.getPath(UM.Resources.Preferences, "");
             if(Qt.platform.os == "windows")
@@ -820,7 +820,7 @@ UM.MainWindow
     Connections
     {
         target: CuraApplication
-        onShowMessageBox:
+        function onShowMessageBox(title, text, informativeText, detailedText, buttons, icon)
         {
             messageDialog.title = title
             messageDialog.text = text
@@ -844,7 +844,7 @@ UM.MainWindow
     Connections
     {
         target: CuraApplication
-        onShowDiscardOrKeepProfileChanges:
+        function onShowDiscardOrKeepProfileChanges()
         {
             discardOrKeepProfileChangesDialogLoader.sourceComponent = discardOrKeepProfileChangesDialogComponent
             discardOrKeepProfileChangesDialogLoader.item.show()
@@ -871,13 +871,13 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.whatsNew
-        onTriggered: whatsNewDialog.show()
+        function onTriggered() { whatsNewDialog.show() }
     }
 
     Connections
     {
         target: Cura.Actions.addMachine
-        onTriggered:
+        function onTriggered()
         {
             // Make sure to show from the first page when the dialog shows up.
             addMachineDialog.resetModelState()
@@ -893,7 +893,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.about
-        onTriggered: aboutDialog.visible = true;
+        function onTriggered() { aboutDialog.visible = true; }
     }
 
     Timer

--- a/resources/qml/ExpandableComponent.qml
+++ b/resources/qml/ExpandableComponent.qml
@@ -92,6 +92,15 @@ Item
         contentContainer.trySetPosition(contentContainer.x, contentContainer.y);
     }
 
+    onEnabledChanged:
+    {
+        if (!base.enabled && expanded)
+        {
+            toggleContent();
+            updateDragPosition();
+        }
+    }
+
     // Add this binding since the background color is not updated otherwise
     Binding
     {
@@ -100,20 +109,6 @@ Item
         value:
         {
             return base.enabled ? (expanded ? headerActiveColor : headerBackgroundColor) : UM.Theme.getColor("disabled")
-        }
-    }
-
-    // The panel needs to close when it becomes disabled
-    Connections
-    {
-        target: base
-        onEnabledChanged:
-        {
-            if (!base.enabled && expanded)
-            {
-                toggleContent();
-                updateDragPosition();
-            }
         }
     }
 
@@ -300,7 +295,7 @@ Item
                 Connections
                 {
                     target: UM.Preferences
-                    onPreferenceChanged:
+                    function onPreferenceChanged(preference)
                     {
                         if
                         (
@@ -342,8 +337,8 @@ Item
     {
         // Since it could be that the content is dynamically populated, we should also take these changes into account.
         target: content.contentItem
-        onWidthChanged: content.width = content.contentItem.width + 2 * content.padding
-        onHeightChanged:
+        function onWidthChanged() { content.width = content.contentItem.width + 2 * content.padding }
+        function onHeightChanged()
         {
             content.height = content.contentItem.height + 2 * content.padding
             contentContainer.height = contentHeader.height + content.height

--- a/resources/qml/ExpandablePopup.qml
+++ b/resources/qml/ExpandablePopup.qml
@@ -78,6 +78,14 @@ Item
 
     property int shadowOffset: 2
 
+    onEnabledChanged:
+    {
+        if (!base.enabled && expanded)
+        {
+            toggleContent()
+        }
+    }
+
     function toggleContent()
     {
         if (content.visible)
@@ -96,19 +104,6 @@ Item
         target: background
         property: "color"
         value: base.enabled ? headerBackgroundColor : UM.Theme.getColor("disabled")
-    }
-
-    // The panel needs to close when it becomes disabled
-    Connections
-    {
-        target: base
-        onEnabledChanged:
-        {
-            if (!base.enabled && expanded)
-            {
-                toggleContent()
-            }
-        }
     }
 
     implicitHeight: 100 * screenScaleFactor
@@ -247,7 +242,7 @@ Item
     {
         // Since it could be that the content is dynamically populated, we should also take these changes into account.
         target: content.contentItem
-        onWidthChanged: content.width = content.contentItem.width + 2 * content.padding
-        onHeightChanged: content.height = content.contentItem.height + 2 * content.padding
+        function onWidthChanged() { content.width = content.contentItem.width + 2 * content.padding }
+        function onHeightChanged() { content.height = content.contentItem.height + 2 * content.padding }
     }
 }

--- a/resources/qml/JobSpecs.qml
+++ b/resources/qml/JobSpecs.qml
@@ -149,7 +149,7 @@ Item
     Connections
     {
         target: CuraApplication
-        onAdditionalComponentsChanged: base.addAdditionalComponents("jobSpecsButton")
+        function onAdditionalComponentsChanged(areaId) { base.addAdditionalComponents("jobSpecsButton") }
     }
 
     function addAdditionalComponents(areaId)

--- a/resources/qml/MachineSettings/ComboBoxWithOptions.qml
+++ b/resources/qml/MachineSettings/ComboBoxWithOptions.qml
@@ -93,8 +93,8 @@ UM.TooltipArea
     Connections
     {
         target: propertyProvider
-        onContainerStackChanged: defaultOptionsModel.updateModel()
-        onIsValueUsedChanged: defaultOptionsModel.updateModel()
+        function onContainerStackChanged() { defaultOptionsModel.updateModel() }
+        function onIsValueUsedChanged() { defaultOptionsModel.updateModel() }
     }
 
     Cura.ComboBox

--- a/resources/qml/MachineSettings/PrintHeadMinMaxTextField.qml
+++ b/resources/qml/MachineSettings/PrintHeadMinMaxTextField.qml
@@ -54,7 +54,7 @@ NumericTextFieldWithUnit
     Connections
     {
         target: textField
-        onActiveFocusChanged:
+        function onActiveFocusChanged()
         {
             // When this text field loses focus and the entered text is not valid, make sure to recreate the binding to
             // show the correct value.

--- a/resources/qml/MainWindow/ApplicationMenu.qml
+++ b/resources/qml/MainWindow/ApplicationMenu.qml
@@ -169,7 +169,7 @@ Item
     Connections
     {
         target: Cura.Actions.newProject
-        onTriggered:
+        function onTriggered()
         {
             if(Printer.platformActivity || Cura.MachineManager.hasUserSettings)
             {
@@ -182,7 +182,7 @@ Item
     Connections
     {
         target: Cura.Actions.browsePackages
-        onTriggered:
+        function onTriggered()
         {
             curaExtensions.callExtensionMethod("Toolbox", "launch")
         }
@@ -192,7 +192,7 @@ Item
     Connections
     {
         target: Cura.Actions.marketplaceMaterials
-        onTriggered:
+        function onTriggered()
         {
             curaExtensions.callExtensionMethod("Toolbox", "launch")
             curaExtensions.callExtensionMethod("Toolbox", "setViewCategoryToMaterials")

--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml
@@ -219,7 +219,7 @@ Button
     Connections
     {
         target: Cura.MachineManager
-        onCurrentConfigurationChanged:
+        function onCurrentConfigurationChanged()
         {
             configurationItem.checked = Cura.MachineManager.matchesConfiguration(configuration)
         }

--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml
@@ -126,7 +126,7 @@ Item
     Connections
     {
         target: outputDevice
-        onUniqueConfigurationsChanged:
+        function onUniqueConfigurationsChanged()
         {
             forceModelUpdate()
         }
@@ -135,7 +135,7 @@ Item
     Connections
     {
         target: Cura.MachineManager
-        onOutputDevicesChanged:
+        function onOutputDevicesChanged()
         {
             forceModelUpdate()
         }

--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -236,6 +236,6 @@ Cura.ExpandablePopup
     Connections
     {
         target: Cura.MachineManager
-        onGlobalContainerChanged: popupItem.manual_selected_method = -1  // When switching printers, reset the value of the manual selected method
+        function onGlobalContainerChanged() { popupItem.manual_selected_method = -1 }  // When switching printers, reset the value of the manual selected method
     }
 }

--- a/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml
+++ b/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml
@@ -118,7 +118,7 @@ Item
         Connections
         {
             target: Cura.ExtruderManager
-            onActiveExtruderChanged:
+            function onActiveExtruderChanged()
             {
                 tabBar.setCurrentIndex(Cura.ExtruderManager.activeExtruderIndex);
             }
@@ -139,7 +139,7 @@ Item
         Connections
         {
             target: repeater.model
-            onModelChanged:
+            function onModelChanged()
             {
                 tabBar.setCurrentIndex(Cura.ExtruderManager.activeExtruderIndex)
             }

--- a/resources/qml/Menus/ContextMenu.qml
+++ b/resources/qml/Menus/ContextMenu.qml
@@ -90,13 +90,13 @@ Menu
     Connections
     {
         target: UM.Controller
-        onContextMenuRequested: base.popup();
+        function onContextMenuRequested() { base.popup(); }
     }
 
     Connections
     {
         target: Cura.Actions.multiplySelection
-        onTriggered: multiplyDialog.open()
+        function onTriggered() { multiplyDialog.open() }
     }
 
     UM.SettingPropertyProvider

--- a/resources/qml/Menus/ViewMenu.qml
+++ b/resources/qml/Menus/ViewMenu.qml
@@ -31,7 +31,7 @@ Menu
         Connections
         {
             target: UM.Preferences
-            onPreferenceChanged:
+            function onPreferenceChanged(preference)
             {
                 if (preference !== "general/camera_perspective_mode")
                 {

--- a/resources/qml/MonitorButton.qml
+++ b/resources/qml/MonitorButton.qml
@@ -252,9 +252,10 @@ Item
             buttonsRow.updateAdditionalComponents("monitorButtons")
         }
 
-        Connections {
+        Connections
+        {
             target: CuraApplication
-            onAdditionalComponentsChanged: buttonsRow.updateAdditionalComponents("monitorButtons")
+            function onAdditionalComponentsChanged() { buttonsRow.updateAdditionalComponents("monitorButtons") }
         }
 
         function updateAdditionalComponents (areaId) {

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -416,7 +416,7 @@ UM.PreferencesPage
                 Connections
                 {
                     target: UM.Preferences
-                    onPreferenceChanged:
+                    function onPreferenceChanged(preference)
                     {
                         if(preference != "general/camera_perspective_mode")
                         {
@@ -856,7 +856,7 @@ UM.PreferencesPage
             Connections
             {
                 target: UM.Preferences
-                onPreferenceChanged:
+                function onPreferenceChanged(preference)
                 {
                     if (preference !== "info/send_slice_info")
                     {

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -166,7 +166,7 @@ UM.ManagementPage
         Connections
         {
             target: Cura.MachineManager
-            onGlobalContainerChanged:
+            function onGlobalContainerChanged()
             {
                 objectList.currentIndex = activeMachineIndex()
                 objectList.onCurrentIndexChanged()

--- a/resources/qml/Preferences/Materials/MaterialsBrandSection.qml
+++ b/resources/qml/Preferences/Materials/MaterialsBrandSection.qml
@@ -134,7 +134,7 @@ Item
     Connections
     {
         target: UM.Preferences
-        onPreferenceChanged:
+        function onPreferenceChanged(preference)
         {
             if (preference !== "cura/expanded_types" && preference !== "cura/expanded_brands")
             {

--- a/resources/qml/Preferences/Materials/MaterialsList.qml
+++ b/resources/qml/Preferences/Materials/MaterialsList.qml
@@ -124,13 +124,13 @@ Item
     Connections
     {
         target: materialsModel
-        onItemsChanged: updateAfterModelChanges()
+        function onItemsChanged() { updateAfterModelChanges() }
     }
 
     Connections
     {
         target: genericMaterialsModel
-        onItemsChanged: updateAfterModelChanges()
+        function onItemsChanged() { updateAfterModelChanges() }
     }
     
     Column

--- a/resources/qml/Preferences/Materials/MaterialsTypeSection.qml
+++ b/resources/qml/Preferences/Materials/MaterialsTypeSection.qml
@@ -124,7 +124,7 @@ Item
     Connections
     {
         target: UM.Preferences
-        onPreferenceChanged:
+        function onPreferenceChanged(preference)
         {
             if (preference !== "cura/expanded_types" && preference !== "cura/expanded_brands")
             {

--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -217,7 +217,7 @@ Item
     Connections
     {
         target: base.qualityManagementModel
-        onItemsChanged:
+        function onItemsChanged()
         {
             var toSelectItemName = base.currentItem == null ? "" : base.currentItem.name;
             if (newQualityNameToSelect != "")

--- a/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml
+++ b/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml
@@ -244,7 +244,7 @@ Item
         Connections
         {
             target: Cura.ExtruderManager
-            onActiveExtruderChanged:
+            function onActiveExtruderChanged()
             {
                 tabBar.setCurrentIndex(Cura.ExtruderManager.activeExtruderIndex);
             }
@@ -256,7 +256,7 @@ Item
         Connections
         {
             target: repeater.model
-            onModelChanged:
+            function onModelChanged()
             {
                 tabBar.setCurrentIndex(Cura.ExtruderManager.activeExtruderIndex)
             }

--- a/resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml
+++ b/resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml
@@ -84,7 +84,7 @@ Item
             Connections
             {
                 target: UM.Preferences
-                onPreferenceChanged:
+                function onPreferenceChanged(preference)
                 {
                     if (preference !== "view/settings_list_height" && preference !== "general/window_height" && preference !== "general/window_state")
                     {

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
@@ -128,7 +128,7 @@ Item
             Connections
             {
                 target: extruderModel
-                onModelChanged:
+                function onModelChanged()
                 {
                     var maybeColor = supportExtruderCombobox.model.getItem(supportExtruderCombobox.currentIndex).color
                     if (maybeColor)

--- a/resources/qml/PrinterOutput/OutputDeviceHeader.qml
+++ b/resources/qml/PrinterOutput/OutputDeviceHeader.qml
@@ -17,7 +17,7 @@ Item
     Connections
     {
         target: Cura.MachineManager
-        onGlobalContainerChanged:
+        function onGlobalContainerChanged()
         {
             outputDevice = Cura.MachineManager.printerOutputDevices.length >= 1 ? Cura.MachineManager.printerOutputDevices[0] : null;
         }

--- a/resources/qml/PrinterSelector/MachineSelectorButton.qml
+++ b/resources/qml/PrinterSelector/MachineSelectorButton.qml
@@ -105,13 +105,13 @@ Button
     Connections
     {
         target: outputDevice
-        onUniqueConfigurationsChanged: updatePrinterTypesFunction()
+        function onUniqueConfigurationsChanged() { updatePrinterTypesFunction() }
     }
 
     Connections
     {
         target: Cura.MachineManager
-        onOutputDevicesChanged: updatePrinterTypesFunction()
+        function onOutputDevicesChanged() { updatePrinterTypesFunction() }
     }
 
     Component.onCompleted: updatePrinterTypesFunction()

--- a/resources/qml/Settings/SettingExtruder.qml
+++ b/resources/qml/Settings/SettingExtruder.qml
@@ -24,7 +24,7 @@ SettingItem
         Connections
         {
             target: extrudersModel
-            onModelChanged:
+            function onModelChanged()
             {
                 control.color = extrudersModel.getItem(control.currentIndex).color
             }

--- a/resources/qml/Settings/SettingOptionalExtruder.qml
+++ b/resources/qml/Settings/SettingOptionalExtruder.qml
@@ -29,7 +29,7 @@ SettingItem
         Connections
         {
             target: base.extrudersWithOptionalModel
-            onModelChanged: control.color = base.extrudersWithOptionalModel.getItem(control.currentIndex).color
+            function onModelChanged() { control.color = base.extrudersWithOptionalModel.getItem(control.currentIndex).color }
         }
 
         textRole: "name"

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -357,16 +357,16 @@ Item
                 Connections
                 {
                     target: item
-                    onContextMenuRequested:
+                    function onContextMenuRequested()
                     {
                         contextMenu.key = model.key;
                         contextMenu.settingVisible = model.visible;
                         contextMenu.provider = provider
                         contextMenu.popup();
                     }
-                    onShowTooltip: base.showTooltip(delegate, Qt.point(-settingsView.x - UM.Theme.getSize("default_margin").width, 0), text)
-                    onHideTooltip: base.hideTooltip()
-                    onShowAllHiddenInheritedSettings:
+                    function onShowTooltip() { base.showTooltip(delegate, Qt.point(-settingsView.x - UM.Theme.getSize("default_margin").width, 0), text) }
+                    function onHideTooltip() { base.hideTooltip() }
+                    function onShowAllHiddenInheritedSettings()
                     {
                         var children_with_override = Cura.SettingInheritanceManager.getChildrenKeysWithOverride(category_id)
                         for(var i = 0; i < children_with_override.length; i++)
@@ -375,7 +375,7 @@ Item
                         }
                         Cura.SettingInheritanceManager.manualRemoveOverride(category_id)
                     }
-                    onFocusReceived:
+                    function onFocusReceived()
                     {
                         contents.indexWithFocus = index;
                         animateContentY.from = contents.contentY;
@@ -383,7 +383,7 @@ Item
                         animateContentY.to = contents.contentY;
                         animateContentY.running = true;
                     }
-                    onSetActiveFocusToNextSetting:
+                    function onSetActiveFocusToNextSetting()
                     {
                         if (forward == undefined || forward)
                         {

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -364,7 +364,7 @@ Item
                         contextMenu.provider = provider
                         contextMenu.popup();
                     }
-                    function onShowTooltip() { base.showTooltip(delegate, Qt.point(-settingsView.x - UM.Theme.getSize("default_margin").width, 0), text) }
+                    function onShowTooltip(text) { base.showTooltip(delegate, Qt.point(-settingsView.x - UM.Theme.getSize("default_margin").width, 0), text) }
                     function onHideTooltip() { base.hideTooltip() }
                     function onShowAllHiddenInheritedSettings()
                     {

--- a/resources/qml/WelcomePages/AddPrinterByIpContent.qml
+++ b/resources/qml/WelcomePages/AddPrinterByIpContent.qml
@@ -41,7 +41,7 @@ Item
     Connections
     {
         target: CuraApplication.getDiscoveredPrintersModel()
-        onDiscoveredPrintersChanged:
+        function onDiscoveredPrintersChanged()
         {
             if (hasRequestFinished && currentRequestAddress)
             {
@@ -310,7 +310,7 @@ Item
                     Connections
                     {
                         target: CuraApplication.getDiscoveredPrintersModel()
-                        onManualDeviceRequestFinished:
+                        function onManualDeviceRequestFinished(success)
                         {
                             var discovered_printers_model = CuraApplication.getDiscoveredPrintersModel()
                             var printer = discovered_printers_model.discoveredPrintersByAddress[hostnameField.text]

--- a/resources/qml/WelcomePages/DropDownWidget.qml
+++ b/resources/qml/WelcomePages/DropDownWidget.qml
@@ -35,7 +35,7 @@ Item
     Connections
     {
         target: header
-        onClicked:
+        function onClicked()
         {
             base.contentShown = !base.contentShown
             clicked()

--- a/resources/qml/WelcomePages/FirstStartMachineActionsContent.qml
+++ b/resources/qml/WelcomePages/FirstStartMachineActionsContent.qml
@@ -27,7 +27,7 @@ Item
     Connections
     {
         target: machineActionsModel
-        onAllFinished:
+        function onAllFinished()
         {
             if (visible)
             {

--- a/resources/qml/WelcomePages/WelcomeDialogItem.qml
+++ b/resources/qml/WelcomePages/WelcomeDialogItem.qml
@@ -61,6 +61,6 @@ Item
     Connections
     {
         target: model
-        onAllFinished: dialog.visible = false
+        function onAllFinished() { dialog.visible = false }
     }
 }

--- a/resources/qml/WelcomePages/WizardDialog.qml
+++ b/resources/qml/WelcomePages/WizardDialog.qml
@@ -47,6 +47,6 @@ Window
     Connections
     {
         target: model
-        onAllFinished: dialog.hide()
+        function onAllFinished() { dialog.hide() }
     }
 }


### PR DESCRIPTION
In Qt5.15 the Connections items should not be using the "on < signal > " format since it is depricated.
They should have the format function "on < signal > (arguments)" instead.