### PR TITLE
Fix test_wrongServerResponses

### DIFF
--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -46,7 +46,7 @@ NO_REFRESH_AUTH_RESPONSE = AuthenticationResponse(
     success = True
 )
 
-MALFORMED_AUTH_RESPONSE = AuthenticationResponse()
+MALFORMED_AUTH_RESPONSE = AuthenticationResponse(success=False)
 
 
 def test_cleanAuthService() -> None:


### PR DESCRIPTION
This test was failing with Python 3.9 while packaging `cura` for Fedora 34.

`authorization_service._onAuthStateChanged()` marks the user as logged-in if `success` is `True` (default value) in `AuthenticationResponse`. (I thikn) setting `success` to `False` produces the expected behavior for the test.