### PR TITLE
CURA-8313: Restore backup messes configurations

### DIFF
--- a/cura/Backups/Backup.py
+++ b/cura/Backups/Backup.py
@@ -194,7 +194,10 @@ class Backup:
         Resources.factoryReset()
         Logger.log("d", "Extracting backup to location: %s", target_path)
         try:
-            archive.extractall(target_path)
+            name_list = archive.namelist()
+            for archive_filename in name_list:
+                archive.extract(archive_filename, target_path)
+                CuraApplication.getInstance().processEvents()
         except (PermissionError, EnvironmentError):
             Logger.logException("e", "Unable to extract the backup due to permission or file system errors.")
             return False

--- a/cura/Backups/Backup.py
+++ b/cura/Backups/Backup.py
@@ -166,6 +166,9 @@ class Backup:
             Logger.log("d", "Moving preferences file from %s to %s", backup_preferences_file, preferences_file)
             shutil.move(backup_preferences_file, preferences_file)
 
+        # Read the preferences from the newly restored configuration (or else the cached Preferences will override the restored ones)
+        self._application.readPreferencesFromConfiguration()
+
         # Restore the obfuscated settings
         self._illuminate(**secrets)
 

--- a/plugins/CuraDrive/src/DriveApiService.py
+++ b/plugins/CuraDrive/src/DriveApiService.py
@@ -93,7 +93,7 @@ class DriveApiService:
     def _onRestoreFinished(self, job: "RestoreBackupJob") -> None:
         if job.restore_backup_error_message != "":
             # If the job contains an error message we pass it along so the UI can display it.
-            self.restoringStateChanged.emit(is_restoring=False)
+            self.restoringStateChanged.emit(is_restoring = False)
         else:
             self.restoringStateChanged.emit(is_restoring = False, error_message = job.restore_backup_error_message)
 

--- a/plugins/CuraDrive/src/DrivePluginExtension.py
+++ b/plugins/CuraDrive/src/DrivePluginExtension.py
@@ -52,6 +52,7 @@ class DrivePluginExtension(QObject, Extension):
 
         # Attach signals.
         CuraApplication.getInstance().getCuraAPI().account.loginStateChanged.connect(self._onLoginStateChanged)
+        CuraApplication.getInstance().applicationShuttingDown.connect(self._onApplicationShuttingDown)
         self._drive_api_service.restoringStateChanged.connect(self._onRestoringStateChanged)
         self._drive_api_service.creatingStateChanged.connect(self._onCreatingStateChanged)
 
@@ -74,6 +75,9 @@ class DrivePluginExtension(QObject, Extension):
         self.refreshBackups()
         if self._drive_window:
             self._drive_window.show()
+
+    def _onApplicationShuttingDown(self):
+        self._drive_window.hide()
 
     def _autoBackup(self) -> None:
         preferences = CuraApplication.getInstance().getPreferences()

--- a/plugins/CuraDrive/src/qml/components/BackupListItem.qml
+++ b/plugins/CuraDrive/src/qml/components/BackupListItem.qml
@@ -71,6 +71,7 @@ Item
             text: catalog.i18nc("@button", "Restore")
             enabled: !CuraDrive.isCreatingBackup && !CuraDrive.isRestoringBackup
             onClicked: confirmRestoreDialog.visible = true
+            busy: CuraDrive.backupIdBeingRestored == modelData.backup_id && CuraDrive.isRestoringBackup
         }
 
         UM.SimpleButton

--- a/plugins/CuraDrive/src/qml/components/BackupListItem.qml
+++ b/plugins/CuraDrive/src/qml/components/BackupListItem.qml
@@ -71,7 +71,6 @@ Item
             text: catalog.i18nc("@button", "Restore")
             enabled: !CuraDrive.isCreatingBackup && !CuraDrive.isRestoringBackup
             onClicked: confirmRestoreDialog.visible = true
-            busy: CuraDrive.backupIdBeingRestored == modelData.backup_id && CuraDrive.isRestoringBackup
         }
 
         UM.SimpleButton


### PR DESCRIPTION
A few issues were happening while restoring the backup:

1. The preferences that were read from the backup were being overridden by the cached preferences when the `illuminate()` function was called, leading to the wrong `cura.cfg` after the backup was restored. This is now fixed by ensuring that the preferences are read _from the restored cura.cfg_ before illuminating the secrets.
2. There was no indication in the interface that a backup restore was in progress after the "Restore" button was pressed. This was giving the impression that Cura stopped working during the backup restore (especially if it took long). This is now fixed by showing a busy wheel in the "restore" button that was pressed
 
![image](https://user-images.githubusercontent.com/19388042/122950818-10bb1180-d37d-11eb-8e54-4fa20c8dc98c.png)

3. The extraction of the backup could take quite some time, during which, the interface was frozen. This has been imporved now by making sure that the `processEvents()` is being called while the backup is being restored.

Requires https://github.com/Ultimaker/Uranium/pull/710.

CURA-8313