### PR TITLE
Rework calculation of min/max flow rates for simulation view colour scheme

### DIFF
--- a/plugins/SimulationView/SimulationView.py
+++ b/plugins/SimulationView/SimulationView.py
@@ -417,10 +417,9 @@ class SimulationView(CuraView):
         return self._max_flow_rate
 
     def getMinFlowRate(self) -> float:
-        min_flow_rate = self._min_flow_rate
-        if abs(min_flow_rate - sys.float_info.max) < 10:  # Some lenience due to floating point rounding.
+        if abs(self._min_flow_rate - sys.float_info.max) < 10:  # Some lenience due to floating point rounding.
             return 0.0  # If it's still max-float, there are no measurements. Use 0 then.
-        return min_flow_rate
+        return self._min_flow_rate
 
     def calculateMaxLayers(self) -> None:
         """

--- a/plugins/SimulationView/SimulationView.py
+++ b/plugins/SimulationView/SimulationView.py
@@ -478,6 +478,8 @@ class SimulationView(CuraView):
         old_max_linewidth = self._max_line_width
         old_min_thickness = self._min_thickness
         old_max_thickness = self._max_thickness
+        old_min_flow_rate = self._min_flow_rate
+        old_max_flow_rate = self._max_flow_rate
 
         self._min_feedrate = sys.float_info.max
         self._max_feedrate = sys.float_info.min
@@ -485,6 +487,8 @@ class SimulationView(CuraView):
         self._max_line_width = sys.float_info.min
         self._min_thickness = sys.float_info.max
         self._max_thickness = sys.float_info.min
+        self._min_flow_rate = sys.float_info.max
+        self._max_flow_rate = sys.float_info.min
 
         # The colour scheme is only influenced by the visible lines, so filter the lines by if they should be visible.
         visible_line_types = []
@@ -539,7 +543,8 @@ class SimulationView(CuraView):
 
         if old_min_feedrate != self._min_feedrate or old_max_feedrate != self._max_feedrate \
                 or old_min_linewidth != self._min_line_width or old_max_linewidth != self._max_line_width \
-                or old_min_thickness != self._min_thickness or old_max_thickness != self._max_thickness:
+                or old_min_thickness != self._min_thickness or old_max_thickness != self._max_thickness \
+                or old_min_flow_rate != self._min_flow_rate or old_max_flow_rate != self._max_flow_rate:
             self.colorSchemeLimitsChanged.emit()
 
     def calculateMaxPathsOnLayer(self, layer_num: int) -> None:

--- a/plugins/SimulationView/SimulationView.py
+++ b/plugins/SimulationView/SimulationView.py
@@ -528,9 +528,10 @@ class SimulationView(CuraView):
                     visible_thicknesses = numpy.take(polyline.lineThicknesses, visible_indices)
                     visible_thicknesses_with_extrusion = numpy.take(polyline.lineThicknesses, visible_indicies_with_extrusion)
                     self._max_feedrate = max(float(visible_feedrates.max()), self._max_feedrate)
-                    flow_rates = visible_feedrates_with_extrusion * visible_linewidths_with_extrusion * visible_thicknesses_with_extrusion
-                    self._min_flow_rate = min(float(flow_rates.min()), self._min_flow_rate)
-                    self._max_flow_rate = max(float(flow_rates.max()), self._max_flow_rate)
+                    if visible_feedrates_with_extrusion.size != 0:
+                        flow_rates = visible_feedrates_with_extrusion * visible_linewidths_with_extrusion * visible_thicknesses_with_extrusion
+                        self._min_flow_rate = min(float(flow_rates.min()), self._min_flow_rate)
+                        self._max_flow_rate = max(float(flow_rates.max()), self._max_flow_rate)
                     self._min_feedrate = min(float(visible_feedrates.min()), self._min_feedrate)
                     self._max_line_width = max(float(visible_linewidths.max()), self._max_line_width)
                     self._min_line_width = min(float(visible_linewidths.min()), self._min_line_width)


### PR DESCRIPTION
The max value was being calculated as the product of the max line width, max layer thickness
and max feedrate but it should be calculated as the maximum of the products of the width,
thickness and feedrate for each individual line. i.e. calculate the flow for each line
and use the max values of the flows. The min value calculation is similarly changed.