### PR TITLE
[CURA-8412] Part of fix for crash on context menu open + click on slice.

### DIFF
--- a/cura/PreviewPass.py
+++ b/cura/PreviewPass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 from typing import Optional, TYPE_CHECKING, cast, List
@@ -74,6 +74,7 @@ class PreviewPass(RenderPass):
                 self._shader.setUniformValue("u_faceId", -1)  # Don't render any selected faces in the preview.
             else:
                 Logger.error("Unable to compile shader program: overhang.shader")
+                return
 
         if not self._non_printing_shader:
             self._non_printing_shader = OpenGL.getInstance().createShaderProgram(Resources.getPath(Resources.Shaders, "transparent_object.shader"))

--- a/cura/Snapshot.py
+++ b/cura/Snapshot.py
@@ -93,7 +93,7 @@ class Snapshot:
             pixel_output = preview_pass.getOutput()
             try:
                 min_x, max_x, min_y, max_y = Snapshot.getImageBoundaries(pixel_output)
-            except ValueError:
+            except (ValueError, AttributeError):
                 return None
 
             size = max((max_x - min_x) / render_width, (max_y - min_y) / render_height)


### PR DESCRIPTION
See also [this more substantial PR](https://github.com/Ultimaker/Uranium/pull/719) in UM.

If the context menu is opened over the slice button, then it _may_ on some cases (on Windows) fail on the creation of the snapshot. Within this fix, the snapshot is then still not created, but at least it doesn't crash any more. (Also the snapshot _will_ be there if a reslice is done.)