### PR TITLE
CURA-8332: Cura crashes when access to keyring is denied

### DIFF
--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -52,7 +52,7 @@ class KeyringAttribute:
             if value is not None:
                 try:
                     keyring.set_password("cura", self._keyring_name, value)
-                except PasswordSetError:
+                except (PasswordSetError, KeyringLocked):
                     self._store_secure = False
                     if self._name not in DONT_EVER_STORE_LOCALLY:
                         setattr(instance, self._name, value)

--- a/cura/OAuth2/KeyringAttribute.py
+++ b/cura/OAuth2/KeyringAttribute.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2021 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
-from typing import Type, TYPE_CHECKING, Optional, List, Union
+from typing import Type, TYPE_CHECKING, Optional, List
 
 import keyring
 from keyring.backend import KeyringBackend
-from keyring.errors import NoKeyringError, PasswordSetError, KeyringError
+from keyring.errors import NoKeyringError, PasswordSetError, KeyringLocked
 
 from UM.Logger import Logger
 
@@ -14,24 +14,13 @@ if TYPE_CHECKING:
 # Need to do some extra workarounds on windows:
 import sys
 from UM.Platform import Platform
-
-
-class _KeychainDenied(Exception):
-    pass
-
-
 if Platform.isWindows() and hasattr(sys, "frozen"):
     import win32timezone
     from keyring.backends.Windows import WinVaultKeyring
     keyring.set_keyring(WinVaultKeyring())
 if Platform.isOSX() and hasattr(sys, "frozen"):
     from keyring.backends.macOS import Keyring
-    from keyring.backends.macOS.api import KeychainDenied as _KeychainDeniedMacOS
-    KeychainDenied: Union[Type[_KeychainDenied], Type[_KeychainDeniedMacOS]] = _KeychainDeniedMacOS
     keyring.set_keyring(Keyring())
-else:
-    KeychainDenied = _KeychainDenied
-
 
 # Even if errors happen, we don't want this stored locally:
 DONT_EVER_STORE_LOCALLY: List[str] = ["refresh_token"]
@@ -50,7 +39,7 @@ class KeyringAttribute:
                 self._store_secure = False
                 Logger.logException("w", "No keyring backend present")
                 return getattr(instance, self._name)
-            except KeychainDenied:
+            except KeyringLocked:
                 self._store_secure = False
                 Logger.log("i", "Access to the keyring was denied.")
                 return getattr(instance, self._name)


### PR DESCRIPTION
It turns out that when the `KeychainDenied` error is raised, it is being caught by the macOS keyring API and the non-macOS-specific `KeyringLocked` error is raised instead, so we need to catch this one.

In addition, it is now being caught also when _setting_ the token in the keyring.

CURA-8332