### PR TITLE
CURA-8313: Ignore files-in-use while restoring a backup

### DIFF
--- a/cura/Backups/Backup.py
+++ b/cura/Backups/Backup.py
@@ -193,14 +193,13 @@ class Backup:
         Logger.log("d", "Removing current data in location: %s", target_path)
         Resources.factoryReset()
         Logger.log("d", "Extracting backup to location: %s", target_path)
-        try:
-            name_list = archive.namelist()
-            for archive_filename in name_list:
+        name_list = archive.namelist()
+        for archive_filename in name_list:
+            try:
                 archive.extract(archive_filename, target_path)
-                CuraApplication.getInstance().processEvents()
-        except (PermissionError, EnvironmentError):
-            Logger.logException("e", "Unable to extract the backup due to permission or file system errors.")
-            return False
+            except (PermissionError, EnvironmentError):
+                Logger.logException("e", f"Unable to extract the file {archive_filename} from the backup due to permission or file system errors.")
+            CuraApplication.getInstance().processEvents()
         return True
 
     def _obfuscate(self) -> Dict[str, str]:


### PR DESCRIPTION
Sometimes, while a backup is being restored, one of the files in the current config folder may still be in use. This means that once the backup tries to replace this file with the one in the backup, the entire backup restoration fails (on Windows, due to a permission error) and half of the configuration folder may end up being missing.

To prevent that, we decided to ignore files that are currently in use while restoring a backup (i.e. keep the current version of those files and not replace them with the ones in the backup). This _may_ lead to a slightly wrong configuration (e.g. a plugin may not be restored properly), but it is an acceptable result, as the rest of the configuration folder is restored properly.

CURA-8313