### PR TITLE
Allow renaming groups to something other than "Group #n"

### DIFF
--- a/cura/UI/ObjectsModel.py
+++ b/cura/UI/ObjectsModel.py
@@ -132,9 +132,26 @@ class ObjectsModel(ListModel):
 
             is_group = bool(node.callDecoration("isGroup"))
 
+            name_handled_as_group = False
             force_rename = False
-            if not is_group:
-                # Handle names for individual nodes
+            if is_group:
+                # Handle names for grouped nodes
+                original_name = self._group_name_prefix
+
+                current_name = node.getName()
+                if current_name.startswith(self._group_name_prefix):
+                    # This group has a standard group name, but we may need to renumber it
+                    name_index = int(current_name.split("#")[-1])
+                    name_handled_as_group = True
+                elif not current_name:
+                    # Force rename this group because this node has not been named as a group yet, probably because
+                    # it's a newly created group.
+                    name_index = 0
+                    force_rename = True
+                    name_handled_as_group = True
+
+            if not is_group or not name_handled_as_group:
+                # Handle names for individual nodes or groups that already have a non-group name
                 name = node.getName()
 
                 name_match = self._naming_regex.fullmatch(name)
@@ -144,18 +161,6 @@ class ObjectsModel(ListModel):
                 else:
                     original_name = name_match.groups()[0]
                     name_index = int(name_match.groups()[1])
-            else:
-                # Handle names for grouped nodes
-                original_name = self._group_name_prefix
-
-                current_name = node.getName()
-                if current_name.startswith(self._group_name_prefix):
-                    name_index = int(current_name.split("#")[-1])
-                else:
-                    # Force rename this group because this node has not been named as a group yet, probably because
-                    # it's a newly created group.
-                    name_index = 0
-                    force_rename = True
 
             if original_name not in name_to_node_info_dict:
                 # Keep track of 2 things:


### PR DESCRIPTION
This PR fixes renaming of groups to something other than "Group #n". Before this, a renamed group would always immediately be renamed by to the "Group #n" pattern.

Fixes https://github.com/Ultimaker/Cura/issues/9531