### PR TITLE
Fix crash on exit on MacOS if using Cura's translations

### DIFF
--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -180,7 +180,14 @@ Item
     Action
     {
         id: preferencesAction
-        text: catalog.i18nc("@action:inmenu", "Configure Cura...")
+        //On MacOS, don't translate the "Configure" word.
+        //Qt moves the "configure" entry to a different place, and if it got renamed can't find it again when it
+        //attempts to delete the item upon closing the application, causing a crash.
+        //In the new location, these items are translated automatically according to the system's language.
+        //For more information, see:
+        //- https://doc.qt.io/qt-5/macos-issues.html#menu-bar
+        //- https://doc.qt.io/qt-5/qmenubar.html#qmenubar-as-a-global-menu-bar
+        text: (Qt.platform.os == "osx") ? "Configure Cura..." : catalog.i18nc("@action:inmenu", "Configure Cura...")
         iconName: "configure"
     }
 

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Ultimaker B.V.
+// Copyright (c) 2021 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 pragma Singleton
@@ -122,7 +122,15 @@ Item
     Action
     {
         id: quitAction
-        text: catalog.i18nc("@action:inmenu menubar:file","&Quit")
+
+        //On MacOS, don't translate the "Quit" word.
+        //Qt moves the "quit" entry to a different place, and if it got renamed can't find it again when it attempts to
+        //delete the item upon closing the application, causing a crash.
+        //In the new location, these items are translated automatically according to the system's language.
+        //For more information, see:
+        //- https://doc.qt.io/qt-5/macos-issues.html#menu-bar
+        //- https://doc.qt.io/qt-5/qmenubar.html#qmenubar-as-a-global-menu-bar
+        text: (Qt.platform.os == "osx") ? "&Quit" : catalog.i18nc("@action:inmenu menubar:file", "&Quit")
         iconName: "application-exit"
         shortcut: StandardKey.Quit
     }
@@ -263,7 +271,15 @@ Item
     Action
     {
         id: aboutAction;
-        text: catalog.i18nc("@action:inmenu menubar:help", "About...");
+
+        //On MacOS, don't translate the "About" word.
+        //Qt moves the "about" entry to a different place, and if it got renamed can't find it again when it
+        //attempts to delete the item upon closing the application, causing a crash.
+        //In the new location, these items are translated automatically according to the system's language.
+        //For more information, see:
+        //- https://doc.qt.io/qt-5/macos-issues.html#menu-bar
+        //- https://doc.qt.io/qt-5/qmenubar.html#qmenubar-as-a-global-menu-bar
+        text: (Qt.platform.os == "osx") ? "About..." : catalog.i18nc("@action:inmenu menubar:help", "About...");
         iconName: "help-about";
     }
 

--- a/resources/qml/MainWindow/ApplicationMenu.qml
+++ b/resources/qml/MainWindow/ApplicationMenu.qml
@@ -109,7 +109,7 @@ Item
             //For more information, see:
             //- https://doc.qt.io/qt-5/macos-issues.html#menu-bar
             //- https://doc.qt.io/qt-5/qmenubar.html#qmenubar-as-a-global-menu-bar
-            title: (Qt.platform.os == "osx") ? "P&references" : catalog.i18nc("@title:menu menubar:toplevel", "P&references")
+            title: (Qt.platform.os == "osx") ? "&Preferences" : catalog.i18nc("@title:menu menubar:toplevel", "P&references")
 
             MenuItem { action: Cura.Actions.preferences }
         }

--- a/resources/qml/MainWindow/ApplicationMenu.qml
+++ b/resources/qml/MainWindow/ApplicationMenu.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Ultimaker B.V.
+// Copyright (c) 2021 Ultimaker B.V.
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.7
@@ -48,7 +48,17 @@ Item
 
         ViewMenu { title: catalog.i18nc("@title:menu menubar:toplevel", "&View") }
 
-        SettingsMenu { title: catalog.i18nc("@title:menu menubar:toplevel", "&Settings") }
+        SettingsMenu
+        {
+            //On MacOS, don't translate the "Settings" word.
+            //Qt moves the "settings" entry to a different place, and if it got renamed can't find it again when it
+            //attempts to delete the item upon closing the application, causing a crash.
+            //In the new location, these items are translated automatically according to the system's language.
+            //For more information, see:
+            //- https://doc.qt.io/qt-5/macos-issues.html#menu-bar
+            //- https://doc.qt.io/qt-5/qmenubar.html#qmenubar-as-a-global-menu-bar
+            title: (Qt.platform.os == "osx") ? "&Settings" : catalog.i18nc("@title:menu menubar:toplevel", "&Settings")
+        }
 
         Menu
         {
@@ -91,7 +101,15 @@ Item
         Menu
         {
             id: preferencesMenu
-            title: catalog.i18nc("@title:menu menubar:toplevel", "P&references")
+
+            //On MacOS, don't translate the "Preferences" word.
+            //Qt moves the "preferences" entry to a different place, and if it got renamed can't find it again when it
+            //attempts to delete the item upon closing the application, causing a crash.
+            //In the new location, these items are translated automatically according to the system's language.
+            //For more information, see:
+            //- https://doc.qt.io/qt-5/macos-issues.html#menu-bar
+            //- https://doc.qt.io/qt-5/qmenubar.html#qmenubar-as-a-global-menu-bar
+            title: (Qt.platform.os == "osx") ? "P&references" : catalog.i18nc("@title:menu menubar:toplevel", "P&references")
 
             MenuItem { action: Cura.Actions.preferences }
         }


### PR DESCRIPTION
If you're using Cura in a different language, it was crashing on MacOS due to being moved to the special "Ultimaker Cura" menu that MacOS creates. These were the reproduction steps:

* Change Cura's language in its preferences menu.
* Restart Cura to complete the language change.
* Exit Cura. MacOS gives an error message then.

To fix this, certain menu entries should not be translated. Translating them causes Cura to update the menu entry's name upon closing down Cura, but the menu entry can't be found in its original place any more. The Qt documentation warns us that signals on the moved Menu elements won't work well any more.

The items changed below are the items that are moved by MacOS. Only those should not be translated any more. The rest should still be translated. MacOS itself should translate the moved menu items into the user's system language (which is out of Cura's control and may be different from the language preference in Cura).

Fixes CURA-8245 and fixes #9837.