### PR TITLE
Added "Relative Extrusion" mode support for PauseAtHeight.py script

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -510,8 +510,7 @@ class PauseAtHeight(Script):
                     extrusion_mode_string = "absolute"
                     extrusion_mode_numeric = 82
 
-                    extruders = list(Application.getInstance().getGlobalContainerStack().extruders.values())
-                    relative_extrusion = extruders[0].getProperty("relative_extrusion", "value")
+                    relative_extrusion = Application.getInstance().getGlobalContainerStack().getProperty("relative_extrusion", "value")
                     if relative_extrusion:
                         extrusion_mode_string = "relative"
                         extrusion_mode_numeric = 83

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -507,7 +507,16 @@ class PauseAtHeight(Script):
                     else:
                         Logger.log("w", "No previous feedrate found in gcode, feedrate for next layer(s) might be incorrect")
 
-                    prepend_gcode += self.putValue(M = 82) + " ; switch back to absolute E values\n"
+                    extrusion_mode_string = "absolute"
+                    extrusion_mode_numeric = 82
+
+                    extruders = list(Application.getInstance().getGlobalContainerStack().extruders.values())
+                    relative_extrusion = extruders[0].getProperty("relative_extrusion", "value")
+                    if relative_extrusion:
+                        extrusion_mode_string = "relative"
+                        extrusion_mode_numeric = 83
+
+                    prepend_gcode += self.putValue(M = extrusion_mode_numeric) + " ; switch back to " + extrusion_mode_string + " E values\n"
 
                 # reset extrude value to pre pause value
                 prepend_gcode += self.putValue(G = 92, E = current_e) + "\n"


### PR DESCRIPTION
The extrusion mode is read from the primary extruder (`extruders[0]`). I am not familiar with multi-extruder setups, but I assume that the relative mode, if enabled, would be active for all extruders anyway (thus validating the use of `extruders[0]`).