### PR TITLE
CURA-8125: Fix marketplace button not directing to the web marketplace

### DIFF
--- a/plugins/Toolbox/resources/qml/components/ToolboxHeader.qml
+++ b/plugins/Toolbox/resources/qml/components/ToolboxHeader.qml
@@ -90,6 +90,7 @@ Item
             rightMargin: UM.Theme.getSize("default_margin").width
             verticalCenter: parent.verticalCenter
         }
+        acceptedButtons: Qt.LeftButton
         onClicked: Qt.openUrlExternally(toolbox.getWebMarketplaceUrl("plugins"))
         UM.RecolorImage
         {


### PR DESCRIPTION
We generally disabled the clicks in the mouseArea of the tooltips.
In this case though it should still accept the left click since it acts as a button.

CURA-8125