### PR TITLE
Only add G92 for Griffin if redoing layer in Pause At Height

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 from ..Script import Script
@@ -517,8 +517,13 @@ class PauseAtHeight(Script):
 
                     prepend_gcode += self.putValue(M = extrusion_mode_numeric) + " ; switch back to " + extrusion_mode_string + " E values\n"
 
-                # reset extrude value to pre pause value
-                prepend_gcode += self.putValue(G = 92, E = current_e) + "\n"
+                    # reset extrude value to pre pause value
+                    prepend_gcode += self.putValue(G = 92, E = current_e) + "\n"
+
+                elif redo_layer:
+                    # All other options reset the E value to what it was before the pause because E things were added.
+                    # If it's not yet reset, it still needs to be reset if there were any redo layers.
+                    prepend_gcode += self.putValue(G = 92, E = current_e) + "\n"
 
                 layer = prepend_gcode + layer
 


### PR DESCRIPTION
Otherwise it is superfluous.

Also, don't add it twice for the Repetier flavour.
This way the code is separated better into if-else cases to make it easier to read, even though it has this line in there 3 times.

Fixes issue CURA-8331.