### PR TITLE
Fix floods of QML errors in styles.qml

### DIFF
--- a/resources/themes/cura-light/styles.qml
+++ b/resources/themes/cura-light/styles.qml
@@ -21,49 +21,49 @@ QtObject
                     {
                         if(control.valueError)
                         {
-                            return Theme.getColor("setting_validation_error_background");
+                            return UM.Theme.getColor("setting_validation_error_background");
                         }
                         else if(control.valueWarning)
                         {
-                            return Theme.getColor("setting_validation_warning_background");
+                            return UM.Theme.getColor("setting_validation_warning_background");
                         }
                         else
                         {
-                            return Theme.getColor("setting_control");
+                            return UM.Theme.getColor("setting_control");
                         }
                     }
                     else
                     {
-                        return Theme.getColor("setting_control_disabled");
+                        return UM.Theme.getColor("setting_control_disabled");
                     }
                 }
 
                 radius: UM.Theme.getSize("setting_control_radius").width
-                border.width: Theme.getSize("default_lining").width
+                border.width: UM.Theme.getSize("default_lining").width
                 border.color:
                 {
                     if (control.enabled)
                     {
                         if (control.valueError)
                         {
-                            return Theme.getColor("setting_validation_error");
+                            return UM.Theme.getColor("setting_validation_error");
                         }
                         else if (control.valueWarning)
                         {
-                            return Theme.getColor("setting_validation_warning");
+                            return UM.Theme.getColor("setting_validation_warning");
                         }
                         else if (control.hovered)
                         {
-                            return Theme.getColor("setting_control_border_highlight");
+                            return UM.Theme.getColor("setting_control_border_highlight");
                         }
                         else
                         {
-                            return Theme.getColor("setting_control_border");
+                            return UM.Theme.getColor("setting_control_border");
                         }
                     }
                     else
                     {
-                        return Theme.getColor("setting_control_disabled_border");
+                        return UM.Theme.getColor("setting_control_disabled_border");
                     }
                 }
                 UM.RecolorImage
@@ -71,25 +71,25 @@ QtObject
                     id: downArrow
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.right: parent.right
-                    anchors.rightMargin: Theme.getSize("default_margin").width
-                    width: Theme.getSize("standard_arrow").width
-                    height: Theme.getSize("standard_arrow").height
+                    anchors.rightMargin: UM.Theme.getSize("default_margin").width
+                    width: UM.Theme.getSize("standard_arrow").width
+                    height: UM.Theme.getSize("standard_arrow").height
                     sourceSize.height: width
-                    color: control.enabled ? Theme.getColor("setting_control_button") : Theme.getColor("setting_category_disabled_text")
-                    source: Theme.getIcon("arrow_bottom")
+                    color: control.enabled ? UM.Theme.getColor("setting_control_button") : UM.Theme.getColor("setting_category_disabled_text")
+                    source: UM.Theme.getIcon("arrow_bottom")
                 }
                 Label
                 {
                     id: printSetupComboBoxLabel
-                    color: control.enabled ? Theme.getColor("setting_control_text") : Theme.getColor("setting_control_disabled_text")
+                    color: control.enabled ? UM.Theme.getColor("setting_control_text") : UM.Theme.getColor("setting_control_disabled_text")
                     text: control.text;
                     elide: Text.ElideRight;
                     anchors.left: parent.left;
-                    anchors.leftMargin: Theme.getSize("setting_unit_margin").width
+                    anchors.leftMargin: UM.Theme.getSize("setting_unit_margin").width
                     anchors.right: downArrow.left;
                     anchors.rightMargin: control.rightMargin;
                     anchors.verticalCenter: parent.verticalCenter;
-                    font: Theme.getFont("default")
+                    font: UM.Theme.getFont("default")
                 }
             }
             label: Label{}
@@ -175,25 +175,25 @@ QtObject
         {
             background: Item
             {
-                implicitWidth: Theme.getSize("button").width
-                implicitHeight: Theme.getSize("button").height
+                implicitWidth: UM.Theme.getSize("button").width
+                implicitHeight: UM.Theme.getSize("button").height
 
                 UM.PointingRectangle
                 {
                     id: button_tooltip
 
                     anchors.left: parent.right
-                    anchors.leftMargin: Theme.getSize("button_tooltip_arrow").width * 2
+                    anchors.leftMargin: UM.Theme.getSize("button_tooltip_arrow").width * 2
                     anchors.verticalCenter: parent.verticalCenter
 
                     target: Qt.point(parent.x, y + Math.round(height/2))
-                    arrowSize: Theme.getSize("button_tooltip_arrow").width
-                    color: Theme.getColor("button_tooltip")
+                    arrowSize: UM.Theme.getSize("button_tooltip_arrow").width
+                    color: UM.Theme.getColor("button_tooltip")
                     opacity: control.hovered ? 1.0 : 0.0;
                     visible: control.text != ""
 
-                    width: control.hovered ? button_tip.width + Theme.getSize("button_tooltip").width : 0
-                    height: Theme.getSize("button_tooltip").height
+                    width: control.hovered ? button_tip.width + UM.Theme.getSize("button_tooltip").width : 0
+                    height: UM.Theme.getSize("button_tooltip").height
 
                     Behavior on width { NumberAnimation { duration: 100; } }
                     Behavior on opacity { NumberAnimation { duration: 100; } }
@@ -206,8 +206,8 @@ QtObject
                         anchors.verticalCenter: parent.verticalCenter
 
                         text: control.text
-                        font: Theme.getFont("default")
-                        color: Theme.getColor("tooltip_text")
+                        font: UM.Theme.getFont("default")
+                        color: UM.Theme.getColor("tooltip_text")
                     }
                 }
 
@@ -226,22 +226,22 @@ QtObject
                         }
                         else if(control.checkable && control.checked && control.hovered)
                         {
-                            return Theme.getColor("toolbar_button_active_hover")
+                            return UM.Theme.getColor("toolbar_button_active_hover")
                         }
                         else if(control.pressed || (control.checkable && control.checked))
                         {
-                            return Theme.getColor("toolbar_button_active")
+                            return UM.Theme.getColor("toolbar_button_active")
                         }
                         else if(control.hovered)
                         {
-                            return Theme.getColor("toolbar_button_hover")
+                            return UM.Theme.getColor("toolbar_button_hover")
                         }
-                        return Theme.getColor("toolbar_background")
+                        return UM.Theme.getColor("toolbar_background")
                     }
                     Behavior on color { ColorAnimation { duration: 50; } }
 
-                    border.width: (control.hasOwnProperty("needBorder") && control.needBorder) ? Theme.getSize("default_lining").width : 0
-                    border.color: control.checked ? Theme.getColor("icon") : Theme.getColor("lining")
+                    border.width: (control.hasOwnProperty("needBorder") && control.needBorder) ? UM.Theme.getSize("default_lining").width : 0
+                    border.color: control.checked ? UM.Theme.getColor("icon") : UM.Theme.getColor("lining")
                 }
             }
 
@@ -252,11 +252,11 @@ QtObject
                     anchors.centerIn: parent
                     opacity: control.enabled ? 1.0 : 0.2
                     source: control.iconSource
-                    width: Theme.getSize("button_icon").width
-                    height: Theme.getSize("button_icon").height
-                    color: Theme.getColor("icon")
+                    width: UM.Theme.getSize("button_icon").width
+                    height: UM.Theme.getSize("button_icon").height
+                    color: UM.Theme.getColor("icon")
 
-                    sourceSize: Theme.getSize("button_icon")
+                    sourceSize: UM.Theme.getSize("button_icon")
                 }
             }
         }
@@ -268,10 +268,10 @@ QtObject
         {
             background: Rectangle
             {
-                implicitWidth: Theme.getSize("message").width - (Theme.getSize("default_margin").width * 2)
-                implicitHeight: Theme.getSize("progressbar").height
-                color: control.hasOwnProperty("backgroundColor") ? control.backgroundColor : Theme.getColor("progressbar_background")
-                radius: Theme.getSize("progressbar_radius").width
+                implicitWidth: UM.Theme.getSize("message").width - (UM.Theme.getSize("default_margin").width * 2)
+                implicitHeight: UM.Theme.getSize("progressbar").height
+                color: control.hasOwnProperty("backgroundColor") ? control.backgroundColor : UM.Theme.getColor("progressbar_background")
+                radius: UM.Theme.getSize("progressbar_radius").width
             }
             progress: Rectangle
             {
@@ -287,22 +287,22 @@ QtObject
                     }
                     else
                     {
-                        return Theme.getColor("progressbar_control");
+                        return UM.Theme.getColor("progressbar_control");
                     }
                 }
-                radius: Theme.getSize("progressbar_radius").width
+                radius: UM.Theme.getSize("progressbar_radius").width
                 Rectangle
                 {
-                    radius: Theme.getSize("progressbar_radius").width
-                    color: control.hasOwnProperty("controlColor") ? control.controlColor : Theme.getColor("progressbar_control")
-                    width: Theme.getSize("progressbar_control").width
-                    height: Theme.getSize("progressbar_control").height
+                    radius: UM.Theme.getSize("progressbar_radius").width
+                    color: control.hasOwnProperty("controlColor") ? control.controlColor : UM.Theme.getColor("progressbar_control")
+                    width: UM.Theme.getSize("progressbar_control").width
+                    height: UM.Theme.getSize("progressbar_control").height
                     visible: control.indeterminate
 
                     SequentialAnimation on x
                     {
                         id: xAnim
-                        property int animEndPoint: Theme.getSize("message").width - Math.round((Theme.getSize("default_margin").width * 2.5)) - Theme.getSize("progressbar_control").width
+                        property int animEndPoint: UM.Theme.getSize("message").width - Math.round((UM.Theme.getSize("default_margin").width * 2.5)) - UM.Theme.getSize("progressbar_control").width
                         running: control.indeterminate && control.visible
                         loops: Animation.Infinite
                         NumberAnimation { from: 0; to: xAnim.animEndPoint; duration: 2000;}
@@ -324,18 +324,18 @@ QtObject
 
             scrollBarBackground: Rectangle
             {
-                implicitWidth: Theme.getSize("scrollbar").width
+                implicitWidth: UM.Theme.getSize("scrollbar").width
                 radius: Math.round(implicitWidth / 2)
-                color: Theme.getColor("scrollbar_background")
+                color: UM.Theme.getColor("scrollbar_background")
             }
 
             handle: Rectangle
             {
                 id: scrollViewHandle
-                implicitWidth: Theme.getSize("scrollbar").width
+                implicitWidth: UM.Theme.getSize("scrollbar").width
                 radius: Math.round(implicitWidth / 2)
 
-                color: styleData.pressed ? Theme.getColor("scrollbar_handle_down") : styleData.hovered ? Theme.getColor("scrollbar_handle_hover") : Theme.getColor("scrollbar_handle")
+                color: styleData.pressed ? UM.Theme.getColor("scrollbar_handle_down") : styleData.hovered ? UM.Theme.getColor("scrollbar_handle_hover") : UM.Theme.getColor("scrollbar_handle")
                 Behavior on color { ColorAnimation { duration: 50; } }
             }
         }
@@ -348,14 +348,14 @@ QtObject
 
             background: Rectangle
             {
-                implicitHeight: Theme.getSize("setting_control").height;
-                implicitWidth: Theme.getSize("setting_control").width;
+                implicitHeight: UM.Theme.getSize("setting_control").height;
+                implicitWidth: UM.Theme.getSize("setting_control").width;
 
                 color: control.hovered ? UM.Theme.getColor("setting_control_highlight") : UM.Theme.getColor("setting_control")
                 Behavior on color { ColorAnimation { duration: 50; } }
 
-                border.width: Theme.getSize("default_lining").width;
-                border.color: control.hovered ? Theme.getColor("setting_control_border_highlight") : Theme.getColor("setting_control_border");
+                border.width: UM.Theme.getSize("default_lining").width;
+                border.color: control.hovered ? UM.Theme.getColor("setting_control_border_highlight") : UM.Theme.getColor("setting_control_border");
                 radius: UM.Theme.getSize("setting_control_radius").width
             }
 
@@ -364,14 +364,14 @@ QtObject
                 Label
                 {
                     anchors.left: parent.left
-                    anchors.leftMargin: Theme.getSize("default_lining").width
+                    anchors.leftMargin: UM.Theme.getSize("default_lining").width
                     anchors.right: downArrow.left
-                    anchors.rightMargin: Theme.getSize("default_lining").width
+                    anchors.rightMargin: UM.Theme.getSize("default_lining").width
                     anchors.verticalCenter: parent.verticalCenter
 
                     text: control.currentText
-                    font: Theme.getFont("default");
-                    color: !enabled ? Theme.getColor("setting_control_disabled_text") : Theme.getColor("setting_control_text")
+                    font: UM.Theme.getFont("default");
+                    color: !enabled ? UM.Theme.getColor("setting_control_disabled_text") : UM.Theme.getColor("setting_control_text")
 
                     elide: Text.ElideRight
                     verticalAlignment: Text.AlignVCenter
@@ -381,16 +381,16 @@ QtObject
                 {
                     id: downArrow
                     anchors.right: parent.right
-                    anchors.rightMargin: Theme.getSize("default_lining").width * 2
+                    anchors.rightMargin: UM.Theme.getSize("default_lining").width * 2
                     anchors.verticalCenter: parent.verticalCenter
 
-                    source: Theme.getIcon("arrow_bottom")
-                    width: Theme.getSize("standard_arrow").width
-                    height: Theme.getSize("standard_arrow").height
+                    source: UM.Theme.getIcon("arrow_bottom")
+                    width: UM.Theme.getSize("standard_arrow").width
+                    height: UM.Theme.getSize("standard_arrow").height
                     sourceSize.width: width + 5 * screenScaleFactor
                     sourceSize.height: width + 5 * screenScaleFactor
 
-                    color: Theme.getColor("setting_control_button");
+                    color: UM.Theme.getColor("setting_control_button");
                 }
             }
         }
@@ -403,16 +403,16 @@ QtObject
             background: Item { }
             indicator: Rectangle
             {
-                implicitWidth:  Theme.getSize("checkbox").width
-                implicitHeight: Theme.getSize("checkbox").height
+                implicitWidth:  UM.Theme.getSize("checkbox").width
+                implicitHeight: UM.Theme.getSize("checkbox").height
 
-                color: (control.hovered || control._hovered) ? Theme.getColor("checkbox_hover") : (control.enabled ? Theme.getColor("checkbox") : Theme.getColor("checkbox_disabled"))
+                color: (control.hovered || control._hovered) ? UM.Theme.getColor("checkbox_hover") : (control.enabled ? UM.Theme.getColor("checkbox") : UM.Theme.getColor("checkbox_disabled"))
                 Behavior on color { ColorAnimation { duration: 50; } }
 
-                radius: control.exclusiveGroup ? Math.round(Theme.getSize("checkbox").width / 2) : Theme.getSize("checkbox_radius").width
+                radius: control.exclusiveGroup ? Math.round(UM.Theme.getSize("checkbox").width / 2) : UM.Theme.getSize("checkbox_radius").width
 
-                border.width: Theme.getSize("default_lining").width
-                border.color: (control.hovered || control._hovered) ? Theme.getColor("checkbox_border_hover") : Theme.getColor("checkbox_border")
+                border.width: UM.Theme.getSize("default_lining").width
+                border.color: (control.hovered || control._hovered) ? UM.Theme.getColor("checkbox_border_hover") : UM.Theme.getColor("checkbox_border")
 
                 UM.RecolorImage
                 {
@@ -421,8 +421,8 @@ QtObject
                     width: Math.round(parent.width / 2.5)
                     height: Math.round(parent.height / 2.5)
                     sourceSize.height: width
-                    color: Theme.getColor("checkbox_mark")
-                    source: control.exclusiveGroup ? Theme.getIcon("dot") : Theme.getIcon("check")
+                    color: UM.Theme.getColor("checkbox_mark")
+                    source: control.exclusiveGroup ? UM.Theme.getIcon("dot") : UM.Theme.getIcon("check")
                     opacity: control.checked
                     Behavior on opacity { NumberAnimation { duration: 100; } }
                 }
@@ -430,8 +430,8 @@ QtObject
             label: Label
             {
                 text: control.text
-                color: Theme.getColor("checkbox_text")
-                font: Theme.getFont("default")
+                color: UM.Theme.getColor("checkbox_text")
+                font: UM.Theme.getFont("default")
                 elide: Text.ElideRight
                 renderType: Text.NativeRendering
             }
@@ -445,16 +445,16 @@ QtObject
             background: Item { }
             indicator: Rectangle
             {
-                implicitWidth:  Theme.getSize("checkbox").width
-                implicitHeight: Theme.getSize("checkbox").height
+                implicitWidth:  UM.Theme.getSize("checkbox").width
+                implicitHeight: UM.Theme.getSize("checkbox").height
 
-                color: (control.hovered || control._hovered) ? Theme.getColor("checkbox_hover") : Theme.getColor("checkbox");
+                color: (control.hovered || control._hovered) ? UM.Theme.getColor("checkbox_hover") : UM.Theme.getColor("checkbox");
                 Behavior on color { ColorAnimation { duration: 50; } }
 
-                radius: control.exclusiveGroup ? Math.round(Theme.getSize("checkbox").width / 2) : UM.Theme.getSize("checkbox_radius").width
+                radius: control.exclusiveGroup ? Math.round(UM.Theme.getSize("checkbox").width / 2) : UM.Theme.getSize("checkbox_radius").width
 
-                border.width: Theme.getSize("default_lining").width;
-                border.color: (control.hovered || control._hovered) ? Theme.getColor("checkbox_border_hover") : Theme.getColor("checkbox_border");
+                border.width: UM.Theme.getSize("default_lining").width;
+                border.color: (control.hovered || control._hovered) ? UM.Theme.getColor("checkbox_border_hover") : UM.Theme.getColor("checkbox_border");
 
                 UM.RecolorImage
                 {
@@ -463,16 +463,16 @@ QtObject
                     width: Math.round(parent.width / 2.5)
                     height: Math.round(parent.height / 2.5)
                     sourceSize.height: width
-                    color: Theme.getColor("checkbox_mark")
+                    color: UM.Theme.getColor("checkbox_mark")
                     source:
                     {
                         if (control.checkbox_state == 2)
                         {
-                            return Theme.getIcon("solid");
+                            return UM.Theme.getIcon("solid");
                         }
                         else
                         {
-                            return control.exclusiveGroup ? Theme.getIcon("dot") : Theme.getIcon("check");
+                            return control.exclusiveGroup ? UM.Theme.getIcon("dot") : UM.Theme.getIcon("check");
                         }
                     }
                     opacity: control.checked
@@ -482,8 +482,8 @@ QtObject
             label: Label
             {
                 text: control.text
-                color: Theme.getColor("checkbox_text")
-                font: Theme.getFont("default")
+                color: UM.Theme.getColor("checkbox_text")
+                font: UM.Theme.getFont("default")
             }
         }
     }
@@ -492,30 +492,30 @@ QtObject
     {
         TextFieldStyle
         {
-            textColor: Theme.getColor("setting_control_text")
-            placeholderTextColor: Theme.getColor("setting_control_text")
-            font: Theme.getFont("default")
+            textColor: UM.Theme.getColor("setting_control_text")
+            placeholderTextColor: UM.Theme.getColor("setting_control_text")
+            font: UM.Theme.getFont("default")
 
             background: Rectangle
             {
                 implicitHeight: control.height;
                 implicitWidth: control.width;
 
-                border.width: Theme.getSize("default_lining").width;
-                border.color: control.hovered ? Theme.getColor("setting_control_border_highlight") : Theme.getColor("setting_control_border");
+                border.width: UM.Theme.getSize("default_lining").width;
+                border.color: control.hovered ? UM.Theme.getColor("setting_control_border_highlight") : UM.Theme.getColor("setting_control_border");
                 radius: UM.Theme.getSize("setting_control_radius").width
 
-                color: Theme.getColor("setting_validation_ok");
+                color: UM.Theme.getColor("setting_validation_ok");
 
                 Label
                 {
                     anchors.right: parent.right;
-                    anchors.rightMargin: Theme.getSize("setting_unit_margin").width;
+                    anchors.rightMargin: UM.Theme.getSize("setting_unit_margin").width;
                     anchors.verticalCenter: parent.verticalCenter;
 
                     text: control.unit ? control.unit : ""
-                    color: Theme.getColor("setting_unit");
-                    font: Theme.getFont("default");
+                    color: UM.Theme.getColor("setting_unit");
+                    font: UM.Theme.getFont("default");
                     renderType: Text.NativeRendering
                 }
             }

--- a/resources/themes/cura-light/styles.qml
+++ b/resources/themes/cura-light/styles.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Ultimaker B.V.
+// Copyright (c) 2021 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.10


### PR DESCRIPTION
This PR prevents hundreds of QML warning messages logged per second in some user reports of Cura being slow.

https://github.com/fieldOfView/Cura-SidebarGUIPlugin/issues/24#issue-872046698 includes a log that has 700 of these warnings in the span of 2 seconds.

https://github.com/Ultimaker/Cura/issues/9628#issuecomment-823952208 also has hundreds of these warnings.

These warnings seem to be more prevalent in combination with the SidebarGUI plugin, but I see them too with "vanilla" Cura, especially when closing the application.

styles.qml currently uses `UM.Theme` and `Theme` interchangeably. This PR changes that to consistently use `UM.Theme` like the rest of Cura. For me that makes all the warnings go away.

I have made this PR against the 4.9 branch, because I think it is imperative that this gets fixed in a 4.9.1 release.

```
2021-04-30 11:42:01,492 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [411]: file:///.../cura/../resources/themes/cura-light/styles.qml:335: TypeError: Cannot read property 'getSize' of null
2021-04-30 11:42:01,492 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [411]: file:///.../cura/../resources/themes/cura-light/styles.qml:338: TypeError: Cannot read property 'getColor' of null
2021-04-30 11:42:01,500 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [411]: file:///.../cura/../resources/themes/cura-light/styles.qml:327: TypeError: Cannot read property 'getSize' of null
2021-04-30 11:42:01,500 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [411]: file:///.../cura/../resources/themes/cura-light/styles.qml:329: TypeError: Cannot read property 'getColor' of null
2021-04-30 11:42:01,500 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [411]: file:///.../cura/../resources/themes/cura-light/styles.qml:335: TypeError: Cannot read property 'getSize' of null
2021-04-30 11:42:01,500 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [411]: file:///.../cura/../resources/themes/cura-light/styles.qml:338: TypeError: Cannot read property 'getColor' of null
2021-04-30 11:42:01,500 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [411]: file:///.../cura/../resources/themes/cura-light/styles.qml:327: TypeError: Cannot read property 'getSize' of null
2021-04-30 11:42:01,500 - WARNING - [MainThread] UM.Qt.QtApplication.__onQmlWarning [411]: file:///.../cura/../resources/themes/cura-light/styles.qml:329: TypeError: Cannot read property 'getColor' of null
```