### PR TITLE
[CURA-8004] Fix wrong 'uploaded print job' cache.

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -269,6 +269,8 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         else:
             PrintJobUploadErrorMessage(I18N_CATALOG.i18nc("@error:send", "Unknown error code when uploading print job: {0}", error_code)).show()
 
+        Logger.log("w", "Upload of print job failed specifically with error code {}".format(error_code))
+
         self._progress.hide()
         self._pre_upload_print_job = None
         self._uploaded_print_job = None
@@ -279,6 +281,8 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         Displays the given message if uploading the mesh has failed due to a generic error (i.e. lost connection).
         :param message: The message to display.
         """
+        Logger.log("w", "Upload error with message {}".format(message))
+
         self._progress.hide()
         self._pre_upload_print_job = None
         self._uploaded_print_job = None

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -191,6 +191,7 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         if self._progress.visible:
             PrintJobUploadBlockedMessage().show()
             return
+        self._progress.show()
 
         # Indicate we have started sending a job.
         self.writeStarted.emit(self)
@@ -229,7 +230,6 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         """
         if not self._tool_path:
             return self._onUploadError()
-        self._progress.show()
         self._pre_upload_print_job = job_response  # store the last uploaded job to prevent re-upload of the same file
         self._api.uploadToolPath(job_response, self._tool_path, self._onPrintJobUploaded, self._progress.update,
                                  self._onUploadError)

--- a/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py
+++ b/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py
@@ -13,6 +13,5 @@ class PrintJobUploadErrorMessage(Message):
     def __init__(self, message: str = None) -> None:
         super().__init__(
             text = message or I18N_CATALOG.i18nc("@info:text", "Could not upload the data to the printer."),
-            title = I18N_CATALOG.i18nc("@info:title", "Network error"),
-            lifetime = 10
+            title = I18N_CATALOG.i18nc("@info:title", "Network error")
         )


### PR DESCRIPTION
Fix 'uploaded print-job cache' set before the mesh upload.

Since we use that to detect when the mesh is already uploaded, and thus can be reprinted, this could cause problems, since, while we do properly set it to None when an error is returned, if the request never returns to us, or if a reprint is started while the mesh is still uploading, the print-job cache could be set while the mesh wasn't actually there yet. Which could in theory have maybe caused the problems we see.