### PR TITLE
Fix positioning of merged transformed meshes

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1526,12 +1526,8 @@ class CuraApplication(QtApplication):
 
         # Compute the center of the objects
         object_centers = []
-        # Forget about the translation that the original objects have
-        zero_translation = Matrix(data=numpy.zeros(3))
         for mesh, node in zip(meshes, group_node.getChildren()):
-            transformation = node.getLocalTransformation()
-            transformation.setTranslation(zero_translation)
-            transformed_mesh = mesh.getTransformed(transformation)
+            transformed_mesh = mesh.getTransformed(Matrix())  # Forget about the transformations that the original object had.
             center = transformed_mesh.getCenterPosition()
             if center is not None:
                 object_centers.append(center)
@@ -1546,7 +1542,7 @@ class CuraApplication(QtApplication):
 
         # Move each node to the same position.
         for mesh, node in zip(meshes, group_node.getChildren()):
-            node.setTransformation(Matrix())
+            node.setTransformation(Matrix())  # Removes any changes in position and rotation.
             # Align the object around its zero position
             # and also apply the offset to center it inside the group.
             node.setPosition(-mesh.getZeroPosition() - offset)

--- a/cura/Scene/CuraSceneNode.py
+++ b/cura/Scene/CuraSceneNode.py
@@ -124,13 +124,14 @@ class CuraSceneNode(SceneNode):
             if child.callDecoration("isNonPrintingMesh"):
                 # Non-printing-meshes inside a group should not affect push apart or drop to build plate
                 continue
-            if child.getBoundingBox().minimum == child.getBoundingBox().maximum:
+            child_bb = child.getBoundingBox()
+            if child_bb is None or child_bb.minimum == child_bb.maximum:
                 # Child had a degenerate bounding box, such as an empty group. Don't count it along.
                 continue
             if self._aabb is None:
-                self._aabb = child.getBoundingBox()
+                self._aabb = child_bb
             else:
-                self._aabb = self._aabb + child.getBoundingBox()
+                self._aabb = self._aabb + child_bb
 
         if self._aabb is None:  # No children that should be included? Just use your own position then, but it's an invalid AABB.
             position = self.getWorldPosition()


### PR DESCRIPTION
The other transformations, in particular rotation, were also influencing the merge. The transformations were not removed when calculating the center position, causing the center position of a mesh to be calculating differently. When the meshes were actually transformed/moved, all of the transformations were removed but this gave the model a different center position. The different center position wasn't properly being compensated for using the previously calculated center position.

This caused a bug to appear where merged meshes were wildly repositioned. This bug started becoming more prominent in Cura 4.8 because newly loaded models there are rotated to fit better, using the new arrange algorithm.

Fixes CURA-7873 and fixes #8765.