### PR TITLE
CURA-8146: Fix getting PyCapsule error on import

### DIFF
--- a/cura_app.py
+++ b/cura_app.py
@@ -16,14 +16,6 @@ import argparse
 import faulthandler
 import os
 
-# Workaround for a race condition on certain systems where there
-# is a race condition between Arcus and PyQt. Importing Arcus
-# first seems to prevent Sip from going into a state where it
-# tries to create PyQt objects on a non-main thread.
-import Arcus  # @UnusedImport
-import Savitar  # @UnusedImport
-import pynest2d # @UnusedImport
-
 from PyQt5.QtNetwork import QSslConfiguration, QSslSocket
 
 from UM.Platform import Platform

--- a/plugins/PostProcessingPlugin/__init__.py
+++ b/plugins/PostProcessingPlugin/__init__.py
@@ -1,14 +1,6 @@
 # Copyright (c) 2020 Jaime van Kessel, Ultimaker B.V.
 # The PostProcessingPlugin is released under the terms of the AGPLv3 or higher.
 
-# Workaround for a race condition on certain systems where there
-# is a race condition between Arcus and PyQt. Importing Arcus
-# first seems to prevent Sip from going into a state where it
-# tries to create PyQt objects on a non-main thread.
-import Arcus  # @UnusedImport
-import Savitar  # @UnusedImport
-import pynest2d  # @UnusedImport
-
 from . import PostProcessingPlugin
 
 

--- a/plugins/UM3NetworkPrinting/src/__init__.py
+++ b/plugins/UM3NetworkPrinting/src/__init__.py
@@ -1,9 +1,2 @@
 # Copyright (c) 2019 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
-
-# Workaround for a race condition on certain systems where there
-# is a race condition between Arcus and PyQt. Importing Arcus
-# first seems to prevent Sip from going into a state where it
-# tries to create PyQt objects on a non-main thread.
-import Arcus #@UnusedImport
-import Savitar #@UnusedImport


### PR DESCRIPTION
Previously, Arcus, Savitar, and pynest2d were being build with a missing sip flag. This led to Cura
getting `ValueError: PyCapsule_GetPointer called with incorrect name`, if those libraries were not
imported (even if they were unused).

This flag was added in the following commits:

* https://github.com/Ultimaker/libSavitar/commit/83393f989c0a8eb0b4ddc00560f028bf4eb4ac6b
* https://github.com/Ultimaker/libArcus/commit/e9e530d96383c18a739e7ad181907c33b30157ec
* https://github.com/Ultimaker/pynest2d/commit/bd440b50ad6fe969063ecafe8ad99a7b7a25ccc2

Since the issue seems to be gone now, the unused imports should be removed from Cura.

All credits go to Rex Dieter for figuring that this missing flag was the issue.
https://src.fedoraproject.org/rpms/libarcus/pull-request/1#request_diff

CURA-8146