### PR TITLE
[CURA-8246] Pause-at-height/repetier: Extrusion should be retraction.

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -387,7 +387,7 @@ class PauseAtHeight(Script):
                     #Retraction
                     prepend_gcode += self.putValue(M = 83) + " ; switch to relative E values for any needed retraction\n"
                     if retraction_amount != 0:
-                        prepend_gcode += self.putValue(G = 1, E = retraction_amount, F = 6000) + "\n"
+                        prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = 6000) + "\n"
 
                     #Move the head away
                     prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + " ; move up a millimeter to get out of the way\n"


### PR DESCRIPTION
Should fix #9752 -- This makes the repetier case completely analogous to the other 'not-griffin' flavours (at least what concerns retraction amounts), and also neatly dove-tails with the first point things start to go wrong in the bug-report.