### PR TITLE
CURA-8178: Fix auth tokens being set to none on startup

### DIFF
--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -45,25 +45,26 @@ class KeyringAttribute:
     def __set__(self, instance: "BaseModel", value: Optional[str]):
         if self._store_secure:
             setattr(instance, self._name, None)
-            try:
-                keyring.set_password("cura", self._keyring_name, value if value is not None else "")
-            except PasswordSetError:
-                self._store_secure = False
-                if self._name not in DONT_EVER_STORE_LOCALLY:
-                    setattr(instance, self._name, value)
-                Logger.logException("w", "Keyring access denied")
-            except NoKeyringError:
-                self._store_secure = False
-                if self._name not in DONT_EVER_STORE_LOCALLY:
-                    setattr(instance, self._name, value)
-                Logger.logException("w", "No keyring backend present")
-            except BaseException as e:
-                # A BaseException can occur in Windows when the keyring attempts to write a token longer than 1024
-                # characters in the Windows Credentials Manager.
-                self._store_secure = False
-                if self._name not in DONT_EVER_STORE_LOCALLY:
-                    setattr(instance, self._name, value)
-                Logger.log("w", "Keyring failed: {}".format(e))
+            if value is not None:
+                try:
+                    keyring.set_password("cura", self._keyring_name, value)
+                except PasswordSetError:
+                    self._store_secure = False
+                    if self._name not in DONT_EVER_STORE_LOCALLY:
+                        setattr(instance, self._name, value)
+                    Logger.logException("w", "Keyring access denied")
+                except NoKeyringError:
+                    self._store_secure = False
+                    if self._name not in DONT_EVER_STORE_LOCALLY:
+                        setattr(instance, self._name, value)
+                    Logger.logException("w", "No keyring backend present")
+                except BaseException as e:
+                    # A BaseException can occur in Windows when the keyring attempts to write a token longer than 1024
+                    # characters in the Windows Credentials Manager.
+                    self._store_secure = False
+                    if self._name not in DONT_EVER_STORE_LOCALLY:
+                        setattr(instance, self._name, value)
+                    Logger.log("w", "Keyring failed: {}".format(e))
         else:
             setattr(instance, self._name, value)
 


### PR DESCRIPTION
When Cura is starting up, it reads the authentication data from the preferences (cura.cfg). If the auth tokens have previously been stored in the keyring, it means that their values will be null in the cura.cfg file. Therefore, on startup, Cura reads the tokens as none from the preferences and then sets the empty values in the keyring as tokens. This leads to the user being signed off every time Cura restarts on Mac.

On Windows, the access token was still stored in the preferences, so on startup it was safe. The refresh token, on the other hand, had the same issue as on Mac, which means that on startup it was read as None from the cura.cfg and was stored in the keyring as an empty string. This meant that, even though on startup (on windows) the user was kept signed in, the next time Cura was attempting to refresh the access token (after 7-8 minutes), it wouldn't be able, since its refresh token was read as "" from the keyring. Also, if the user would close Cura and reopen it after 10 minutes (so after the access token had expired) then they would be signed off on windows too.

This commit fixes that by making sure that if the given value of the refresh and access tokens are empty, then they will not be stored in the keyring.

CURA-8178