### PR TITLE
Add a drop-down to the open-file button if multiple options are available

### DIFF
--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -78,35 +78,28 @@ Item
         {
             id: openFileButton
 
-            //Make the button square if the contents are.
+            //Make the padding such that the main icon is centred, even if something else is placed besides it.
+            topPadding: Math.round((parent.height - buttonIcon.height) / 2)
             leftPadding: topPadding
             rightPadding: topPadding
             bottomPadding: topPadding
 
             height: UM.Theme.getSize("stage_menu").height
-            width: leftPadding + openFileIconContainer.width + openFileChevronContainer.width + rightPadding
+            width: leftPadding + buttonIcon.width + openFileChevronContainer.width + rightPadding
             onClicked: Cura.Actions.open.trigger()
             hoverEnabled: true
 
             contentItem: Row
             {
-                Item
+                UM.RecolorImage
                 {
-                    id: openFileIconContainer
-                    height: parent.height
-                    width: height //Square button.
+                    id: buttonIcon
+                    source: UM.Theme.getIcon("Folder", "medium")
+                    width: UM.Theme.getSize("button_icon").width
+                    height: UM.Theme.getSize("button_icon").height
+                    color: UM.Theme.getColor("icon")
 
-                    UM.RecolorImage
-                    {
-                        id: buttonIcon
-                        anchors.centerIn: parent
-                        source: UM.Theme.getIcon("Folder", "medium")
-                        width: UM.Theme.getSize("button_icon").width
-                        height: UM.Theme.getSize("button_icon").height
-                        color: UM.Theme.getColor("icon")
-
-                        sourceSize.height: height
-                    }
+                    sourceSize.height: height
                 }
                 Item
                 {

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Ultimaker B.V.
+// Copyright (c) 2021 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.7
@@ -36,9 +36,9 @@ Item
         {
             id: itemRow
 
-            anchors.left: openFileButton.right
+            anchors.left: parent.left
             anchors.right: parent.right
-            anchors.leftMargin: UM.Theme.getSize("default_margin").width
+            anchors.leftMargin: UM.Theme.getSize("default_margin").width + openFileButton.width + openFileMenu.width
             property int machineSelectorWidth: Math.round((width - printSetupSelectorItem.width) / 3)
 
             height: parent.height
@@ -74,49 +74,58 @@ Item
             }
         }
 
+        //Pop-up shown when there are multiple items to select from.
+        Cura.ExpandablePopup
+        {
+            id: openFileMenu
+            contentAlignment: Cura.ExpandablePopup.ContentAlignment.AlignLeft
+            headerCornerSide: Cura.RoundedRectangle.Direction.All
+            headerPadding: Math.round((parent.height - UM.Theme.getSize("button_icon").height) / 2)
+            enabled: visible
+
+            height: parent.height
+            width: visible ? (headerPadding * 3 + UM.Theme.getSize("button_icon").height + iconSize) : 0
+
+            headerItem: UM.RecolorImage
+            {
+                id: menuIcon
+                source: UM.Theme.getIcon("Folder", "medium")
+                color: UM.Theme.getColor("icon")
+
+                sourceSize.height: height
+            }
+
+            contentItem: Rectangle
+            {
+                width: 100
+                height: 100
+                color: "red"
+            }
+        }
+
+        //If there is just a single item, show a button instead that directly chooses the one option.
         Button
         {
             id: openFileButton
 
-            //Make the padding such that the main icon is centred, even if something else is placed besides it.
-            topPadding: Math.round((parent.height - buttonIcon.height) / 2)
-            leftPadding: topPadding
-            rightPadding: topPadding
-            bottomPadding: topPadding
-
-            height: UM.Theme.getSize("stage_menu").height
-            width: leftPadding + buttonIcon.width + openFileChevronContainer.width + rightPadding
+            height: parent.height
+            width: height //Square button.
             onClicked: Cura.Actions.open.trigger()
+            enabled: visible
             hoverEnabled: true
 
-            contentItem: Row
+            contentItem: Item
             {
                 UM.RecolorImage
                 {
                     id: buttonIcon
                     source: UM.Theme.getIcon("Folder", "medium")
+                    anchors.centerIn: parent
                     width: UM.Theme.getSize("button_icon").width
                     height: UM.Theme.getSize("button_icon").height
                     color: UM.Theme.getColor("icon")
 
                     sourceSize.height: height
-                }
-                Item
-                {
-                    id: openFileChevronContainer
-                    height: parent.height
-                    width: UM.Theme.getSize("small_button_icon").width
-
-                    UM.RecolorImage
-                    {
-                        anchors.centerIn: parent
-                        source: UM.Theme.getIcon("ChevronSingleLeft")
-                        width: UM.Theme.getSize("standard_arrow").width
-                        height: UM.Theme.getSize("standard_arrow").height
-                        color: UM.Theme.getColor("small_button_text")
-
-                        sourceSize.height: height
-                    }
                 }
             }
 

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -1,7 +1,7 @@
 // Copyright (c) 2021 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
-import QtQuick 2.7
+import QtQuick 2.9
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.3
 
@@ -99,11 +99,39 @@ Item
                 sourceSize.height: height
             }
 
-            contentItem: Rectangle
+            contentItem: Item
             {
-                width: 100
-                height: 100
-                color: "red"
+                id: popup
+                width: openProviderColumn.width
+                height: openProviderColumn.height
+
+                Column
+                {
+                    id: openProviderColumn
+
+                    //The column doesn't automatically listen to its children rect if the children change internally, so we need to explicitly update the size.
+                    onChildrenRectChanged:
+                    {
+                        popup.height = childrenRect.height
+                        popup.width = childrenRect.width
+                    }
+                    onPositioningComplete:
+                    {
+                        popup.height = childrenRect.height
+                        popup.width = childrenRect.width
+                    }
+
+                    Label
+                    {
+                        text: catalog.i18nc("@menu:header", "Open file")
+                        color: UM.Theme.getColor("text_medium")
+                        font: UM.Theme.getFont("medium")
+                        renderType: Text.NativeRendering
+
+                        width: contentWidth
+                        height: contentHeight
+                    }
+                }
             }
         }
 

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -85,6 +85,7 @@ Item
             contentAlignment: Cura.ExpandablePopup.ContentAlignment.AlignLeft
             headerCornerSide: Cura.RoundedRectangle.Direction.All
             headerPadding: Math.round((parent.height - UM.Theme.getSize("button_icon").height) / 2)
+            contentPadding: UM.Theme.getSize("default_lining").width
             enabled: visible
 
             height: parent.height
@@ -102,8 +103,6 @@ Item
             contentItem: Item
             {
                 id: popup
-                width: openProviderColumn.width
-                height: openProviderColumn.height
 
                 Column
                 {
@@ -127,9 +126,11 @@ Item
                         color: UM.Theme.getColor("text_medium")
                         font: UM.Theme.getFont("medium")
                         renderType: Text.NativeRendering
+                        verticalAlignment: Text.AlignVCenter
 
                         width: contentWidth
-                        height: contentHeight
+                        height: UM.Theme.getSize("action_button").height
+                        leftPadding: UM.Theme.getSize("default_margin").width
                     }
 
                     Repeater
@@ -152,7 +153,7 @@ Item
                                 verticalAlignment: Text.AlignVCenter
 
                                 width: contentWidth
-                                height: contentHeight
+                                height: parent.height
                             }
 
                             onClicked:
@@ -171,6 +172,7 @@ Item
                             {
                                 color: parent.hovered ? UM.Theme.getColor("action_button_hovered") : "transparent"
                                 radius: UM.Theme.getSize("action_button_radius").width
+                                width: popup.width
                             }
                         }
                     }

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -77,24 +77,36 @@ Item
         Button
         {
             id: openFileButton
+
+            //Make the button square if the contents are.
+            leftPadding: topPadding
+            rightPadding: topPadding
+            bottomPadding: topPadding
+
             height: UM.Theme.getSize("stage_menu").height
-            width: UM.Theme.getSize("stage_menu").height
+            width: openFileIconContainer.width + leftPadding + rightPadding
             onClicked: Cura.Actions.open.trigger()
             hoverEnabled: true
 
-            contentItem: Item
+            contentItem: Row
             {
-                anchors.fill: parent
-                UM.RecolorImage
+                Item
                 {
-                    id: buttonIcon
-                    anchors.centerIn: parent
-                    source: UM.Theme.getIcon("Folder", "medium")
-                    width: UM.Theme.getSize("button_icon").width
-                    height: UM.Theme.getSize("button_icon").height
-                    color: UM.Theme.getColor("icon")
+                    id: openFileIconContainer
+                    height: parent.height
+                    width: height //Square button.
 
-                    sourceSize.height: height
+                    UM.RecolorImage
+                    {
+                        id: buttonIcon
+                        anchors.centerIn: parent
+                        source: UM.Theme.getIcon("Folder", "medium")
+                        width: UM.Theme.getSize("button_icon").width
+                        height: UM.Theme.getSize("button_icon").height
+                        color: UM.Theme.getColor("icon")
+
+                        sourceSize.height: height
+                    }
                 }
             }
 

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -13,6 +13,8 @@ Item
 {
     id: prepareMenu
 
+    property var fileProviderModel: CuraApplication.getFileProviderModel()
+
     UM.I18nCatalog
     {
         id: catalog
@@ -78,6 +80,8 @@ Item
         Cura.ExpandablePopup
         {
             id: openFileMenu
+            visible: prepareMenu.fileProviderModel.count > 1
+
             contentAlignment: Cura.ExpandablePopup.ContentAlignment.AlignLeft
             headerCornerSide: Cura.RoundedRectangle.Direction.All
             headerPadding: Math.round((parent.height - UM.Theme.getSize("button_icon").height) / 2)
@@ -107,11 +111,12 @@ Item
         Button
         {
             id: openFileButton
+            visible: prepareMenu.fileProviderModel.count <= 1
 
             height: parent.height
-            width: height //Square button.
+            width: visible ? height : 0 //Square button (and don't take up space if invisible).
             onClicked: Cura.Actions.open.trigger()
-            enabled: visible
+            enabled: visible && prepareMenu.fileProviderModel.count > 0
             hoverEnabled: true
 
             contentItem: Item

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -138,8 +138,8 @@ Item
                         model: prepareMenu.fileProviderModel
                         delegate: Button
                         {
-                            leftPadding: UM.Theme.getSize("thick_margin").width
-                            rightPadding: UM.Theme.getSize("thick_margin").width
+                            leftPadding: UM.Theme.getSize("default_margin").width
+                            rightPadding: UM.Theme.getSize("default_margin").width
                             width: contentItem.width + leftPadding + rightPadding
                             height: UM.Theme.getSize("action_button").height
                             hoverEnabled: true

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -131,6 +131,49 @@ Item
                         width: contentWidth
                         height: contentHeight
                     }
+
+                    Repeater
+                    {
+                        model: prepareMenu.fileProviderModel
+                        delegate: Button
+                        {
+                            leftPadding: UM.Theme.getSize("thick_margin").width
+                            rightPadding: UM.Theme.getSize("thick_margin").width
+                            width: contentItem.width + leftPadding + rightPadding
+                            height: UM.Theme.getSize("action_button").height
+                            hoverEnabled: true
+
+                            contentItem: Label
+                            {
+                                text: model.displayText
+                                color: UM.Theme.getColor("text")
+                                font: UM.Theme.getFont("medium")
+                                renderType: Text.NativeRendering
+                                verticalAlignment: Text.AlignVCenter
+
+                                width: contentWidth
+                                height: contentHeight
+                            }
+
+                            onClicked:
+                            {
+                                if(model.index == 0) //The 0th element is the "From Disk" option, which should activate the open local file dialog.
+                                {
+                                    Cura.Actions.open.trigger();
+                                }
+                                else
+                                {
+                                    prepareMenu.fileProviderModel.trigger(model.name);
+                                }
+                            }
+
+                            background: Rectangle
+                            {
+                                color: parent.hovered ? UM.Theme.getColor("action_button_hovered") : "transparent"
+                                radius: UM.Theme.getSize("action_button_radius").width
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -84,7 +84,7 @@ Item
             bottomPadding: topPadding
 
             height: UM.Theme.getSize("stage_menu").height
-            width: openFileIconContainer.width + leftPadding + rightPadding
+            width: leftPadding + openFileIconContainer.width + openFileChevronContainer.width + rightPadding
             onClicked: Cura.Actions.open.trigger()
             hoverEnabled: true
 
@@ -108,13 +108,30 @@ Item
                         sourceSize.height: height
                     }
                 }
+                Item
+                {
+                    id: openFileChevronContainer
+                    height: parent.height
+                    width: UM.Theme.getSize("small_button_icon").width
+
+                    UM.RecolorImage
+                    {
+                        anchors.centerIn: parent
+                        source: UM.Theme.getIcon("ChevronSingleDown")
+                        width: UM.Theme.getSize("small_button_icon").width
+                        height: UM.Theme.getSize("small_button_icon").height
+                        color: UM.Theme.getColor("icon")
+
+                        sourceSize.height: height
+                    }
+                }
             }
 
             background: Rectangle
             {
                 id: background
-                height: UM.Theme.getSize("stage_menu").height
-                width: UM.Theme.getSize("stage_menu").height
+                height: parent.height
+                width: parent.width
                 border.color: UM.Theme.getColor("lining")
                 border.width: UM.Theme.getSize("default_lining").width
 

--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -110,10 +110,10 @@ Item
                     UM.RecolorImage
                     {
                         anchors.centerIn: parent
-                        source: UM.Theme.getIcon("ChevronSingleDown")
-                        width: UM.Theme.getSize("small_button_icon").width
-                        height: UM.Theme.getSize("small_button_icon").height
-                        color: UM.Theme.getColor("icon")
+                        source: UM.Theme.getIcon("ChevronSingleLeft")
+                        width: UM.Theme.getSize("standard_arrow").width
+                        height: UM.Theme.getSize("standard_arrow").height
+                        color: UM.Theme.getColor("small_button_text")
 
                         sourceSize.height: height
                     }

--- a/resources/qml/ExpandableComponent.qml
+++ b/resources/qml/ExpandableComponent.qml
@@ -167,7 +167,7 @@ Item
                     verticalCenter: parent.verticalCenter
                     margins: background.padding
                 }
-                source: expanded ? UM.Theme.getIcon("ChevronSingleDown") : UM.Theme.getIcon("ChevronSingleLeft")
+                source: UM.Theme.getIcon("ChevronSingleDown")
                 visible: source != ""
                 width: UM.Theme.getSize("standard_arrow").width
                 height: UM.Theme.getSize("standard_arrow").height

--- a/resources/qml/ExpandablePopup.qml
+++ b/resources/qml/ExpandablePopup.qml
@@ -180,7 +180,7 @@ Item
                     verticalCenter: parent.verticalCenter
                     margins: background.padding
                 }
-                source: expanded ? UM.Theme.getIcon("ChevronSingleDown") : UM.Theme.getIcon("ChevronSingleLeft")
+                source: UM.Theme.getIcon("ChevronSingleDown")
                 visible: source != ""
                 width: UM.Theme.getSize("standard_arrow").width
                 height: UM.Theme.getSize("standard_arrow").height


### PR DESCRIPTION
If there are multiple sources from which you can open files, the open file button turns into a drop-down menu.

![image](https://user-images.githubusercontent.com/2448634/125263955-bbcb4500-e303-11eb-913d-067042a4e120.png)

The drop-down menu then allows you to select the source from which to open files.

If there is only one option, it shows the old button.

Implements CURA-8008.