### PR TITLE
Remove the "Open file" label from the open file dropdown menu

### DIFF
--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -120,19 +120,6 @@ Item
                         popup.width = childrenRect.width
                     }
 
-                    Label
-                    {
-                        text: catalog.i18nc("@menu:header", "Open file")
-                        color: UM.Theme.getColor("text_medium")
-                        font: UM.Theme.getFont("medium")
-                        renderType: Text.NativeRendering
-                        verticalAlignment: Text.AlignVCenter
-
-                        width: contentWidth
-                        height: UM.Theme.getSize("action_button").height
-                        leftPadding: UM.Theme.getSize("default_margin").width
-                    }
-
                     Repeater
                     {
                         model: prepareMenu.fileProviderModel


### PR DESCRIPTION
Instead of translating "open file" and "from Disk" separately, which could make the some translation results making less sense, it's better to just keep the dropdown entries only.

![image](https://user-images.githubusercontent.com/19388042/126486812-978fa214-3b09-4c55-ad1b-40cb09d19dad.png)


CURA-8411