### PR TITLE
Draw simulation view lines with a constant colour for the entire line

### DIFF
--- a/plugins/SimulationView/layers3d.shader
+++ b/plugins/SimulationView/layers3d.shader
@@ -221,20 +221,20 @@ geometry41core =
             vec4 vb_up = viewProjectionMatrix * (gl_in[1].gl_Position + g_vertex_offset_horz + g_vertex_offset_vert);
 
             // Travels: flat plane with pointy ends
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_up);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_head);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_down);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_up);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_up);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_head);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_down);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_up);
             myEmitVertex(v_vertex[1], v_color[1], g_vertex_normal_vert, vb_down);
             myEmitVertex(v_vertex[1], v_color[1], g_vertex_normal_vert, vb_up);
             myEmitVertex(v_vertex[1], v_color[1], g_vertex_normal_vert, vb_head);
             //And reverse so that the line is also visible from the back side.
             myEmitVertex(v_vertex[1], v_color[1], g_vertex_normal_vert, vb_up);
             myEmitVertex(v_vertex[1], v_color[1], g_vertex_normal_vert, vb_down);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_up);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_down);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_head);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_up);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_up);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_down);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_head);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_up);
 
             EndPrimitive();
         } else {
@@ -250,31 +250,31 @@ geometry41core =
             vec4 vb_head   = viewProjectionMatrix * (gl_in[1].gl_Position - g_vertex_offset_horz_head); //Line end, tip.
 
             // All normal lines are rendered as 3d tubes.
-            myEmitVertex(v_vertex[0], v_color[0], -g_vertex_normal_horz, va_m_horz);
+            myEmitVertex(v_vertex[0], v_color[1], -g_vertex_normal_horz, va_m_horz);
             myEmitVertex(v_vertex[1], v_color[1], -g_vertex_normal_horz, vb_m_horz);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_p_vert);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_p_vert);
             myEmitVertex(v_vertex[1], v_color[1], g_vertex_normal_vert, vb_p_vert);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_horz, va_p_horz);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_horz, va_p_horz);
             myEmitVertex(v_vertex[1], v_color[1], g_vertex_normal_horz, vb_p_horz);
-            myEmitVertex(v_vertex[0], v_color[0], -g_vertex_normal_vert, va_m_vert);
+            myEmitVertex(v_vertex[0], v_color[1], -g_vertex_normal_vert, va_m_vert);
             myEmitVertex(v_vertex[1], v_color[1], -g_vertex_normal_vert, vb_m_vert);
-            myEmitVertex(v_vertex[0], v_color[0], -g_vertex_normal_horz, va_m_horz);
+            myEmitVertex(v_vertex[0], v_color[1], -g_vertex_normal_horz, va_m_horz);
             myEmitVertex(v_vertex[1], v_color[1], -g_vertex_normal_horz, vb_m_horz);
 
             EndPrimitive();
 
             // left side
-            myEmitVertex(v_vertex[0], v_color[0], -g_vertex_normal_horz, va_m_horz);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_vert, va_p_vert);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_horz_head, va_head);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_horz, va_p_horz);
+            myEmitVertex(v_vertex[0], v_color[1], -g_vertex_normal_horz, va_m_horz);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_vert, va_p_vert);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_horz_head, va_head);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_horz, va_p_horz);
 
             EndPrimitive();
 
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_horz, va_p_horz);
-            myEmitVertex(v_vertex[0], v_color[0], -g_vertex_normal_vert, va_m_vert);
-            myEmitVertex(v_vertex[0], v_color[0], g_vertex_normal_horz_head, va_head);
-            myEmitVertex(v_vertex[0], v_color[0], -g_vertex_normal_horz, va_m_horz);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_horz, va_p_horz);
+            myEmitVertex(v_vertex[0], v_color[1], -g_vertex_normal_vert, va_m_vert);
+            myEmitVertex(v_vertex[0], v_color[1], g_vertex_normal_horz_head, va_head);
+            myEmitVertex(v_vertex[0], v_color[1], -g_vertex_normal_horz, va_m_horz);
 
             EndPrimitive();
 


### PR DESCRIPTION
All of our current layer view colour schemes are properties of a line, not of a vertex. The line has a single feedrate, a single line type, a single layer thickness, a single material colour and a single width. This is even limited by the g-code specification itself, which is unable to represent lines with varying line width. However, we store this information in the vertices, the vertex data being the only data sent to layer view since layer view is sent as polylines to the shader.

This change makes the entire line take on the colour scheme of the vertex where its representative data is stored. This data is intended for the line, not just for that vertex, so it makes sense that the entire line listens to the data of the correct vertex, not just the nearest vertex of the line's endpoint.

This change is really only effective for the Line Width and Speed colour schemes. The other colour schemes (line type, layer thickness and material colour) don't currently vary within one polygon. But in the code it applies to all colour schemes.

Line width before:
![image](https://user-images.githubusercontent.com/2448634/113480458-958c4280-9494-11eb-925d-8a7ef20c11fc.png)

Line width after:
![image](https://user-images.githubusercontent.com/2448634/113480386-4514e500-9494-11eb-9686-d76de4b3933f.png)

I am making this change because it makes the screenshots in the Settings Guide more clear, especially for Arachne (and because it's a bit of a pet peeve). Since the line width colour scheme was added, this became more clear since we very rarely adjusted the speed within one path. The speed is really only modified within one path for the gap filling with Equalize Filament Flow, and for bridging. Line Width is modified more often within the path, so this new feature made the bug more visible.