### PR TITLE
Lower QtQuick.Controls version to a version that actually exists

### DIFF
--- a/resources/qml/Menus/SettingVisibilityPresetsMenu.qml
+++ b/resources/qml/Menus/SettingVisibilityPresetsMenu.qml
@@ -2,7 +2,7 @@
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.10
-import QtQuick.Controls 2.11
+import QtQuick.Controls 2.4
 import QtQml.Models 2.14 as Models
 
 import UM 1.2 as UM


### PR DESCRIPTION
This PR lowers the QtQuick.Controls version to a version that actually exists. Qt 5.11 uses QtQuick.Controls 2.4. QtQuick.Controls 2.11 won't exist for several years (if ever). See https://doc.qt.io/archives/qt-5.11/qtquickcontrols2-index.html#versions

This PR is against the 4.9 branch, hopefully for inclusion in 4.9.1. While it seams that the non-existing QtQuick controls version is not a problem for most installs, some people running the 4.9 branch from source or using non-official distributions would run in the problems, eg https://github.com/Ultimaker/Cura/pull/9410#issuecomment-835710782