### PR TITLE
[CURA-8320] Update SDK/API from 7.5.0 to 7.6.0 for 4.10

### DIFF
--- a/cura/ApplicationMetadata.py
+++ b/cura/ApplicationMetadata.py
@@ -13,7 +13,7 @@ DEFAULT_CURA_DEBUG_MODE = False
 # Each release has a fixed SDK version coupled with it. It doesn't make sense to make it configurable because, for
 # example Cura 3.2 with SDK version 6.1 will not work. So the SDK version is hard-coded here and left out of the
 # CuraVersion.py.in template.
-CuraSDKVersion = "7.5.0"
+CuraSDKVersion = "7.6.0"
 
 try:
     from cura.CuraVersion import CuraAppName  # type: ignore

--- a/plugins/3MFReader/plugin.json
+++ b/plugins/3MFReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides support for reading 3MF files.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/3MFWriter/plugin.json
+++ b/plugins/3MFWriter/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides support for writing 3MF files.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/AMFReader/plugin.json
+++ b/plugins/AMFReader/plugin.json
@@ -3,5 +3,5 @@
     "author": "fieldOfView",
     "version": "1.0.0",
     "description": "Provides support for reading AMF files.",
-    "api": "7.5.0"
+    "api": "7.6.0"
 }

--- a/plugins/CuraDrive/plugin.json
+++ b/plugins/CuraDrive/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "description": "Backup and restore your configuration.",
     "version": "1.2.0",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/CuraEngineBackend/plugin.json
+++ b/plugins/CuraEngineBackend/plugin.json
@@ -2,7 +2,7 @@
     "name": "CuraEngine Backend",
     "author": "Ultimaker B.V.",
     "description": "Provides the link to the CuraEngine slicing backend.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "version": "1.0.1",
     "i18n-catalog": "cura"
 }

--- a/plugins/CuraProfileReader/plugin.json
+++ b/plugins/CuraProfileReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides support for importing Cura profiles.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/CuraProfileWriter/plugin.json
+++ b/plugins/CuraProfileWriter/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides support for exporting Cura profiles.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog":"cura"
 }

--- a/plugins/DigitalLibrary/plugin.json
+++ b/plugins/DigitalLibrary/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "description": "Connects to the Digital Library, allowing Cura to open files from and save files to the Digital Library.",
     "version": "1.0.0",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/FirmwareUpdateChecker/plugin.json
+++ b/plugins/FirmwareUpdateChecker/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Checks for firmware updates.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/FirmwareUpdater/plugin.json
+++ b/plugins/FirmwareUpdater/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides a machine actions for updating firmware.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/GCodeGzReader/plugin.json
+++ b/plugins/GCodeGzReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Reads g-code from a compressed archive.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/GCodeGzWriter/plugin.json
+++ b/plugins/GCodeGzWriter/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Writes g-code to a compressed archive.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/GCodeProfileReader/plugin.json
+++ b/plugins/GCodeProfileReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides support for importing profiles from g-code files.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/GCodeReader/plugin.json
+++ b/plugins/GCodeReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Victor Larchenko, Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Allows loading and displaying G-code files.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/GCodeWriter/plugin.json
+++ b/plugins/GCodeWriter/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Writes g-code to a file.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/ImageReader/plugin.json
+++ b/plugins/ImageReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Enables ability to generate printable geometry from 2D image files.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/LegacyProfileReader/plugin.json
+++ b/plugins/LegacyProfileReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides support for importing profiles from legacy Cura versions.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/MachineSettingsAction/plugin.json
+++ b/plugins/MachineSettingsAction/plugin.json
@@ -3,6 +3,6 @@
     "author": "fieldOfView, Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides a way to change machine settings (such as build volume, nozzle size, etc.).",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/ModelChecker/plugin.json
+++ b/plugins/ModelChecker/plugin.json
@@ -2,7 +2,7 @@
     "name": "Model Checker",
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "description": "Checks models and print configuration for possible printing issues and give suggestions.",
     "i18n-catalog": "cura"
 }

--- a/plugins/MonitorStage/plugin.json
+++ b/plugins/MonitorStage/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides a monitor stage in Cura.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/PerObjectSettingsTool/plugin.json
+++ b/plugins/PerObjectSettingsTool/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides the Per Model Settings.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/PostProcessingPlugin/plugin.json
+++ b/plugins/PostProcessingPlugin/plugin.json
@@ -2,7 +2,7 @@
     "name": "Post Processing",
     "author": "Ultimaker",
     "version": "2.2.1",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "description": "Extension that allows for user created scripts for post processing",
     "catalog": "cura"
 }

--- a/plugins/PrepareStage/plugin.json
+++ b/plugins/PrepareStage/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides a prepare stage in Cura.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/PreviewStage/plugin.json
+++ b/plugins/PreviewStage/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides a preview stage in Cura.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/RemovableDriveOutputDevice/plugin.json
+++ b/plugins/RemovableDriveOutputDevice/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "description": "Provides removable drive hotplugging and writing support.",
     "version": "1.0.1",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/SentryLogger/plugin.json
+++ b/plugins/SentryLogger/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Logs certain events so that they can be used by the crash reporter",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/SimulationView/plugin.json
+++ b/plugins/SimulationView/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides the Simulation view.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/SliceInfoPlugin/plugin.json
+++ b/plugins/SliceInfoPlugin/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Submits anonymous slice info. Can be disabled through preferences.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/SolidView/plugin.json
+++ b/plugins/SolidView/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides a normal solid mesh view.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/SupportEraser/plugin.json
+++ b/plugins/SupportEraser/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Creates an eraser mesh to block the printing of support in certain places",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/Toolbox/plugin.json
+++ b/plugins/Toolbox/plugin.json
@@ -2,6 +2,6 @@
     "name": "Toolbox",
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "description": "Find, manage and install new Cura packages."
 }

--- a/plugins/TrimeshReader/plugin.json
+++ b/plugins/TrimeshReader/plugin.json
@@ -3,5 +3,5 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides support for reading model files.",
-    "api": "7.5.0"
+    "api": "7.6.0"
 }

--- a/plugins/UFPReader/plugin.json
+++ b/plugins/UFPReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Provides support for reading Ultimaker Format Packages.",
-    "supported_sdk_versions": ["7.5.0"],
+    "supported_sdk_versions": ["7.6.0"],
     "i18n-catalog": "cura"
 }

--- a/plugins/UFPWriter/plugin.json
+++ b/plugins/UFPWriter/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides support for writing Ultimaker Format Packages.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/UM3NetworkPrinting/plugin.json
+++ b/plugins/UM3NetworkPrinting/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "description": "Manages network connections to Ultimaker networked printers.",
     "version": "2.0.0",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/USBPrinting/plugin.json
+++ b/plugins/USBPrinting/plugin.json
@@ -2,7 +2,7 @@
     "name": "USB printing",
     "author": "Ultimaker B.V.",
     "version": "1.0.2",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "description": "Accepts G-Code and sends them to a printer. Plugin can also update firmware.",
     "i18n-catalog": "cura"
 }

--- a/plugins/UltimakerMachineActions/plugin.json
+++ b/plugins/UltimakerMachineActions/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides machine actions for Ultimaker machines (such as bed leveling wizard, selecting upgrades, etc.).",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade21to22/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade21to22/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 2.1 to Cura 2.2.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade22to24/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade22to24/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 2.2 to Cura 2.4.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade25to26/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade25to26/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 2.5 to Cura 2.6.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade26to27/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade26to27/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 2.6 to Cura 2.7.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade27to30/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade27to30/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 2.7 to Cura 3.0.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade30to31/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade30to31/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 3.0 to Cura 3.1.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade32to33/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade32to33/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 3.2 to Cura 3.3.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade33to34/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade33to34/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 3.3 to Cura 3.4.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade34to35/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade34to35/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 3.4 to Cura 3.5.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade35to40/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade35to40/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 3.5 to Cura 4.0.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade40to41/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade40to41/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Upgrades configurations from Cura 4.0 to Cura 4.1.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade41to42/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade41to42/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.1 to Cura 4.2.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade42to43/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade42to43/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.2 to Cura 4.3.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade43to44/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade43to44/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.3 to Cura 4.4.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade44to45/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade44to45/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.4 to Cura 4.5.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade45to46/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade45to46/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.5 to Cura 4.6.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade460to462/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade460to462/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.6.0 to Cura 4.6.2.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade462to47/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade462to47/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.6.2 to Cura 4.7.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade47to48/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade47to48/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.7 to Cura 4.8.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade48to49/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade48to49/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.8 to Cura 4.9.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/VersionUpgrade/VersionUpgrade49to410/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade49to410/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.0",
     "description": "Upgrades configurations from Cura 4.9 to Cura 4.10.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/X3DReader/plugin.json
+++ b/plugins/X3DReader/plugin.json
@@ -3,6 +3,6 @@
     "author": "Seva Alekseyev, Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides support for reading X3D files.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/XRayView/plugin.json
+++ b/plugins/XRayView/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides the X-Ray view.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/plugins/XmlMaterialProfile/plugin.json
+++ b/plugins/XmlMaterialProfile/plugin.json
@@ -3,6 +3,6 @@
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
     "description": "Provides capabilities to read and write XML-based material profiles.",
-    "api": "7.5.0",
+    "api": "7.6.0",
     "i18n-catalog": "cura"
 }

--- a/resources/bundled_packages/cura.json
+++ b/resources/bundled_packages/cura.json
@@ -6,7 +6,7 @@
             "display_name": "3MF Reader",
             "description": "Provides support for reading 3MF files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -23,7 +23,7 @@
             "display_name": "3MF Writer",
             "description": "Provides support for writing 3MF files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -40,7 +40,7 @@
             "display_name": "AMF Reader",
             "description": "Provides support for reading AMF files.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "fieldOfView",
@@ -57,7 +57,7 @@
             "display_name": "Cura Backups",
             "description": "Backup and restore your configuration.",
             "package_version": "1.2.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -74,7 +74,7 @@
             "display_name": "CuraEngine Backend",
             "description": "Provides the link to the CuraEngine slicing backend.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -91,7 +91,7 @@
             "display_name": "Cura Profile Reader",
             "description": "Provides support for importing Cura profiles.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -108,7 +108,7 @@
             "display_name": "Cura Profile Writer",
             "description": "Provides support for exporting Cura profiles.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -125,7 +125,7 @@
             "display_name": "Ultimaker Digital Library",
             "description": "Connects to the Digital Library, allowing Cura to open files from and save files to the Digital Library.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -142,7 +142,7 @@
             "display_name": "Firmware Update Checker",
             "description": "Checks for firmware updates.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -159,7 +159,7 @@
             "display_name": "Firmware Updater",
             "description": "Provides a machine actions for updating firmware.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -176,7 +176,7 @@
             "display_name": "Compressed G-code Reader",
             "description": "Reads g-code from a compressed archive.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -193,7 +193,7 @@
             "display_name": "Compressed G-code Writer",
             "description": "Writes g-code to a compressed archive.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -210,7 +210,7 @@
             "display_name": "G-Code Profile Reader",
             "description": "Provides support for importing profiles from g-code files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -227,7 +227,7 @@
             "display_name": "G-Code Reader",
             "description": "Allows loading and displaying G-code files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "VictorLarchenko",
@@ -244,7 +244,7 @@
             "display_name": "G-Code Writer",
             "description": "Writes g-code to a file.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -261,7 +261,7 @@
             "display_name": "Image Reader",
             "description": "Enables ability to generate printable geometry from 2D image files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -278,7 +278,7 @@
             "display_name": "Legacy Cura Profile Reader",
             "description": "Provides support for importing profiles from legacy Cura versions.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -295,7 +295,7 @@
             "display_name": "Machine Settings Action",
             "description": "Provides a way to change machine settings (such as build volume, nozzle size, etc.).",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "fieldOfView",
@@ -312,7 +312,7 @@
             "display_name": "Model Checker",
             "description": "Checks models and print configuration for possible printing issues and give suggestions.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -329,7 +329,7 @@
             "display_name": "Monitor Stage",
             "description": "Provides a monitor stage in Cura.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -346,7 +346,7 @@
             "display_name": "Per-Object Settings Tool",
             "description": "Provides the per-model settings.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -363,7 +363,7 @@
             "display_name": "Post Processing",
             "description": "Extension that allows for user created scripts for post processing.",
             "package_version": "2.2.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -380,7 +380,7 @@
             "display_name": "Prepare Stage",
             "description": "Provides a prepare stage in Cura.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -397,7 +397,7 @@
             "display_name": "Preview Stage",
             "description": "Provides a preview stage in Cura.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -414,7 +414,7 @@
             "display_name": "Removable Drive Output Device",
             "description": "Provides removable drive hotplugging and writing support.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -431,7 +431,7 @@
             "display_name": "Sentry Logger",
             "description": "Logs certain events so that they can be used by the crash reporter",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -448,7 +448,7 @@
             "display_name": "Simulation View",
             "description": "Provides the Simulation view.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -465,7 +465,7 @@
             "display_name": "Slice Info",
             "description": "Submits anonymous slice info. Can be disabled through preferences.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -482,7 +482,7 @@
             "display_name": "Solid View",
             "description": "Provides a normal solid mesh view.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -499,7 +499,7 @@
             "display_name": "Support Eraser Tool",
             "description": "Creates an eraser mesh to block the printing of support in certain places.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -516,7 +516,7 @@
             "display_name": "Trimesh Reader",
             "description": "Provides support for reading model files.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -533,7 +533,7 @@
             "display_name": "Toolbox",
             "description": "Find, manage and install new Cura packages.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -550,7 +550,7 @@
             "display_name": "UFP Reader",
             "description": "Provides support for reading Ultimaker Format Packages.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -567,7 +567,7 @@
             "display_name": "UFP Writer",
             "description": "Provides support for writing Ultimaker Format Packages.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -584,7 +584,7 @@
             "display_name": "Ultimaker Machine Actions",
             "description": "Provides machine actions for Ultimaker machines (such as bed leveling wizard, selecting upgrades, etc.).",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -601,7 +601,7 @@
             "display_name": "UM3 Network Printing",
             "description": "Manages network connections to Ultimaker 3 printers.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -618,7 +618,7 @@
             "display_name": "USB Printing",
             "description": "Accepts G-Code and sends them to a printer. Plugin can also update firmware.",
             "package_version": "1.0.2",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -635,7 +635,7 @@
             "display_name": "Version Upgrade 2.1 to 2.2",
             "description": "Upgrades configurations from Cura 2.1 to Cura 2.2.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -652,7 +652,7 @@
             "display_name": "Version Upgrade 2.2 to 2.4",
             "description": "Upgrades configurations from Cura 2.2 to Cura 2.4.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -669,7 +669,7 @@
             "display_name": "Version Upgrade 2.5 to 2.6",
             "description": "Upgrades configurations from Cura 2.5 to Cura 2.6.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -686,7 +686,7 @@
             "display_name": "Version Upgrade 2.6 to 2.7",
             "description": "Upgrades configurations from Cura 2.6 to Cura 2.7.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -703,7 +703,7 @@
             "display_name": "Version Upgrade 2.7 to 3.0",
             "description": "Upgrades configurations from Cura 2.7 to Cura 3.0.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -720,7 +720,7 @@
             "display_name": "Version Upgrade 3.0 to 3.1",
             "description": "Upgrades configurations from Cura 3.0 to Cura 3.1.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -737,7 +737,7 @@
             "display_name": "Version Upgrade 3.2 to 3.3",
             "description": "Upgrades configurations from Cura 3.2 to Cura 3.3.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -754,7 +754,7 @@
             "display_name": "Version Upgrade 3.3 to 3.4",
             "description": "Upgrades configurations from Cura 3.3 to Cura 3.4.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -771,7 +771,7 @@
             "display_name": "Version Upgrade 3.4 to 3.5",
             "description": "Upgrades configurations from Cura 3.4 to Cura 3.5.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -788,7 +788,7 @@
             "display_name": "Version Upgrade 3.5 to 4.0",
             "description": "Upgrades configurations from Cura 3.5 to Cura 4.0.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -805,7 +805,7 @@
             "display_name": "Version Upgrade 4.0 to 4.1",
             "description": "Upgrades configurations from Cura 4.0 to Cura 4.1.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -822,7 +822,7 @@
             "display_name": "Version Upgrade 4.1 to 4.2",
             "description": "Upgrades configurations from Cura 4.1 to Cura 4.2.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -839,7 +839,7 @@
             "display_name": "Version Upgrade 4.2 to 4.3",
             "description": "Upgrades configurations from Cura 4.2 to Cura 4.3.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -856,7 +856,7 @@
             "display_name": "Version Upgrade 4.3 to 4.4",
             "description": "Upgrades configurations from Cura 4.3 to Cura 4.4.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -873,7 +873,7 @@
             "display_name": "Version Upgrade 4.4 to 4.5",
             "description": "Upgrades configurations from Cura 4.4 to Cura 4.5.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -890,7 +890,7 @@
             "display_name": "Version Upgrade 4.5 to 4.6",
             "description": "Upgrades configurations from Cura 4.5 to Cura 4.6.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -907,7 +907,7 @@
             "display_name": "Version Upgrade 4.6.0 to 4.6.2",
             "description": "Upgrades configurations from Cura 4.6.0 to Cura 4.6.2.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -924,7 +924,7 @@
             "display_name": "Version Upgrade 4.6.2 to 4.7",
             "description": "Upgrades configurations from Cura 4.6.2 to Cura 4.7.",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -941,7 +941,7 @@
             "display_name": "Version Upgrade 4.7.0 to 4.8.0",
             "description": "Upgrades configurations from Cura 4.7.0 to Cura 4.8.0",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -958,7 +958,7 @@
             "display_name": "Version Upgrade 4.8.0 to 4.9.0",
             "description": "Upgrades configurations from Cura 4.8.0 to Cura 4.9.0",
             "package_version": "1.0.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -975,7 +975,7 @@
             "display_name": "X3D Reader",
             "description": "Provides support for reading X3D files.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "SevaAlekseyev",
@@ -992,7 +992,7 @@
             "display_name": "XML Material Profiles",
             "description": "Provides capabilities to read and write XML-based material profiles.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1009,7 +1009,7 @@
             "display_name": "X-Ray View",
             "description": "Provides the X-Ray view.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1026,7 +1026,7 @@
             "display_name": "Generic ABS",
             "description": "The generic ABS profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1044,7 +1044,7 @@
             "display_name": "Generic BAM",
             "description": "The generic BAM profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1062,7 +1062,7 @@
             "display_name": "Generic CFF CPE",
             "description": "The generic CFF CPE profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1080,7 +1080,7 @@
             "display_name": "Generic CFF PA",
             "description": "The generic CFF PA profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1098,7 +1098,7 @@
             "display_name": "Generic CPE",
             "description": "The generic CPE profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1116,7 +1116,7 @@
             "display_name": "Generic CPE+",
             "description": "The generic CPE+ profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1134,7 +1134,7 @@
             "display_name": "Generic GFF CPE",
             "description": "The generic GFF CPE profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1152,7 +1152,7 @@
             "display_name": "Generic GFF PA",
             "description": "The generic GFF PA profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1170,7 +1170,7 @@
             "display_name": "Generic HIPS",
             "description": "The generic HIPS profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1188,7 +1188,7 @@
             "display_name": "Generic Nylon",
             "description": "The generic Nylon profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1206,7 +1206,7 @@
             "display_name": "Generic PC",
             "description": "The generic PC profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1224,7 +1224,7 @@
             "display_name": "Generic PETG",
             "description": "The generic PETG profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1242,7 +1242,7 @@
             "display_name": "Generic PLA",
             "description": "The generic PLA profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1260,7 +1260,7 @@
             "display_name": "Generic PP",
             "description": "The generic PP profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1278,7 +1278,7 @@
             "display_name": "Generic PVA",
             "description": "The generic PVA profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1296,7 +1296,7 @@
             "display_name": "Generic Tough PLA",
             "description": "The generic Tough PLA profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1314,7 +1314,7 @@
             "display_name": "Generic TPU",
             "description": "The generic TPU profile which other profiles can be based upon.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://github.com/Ultimaker/fdm_materials",
             "author": {
                 "author_id": "Generic",
@@ -1332,7 +1332,7 @@
             "display_name": "Dagoma Chromatik PLA",
             "description": "Filament testé et approuvé pour les imprimantes 3D Dagoma. Chromatik est l'idéal pour débuter et suivre les tutoriels premiers pas. Il vous offre qualité et résistance pour chacune de vos impressions.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://dagoma.fr/boutique/filaments.html",
             "author": {
                 "author_id": "Dagoma",
@@ -1349,7 +1349,7 @@
             "display_name": "FABtotum ABS",
             "description": "This material is easy to be extruded but it is not the simplest to use. It is one of the most used in 3D printing to get very well finished objects. It is not sustainable and its smoke can be dangerous if inhaled. The reason to prefer this filament to PLA is mainly because of its precision and mechanical specs. ABS (for plastic) stands for Acrylonitrile Butadiene Styrene and it is a thermoplastic which is widely used in everyday objects. It can be printed with any FFF 3D printer which can get to high temperatures as it must be extruded in a range between 220° and 245°, so it’s compatible with all versions of the FABtotum Personal fabricator.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://store.fabtotum.com/eu/products/filaments.html?filament_type=40",
             "author": {
                 "author_id": "FABtotum",
@@ -1366,7 +1366,7 @@
             "display_name": "FABtotum Nylon",
             "description": "When 3D printing started this material was not listed among the extrudable filaments. It is flexible as well as resistant to tractions. It is well known for its uses in textile but also in industries which require a strong and flexible material. There are different kinds of Nylon: 3D printing mostly uses Nylon 6 and Nylon 6.6, which are the most common. It requires higher temperatures to be printed, so a 3D printer must be able to reach them (around 240°C): the FABtotum, of course, can.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://store.fabtotum.com/eu/products/filaments.html?filament_type=53",
             "author": {
                 "author_id": "FABtotum",
@@ -1383,7 +1383,7 @@
             "display_name": "FABtotum PLA",
             "description": "It is the most common filament used for 3D printing. It is studied to be bio-degradable as it comes from corn starch’s sugar mainly. It is completely made of renewable sources and has no footprint on polluting. PLA stands for PolyLactic Acid and it is a thermoplastic that today is still considered the easiest material to be 3D printed. It can be extruded at lower temperatures: the standard range of FABtotum’s one is between 185° and 195°.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://store.fabtotum.com/eu/products/filaments.html?filament_type=39",
             "author": {
                 "author_id": "FABtotum",
@@ -1400,7 +1400,7 @@
             "display_name": "FABtotum TPU Shore 98A",
             "description": "",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://store.fabtotum.com/eu/products/filaments.html?filament_type=66",
             "author": {
                 "author_id": "FABtotum",
@@ -1417,7 +1417,7 @@
             "display_name": "Fiberlogy HD PLA",
             "description": "With our HD PLA you have many more options. You can use this material in two ways. Choose the one you like best. You can use it as a normal PLA and get prints characterized by a very good adhesion between the layers and high precision. You can also make your prints acquire similar properties to that of ABS – better impact resistance and high temperature resistance. All you need is an oven. Yes, an oven! By annealing our HD PLA in an oven, in accordance with the manual, you will avoid all the inconveniences of printing with ABS, such as unpleasant odour or hazardous fumes.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "http://fiberlogy.com/en/fiberlogy-filaments/filament-hd-pla/",
             "author": {
                 "author_id": "Fiberlogy",
@@ -1434,7 +1434,7 @@
             "display_name": "Filo3D PLA",
             "description": "Fast, safe and reliable printing. PLA is ideal for the fast and reliable printing of parts and prototypes with a great surface quality.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://dagoma.fr",
             "author": {
                 "author_id": "Dagoma",
@@ -1451,7 +1451,7 @@
             "display_name": "IMADE3D JellyBOX PETG",
             "description": "",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "http://shop.imade3d.com/filament.html",
             "author": {
                 "author_id": "IMADE3D",
@@ -1468,7 +1468,7 @@
             "display_name": "IMADE3D JellyBOX PLA",
             "description": "",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "http://shop.imade3d.com/filament.html",
             "author": {
                 "author_id": "IMADE3D",
@@ -1485,7 +1485,7 @@
             "display_name": "Octofiber PLA",
             "description": "PLA material from Octofiber.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://nl.octofiber.com/3d-printing-filament/pla.html",
             "author": {
                 "author_id": "Octofiber",
@@ -1502,7 +1502,7 @@
             "display_name": "PolyFlex™ PLA",
             "description": "PolyFlex™ is a highly flexible yet easy to print 3D printing material. Featuring good elasticity and a large strain-to- failure, PolyFlex™ opens up a completely new realm of applications.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "http://www.polymaker.com/shop/polyflex/",
             "author": {
                 "author_id": "Polymaker",
@@ -1519,7 +1519,7 @@
             "display_name": "PolyMax™ PLA",
             "description": "PolyMax™ PLA is a 3D printing material with excellent mechanical properties and printing quality. PolyMax™ PLA has an impact resistance of up to nine times that of regular PLA, and better overall mechanical properties than ABS.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "http://www.polymaker.com/shop/polymax/",
             "author": {
                 "author_id": "Polymaker",
@@ -1536,7 +1536,7 @@
             "display_name": "PolyPlus™ PLA True Colour",
             "description": "PolyPlus™ PLA is a premium PLA designed for all desktop FDM/FFF 3D printers. It is produced with our patented Jam-Free™ technology that ensures consistent extrusion and prevents jams.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "http://www.polymaker.com/shop/polyplus-true-colour/",
             "author": {
                 "author_id": "Polymaker",
@@ -1553,7 +1553,7 @@
             "display_name": "PolyWood™ PLA",
             "description": "PolyWood™ is a wood mimic printing material that contains no actual wood ensuring a clean Jam-Free™ printing experience.",
             "package_version": "1.0.1",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "http://www.polymaker.com/shop/polywood/",
             "author": {
                 "author_id": "Polymaker",
@@ -1570,7 +1570,7 @@
             "display_name": "Ultimaker ABS",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/abs",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1589,7 +1589,7 @@
             "display_name": "Ultimaker Breakaway",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/breakaway",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1608,7 +1608,7 @@
             "display_name": "Ultimaker CPE",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/abs",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1627,7 +1627,7 @@
             "display_name": "Ultimaker CPE+",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/cpe",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1646,7 +1646,7 @@
             "display_name": "Ultimaker Nylon",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/abs",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1665,7 +1665,7 @@
             "display_name": "Ultimaker PC",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/pc",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1684,7 +1684,7 @@
             "display_name": "Ultimaker PLA",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/abs",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1703,7 +1703,7 @@
             "display_name": "Ultimaker PP",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/pp",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1722,7 +1722,7 @@
             "display_name": "Ultimaker PVA",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/abs",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1741,7 +1741,7 @@
             "display_name": "Ultimaker TPU 95A",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/tpu-95a",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1760,7 +1760,7 @@
             "display_name": "Ultimaker Tough PLA",
             "description": "Example package for material and quality profiles for Ultimaker materials.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://ultimaker.com/products/materials/tough-pla",
             "author": {
                 "author_id": "UltimakerPackages",
@@ -1779,7 +1779,7 @@
             "display_name": "Vertex Delta ABS",
             "description": "ABS material and quality files for the Delta Vertex K8800.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://vertex3dprinter.eu",
             "author": {
                 "author_id": "Velleman",
@@ -1796,7 +1796,7 @@
             "display_name": "Vertex Delta PET",
             "description": "ABS material and quality files for the Delta Vertex K8800.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://vertex3dprinter.eu",
             "author": {
                 "author_id": "Velleman",
@@ -1813,7 +1813,7 @@
             "display_name": "Vertex Delta PLA",
             "description": "ABS material and quality files for the Delta Vertex K8800.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://vertex3dprinter.eu",
             "author": {
                 "author_id": "Velleman",
@@ -1830,7 +1830,7 @@
             "display_name": "Vertex Delta TPU",
             "description": "ABS material and quality files for the Delta Vertex K8800.",
             "package_version": "1.4.0",
-            "sdk_version": "7.5.0",
+            "sdk_version": "7.6.0",
             "website": "https://vertex3dprinter.eu",
             "author": {
                 "author_id": "Velleman",


### PR DESCRIPTION
Will amend this description with the changes shortly, as well as (attempt to) mail our plugin contributors.

In Cura (so excluding Uranium, see the other PR for that):

**added method signatures**

- in Cura/Machines/Models/MaterialManagementModel:
`[pyqtProperty] MaterialManagementModel.preferredExportAllPath(self) -> QUrl`
  _Get the preferred path to export materials to._
- in Cura/Machines/Models/MaterialManagementModel:
`[pyqtSlot] MaterialManagementModel.exportAll(self, file_path: QUrl) -> None`
  _Export all materials to a certain file path._
- in Cura/Settings/GlobalStack:
`[pyqtProperty] GlobalStack.supportsMaterialExport(self)`
  _Whether the printer supports Cura's export format of material profiles_


See also: https://github.com/Ultimaker/Uranium/pull/706