### PR TITLE
CURA-8334: Don't draw tooltip background if height is 0

### DIFF
--- a/resources/qml/ToolTip.qml
+++ b/resources/qml/ToolTip.qml
@@ -59,6 +59,7 @@ ToolTip
         color: UM.Theme.getColor("tooltip")
         target: Qt.point(targetPoint.x - tooltip.x, targetPoint.y - tooltip.y)
         arrowSize: UM.Theme.getSize("default_arrow").width
+        visible: tooltip.height != 0
     }
 
     contentItem: Label


### PR DESCRIPTION
In some buttons (specifically, the "Manage printers" button), the tooltip arrow is being drawn even though the tooltip text is empty. This commit fixes that by making sure that the background rectangle (PointingRectangle) of the tooltip is not be visible if the height of the tooltip is 0.
![image](https://user-images.githubusercontent.com/19388042/122755605-7f24a480-d295-11eb-9a49-5bdebfd532ba.png)


CURA-8334