### PR TITLE
CURA-8444: The Digital Library does not work on earlier Cura versions

### DIFF
--- a/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
+++ b/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
@@ -49,11 +49,27 @@ Item
             id: searchBar
             Layout.fillWidth: true
             implicitHeight: createNewProjectButton.height
+            leftPadding: searchIcon.width + UM.Theme.getSize("default_margin").width * 2
 
             onTextEdited: manager.projectFilter = text //Update the search filter when editing this text field.
 
-            leftIcon: UM.Theme.getIcon("Magnifier")
             placeholderText: "Search"
+
+            UM.RecolorImage
+            {
+                id: searchIcon
+
+                anchors
+                {
+                    verticalCenter: parent.verticalCenter
+                    left: parent.left
+                    leftMargin: UM.Theme.getSize("default_margin").width
+                }
+                source: UM.Theme.getIcon("Magnifier")
+                height: UM.Theme.getSize("small_button_icon").height
+                width: height
+                color: UM.Theme.getColor("text")
+            }
         }
 
         Cura.SecondaryButton

--- a/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
+++ b/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
@@ -65,7 +65,7 @@ Item
                     left: parent.left
                     leftMargin: UM.Theme.getSize("default_margin").width
                 }
-                source: UM.Theme.getIcon("Magnifier")
+                source: UM.Theme.getIcon("search")
                 height: UM.Theme.getSize("small_button_icon").height
                 width: height
                 color: UM.Theme.getColor("text")
@@ -92,7 +92,7 @@ Item
             id: upgradePlanButton
 
             text: "Upgrade plan"
-            iconSource: UM.Theme.getIcon("LinkExternal")
+            iconSource: UM.Theme.getIcon("external_link")
             visible: createNewProjectButtonVisible && !manager.userAccountCanCreateNewLibraryProject && (manager.retrievingProjectsStatus == DF.RetrievalStatus.Success || manager.retrievingProjectsStatus == DF.RetrievalStatus.Failed)
             tooltip: "Maximum number of projects reached. Please upgrade your subscription to create more projects."
 

--- a/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
+++ b/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
@@ -94,8 +94,7 @@ Item
             text: "Upgrade plan"
             iconSource: UM.Theme.getIcon("LinkExternal")
             visible: createNewProjectButtonVisible && !manager.userAccountCanCreateNewLibraryProject && (manager.retrievingProjectsStatus == DF.RetrievalStatus.Success || manager.retrievingProjectsStatus == DF.RetrievalStatus.Failed)
-            tooltip: "You have reached the maximum number of projects allowed by your subscription. Please upgrade to the Professional subscription to create more projects."
-            tooltipWidth: parent.width * 0.5
+            tooltip: "Maximum number of projects reached. Please upgrade your subscription to create more projects."
 
             onClicked: Qt.openUrlExternally("https://ultimaker.com/software/ultimaker-essentials/sign-up-cura?utm_source=cura&utm_medium=software&utm_campaign=lib-max")
         }


### PR DESCRIPTION
The following things were incompatible with 4.9/4.10:

- `Cura.TextField` doesn't have a `leftIcon` property in these versions. This is the property intented to add the "search" icon. To fix that, I did not use the property and instead I added a `UM.RecolorImage` manually inside the `TextField` to hold the "search" icon.
- `Cura.SecondaryButton` doesn't have a `tooltipWidth` property in earlier versions. This property was added to make sure that the tooltip has a smaller width than the DigitalLibrary window, or else it doesn't get drawn at all, which is confusing. Since it was not available in 4.9 and 4.10, I had to make the tooltip text smaller to make sure that it will fit.
  - Previous text: "You have reached the maximum number of projects allowed by your subscription. Please upgrade to the Professional subscription to create more projects."
  - New text: "Maximum number of projects reached. Please upgrade your subscription to create more projects."
- The "Magnifier" and "LinkExternal" icons are called by their old names in 4.9 and 4.10, so I had to retrieve them using the old names. This means that the DigitalLibrary now will produce a warning in 4.11 onwards that the old names are deprecated. But this is acceptable, considering it's the only way to show the icons in 4.9 and 4.10.

CURA-8444