### PR TITLE
Export all materials to archive

### DIFF
--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -298,14 +298,13 @@ class MaterialManagementModel(QObject):
     def exportAll(self, file_path: QUrl) -> None:
         registry = CuraContainerRegistry.getInstance()
 
-        with open(file_path.toLocalFile(), "w") as stream:
-            archive = zipfile.ZipFile(stream, "w", compression = zipfile.ZIP_DEFLATED)
-            for metadata in registry.findInstanceContainersMetadata(type = "material"):
-                if metadata["base_file"] != metadata["id"]:  # Only process base files.
-                    continue
-                if metadata["id"] == "empty_material":  # Don't export the empty material.
-                    continue
-                material = registry.findContainers(id = metadata["id"])[0]
-                suffix = registry.getMimeTypeForContainer(type(material)).preferredSuffix
-                filename = metadata["id"] + "." + suffix
-                archive.writestr(filename, material.serialize())
+        archive = zipfile.ZipFile(file_path.toLocalFile(), "w")
+        for metadata in registry.findInstanceContainersMetadata(type = "material"):
+            if metadata["base_file"] != metadata["id"]:  # Only process base files.
+                continue
+            if metadata["id"] == "empty_material":  # Don't export the empty material.
+                continue
+            material = registry.findContainers(id = metadata["id"])[0]
+            suffix = registry.getMimeTypeForContainer(type(material)).preferredSuffix
+            filename = metadata["id"] + "." + suffix
+            archive.writestr(filename, material.serialize())

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -290,12 +290,23 @@ class MaterialManagementModel(QObject):
     outputDevicesChanged = pyqtSignal()  # Triggered when adding or removing removable drives.
     @pyqtProperty(QUrl, notify = outputDevicesChanged)
     def preferredExportAllPath(self) -> QUrl:
+        """
+        Get the preferred path to export materials to.
+
+        If there is a removable drive, that should be the preferred path. Otherwise it should be the most recent local
+        file path.
+        :return: The preferred path to export all materials to.
+        """
         if self._preferred_export_all_path is None:  # Not initialised yet. Can happen when output devices changed before class got created.
             self._onOutputDevicesChanged()
         return self._preferred_export_all_path
 
     @pyqtSlot(QUrl)
     def exportAll(self, file_path: QUrl) -> None:
+        """
+        Export all materials to a certain file path.
+        :param file_path: The path to export the materials to.
+        """
         registry = CuraContainerRegistry.getInstance()
 
         archive = zipfile.ZipFile(file_path.toLocalFile(), "w")

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -309,7 +309,7 @@ class MaterialManagementModel(QObject):
         """
         registry = CuraContainerRegistry.getInstance()
 
-        archive = zipfile.ZipFile(file_path.toLocalFile(), "w")
+        archive = zipfile.ZipFile(file_path.toLocalFile(), "w", compression = zipfile.ZIP_DEFLATED)
         for metadata in registry.findInstanceContainersMetadata(type = "material"):
             if metadata["base_file"] != metadata["id"]:  # Only process base files.
                 continue

--- a/cura/Settings/GlobalStack.py
+++ b/cura/Settings/GlobalStack.py
@@ -86,6 +86,14 @@ class GlobalStack(CuraContainerStack):
     def supportsNetworkConnection(self):
         return self.getMetaDataEntry("supports_network_connection", False)
 
+    @pyqtProperty(bool, constant = True)
+    def supportsMaterialExport(self):
+        """
+        Whether the printer supports Cura's export format of material profiles.
+        :return: ``True`` if it supports it, or ``False`` if not.
+        """
+        return self.getMetaDataEntry("supports_material_export", False)
+
     @classmethod
     def getLoadingPriority(cls) -> int:
         return 2

--- a/resources/definitions/ultimaker2_plus_connect.def.json
+++ b/resources/definitions/ultimaker2_plus_connect.def.json
@@ -22,7 +22,8 @@
             "0": "ultimaker2_plus_connect_extruder_0"
         },
         "supports_usb_connection": false,
-        "supports_network_connection": true
+        "supports_network_connection": true,
+        "supports_material_export": true
     },
 
     "overrides": {

--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -27,6 +27,7 @@
         "first_start_actions": [ "DiscoverUM3Action" ],
         "supported_actions": [ "DiscoverUM3Action" ],
         "supports_usb_connection": false,
+        "supports_material_export": true,
         "weight": -1,
         "firmware_update_info": {
             "id": 213482,

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -28,6 +28,7 @@
         "supported_actions": [ "DiscoverUM3Action" ],
         "supports_usb_connection": false,
         "supports_network_connection": true,
+        "supports_material_export": true,
         "weight": -2,
         "firmware_update_info": {
             "id": 9051,

--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -203,7 +203,7 @@ Item
                 forceActiveFocus();
                 exportAllMaterialsDialog.open();
             }
-            enabled: Cura.MachineManager.activeMachine.supportsMaterialExport
+            visible: Cura.MachineManager.activeMachine.supportsMaterialExport
         }
     }
 

--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -387,7 +387,7 @@ Item
         id: exportAllMaterialsDialog
         title: catalog.i18nc("@title:window", "Export All Materials")
         selectExisting: false
-        nameFilters: ["Material archives (*.zip)", "All files (*)"]
+        nameFilters: ["Material archives (*.umm)", "All files (*)"]
         folder: base.materialManagementModel.preferredExportAllPath
         onAccepted:
         {

--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -1,5 +1,5 @@
-// Copyright (c) 2018 Ultimaker B.V.
-// Uranium is released under the terms of the LGPLv3 or higher.
+// Copyright (c) 2021 Ultimaker B.V.
+// Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.7
 import QtQuick.Controls 1.4
@@ -191,6 +191,20 @@ Item
             }
             enabled: base.hasCurrentItem
         }
+
+        //Sync button.
+        Button
+        {
+            id: syncMaterialsButton
+            text: catalog.i18nc("@action:button Sending materials to printers", "Sync with Printers")
+            iconName: "sync-synchronizing"
+            onClicked:
+            {
+                forceActiveFocus();
+                exportAllMaterialsDialog.open();
+            }
+            enabled: Cura.MachineManager.activeMachine.supportsMaterialExport()
+        }
     }
 
     Item {
@@ -366,6 +380,16 @@ Item
             }
             CuraApplication.setDefaultPath("dialog_material_path", folder);
         }
+    }
+
+    FileDialog
+    {
+        id: exportAllMaterialsDialog
+        title: catalog.i18nc("@title:window", "Export All Materials")
+        selectExisting: false
+        nameFilters: ["Material archives (*.zip)", "All files (*)"]
+        folder: CuraApplication.getDefaultPath("dialog_material_path") //TODO: Implement preference for removable drives.
+        //TODO: Implement onAccepted event to save the profiles.
     }
 
     MessageDialog

--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -388,7 +388,7 @@ Item
         title: catalog.i18nc("@title:window", "Export All Materials")
         selectExisting: false
         nameFilters: ["Material archives (*.zip)", "All files (*)"]
-        folder: CuraApplication.getDefaultPath("dialog_material_path") //TODO: Implement preference for removable drives.
+        folder: base.materialManagementModel.preferredExportAllPath
         //TODO: Implement onAccepted event to save the profiles.
     }
 

--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -203,7 +203,7 @@ Item
                 forceActiveFocus();
                 exportAllMaterialsDialog.open();
             }
-            enabled: Cura.MachineManager.activeMachine.supportsMaterialExport()
+            enabled: Cura.MachineManager.activeMachine.supportsMaterialExport
         }
     }
 
@@ -389,7 +389,11 @@ Item
         selectExisting: false
         nameFilters: ["Material archives (*.zip)", "All files (*)"]
         folder: base.materialManagementModel.preferredExportAllPath
-        //TODO: Implement onAccepted event to save the profiles.
+        onAccepted:
+        {
+            base.materialManagementModel.exportAll(fileUrl);
+            CuraApplication.setDefaultPath("dialog_material_path", folder);
+        }
     }
 
     MessageDialog


### PR DESCRIPTION
This is a feature to export all materials to a .umm archive from Cura.

Requirements, as from the ticket, are:

> requirements:
> 
> * ONE save all button
> * button to export all material profiles to a zip to specific location on disk
> * File-format should work with the firmware of both the s-line and UM2+c (just a .ZIP with the .xml files)
> * Default to removable drive if it is available
> * Only visible on UM-printers

The name of the button is taken from the GUI design by @lorenzoromagnoli . The rest of that design is explicitly considered out of scope.

Implements CURA-8055.