### PR TITLE
CURA-8496: Fix long material names overlapping with icon

### DIFF
--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -48,6 +48,7 @@ Cura.ExpandablePopup
                 delegate: Item
                 {
                     Layout.preferredWidth: Math.round(parent.width / extrudersModel.count)
+                    Layout.maximumWidth: Math.round(parent.width / extrudersModel.count)
                     Layout.fillHeight: true
 
                     // Extruder icon. Shows extruder index and has the same color as the active material.
@@ -63,6 +64,7 @@ Cura.ExpandablePopup
                     {
                         opacity: model.enabled ? 1 : UM.Theme.getColor("extruder_disabled").a
                         spacing: 0
+                        visible: width > 0
                         anchors
                         {
                             left: extruderIcon.right
@@ -81,6 +83,7 @@ Cura.ExpandablePopup
                             font: UM.Theme.getFont("default")
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
+                            Layout.preferredWidth: parent.width
                             width: parent.width
 
                             visible: !truncated
@@ -95,6 +98,7 @@ Cura.ExpandablePopup
                             font: UM.Theme.getFont("default")
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
+                            Layout.preferredWidth: parent.width
                             width: parent.width
 
                             visible: !materialBrandColorTypeLabel.visible && !truncated
@@ -109,6 +113,7 @@ Cura.ExpandablePopup
                             font: UM.Theme.getFont("default")
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
+                            Layout.preferredWidth: parent.width
                             width: parent.width
                             visible: !materialBrandColorTypeLabel.visible && !materialColorTypeLabel.visible
                         }
@@ -124,6 +129,7 @@ Cura.ExpandablePopup
                             font: UM.Theme.getFont("default_bold")
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
+                            Layout.preferredWidth: parent.width
                             width: parent.width
                         }
                     }

--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -84,8 +84,6 @@ Cura.ExpandablePopup
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
                             Layout.preferredWidth: parent.width
-                            width: parent.width
-
                             visible: !truncated
                         }
 
@@ -99,8 +97,6 @@ Cura.ExpandablePopup
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
                             Layout.preferredWidth: parent.width
-                            width: parent.width
-
                             visible: !materialBrandColorTypeLabel.visible && !truncated
                         }
 
@@ -114,7 +110,6 @@ Cura.ExpandablePopup
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
                             Layout.preferredWidth: parent.width
-                            width: parent.width
                             visible: !materialBrandColorTypeLabel.visible && !materialColorTypeLabel.visible
                         }
                         // Label that shows the name of the variant
@@ -130,7 +125,6 @@ Cura.ExpandablePopup
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
                             Layout.preferredWidth: parent.width
-                            width: parent.width
                         }
                     }
                 }


### PR DESCRIPTION
Both the `preferredWidth` AND the `width` need to be set for the labels to be properly elided if there is no more room  in the `ColumnLayout`. In addition, the `ColumnLayout` that contains the variants and material names needs to be visible only if `width>0` otherwise when the width is negative, for some reason, the `materialTypeLabel` appears again.

Before
![image](https://user-images.githubusercontent.com/19388042/130199653-a166377c-089b-42b2-9644-74491cb0763d.png)


After
![image](https://user-images.githubusercontent.com/19388042/130199554-ab66c9ca-5143-4af0-bba0-d7baba59f75d.png)

CURA-8496