### PR TITLE
MP Mini Delta V2 Printer Definition

### DIFF
--- a/resources/definitions/mp_mini_delta.def.json
+++ b/resources/definitions/mp_mini_delta.def.json
@@ -3,7 +3,7 @@
     "name": "MP Mini Delta",
     "inherits": "fdmprinter",
     "metadata": {
-        "author": "MPMD Facebook Group",
+        "author": "MPMD V1 Facebook Group",
         "manufacturer": "Monoprice",
         "file_formats": "text/x-gcode",
         "platform": "mp_mini_delta_platform.3mf",
@@ -25,7 +25,7 @@
     "overrides": {
         "machine_start_gcode":
         {
-            "default_value": ";MPMD Basic Calibration Tutorial: \n; https://www.thingiverse.com/thing:3892011 \n; \n; If you want to put calibration values in your \n; Start Gcode, put them here. \n; \n;If on stock firmware, at minimum, consider adding \n;M665 R here since there is a firmware bug.  \n; \n; Calibration part ends here \n; \nG90 ; switch to absolute positioning \nG92 E0 ; reset extrusion distance \nG1 E20 F200 ; purge 20mm of filament to prime nozzle. \nG92 E0 ; reset extrusion distance \nG4 S5 ; Pause for 5 seconds to allow time for removing extruded filament \nG28 ; start from home position \nG1 E-6 F900 ; retract 6mm of filament before starting the bed leveling process \nG92 E0 ; reset extrusion distance \nG4 S5 ; pause for 5 seconds to allow time for removing extruded filament \nG29 P2 Z0.28 ; Auto-level ; ADJUST Z higher or lower to set first layer height. Start with 0.02 adjustments. \nG1 Z30 ; raise Z 30mm to prepare for priming the nozzle \nG1 E5 F200 ; extrude 5mm of filament to help prime the nozzle just prior to the start of the print \nG92 E0 ; reset extrusion distance \nG4 S5 ; pause for 5 seconds to allow time for cleaning the nozzle and build plate if needed "
+            "default_value": ";MPMD V1 Basic Calibration Tutorial: \n; https://www.thingiverse.com/thing:3892011 \n; \n; If you want to put calibration values in your \n; Start Gcode, put them here. \n; \n;If on stock firmware, at minimum, consider adding \n;M665 R here since there is a firmware bug.  \n; \n; Calibration part ends here \n; \nG90 ; switch to absolute positioning \nG92 E0 ; reset extrusion distance \nG1 E20 F200 ; purge 20mm of filament to prime nozzle. \nG92 E0 ; reset extrusion distance \nG4 S5 ; Pause for 5 seconds to allow time for removing extruded filament \nG28 ; start from home position \nG1 E-6 F900 ; retract 6mm of filament before starting the bed leveling process \nG92 E0 ; reset extrusion distance \nG4 S5 ; pause for 5 seconds to allow time for removing extruded filament \nG29 P2 Z0.28 ; Auto-level ; ADJUST Z higher or lower to set first layer height. Start with 0.02 adjustments. \nG1 Z30 ; raise Z 30mm to prepare for priming the nozzle \nG1 E5 F200 ; extrude 5mm of filament to help prime the nozzle just prior to the start of the print \nG92 E0 ; reset extrusion distance \nG4 S5 ; pause for 5 seconds to allow time for cleaning the nozzle and build plate if needed "
         },
         "machine_end_gcode":
         {        
@@ -47,9 +47,9 @@
             "default_value": 0.21
         },
         "material_bed_temperature": { "value": 40 },
-        "line_width": { "value": "round(machine_nozzle_size * 0.875, 2)" },
-        "material_print_temperature_layer_0": { "value": "material_print_temperature + 5" },
-        "material_bed_temperature_layer_0": { "value": "material_bed_temperature + 5" },
+        "line_width": { "value": "round(machine_nozzle_size, 2)" },
+        "material_print_temperature_layer_0": { "value": "material_print_temperature" },
+        "material_bed_temperature_layer_0": { "value": "material_bed_temperature" },
         "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
         "machine_max_feedrate_x": { "default_value": 150 },
         "machine_max_feedrate_y": { "default_value": 150 },

--- a/resources/definitions/mp_mini_delta_v2.def.json
+++ b/resources/definitions/mp_mini_delta_v2.def.json
@@ -1,9 +1,9 @@
 {
-    "version": 3,
+    "version": 2,
     "name": "MP Mini Delta V2",
     "inherits": "fdmprinter",
     "metadata": {
-        "author": "r/mpminidelta",
+        "author": "mpminidelta subreddit",
         "manufacturer": "Monoprice",
         "file_formats": "text/x-gcode",
         "platform": "mp_mini_delta_platform.3mf",
@@ -28,8 +28,15 @@
           "default_value": ";(**** start.gcode for MP Mini Delta V2****)\nG21\nG90\nM82\nM107\nM104 S170\nG28 X0 Y0\nG28 Z0\nG29 Z0.4\nG1 Z15 F300\nM109 S{material_print_temperature_layer_0}\nG92 E0\nG1 F200 E3\nG92 E0\nG1 F2000\n"
         },
         "machine_end_gcode": {
-          "default_value": ";(**** end.gcode for MP Mini Delta****)\nG28;(Stick out the part)\nM190 S0;(Turn off heat bed, don't wait.)\nG92 E10;(Set extruder to 10)\nG1 E7 F200;(retract 3mm)\nM104 S0;(Turn off nozzle, don't wait)\nG4 S300;(Delay 5 minutes)\nM107;(Turn off part fan)\nM84;(Turn off stepper motors.)"
+          "default_value": ";(**** end.gcode for MP Mini Delta V2****)\nG28;(Stick out the part)\nM190 S0;(Turn off heat bed, don't wait.)\nG92 E10;(Set extruder to 10)\nG1 E7 F200;(retract 3mm)\nM104 S0;(Turn off nozzle, don't wait)\nG4 S300;(Delay 5 minutes)\nM107;(Turn off part fan)\nM84;(Turn off stepper motors.)"
         },
+        "material_print_temp_prepend":{"default_value":false},
+        "default_material_bed_temperature":{
+          "default_value": 40
+		},
+		"material_bed_temperature":{
+          "default_value": 40
+		},
         "machine_width": { "default_value": 110 },
         "machine_depth": { "default_value": 110 },
         "machine_height": { "default_value": 120 },
@@ -39,10 +46,7 @@
         "machine_nozzle_size": {
             "default_value": 0.4
         },
-        "material_bed_temperature": { "value": 40 },
         "line_width": { "value": "round(machine_nozzle_size, 2)" },
-        "material_print_temperature_layer_0": { "value": "material_print_temperature" },
-        "material_bed_temperature_layer_0": { "value": "material_bed_temperature" },
         "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
         "retraction_amount": { "default_value": 5 },
         "retraction_speed": { "default_value": 28 },

--- a/resources/definitions/mp_mini_delta_v2.def.json
+++ b/resources/definitions/mp_mini_delta_v2.def.json
@@ -31,12 +31,7 @@
           "default_value": ";(**** end.gcode for MP Mini Delta V2****)\nG28;(Stick out the part)\nM190 S0;(Turn off heat bed, don't wait.)\nG92 E10;(Set extruder to 10)\nG1 E7 F200;(retract 3mm)\nM104 S0;(Turn off nozzle, don't wait)\nG4 S300;(Delay 5 minutes)\nM107;(Turn off part fan)\nM84;(Turn off stepper motors.)"
         },
         "material_print_temp_prepend":{"default_value":false},
-        "default_material_bed_temperature":{
-          "default_value": 40
-		},
-		"material_bed_temperature":{
-          "default_value": 40
-		},
+        "material_bed_temperature": { "value": 40 },
         "machine_width": { "default_value": 110 },
         "machine_depth": { "default_value": 110 },
         "machine_height": { "default_value": 120 },

--- a/resources/definitions/mp_mini_delta_v2.def.json
+++ b/resources/definitions/mp_mini_delta_v2.def.json
@@ -1,0 +1,52 @@
+{
+    "version": 3,
+    "name": "MP Mini Delta V2",
+    "inherits": "fdmprinter",
+    "metadata": {
+        "author": "r/mpminidelta",
+        "manufacturer": "Monoprice",
+        "file_formats": "text/x-gcode",
+        "platform": "mp_mini_delta_platform.3mf",
+        "supports_usb_connection": true,
+        "has_machine_quality": false,
+        "visible": true,
+        "platform_offset": [0, 0, 0],
+        "has_materials": true,
+        "has_variants": false,
+        "has_machine_materials": false,
+        "has_variant_materials": false,
+        "preferred_quality_type": "normal",
+        "machine_extruder_trains":
+        {
+            "0": "mp_mini_delta_v2_extruder_0"
+        }
+    },
+
+    "overrides": {
+        "machine_start_gcode":
+        {
+          "default_value": ";(**** start.gcode for MP Mini Delta V2****)\nG21\nG90\nM82\nM107\nM104 S170\nG28 X0 Y0\nG28 Z0\nG29 Z0.4\nG1 Z15 F300\nM109 S{material_print_temperature_layer_0}\nG92 E0\nG1 F200 E3\nG92 E0\nG1 F2000\n"
+        },
+        "machine_end_gcode": {
+          "default_value": ";(**** end.gcode for MP Mini Delta****)\nG28;(Stick out the part)\nM190 S0;(Turn off heat bed, don't wait.)\nG92 E10;(Set extruder to 10)\nG1 E7 F200;(retract 3mm)\nM104 S0;(Turn off nozzle, don't wait)\nG4 S300;(Delay 5 minutes)\nM107;(Turn off part fan)\nM84;(Turn off stepper motors.)"
+        },
+        "machine_width": { "default_value": 110 },
+        "machine_depth": { "default_value": 110 },
+        "machine_height": { "default_value": 120 },
+        "machine_heated_bed": { "default_value": true },
+        "machine_shape": { "default_value": "elliptic" },
+        "machine_center_is_zero": { "default_value": true },
+        "machine_nozzle_size": {
+            "default_value": 0.4
+        },
+        "material_bed_temperature": { "value": 40 },
+        "line_width": { "value": "round(machine_nozzle_size, 2)" },
+        "material_print_temperature_layer_0": { "value": "material_print_temperature" },
+        "material_bed_temperature_layer_0": { "value": "material_bed_temperature" },
+        "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
+        "retraction_amount": { "default_value": 5 },
+        "retraction_speed": { "default_value": 28 },
+        "retraction_hop_enabled": { "default_value": false },
+        "retract_at_layer_change": { "default_value": true }
+    }
+}

--- a/resources/extruders/mp_mini_delta_v2_extruder_0.def.json
+++ b/resources/extruders/mp_mini_delta_v2_extruder_0.def.json
@@ -1,0 +1,15 @@
+{
+    "version": 2,
+    "name": "Extruder 0",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "mp_mini_delta_v2",
+        "position": "0"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 0 },
+        "machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 }
+    }
+}


### PR DESCRIPTION
Adding the MP Mini Delta V2. While this printer has the same form factor as the original MP Mini Delta, it is actually made by a different manufacturer (WEEBO instead of Malyan). The different mainboard, firmware, and other minor changes calls for different Start Gcode, as well as some other settings tweaks. 

I also made some minor changes to the original MP Mini Delta def. 

I am behind on the process for adding printers to Cura manually (via file copy), so I have not tested this def outside of making sure the Start/End gcode makes the old V1 def work for the V2. I can dig into this more if the build test cases report errors. 