### PR TITLE
Petg updates 410

### DIFF
--- a/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.25_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.25_normal.inst.cfg
@@ -21,4 +21,4 @@ speed_layer_0 = 30
 speed_print = 30
 top_bottom_thickness = 0.72
 wall_thickness = 0.88
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8

--- a/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.4_draft.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.4_draft.inst.cfg
@@ -27,4 +27,4 @@ speed_wall_0 = =math.ceil(speed_print * 30 / 45)
 speed_topbottom = =math.ceil(speed_print * 30 / 45)
 speed_wall_x = =math.ceil(speed_print * 40 / 45)
 speed_infill = =math.ceil(speed_print * 45 / 45)
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8

--- a/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.4_fast.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.4_fast.inst.cfg
@@ -27,4 +27,4 @@ speed_wall_0 = =math.ceil(speed_print * 30 / 45)
 speed_topbottom = =math.ceil(speed_print * 30 / 45)
 speed_wall_x = =math.ceil(speed_print * 40 / 45)
 speed_infill = =math.ceil(speed_print * 45 / 45)
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8

--- a/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.4_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.4_normal.inst.cfg
@@ -22,4 +22,4 @@ speed_print = 45
 speed_wall = =math.ceil(speed_print * 30 / 45)
 top_bottom_thickness = 0.8
 wall_thickness = 1.05
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8

--- a/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.6_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.6_normal.inst.cfg
@@ -21,4 +21,4 @@ speed_layer_0 = 30
 speed_print = 40
 top_bottom_thickness = 1.2
 wall_thickness = 1.59
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8

--- a/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.8_normal.inst.cfg
+++ b/resources/quality/ultimaker2_plus_connect/um2pc_petg_0.8_normal.inst.cfg
@@ -21,4 +21,4 @@ speed_layer_0 = 30
 speed_print = 40
 top_bottom_thickness = 1.2
 wall_thickness = 2.1
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8

--- a/resources/quality/ultimaker3/um3_aa0.25_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.25_PETG_Normal_Quality.inst.cfg
@@ -18,5 +18,5 @@ speed_topbottom = =math.ceil(speed_print * 30 / 55)
 top_bottom_thickness = 0.8
 wall_thickness = 0.92
 material_print_temperature = =default_material_print_temperature - 5
-retraction_combing_max_distance = 40
+retraction_combing_max_distance = 8
 retraction_combing = all

--- a/resources/quality/ultimaker3/um3_aa0.4_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PETG_Draft_Print.inst.cfg
@@ -23,5 +23,5 @@ speed_topbottom = =math.ceil(speed_print * 35 / 60)
 speed_wall = =math.ceil(speed_print * 45 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
 wall_thickness = 1
-retraction_combing_max_distance = 40
+retraction_combing_max_distance = 8
 retraction_combing = all

--- a/resources/quality/ultimaker3/um3_aa0.4_PETG_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PETG_Fast_Print.inst.cfg
@@ -23,5 +23,5 @@ speed_topbottom = =math.ceil(speed_print * 30 / 60)
 speed_wall = =math.ceil(speed_print * 40 / 60)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
 speed_infill = =math.ceil(speed_print * 50 / 60)
-retraction_combing_max_distance = 40
+retraction_combing_max_distance = 8
 retraction_combing = all

--- a/resources/quality/ultimaker3/um3_aa0.4_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_PETG_Normal_Quality.inst.cfg
@@ -23,5 +23,5 @@ speed_layer_0 = =math.ceil(speed_print * 20 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 speed_wall = =math.ceil(speed_print * 30 / 55)
 speed_infill = =math.ceil(speed_print * 45 / 55)
-retraction_combing_max_distance = 40
+retraction_combing_max_distance = 8
 retraction_combing = all

--- a/resources/quality/ultimaker3/um3_aa0.8_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PETG_Draft_Print.inst.cfg
@@ -20,5 +20,5 @@ prime_tower_enable = True
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)
-retraction_combing_max_distance = 40
+retraction_combing_max_distance = 8
 retraction_combing = all

--- a/resources/quality/ultimaker3/um3_aa0.8_PETG_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PETG_Superdraft_Print.inst.cfg
@@ -22,5 +22,5 @@ speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 30 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)
 speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
-retraction_combing_max_distance = 40
+retraction_combing_max_distance = 8
 retraction_combing = all

--- a/resources/quality/ultimaker3/um3_aa0.8_PETG_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.8_PETG_Verydraft_Print.inst.cfg
@@ -21,5 +21,5 @@ prime_tower_enable = True
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)
-retraction_combing_max_distance = 40
+retraction_combing_max_distance = 8
 retraction_combing = all

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_PETG_Normal_Quality.inst.cfg
@@ -12,7 +12,7 @@ material = generic_petg
 variant = AA 0.25
 
 [values]
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 retraction_extrusion_window = 0.5
 speed_infill = =math.ceil(speed_print * 40 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Draft_Print.inst.cfg
@@ -15,7 +15,7 @@ variant = AA 0.4
 material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature - 5
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 skin_overlap = 20
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Fast_Print.inst.cfg
@@ -16,7 +16,7 @@ cool_min_speed = 7
 material_print_temperature = =default_material_print_temperature
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 30 / 60)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_High_Quality.inst.cfg
@@ -18,7 +18,7 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 10
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 50
 speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_topbottom = =math.ceil(speed_print * 30 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Normal_Quality.inst.cfg
@@ -17,7 +17,7 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 55
 speed_layer_0 = =math.ceil(speed_print * 20 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Draft_Print.inst.cfg
@@ -17,7 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Superdraft_Print.inst.cfg
@@ -17,7 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 30 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Verydraft_Print.inst.cfg
@@ -17,7 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PETG_Normal_Quality.inst.cfg
@@ -12,7 +12,7 @@ material = generic_petg
 variant = AA 0.25
 
 [values]
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 retraction_extrusion_window = 0.5
 speed_infill = =math.ceil(speed_print * 40 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Draft_Print.inst.cfg
@@ -15,7 +15,7 @@ variant = AA 0.4
 material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature - 5
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 skin_edge_support_thickness = =0.8 if infill_sparse_density < 30 else 0
 skin_overlap = 20
 speed_print = 60

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Fast_Print.inst.cfg
@@ -16,7 +16,7 @@ cool_min_speed = 7
 material_print_temperature = =default_material_print_temperature
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)
 speed_topbottom = =math.ceil(speed_print * 30 / 60)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_High_Quality.inst.cfg
@@ -18,7 +18,7 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 10
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 50
 speed_layer_0 = =math.ceil(speed_print * 20 / 50)
 speed_topbottom = =math.ceil(speed_print * 30 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Normal_Quality.inst.cfg
@@ -17,7 +17,7 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 55
 speed_layer_0 = =math.ceil(speed_print * 20 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Draft_Print.inst.cfg
@@ -17,7 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Superdraft_Print.inst.cfg
@@ -17,7 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 45
 speed_topbottom = =math.ceil(speed_print * 30 / 45)
 speed_wall = =math.ceil(speed_print * 40 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Verydraft_Print.inst.cfg
@@ -17,7 +17,7 @@ line_width = =machine_nozzle_size * 0.875
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
 prime_tower_enable = True
-retraction_combing_max_distance = 50
+retraction_combing_max_distance = 8
 speed_print = 40
 speed_topbottom = =math.ceil(speed_print * 25 / 40)
 speed_wall = =math.ceil(speed_print * 30 / 40)


### PR DESCRIPTION
Changed max combing distance for UMS3, UMS5, UM2C and UM3 to reduce stringing for PETG.
Fixed distance of 8mm.