### PR TITLE
Make parking optional in all "methods" of Pause at Height

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -54,10 +54,10 @@ class PauseAtHeight(Script):
                     "label": "Method",
                     "description": "The method or gcode command to use for pausing.",
                     "type": "enum",
-                    "options": {"marlin": "Marlin (M0)", "griffin": "Griffin (M0, firmware retract)", "bq": "BQ (M25)", "reprap": "RepRap (M226)", "repetier": "Repetier (@pause)"},
+                    "options": {"marlin": "Marlin (M0)", "griffin": "Griffin (M0, firmware retract)", "bq": "BQ (M25)", "reprap": "RepRap (M226)", "repetier": "Repetier/OctoPrint (@pause)"},
                     "default_value": "marlin",
                     "value": "\\\"griffin\\\" if machine_gcode_flavor==\\\"Griffin\\\" else \\\"reprap\\\" if machine_gcode_flavor==\\\"RepRap (RepRap)\\\" else \\\"repetier\\\" if machine_gcode_flavor==\\\"Repetier\\\" else \\\"bq\\\" if \\\"BQ\\\" in machine_name or \\\"Flying Bear Ghost 4S\\\" in machine_name  else \\\"marlin\\\""
-                },                    
+                },
                 "disarm_timeout":
                 {
                     "label": "Disarm timeout",
@@ -69,6 +69,14 @@ class PauseAtHeight(Script):
                     "maximum_value_warning": "1800",
                     "unit": "s"
                 },
+                "head_park_enabled":
+                {
+                    "label": "Park Print",
+                    "description": "Instruct the head to move to a safe location when pausing. Leave this unchecked if your printer handles parking for you.",
+                    "type": "bool",
+                    "default_value": True,
+                    "enabled": "pause_method != \\\"griffin\\\""
+                },
                 "head_park_x":
                 {
                     "label": "Park Print Head X",
@@ -76,7 +84,7 @@ class PauseAtHeight(Script):
                     "unit": "mm",
                     "type": "float",
                     "default_value": 190,
-                    "enabled": "pause_method != \\\"griffin\\\""
+                    "enabled": "head_park_enabled and pause_method != \\\"griffin\\\""
                 },
                 "head_park_y":
                 {
@@ -85,7 +93,7 @@ class PauseAtHeight(Script):
                     "unit": "mm",
                     "type": "float",
                     "default_value": 190,
-                    "enabled": "pause_method != \\\"griffin\\\""
+                    "enabled": "head_park_enabled and pause_method != \\\"griffin\\\""
                 },
                 "head_move_z":
                 {
@@ -94,7 +102,7 @@ class PauseAtHeight(Script):
                     "unit": "mm",
                     "type": "float",
                     "default_value": 15.0,
-                    "enabled": "pause_method == \\\"repetier\\\""
+                    "enabled": "head_park_enabled and pause_method == \\\"repetier\\\""
                 },
                 "retraction_amount":
                 {
@@ -239,6 +247,7 @@ class PauseAtHeight(Script):
         retraction_speed = self.getSettingValueByKey("retraction_speed")
         extrude_amount = self.getSettingValueByKey("extrude_amount")
         extrude_speed = self.getSettingValueByKey("extrude_speed")
+        park_enabled = self.getSettingValueByKey("head_park_enabled")
         park_x = self.getSettingValueByKey("head_park_x")
         park_y = self.getSettingValueByKey("head_park_y")
         move_z = self.getSettingValueByKey("head_move_z")
@@ -389,11 +398,12 @@ class PauseAtHeight(Script):
                     if retraction_amount != 0:
                         prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = 6000) + "\n"
 
-                    #Move the head away
-                    prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + " ; move up a millimeter to get out of the way\n"
-                    prepend_gcode += self.putValue(G = 1, X = park_x, Y = park_y, F = 9000) + "\n"
-                    if current_z < move_z:
-                        prepend_gcode += self.putValue(G = 1, Z = current_z + move_z, F = 300) + "\n"
+                    if park_enabled:
+                        #Move the head away
+                        prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + " ; move up a millimeter to get out of the way\n"
+                        prepend_gcode += self.putValue(G = 1, X = park_x, Y = park_y, F = 9000) + "\n"
+                        if current_z < move_z:
+                            prepend_gcode += self.putValue(G = 1, Z = current_z + move_z, F = 300) + "\n"
 
                     #Disable the E steppers
                     prepend_gcode += self.putValue(M = 84, E = 0) + "\n"
@@ -409,14 +419,15 @@ class PauseAtHeight(Script):
                         else:
                             prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = retraction_speed * 60) + "\n"
 
-                    # Move the head away
-                    prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + " ; move up a millimeter to get out of the way\n"
+                    if park_enabled:
+                        # Move the head away
+                        prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + " ; move up a millimeter to get out of the way\n"
 
-                    # This line should be ok
-                    prepend_gcode += self.putValue(G = 1, X = park_x, Y = park_y, F = 9000) + "\n"
+                        # This line should be ok
+                        prepend_gcode += self.putValue(G = 1, X = park_x, Y = park_y, F = 9000) + "\n"
 
-                    if current_z < 15:
-                        prepend_gcode += self.putValue(G = 1, Z = 15, F = 300) + " ; too close to bed--move to at least 15mm\n"
+                        if current_z < 15:
+                            prepend_gcode += self.putValue(G = 1, Z = 15, F = 300) + " ; too close to bed--move to at least 15mm\n"
 
                     if control_temperatures:
                         # Set extruder standby temperature
@@ -456,8 +467,10 @@ class PauseAtHeight(Script):
                         prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = 6000) + "\n"
 
                     #Move the head back
-                    prepend_gcode += self.putValue(G = 1, Z = current_z, F = 300) + "\n"
-                    prepend_gcode += self.putValue(G = 1, X = x, Y = y, F = 9000) + "\n"
+                    if park_enabled:
+                        prepend_gcode += self.putValue(G = 1, Z = current_z, F = 300) + "\n"
+                        prepend_gcode += self.putValue(G = 1, X = x, Y = y, F = 9000) + "\n"
+
                     if retraction_amount != 0:
                         prepend_gcode += self.putValue(G = 1, E = retraction_amount, F = 6000) + "\n"
 
@@ -490,10 +503,12 @@ class PauseAtHeight(Script):
                         prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = retraction_speed * 60) + "\n"
 
                     # Move the head back
-                    if current_z < 15:
-                        prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + "\n"
-                    prepend_gcode += self.putValue(G = 1, X = x, Y = y, F = 9000) + "\n"
-                    prepend_gcode += self.putValue(G = 1, Z = current_z, F = 300) + " ; move back down to resume height\n"
+                    if park_enabled:
+                        if current_z < 15:
+                            prepend_gcode += self.putValue(G = 1, Z = current_z + 1, F = 300) + "\n"
+                        prepend_gcode += self.putValue(G = 1, X = x, Y = y, F = 9000) + "\n"
+                        prepend_gcode += self.putValue(G = 1, Z = current_z, F = 300) + " ; move back down to resume height\n"
+
                     if retraction_amount != 0:
                         if firmware_retract: #Can't set the distance directly to what the user wants. We have to choose ourselves.
                             retraction_count = 1 if control_temperatures else 3 #Retract more if we don't control the temperature.

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -74,7 +74,7 @@ class PauseAtHeight(Script):
                     "label": "Park Print",
                     "description": "Instruct the head to move to a safe location when pausing. Leave this unchecked if your printer handles parking for you.",
                     "type": "bool",
-                    "default_value": True,
+                    "default_value": true,
                     "enabled": "pause_method != \\\"griffin\\\""
                 },
                 "head_park_x":


### PR DESCRIPTION
This PR makes parking the head optional (for all methods, except Griffin which handles the parking in the firmware so it is never added to the gcode). Not adding parking gcode makes the repetier `@pause` method suitable for use with OctoPrint (which similarly handles the parking in most cases). Not adding parking gcode can also be beneficial in modern Marlin flavors, since those too can handle the parking by themselves.

Contributes to #7842