### PR TITLE
CURA-8332: Don't crash if keyring access is denied on Mac

### DIFF
--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -42,10 +42,10 @@ class KeyringAttribute:
                 return getattr(instance, self._name)
             except Exception as e:
                 self._store_secure = False
-                exception_message = f"Something went wrong while trying to retrieve the password from the Keyring. Exception: {e}"
                 if Platform.isOSX() and hasattr(sys, "frozen") and type(e) == KeychainDenied:
-                    exception_message = "Access to the keyring was denied."
-                Logger.logException("w", exception_message)
+                    Logger.log("i", "Access to the keyring was denied.")
+                else:
+                    Logger.logException("w", f"Something went wrong while trying to retrieve the password from the Keyring. Exception: {e}")
                 return getattr(instance, self._name)
         else:
             return getattr(instance, self._name)

--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -14,17 +14,24 @@ if TYPE_CHECKING:
 # Need to do some extra workarounds on windows:
 import sys
 from UM.Platform import Platform
+
+
+class _KeychainDenied(Exception):
+    pass
+
+
 if Platform.isWindows() and hasattr(sys, "frozen"):
     import win32timezone
     from keyring.backends.Windows import WinVaultKeyring
     keyring.set_keyring(WinVaultKeyring())
 if Platform.isOSX() and hasattr(sys, "frozen"):
     from keyring.backends.macOS import Keyring
-    from keyring.backends.macOS.api import KeychainDenied
+    from keyring.backends.macOS.api import KeychainDenied as _KeychainDeniedMacOS
+    KeychainDenied = _KeychainDeniedMacOS
     keyring.set_keyring(Keyring())
 else:
-    class KeychainDenied(Exception):
-        pass
+    KeychainDenied = _KeychainDenied
+
 
 # Even if errors happen, we don't want this stored locally:
 DONT_EVER_STORE_LOCALLY: List[str] = ["refresh_token"]

--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -4,7 +4,6 @@ from typing import Type, TYPE_CHECKING, Optional, List
 
 import keyring
 from keyring.backend import KeyringBackend
-from keyring.backends.macOS.api import KeychainDenied
 from keyring.errors import NoKeyringError, PasswordSetError
 
 from UM.Logger import Logger
@@ -21,6 +20,7 @@ if Platform.isWindows() and hasattr(sys, "frozen"):
     keyring.set_keyring(WinVaultKeyring())
 if Platform.isOSX() and hasattr(sys, "frozen"):
     from keyring.backends.macOS import Keyring
+    from keyring.backends.macOS.api import KeychainDenied
     keyring.set_keyring(Keyring())
 
 # Even if errors happen, we don't want this stored locally:

--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2021 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
-from typing import Type, TYPE_CHECKING, Optional, List
+from typing import Type, TYPE_CHECKING, Optional, List, Union
 
 import keyring
 from keyring.backend import KeyringBackend
@@ -27,7 +27,7 @@ if Platform.isWindows() and hasattr(sys, "frozen"):
 if Platform.isOSX() and hasattr(sys, "frozen"):
     from keyring.backends.macOS import Keyring
     from keyring.backends.macOS.api import KeychainDenied as _KeychainDeniedMacOS
-    KeychainDenied = _KeychainDeniedMacOS
+    KeychainDenied: Union[Type[_KeychainDenied], Type[_KeychainDeniedMacOS]] = _KeychainDeniedMacOS
     keyring.set_keyring(Keyring())
 else:
     KeychainDenied = _KeychainDenied

--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -4,6 +4,7 @@ from typing import Type, TYPE_CHECKING, Optional, List
 
 import keyring
 from keyring.backend import KeyringBackend
+from keyring.backends.macOS.api import KeychainDenied
 from keyring.errors import NoKeyringError, PasswordSetError
 
 from UM.Logger import Logger
@@ -38,6 +39,14 @@ class KeyringAttribute:
             except NoKeyringError:
                 self._store_secure = False
                 Logger.logException("w", "No keyring backend present")
+                return getattr(instance, self._name)
+            except KeychainDenied:
+                self._store_secure = False
+                Logger.logException("w", "Access to the keyring was denied.")
+                return getattr(instance, self._name)
+            except Exception as e:
+                self._store_secure = False
+                Logger.logException("w", f"Something went wrong while trying to retrieve the password from the Keyring. Exception: {e}")
                 return getattr(instance, self._name)
         else:
             return getattr(instance, self._name)

--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -40,13 +40,12 @@ class KeyringAttribute:
                 self._store_secure = False
                 Logger.logException("w", "No keyring backend present")
                 return getattr(instance, self._name)
-            except KeychainDenied:
-                self._store_secure = False
-                Logger.logException("w", "Access to the keyring was denied.")
-                return getattr(instance, self._name)
             except Exception as e:
                 self._store_secure = False
-                Logger.logException("w", f"Something went wrong while trying to retrieve the password from the Keyring. Exception: {e}")
+                exception_message = f"Something went wrong while trying to retrieve the password from the Keyring. Exception: {e}"
+                if Platform.isOSX() and hasattr(sys, "frozen") and type(e) == KeychainDenied:
+                    exception_message = "Access to the keyring was denied."
+                Logger.logException("w", exception_message)
                 return getattr(instance, self._name)
         else:
             return getattr(instance, self._name)


### PR DESCRIPTION
Denying access to the keyring was causing Cura to crash on MacOS.

Contributes to issue CURA-8332 and sentry issue CURA-2EW