### PR TITLE
[CURA-8161] Remove donkey and other UX adventures

### DIFF
--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -197,20 +197,6 @@ UM.PreferencesPage
                         }
                     }
                     onActivated: UM.Preferences.setValue("general/language", model.get(index).code)
-
-                    Component.onCompleted:
-                    {
-                        // Because ListModel is stupid and does not allow using qsTr() for values.
-                        for(var i = 0; i < languageList.count; ++i)
-                        {
-                            languageList.setProperty(i, "text", catalog.i18n(languageList.get(i).text));
-                        }
-
-                        // Glorious hack time. ComboBox does not update the text properly after changing the
-                        // model. So change the indices around to force it to update.
-                        currentIndex += 1;
-                        currentIndex -= 1;
-                    }
                 }
 
                 Label
@@ -265,21 +251,6 @@ UM.PreferencesPage
                         return 0;
                     }
                     onActivated: UM.Preferences.setValue("general/theme", model.get(index).code)
-
-                    Component.onCompleted:
-                    {
-                        // Because ListModel is stupid and does not allow using qsTr() for values.
-                        for(var i = 0; i < themeList.count; ++i)
-                        {
-                            themeList.setProperty(i, "text", catalog.i18n(themeList.get(i).text));
-                        }
-
-                        // Glorious hack time. ComboBox does not update the text properly after changing the
-                        // model. So change the indices around to force it to update.
-                        currentIndex += 1;
-                        currentIndex -= 1;
-                    }
-
                 }
             }
 

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -2,9 +2,11 @@
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.10
-import QtQuick.Controls 2.3
+import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
 import QtQuick.Controls.Styles 1.1
+
+import QtQuick.Controls 2.3 as NewControls
 
 import UM 1.1 as UM
 import Cura 1.1 as Cura
@@ -139,6 +141,7 @@ UM.PreferencesPage
             {
                 id: interfaceGrid
                 columns: 4
+                width: parent.width
 
                 Label
                 {
@@ -178,12 +181,13 @@ UM.PreferencesPage
                     }
                 }
 
-                ComboBox
+                NewControls.ComboBox
                 {
                     id: languageComboBox
 
                     textRole: "text"
                     model: languageList
+                    Layout.fillWidth: true
 
                     currentIndex:
                     {
@@ -231,12 +235,13 @@ UM.PreferencesPage
                     }
                 }
 
-                ComboBox
+                NewControls.ComboBox
                 {
                     id: themeComboBox
 
                     model: themeList
                     textRole: "text"
+                    Layout.fillWidth: true
 
                     currentIndex:
                     {
@@ -506,7 +511,7 @@ UM.PreferencesPage
                         }
                     }
 
-                    ComboBox
+                    NewControls.ComboBox
                     {
                         id: cameraComboBox
 
@@ -647,7 +652,7 @@ UM.PreferencesPage
                         text: catalog.i18nc("@window:text", "Default behavior when opening a project file: ")
                     }
 
-                    ComboBox
+                    NewControls.ComboBox
                     {
                         id: choiceOnOpenProjectDropDownButton
                         width: 200 * screenScaleFactor
@@ -714,7 +719,7 @@ UM.PreferencesPage
                         text: catalog.i18nc("@window:text", "Default behavior for changed setting values when switching to a different profile: ")
                     }
 
-                    ComboBox
+                    NewControls.ComboBox
                     {
                         id: choiceOnProfileOverrideDropDownButton
                         width: 200 * screenScaleFactor

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -655,7 +655,7 @@ UM.PreferencesPage
                     NewControls.ComboBox
                     {
                         id: choiceOnOpenProjectDropDownButton
-                        width: 200 * screenScaleFactor
+                        width: Math.round(250 * screenScaleFactor)
 
                         model: ListModel
                         {
@@ -722,8 +722,8 @@ UM.PreferencesPage
                     NewControls.ComboBox
                     {
                         id: choiceOnProfileOverrideDropDownButton
-                        width: 200 * screenScaleFactor
-
+                        width: Math.round(250 * screenScaleFactor)
+                        popup.width: Math.round(350 * screenScaleFactor)
                         model: ListModel
                         {
                             id: discardOrKeepProfileListModel


### PR DESCRIPTION
- Language and Theme selections where empty and 'Colorblind' no matter what. This was an UX issue, since selecting and changeing them still worked, it just didn't show the active ones.
- Remove donkey: We where showing our donkey due to an unfortunate abbreviation/truncation of 'Colorblind Assist'. Now that should already not show in for a default install (see previous point) but also just give the box some more space.
- Revert most of the rest of the preferences/general page back to the old controls (except for the combo-boxes, which needed to be upgraded in order to work on MacOS 11), pending a _proper_ redesign to the newer style of this page.