### PR TITLE
CURA-8126: Fix Toolbox window not closing instantly after pressing "Quit Cura"

### DIFF
--- a/plugins/Toolbox/resources/qml/components/ToolboxFooter.qml
+++ b/plugins/Toolbox/resources/qml/components/ToolboxFooter.qml
@@ -44,7 +44,11 @@ Item
         }
         height: UM.Theme.getSize("toolbox_footer_button").height
         text: catalog.i18nc("@info:button, %1 is the application name", "Quit %1").arg(CuraApplication.applicationDisplayName)
-        onClicked: toolbox.restart()
+        onClicked:
+        {
+            base.hide()
+            toolbox.restart()
+        }
     }
 
     ToolboxShadow


### PR DESCRIPTION
After installing a package and hitting the "Close Ultimaker Cura" button, the Toolbox window was remaining open for a few seconds, even though the Cura window was instantly closing.

This is not fixed by explicitly hiding the Toolbox dialog once that button is pressed.

CURA-8126