### PR TITLE
CURA-8166: Fix tab button not switching to the next print setting field

### DIFF
--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -383,7 +383,7 @@ Item
                         animateContentY.to = contents.contentY;
                         animateContentY.running = true;
                     }
-                    function onSetActiveFocusToNextSetting()
+                    function onSetActiveFocusToNextSetting(forward)
                     {
                         if (forward == undefined || forward)
                         {


### PR DESCRIPTION
The signal `setActiveFocusToNextSetting` has an argument which wasn't being passed in the `onSetActiveFocusToNextSetting()` function, causing the broken behavior.

Fixes https://github.com/Ultimaker/Cura/issues/9529.

CURA-8166