### PR TITLE
Add source file type to anonymous usage statistics

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1867,6 +1867,7 @@ class CuraApplication(QtApplication):
             else:
                 node = CuraSceneNode()
                 node.setMeshData(original_node.getMeshData())
+                node.source_mime_type = original_node.source_mime_type
 
                 # Setting meshdata does not apply scaling.
                 if original_node.getScale() != Vector(1.0, 1.0, 1.0):

--- a/cura/Scene/CuraSceneNode.py
+++ b/cura/Scene/CuraSceneNode.py
@@ -142,6 +142,7 @@ class CuraSceneNode(SceneNode):
         copy.setTransformation(self.getLocalTransformation(copy= False))
         copy.setMeshData(self._mesh_data)
         copy.setVisible(cast(bool, deepcopy(self._visible, memo)))
+        copy.source_mime_type = cast(str, deepcopy(self.source_mime_type, memo))
         copy._selectable = cast(bool, deepcopy(self._selectable, memo))
         copy._name = cast(str, deepcopy(self._name, memo))
         for decorator in self._decorators:

--- a/plugins/SliceInfoPlugin/SliceInfo.py
+++ b/plugins/SliceInfoPlugin/SliceInfo.py
@@ -229,6 +229,11 @@ class SliceInfo(QObject, Extension):
 
                     model["model_settings"] = model_settings
 
+                    if node.source_mime_type is None:
+                        model["mime_type"] = ""
+                    else:
+                        model["mime_type"] = node.source_mime_type
+
                     data["models"].append(model)
 
             print_times = print_information.printTimes()

--- a/plugins/SliceInfoPlugin/SliceInfo.py
+++ b/plugins/SliceInfoPlugin/SliceInfo.py
@@ -232,7 +232,7 @@ class SliceInfo(QObject, Extension):
                     if node.source_mime_type is None:
                         model["mime_type"] = ""
                     else:
-                        model["mime_type"] = node.source_mime_type
+                        model["mime_type"] = node.source_mime_type.name
 
                     data["models"].append(model)
 

--- a/plugins/SliceInfoPlugin/example_data.html
+++ b/plugins/SliceInfoPlugin/example_data.html
@@ -54,6 +54,7 @@
                 <li><b>Bounding Box:</b> [minimum x, y, z; maximum x, y, z]</li>
                 <li><b>Is Helper Mesh:</b> no</li>
                 <li><b>Helper Mesh Type:</b> support mesh</li>
+                <li><b>File type:</b> STL</li>
             </ul>
         </li>
     </ul>


### PR DESCRIPTION
We'd like to see which file type people are opening in our anonymous usage statistics.

This PR requires https://github.com/Ultimaker/Uranium/pull/696 .
It is currently marked as a draft because the statistics database is not yet ready to accept this data.

Contributes to issue CURA-8232.