### PR TITLE
Store metadata in database

### DIFF
--- a/cura/Settings/CuraContainerRegistry.py
+++ b/cura/Settings/CuraContainerRegistry.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import QMessageBox
 
 from UM.Decorators import override
 from UM.Settings.ContainerFormatError import ContainerFormatError
+from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.Interfaces import ContainerInterface
 from UM.Settings.ContainerRegistry import ContainerRegistry
 from UM.Settings.ContainerStack import ContainerStack
@@ -32,6 +33,10 @@ from cura.Machines.ContainerTree import ContainerTree
 from cura.ReaderWriters.ProfileReader import NoProfileException, ProfileReader
 
 from UM.i18n import i18nCatalog
+from .DatabaseHandlers.IntentDatabaseHandler import IntentDatabaseHandler
+from .DatabaseHandlers.QualityDatabaseHandler import QualityDatabaseHandler
+from .DatabaseHandlers.VariantDatabaseHandler import VariantDatabaseHandler
+
 catalog = i18nCatalog("cura")
 
 
@@ -44,106 +49,10 @@ class CuraContainerRegistry(ContainerRegistry):
         # is added, we check to see if an extruder stack needs to be added.
         self.containerAdded.connect(self._onContainerAdded)
 
-        self._prepare_for_database_handlers["variant"] = self._prepareVariantForDatabase
-        self._prepare_for_database_handlers["quality"] = self._prepareQualityForDatabase
-        self._prepare_for_database_handlers["intent"] = self._prepareIntentForDatabase
+        self._database_handlers["variant"] = VariantDatabaseHandler()
+        self._database_handlers["quality"] = QualityDatabaseHandler()
+        self._database_handlers["intent"] = IntentDatabaseHandler()
 
-        self._get_from_database_handlers["variant"] = self._getVariantFromDatabase
-        self._get_from_database_handlers["quality"] = self._getQualityFromDatabase
-        self._get_from_database_handlers["intent"] = self._getIntentFromDatabase
-
-        self._insert_into_database_queries["variant"] = "INSERT INTO variants (id, name, hardware_type, definition, version, setting_version) VALUES (?, ?, ?, ?, ?, ?)"
-        self._insert_into_database_queries["quality"] = "INSERT INTO qualities (id, name, quality_type, material, variant, global_quality, definition, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)"
-        self._insert_into_database_queries["intent"] = "INSERT INTO intents (id, name, quality_type, intent_category, variant, definition, material, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)"
-
-    def _getQualityFromDatabase(self, container_id):
-        connection = self._getDatabaseConnection()
-        result = connection.cursor().execute("SELECT * FROM qualities where id = ?", (container_id,))
-        data = result.fetchone()
-        return {"id": data[0], "name": data[1], "quality_type": data[2], "material": data[3], "variant": data[4], "global_quality": data[5], "definition": data[6], "container_type": InstanceContainer, "version": data[7], "setting_version": data[8], "type": "quality"}
-
-    def _getVariantFromDatabase(self, container_id):
-        connection = self._getDatabaseConnection()
-        result = connection.cursor().execute("SELECT * FROM variants where id = ?", (container_id,))
-        data = result.fetchone()
-        return {"id": data[0], "name": data[1], "hardware_type": data[2], "definition": data[3], "container_type": InstanceContainer, "version": data[4], "setting_version": data[5], "type": "variant"}
-
-    def _getIntentFromDatabase(self, container_id):
-        connection = self._getDatabaseConnection()
-        result = connection.cursor().execute("SELECT * FROM intents where id = ?", (container_id,))
-        data = result.fetchone()
-        return {"id": data[0], "name": data[1], "quality_type": data[2], "intent_category": data[3], "variant": data[4], "definition": data[5], "container_type": InstanceContainer, "material": data[6], "version": data[7], "setting_version": data[8], "type": "intent"}
-
-    def _prepareVariantForDatabase(self, metadata):
-        return metadata["id"], metadata["name"], metadata["hardware_type"], metadata["definition"], metadata["version"], metadata["setting_version"]
-
-    def _prepareQualityForDatabase(self, metadata):
-        global_quality = False
-        if "global_quality" in metadata:
-            global_quality = metadata["global_quality"]
-        material = ""
-        if "material" in metadata:
-            material = metadata["material"]
-        variant = ""
-        if "variant" in metadata:
-            variant = metadata["variant"]
-
-        return metadata["id"], metadata["name"], metadata["quality_type"], material, variant, global_quality, metadata["definition"], metadata["version"], metadata["setting_version"]
-
-    def _prepareIntentForDatabase(self, metadata) -> None:
-        return metadata["id"], metadata["name"], metadata["quality_type"], metadata["intent_category"], metadata["variant"], metadata["definition"], metadata["material"], metadata["version"], metadata["setting_version"]
-        connection = self._getDatabaseConnection()
-
-        connection.cursor().execute(
-            "INSERT INTO intents (id, name, quality_type, intent_category, variant, definition) VALUES (?, ?, ? ,?, ?, ?)",
-            ())
-
-
-    @override(ContainerRegistry)
-    def _createDatabaseFile(self, db_path: str) -> None:
-        connection = super()._createDatabaseFile(db_path)
-        cursor = connection.cursor()
-        cursor.execute("""
-                CREATE TABLE qualities
-                (
-                    id text,
-                    name text,
-                    quality_type text,
-                    material text,
-                    variant text,
-                    global_quality bool,
-                    definition text,
-                    version text,
-                    setting_version text
-                );
-                CREATE UNIQUE INDEX idx_qualities_id on qualities (id);
-
-                CREATE TABLE variants
-                (
-                    id text,
-                    name text,
-                    hardware_type text,
-                    definition text,
-                    version text,
-                    setting_version text
-                );
-                CREATE UNIQUE INDEX idx_variants_id on variants (id);
-
-                CREATE TABLE intents
-                (
-                    id text,
-                    name text,
-                    quality_type text,
-                    intent_category text,
-                    variant text,
-                    definition text,
-                    material text,
-                    version text,
-                    setting_version text
-                );
-                CREATE UNIQUE INDEX idx_intents_id on intents (id);
-            """)
-        return connection
 
     @override(ContainerRegistry)
     def addContainer(self, container: ContainerInterface) -> bool:

--- a/cura/Settings/CuraContainerRegistry.py
+++ b/cura/Settings/CuraContainerRegistry.py
@@ -45,6 +45,32 @@ class CuraContainerRegistry(ContainerRegistry):
         self.containerAdded.connect(self._onContainerAdded)
 
     @override(ContainerRegistry)
+    def _createDatabaseFile(self, db_path: str) -> None:
+        connection = super()._createDatabaseFile(db_path)
+        cursor = connection.cursor()
+        cursor.execute("""
+                CREATE TABLE qualities(
+                    id text,
+                    name text,
+                    quality_type text,
+                    material text,
+                    variant text,
+                    global_quality bool,
+                    definition text
+                );
+                CREATE UNIQUE INDEX idx_qualities_id on qualities (id);
+
+                CREATE TABLE variants(
+                    id text,
+                    name text,
+                    hardware_type text,
+                    definition text
+                );
+                CREATE UNIQUE INDEX idx_variants_id on variants (id);
+            """)
+        return connection
+
+    @override(ContainerRegistry)
     def addContainer(self, container: ContainerInterface) -> bool:
         """Overridden from ContainerRegistry
 

--- a/cura/Settings/CuraContainerRegistry.py
+++ b/cura/Settings/CuraContainerRegistry.py
@@ -53,7 +53,6 @@ class CuraContainerRegistry(ContainerRegistry):
         self._database_handlers["quality"] = QualityDatabaseHandler()
         self._database_handlers["intent"] = IntentDatabaseHandler()
 
-
     @override(ContainerRegistry)
     def addContainer(self, container: ContainerInterface) -> bool:
         """Overridden from ContainerRegistry

--- a/cura/Settings/CuraContainerRegistry.py
+++ b/cura/Settings/CuraContainerRegistry.py
@@ -52,30 +52,30 @@ class CuraContainerRegistry(ContainerRegistry):
         self._get_from_database_handlers["quality"] = self._getQualityFromDatabase
         self._get_from_database_handlers["intent"] = self._getIntentFromDatabase
 
-        self._insert_into_database_queries["variant"] = "INSERT INTO variants (id, name, hardware_type, definition) VALUES (?, ?, ? ,?)"
-        self._insert_into_database_queries["quality"] = "INSERT INTO qualities (id, name, quality_type, material, variant, global_quality, definition) VALUES (?, ?, ? ,?, ?, ?, ?)"
-        self._insert_into_database_queries["intent"] = "INSERT INTO intents (id, name, quality_type, intent_category, variant, definition) VALUES (?, ?, ? ,?, ?, ?)"
+        self._insert_into_database_queries["variant"] = "INSERT INTO variants (id, name, hardware_type, definition, version, setting_version) VALUES (?, ?, ?, ?, ?, ?)"
+        self._insert_into_database_queries["quality"] = "INSERT INTO qualities (id, name, quality_type, material, variant, global_quality, definition, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)"
+        self._insert_into_database_queries["intent"] = "INSERT INTO intents (id, name, quality_type, intent_category, variant, definition, material, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)"
 
     def _getQualityFromDatabase(self, container_id):
         connection = self._getDatabaseConnection()
         result = connection.cursor().execute("SELECT * FROM qualities where id = ?", (container_id,))
         data = result.fetchone()
-        return {"id": data[0], "name": data[1], "quality_type": data[2], "material": data[3], "variant": data[4], "global_quality": data[5], "definition": data[6]}
+        return {"id": data[0], "name": data[1], "quality_type": data[2], "material": data[3], "variant": data[4], "global_quality": data[5], "definition": data[6], "container_type": InstanceContainer, "version": data[7], "setting_version": data[8], "type": "quality"}
 
     def _getVariantFromDatabase(self, container_id):
         connection = self._getDatabaseConnection()
         result = connection.cursor().execute("SELECT * FROM variants where id = ?", (container_id,))
         data = result.fetchone()
-        return {"id": data[0], "name": data[1], "hardware_type": data[2], "definition": data[3]}
+        return {"id": data[0], "name": data[1], "hardware_type": data[2], "definition": data[3], "container_type": InstanceContainer, "version": data[4], "setting_version": data[5], "type": "variant"}
 
     def _getIntentFromDatabase(self, container_id):
         connection = self._getDatabaseConnection()
         result = connection.cursor().execute("SELECT * FROM intents where id = ?", (container_id,))
         data = result.fetchone()
-        return {"id": data[0], "name": data[1], "quality_type": data[2], "intent_category": data[3], "variant": data[4], "definition": data[5]}
+        return {"id": data[0], "name": data[1], "quality_type": data[2], "intent_category": data[3], "variant": data[4], "definition": data[5], "container_type": InstanceContainer, "material": data[6], "version": data[7], "setting_version": data[8], "type": "intent"}
 
     def _prepareVariantForDatabase(self, metadata):
-        return metadata["id"], metadata["name"], metadata["hardware_type"], metadata["definition"]
+        return metadata["id"], metadata["name"], metadata["hardware_type"], metadata["definition"], metadata["version"], metadata["setting_version"]
 
     def _prepareQualityForDatabase(self, metadata):
         global_quality = False
@@ -88,10 +88,10 @@ class CuraContainerRegistry(ContainerRegistry):
         if "variant" in metadata:
             variant = metadata["variant"]
 
-        return metadata["id"], metadata["name"], metadata["quality_type"], material, variant, global_quality, metadata["definition"]
+        return metadata["id"], metadata["name"], metadata["quality_type"], material, variant, global_quality, metadata["definition"], metadata["version"], metadata["setting_version"]
 
     def _prepareIntentForDatabase(self, metadata) -> None:
-        return metadata["id"], metadata["name"], metadata["quality_type"], metadata["intent_category"], metadata["variant"], metadata["definition"]
+        return metadata["id"], metadata["name"], metadata["quality_type"], metadata["intent_category"], metadata["variant"], metadata["definition"], metadata["material"], metadata["version"], metadata["setting_version"]
         connection = self._getDatabaseConnection()
 
         connection.cursor().execute(
@@ -112,7 +112,9 @@ class CuraContainerRegistry(ContainerRegistry):
                     material text,
                     variant text,
                     global_quality bool,
-                    definition text
+                    definition text,
+                    version text,
+                    setting_version text
                 );
                 CREATE UNIQUE INDEX idx_qualities_id on qualities (id);
 
@@ -121,7 +123,9 @@ class CuraContainerRegistry(ContainerRegistry):
                     id text,
                     name text,
                     hardware_type text,
-                    definition text
+                    definition text,
+                    version text,
+                    setting_version text
                 );
                 CREATE UNIQUE INDEX idx_variants_id on variants (id);
 
@@ -132,7 +136,10 @@ class CuraContainerRegistry(ContainerRegistry):
                     quality_type text,
                     intent_category text,
                     variant text,
-                    definition text
+                    definition text,
+                    material text,
+                    version text,
+                    setting_version text
                 );
                 CREATE UNIQUE INDEX idx_intents_id on intents (id);
             """)

--- a/cura/Settings/CuraContainerRegistry.py
+++ b/cura/Settings/CuraContainerRegistry.py
@@ -10,7 +10,6 @@ from PyQt5.QtWidgets import QMessageBox
 
 from UM.Decorators import override
 from UM.Settings.ContainerFormatError import ContainerFormatError
-from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.Interfaces import ContainerInterface
 from UM.Settings.ContainerRegistry import ContainerRegistry
 from UM.Settings.ContainerStack import ContainerStack

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -1,0 +1,35 @@
+from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
+from UM.Settings.InstanceContainer import InstanceContainer
+
+
+class IntentDatabaseHandler(DatabaseMetadataContainerController):
+    def __init__(self) -> None:
+        super().__init__(
+            insert_query="INSERT INTO intents (id, name, quality_type, intent_category, variant, definition, material, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)",
+            update_query="",
+            select_query = "SELECT * FROM intents where id = ?",
+            table_query="""CREATE TABLE intents
+               (
+                   id text,
+                   name text,
+                   quality_type text,
+                   intent_category text,
+                   variant text,
+                   definition text,
+                   material text,
+                   version text,
+                   setting_version text
+               );
+               CREATE UNIQUE INDEX idx_intents_id on intents (id);"""
+        )
+
+    def _convertRawDataToMetadata(self, data):
+        return {"id": data[0], "name": data[1], "quality_type": data[2], "intent_category": data[3], "variant": data[4], "definition": data[5], "container_type": InstanceContainer, "material": data[6], "version": data[7], "setting_version": data[8], "type": "intent"}
+
+
+    def _convertMetadataToInsertBatch(self, metadata):
+        return metadata["id"], metadata["name"], metadata["quality_type"], metadata["intent_category"], metadata[
+            "variant"], metadata["definition"], metadata["material"], metadata["version"], metadata["setting_version"]
+
+
+

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -1,6 +1,5 @@
 from UM.Settings.SQLQueryFactory import SQLQueryFactory
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
-from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class IntentDatabaseHandler(DatabaseMetadataContainerController):
@@ -9,7 +8,6 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self) -> None:
         super().__init__(SQLQueryFactory(table = "intents",
                                          fields = {
-                                             "id": "text",
                                              "name": "text",
                                              "quality_type": "text",
                                              "intent_category": "text",
@@ -19,4 +17,3 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
-        self.container_type = InstanceContainer

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -1,49 +1,22 @@
+from UM.Settings.SQLQueryFactory import SQLQueryFactory
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class IntentDatabaseHandler(DatabaseMetadataContainerController):
+    """The Database handler for Intent containers"""
+
     def __init__(self) -> None:
-        super().__init__(
-            insert_query = """  INSERT INTO intents (id, name, quality_type, intent_category, variant, definition, material, version, setting_version)
-                                VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)""",
-            update_query="""UPDATE intents
-                            SET name = ?,
-                                quality_type = ?,
-                                intent_category = ?,
-                                variant = ?,
-                                definition = ?,
-                                material = ?,
-                                version = ?,
-                                setting_version = ?
-                            WHERE id = ?
-                        """,
-            select_query = "SELECT * FROM intents WHERE id = ?",
-            delete_query = "DELETE FROM intents WHERE id = ?",
-            table_query="""CREATE TABLE intents
-               (
-                   id text,
-                   name text,
-                   quality_type text,
-                   intent_category text,
-                   variant text,
-                   definition text,
-                   material text,
-                   version text,
-                   setting_version text
-               );
-               CREATE UNIQUE INDEX idx_intents_id on intents (id);"""
-        )
-
-    def _convertMetadataToUpdateBatch(self, metadata):
-        return self._convertMetadataToInsertBatch(metadata)[1:]
-
-    def _convertRawDataToMetadata(self, data):
-        return {"id": data[0], "name": data[1], "quality_type": data[2], "intent_category": data[3], "variant": data[4], "definition": data[5], "container_type": InstanceContainer, "material": data[6], "version": data[7], "setting_version": data[8], "type": "intent"}
-
-    def _convertMetadataToInsertBatch(self, metadata):
-        return metadata["id"], metadata["name"], metadata["quality_type"], metadata["intent_category"], metadata[
-            "variant"], metadata["definition"], metadata["material"], metadata["version"], metadata["setting_version"]
-
-
-
+        super().__init__(SQLQueryFactory(table = "intents",
+                                         fields = {
+                                             "id": "text",
+                                             "name": "text",
+                                             "quality_type": "text",
+                                             "intent_category": "text",
+                                             "variant": "text",
+                                             "definition": "text",
+                                             "material": "text",
+                                             "version": "text",
+                                             "setting_version": "text"
+                                         }))
+        self.container_type = InstanceContainer

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -18,7 +18,8 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
                                 setting_version = ?
                             WHERE id = ?
                         """,
-            select_query = "SELECT * FROM intents where id = ?",
+            select_query = "SELECT * FROM intents WHERE id = ?",
+            delete_query = "DELETE FROM intents WHERE id = ?",
             table_query="""CREATE TABLE intents
                (
                    id text,

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -1,5 +1,6 @@
 from UM.Settings.SQLQueryFactory import SQLQueryFactory
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
+from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class IntentDatabaseHandler(DatabaseMetadataContainerController):
@@ -8,6 +9,7 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self) -> None:
         super().__init__(SQLQueryFactory(table = "intents",
                                          fields = {
+                                             "id": "text",
                                              "name": "text",
                                              "quality_type": "text",
                                              "intent_category": "text",
@@ -17,3 +19,4 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
+        self.container_type = InstanceContainer

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -5,7 +5,8 @@ from UM.Settings.InstanceContainer import InstanceContainer
 class IntentDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self) -> None:
         super().__init__(
-            insert_query="INSERT INTO intents (id, name, quality_type, intent_category, variant, definition, material, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)",
+            insert_query = """  INSERT INTO intents (id, name, quality_type, intent_category, variant, definition, material, version, setting_version)
+                                VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)""",
             update_query="""UPDATE intents
                             SET name = ?,
                                 quality_type = ?,

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -6,7 +6,17 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self) -> None:
         super().__init__(
             insert_query="INSERT INTO intents (id, name, quality_type, intent_category, variant, definition, material, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)",
-            update_query="",
+            update_query="""UPDATE intents
+                            SET name = ?,
+                                quality_type = ?,
+                                intent_category = ?,
+                                variant = ?,
+                                definition = ?,
+                                material = ?,
+                                version = ?,
+                                setting_version = ?
+                            WHERE id = ?
+                        """,
             select_query = "SELECT * FROM intents where id = ?",
             table_query="""CREATE TABLE intents
                (
@@ -23,9 +33,11 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
                CREATE UNIQUE INDEX idx_intents_id on intents (id);"""
         )
 
+    def _convertMetadataToUpdateBatch(self, metadata):
+        return self._convertMetadataToInsertBatch(metadata)[1:]
+
     def _convertRawDataToMetadata(self, data):
         return {"id": data[0], "name": data[1], "quality_type": data[2], "intent_category": data[3], "variant": data[4], "definition": data[5], "container_type": InstanceContainer, "material": data[6], "version": data[7], "setting_version": data[8], "type": "intent"}
-
 
     def _convertMetadataToInsertBatch(self, metadata):
         return metadata["id"], metadata["name"], metadata["quality_type"], metadata["intent_category"], metadata[

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -19,4 +19,4 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
-        self.container_type = InstanceContainer
+        self._container_type = InstanceContainer

--- a/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/IntentDatabaseHandler.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
 from UM.Settings.SQLQueryFactory import SQLQueryFactory
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.InstanceContainer import InstanceContainer
@@ -7,7 +10,7 @@ class IntentDatabaseHandler(DatabaseMetadataContainerController):
     """The Database handler for Intent containers"""
 
     def __init__(self) -> None:
-        super().__init__(SQLQueryFactory(table = "intents",
+        super().__init__(SQLQueryFactory(table = "intent",
                                          fields = {
                                              "id": "text",
                                              "name": "text",

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
 from UM.Settings.SQLQueryFactory import SQLQueryFactory, metadata_type
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.InstanceContainer import InstanceContainer
@@ -7,7 +10,7 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
     """The Database handler for Quality containers"""
 
     def __init__(self):
-        super().__init__(SQLQueryFactory(table = "qualities",
+        super().__init__(SQLQueryFactory(table = "quality",
                                          fields = {
                                              "id": "text",
                                              "name": "text",

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -6,7 +6,17 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self) -> None:
         super().__init__(
             insert_query = "INSERT INTO qualities (id, name, quality_type, material, variant, global_quality, definition, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)",
-            update_query = "",
+            update_query = """  UPDATE qualities
+                                SET name = ?,
+                                    quality_type = ?,
+                                    material = ?,
+                                    variant = ?,
+                                    global_quality = ?,
+                                    definition = ?,
+                                    version = ?,
+                                    setting_version = ?
+                                WHERE id = ?
+                            """,
             select_query = "SELECT * FROM qualities where id = ?",
             table_query = """CREATE TABLE qualities
                 (
@@ -22,6 +32,9 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
                 );
                 CREATE UNIQUE INDEX idx_qualities_id on qualities (id);"""
         )
+
+    def _convertMetadataToUpdateBatch(self, metadata):
+        return self._convertMetadataToInsertBatch(metadata)[1:]
 
     def _convertRawDataToMetadata(self, data):
         return {"id": data[0], "name": data[1], "quality_type": data[2], "material": data[3], "variant": data[4],

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -1,5 +1,6 @@
 from UM.Settings.SQLQueryFactory import SQLQueryFactory, metadata_type
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
+from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class QualityDatabaseHandler(DatabaseMetadataContainerController):
@@ -8,6 +9,7 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self):
         super().__init__(SQLQueryFactory(table = "qualities",
                                          fields = {
+                                             "id": "text",
                                              "name": "text",
                                              "quality_type": "text",
                                              "material": "text",
@@ -17,6 +19,7 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
+        self.container_type = InstanceContainer
 
     def groomMetadata(self, metadata: metadata_type) -> metadata_type:
         """

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -19,7 +19,7 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
-        self.container_type = InstanceContainer
+        self._container_type = InstanceContainer
 
     def groomMetadata(self, metadata: metadata_type) -> metadata_type:
         """

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -1,6 +1,5 @@
 from UM.Settings.SQLQueryFactory import SQLQueryFactory, metadata_type
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
-from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class QualityDatabaseHandler(DatabaseMetadataContainerController):
@@ -9,7 +8,6 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self):
         super().__init__(SQLQueryFactory(table = "qualities",
                                          fields = {
-                                             "id": "text",
                                              "name": "text",
                                              "quality_type": "text",
                                              "material": "text",
@@ -19,7 +17,6 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
-        self.container_type = InstanceContainer
 
     def groomMetadata(self, metadata: metadata_type) -> metadata_type:
         """

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -1,5 +1,3 @@
-from typing import Generator
-
 from UM.Settings.SQLQueryFactory import SQLQueryFactory, metadata_type
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.InstanceContainer import InstanceContainer

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -1,0 +1,44 @@
+from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
+from UM.Settings.InstanceContainer import InstanceContainer
+
+
+class QualityDatabaseHandler(DatabaseMetadataContainerController):
+    def __init__(self) -> None:
+        super().__init__(
+            insert_query = "INSERT INTO qualities (id, name, quality_type, material, variant, global_quality, definition, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)",
+            update_query = "",
+            select_query = "SELECT * FROM qualities where id = ?",
+            table_query = """CREATE TABLE qualities
+                (
+                    id text,
+                    name text,
+                    quality_type text,
+                    material text,
+                    variant text,
+                    global_quality bool,
+                    definition text,
+                    version text,
+                    setting_version text
+                );
+                CREATE UNIQUE INDEX idx_qualities_id on qualities (id);"""
+        )
+
+    def _convertRawDataToMetadata(self, data):
+        return {"id": data[0], "name": data[1], "quality_type": data[2], "material": data[3], "variant": data[4],
+                "global_quality": data[5], "definition": data[6], "container_type": InstanceContainer,
+                "version": data[7], "setting_version": data[8], "type": "quality"}
+
+    def _convertMetadataToInsertBatch(self, metadata):
+        global_quality = False
+        if "global_quality" in metadata:
+            global_quality = metadata["global_quality"]
+        material = ""
+        if "material" in metadata:
+            material = metadata["material"]
+        variant = ""
+        if "variant" in metadata:
+            variant = metadata["variant"]
+
+        return metadata["id"], metadata["name"], metadata["quality_type"], material, variant, global_quality, metadata["definition"], metadata["version"], metadata["setting_version"]
+
+

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -18,7 +18,8 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
                                     setting_version = ?
                                 WHERE id = ?
                             """,
-            select_query = "SELECT * FROM qualities where id = ?",
+            select_query = "SELECT * FROM qualities WHERE id = ?",
+            delete_query = "DELETE FROM qualities WHERE id = ?",
             table_query = """CREATE TABLE qualities
                 (
                     id text,

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -1,59 +1,29 @@
+from typing import Generator
+
+from UM.Settings.SQLQueryFactory import SQLQueryFactory, metadata_type
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class QualityDatabaseHandler(DatabaseMetadataContainerController):
-    def __init__(self) -> None:
-        super().__init__(
-            insert_query = """  INSERT INTO qualities (id, name, quality_type, material, variant, global_quality, definition, version, setting_version) 
-                                VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)""",
-            update_query = """  UPDATE qualities
-                                SET name = ?,
-                                    quality_type = ?,
-                                    material = ?,
-                                    variant = ?,
-                                    global_quality = ?,
-                                    definition = ?,
-                                    version = ?,
-                                    setting_version = ?
-                                WHERE id = ?
-                            """,
-            select_query = "SELECT * FROM qualities WHERE id = ?",
-            delete_query = "DELETE FROM qualities WHERE id = ?",
-            table_query = """CREATE TABLE qualities
-                (
-                    id text,
-                    name text,
-                    quality_type text,
-                    material text,
-                    variant text,
-                    global_quality bool,
-                    definition text,
-                    version text,
-                    setting_version text
-                );
-                CREATE UNIQUE INDEX idx_qualities_id on qualities (id);"""
-        )
+    """The Database handler for Quality containers"""
 
-    def _convertMetadataToUpdateBatch(self, metadata):
-        return self._convertMetadataToInsertBatch(metadata)[1:]
+    def __init__(self):
+        super().__init__(SQLQueryFactory(table = "qualities",
+                                         fields = {
+                                             "id": "text",
+                                             "name": "text",
+                                             "quality_type": "text",
+                                             "material": "text",
+                                             "variant": "text",
+                                             "global_quality": "bool",
+                                             "definition": "text",
+                                             "version": "text",
+                                             "setting_version": "text"
+                                         }))
+        self.container_type = InstanceContainer
 
-    def _convertRawDataToMetadata(self, data):
-        return {"id": data[0], "name": data[1], "quality_type": data[2], "material": data[3], "variant": data[4],
-                "global_quality": data[5], "definition": data[6], "container_type": InstanceContainer,
-                "version": data[7], "setting_version": data[8], "type": "quality"}
-
-    def _convertMetadataToInsertBatch(self, metadata):
-        global_quality = False
-        if "global_quality" in metadata:
-            global_quality = metadata["global_quality"]
-        material = ""
-        if "material" in metadata:
-            material = metadata["material"]
-        variant = ""
-        if "variant" in metadata:
-            variant = metadata["variant"]
-
-        return metadata["id"], metadata["name"], metadata["quality_type"], material, variant, global_quality, metadata["definition"], metadata["version"], metadata["setting_version"]
-
-
+    def groomMetadata(self, metadata: metadata_type) -> metadata_type:
+        if "global_quality" not in metadata:
+            metadata["global_quality"] = "False"
+        return super().groomMetadata(metadata)

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -5,7 +5,8 @@ from UM.Settings.InstanceContainer import InstanceContainer
 class QualityDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self) -> None:
         super().__init__(
-            insert_query = "INSERT INTO qualities (id, name, quality_type, material, variant, global_quality, definition, version, setting_version) VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)",
+            insert_query = """  INSERT INTO qualities (id, name, quality_type, material, variant, global_quality, definition, version, setting_version) 
+                                VALUES (?, ?, ? ,?, ?, ?, ?, ?, ?)""",
             update_query = """  UPDATE qualities
                                 SET name = ?,
                                     quality_type = ?,

--- a/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/QualityDatabaseHandler.py
@@ -24,6 +24,14 @@ class QualityDatabaseHandler(DatabaseMetadataContainerController):
         self.container_type = InstanceContainer
 
     def groomMetadata(self, metadata: metadata_type) -> metadata_type:
+        """
+        Ensures that the metadata is in the order of the field keys and has the right size.
+        if the metadata doesn't contains a key which is stored in the DB it will add it as
+        an empty string. Key, value pairs that are not stored in the DB are dropped.
+        If the `global_quality` isn't set it well default to 'False'
+
+        :param metadata: The container metadata
+        """
         if "global_quality" not in metadata:
             metadata["global_quality"] = "False"
         return super().groomMetadata(metadata)

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -1,40 +1,19 @@
+from UM.Settings.SQLQueryFactory import SQLQueryFactory
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class VariantDatabaseHandler(DatabaseMetadataContainerController):
-    def __init__(self) -> None:
-        super().__init__(
-            insert_query = """INSERT INTO variants (id, name, hardware_type, definition, version, setting_version) 
-                             VALUES (?, ?, ?, ?, ?, ?)""",
-            update_query = """  UPDATE variants
-                                SET name = ?,
-                                    hardware_type = ?,
-                                    definition = ?,
-                                    version = ?,
-                                    setting_version = ?
-                                WHERE id = ?
-                           """,
-            select_query = "SELECT * FROM variants WHERE id = ?",
-            delete_query = "DELETE FROM variants WHERE id = ?",
-            table_query = """CREATE TABLE variants
-                (
-                    id text,
-                    name text,
-                    hardware_type text,
-                    definition text,
-                    version text,
-                    setting_version text
-                );
-                CREATE UNIQUE INDEX idx_variants_id on variants (id);"""
-        )
+    """The Database handler for Variant containers"""
 
-    def _convertMetadataToUpdateBatch(self, metadata):
-        return self._convertMetadataToInsertBatch(metadata)[1:]
-
-    def _convertRawDataToMetadata(self, data):
-        return {"id": data[0], "name": data[1], "hardware_type": data[2], "definition": data[3], "container_type": InstanceContainer, "version": data[4], "setting_version": data[5], "type": "variant"}
-
-    def _convertMetadataToInsertBatch(self, metadata):
-        return metadata["id"], metadata["name"], metadata["hardware_type"], metadata["definition"], metadata["version"], \
-               metadata["setting_version"]
+    def __init__(self):
+        super().__init__(SQLQueryFactory(table = "variants",
+                                         fields = {
+                                             "id": "text",
+                                             "name": "text",
+                                             "hardware_type": "text",
+                                             "definition": "text",
+                                             "version": "text",
+                                             "setting_version": "text"
+                                         }))
+        self.container_type = InstanceContainer

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -5,17 +5,18 @@ from UM.Settings.InstanceContainer import InstanceContainer
 class VariantDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self) -> None:
         super().__init__(
-            insert_query= "INSERT INTO variants (id, name, hardware_type, definition, version, setting_version) VALUES (?, ?, ?, ?, ?, ?)",
-            update_query="""UPDATE variants
-                            SET name = ?,
-                                hardware_type = ?,
-                                definition = ?,
-                                version = ?,
-                                setting_version = ?
-                            WHERE id = ?
-                        """,
+            insert_query = """INSERT INTO variants (id, name, hardware_type, definition, version, setting_version) 
+                             VALUES (?, ?, ?, ?, ?, ?)""",
+            update_query = """  UPDATE variants
+                                SET name = ?,
+                                    hardware_type = ?,
+                                    definition = ?,
+                                    version = ?,
+                                    setting_version = ?
+                                WHERE id = ?
+                           """,
             select_query= "SELECT * FROM variants where id = ?",
-            table_query="""CREATE TABLE variants
+            table_query = """CREATE TABLE variants
                 (
                     id text,
                     name text,

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -1,6 +1,5 @@
 from UM.Settings.SQLQueryFactory import SQLQueryFactory
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
-from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class VariantDatabaseHandler(DatabaseMetadataContainerController):
@@ -9,11 +8,9 @@ class VariantDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self):
         super().__init__(SQLQueryFactory(table = "variants",
                                          fields = {
-                                             "id": "text",
                                              "name": "text",
                                              "hardware_type": "text",
                                              "definition": "text",
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
-        self.container_type = InstanceContainer

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2021 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
 from UM.Settings.SQLQueryFactory import SQLQueryFactory
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
 from UM.Settings.InstanceContainer import InstanceContainer
@@ -7,7 +10,7 @@ class VariantDatabaseHandler(DatabaseMetadataContainerController):
     """The Database handler for Variant containers"""
 
     def __init__(self):
-        super().__init__(SQLQueryFactory(table = "variants",
+        super().__init__(SQLQueryFactory(table = "variant",
                                          fields = {
                                              "id": "text",
                                              "name": "text",

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -1,0 +1,29 @@
+from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
+from UM.Settings.InstanceContainer import InstanceContainer
+
+
+class VariantDatabaseHandler(DatabaseMetadataContainerController):
+    def __init__(self) -> None:
+        super().__init__(
+            insert_query= "INSERT INTO variants (id, name, hardware_type, definition, version, setting_version) VALUES (?, ?, ?, ?, ?, ?)",
+            update_query= "",
+            select_query= "SELECT * FROM variants where id = ?",
+            table_query="""CREATE TABLE variants
+                (
+                    id text,
+                    name text,
+                    hardware_type text,
+                    definition text,
+                    version text,
+                    setting_version text
+                );
+                CREATE UNIQUE INDEX idx_variants_id on variants (id);"""
+        )
+
+    def _convertRawDataToMetadata(self, data):
+        return {"id": data[0], "name": data[1], "hardware_type": data[2], "definition": data[3], "container_type": InstanceContainer, "version": data[4], "setting_version": data[5], "type": "variant"}
+
+
+    def _convertMetadataToInsertBatch(self, metadata):
+        return metadata["id"], metadata["name"], metadata["hardware_type"], metadata["definition"], metadata["version"], \
+               metadata["setting_version"]

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -1,5 +1,6 @@
 from UM.Settings.SQLQueryFactory import SQLQueryFactory
 from UM.Settings.DatabaseContainerMetadataController import DatabaseMetadataContainerController
+from UM.Settings.InstanceContainer import InstanceContainer
 
 
 class VariantDatabaseHandler(DatabaseMetadataContainerController):
@@ -8,9 +9,11 @@ class VariantDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self):
         super().__init__(SQLQueryFactory(table = "variants",
                                          fields = {
+                                             "id": "text",
                                              "name": "text",
                                              "hardware_type": "text",
                                              "definition": "text",
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
+        self.container_type = InstanceContainer

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -16,4 +16,4 @@ class VariantDatabaseHandler(DatabaseMetadataContainerController):
                                              "version": "text",
                                              "setting_version": "text"
                                          }))
-        self.container_type = InstanceContainer
+        self._container_type = InstanceContainer

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -15,7 +15,8 @@ class VariantDatabaseHandler(DatabaseMetadataContainerController):
                                     setting_version = ?
                                 WHERE id = ?
                            """,
-            select_query= "SELECT * FROM variants where id = ?",
+            select_query = "SELECT * FROM variants WHERE id = ?",
+            delete_query = "DELETE FROM variants WHERE id = ?",
             table_query = """CREATE TABLE variants
                 (
                     id text,

--- a/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
+++ b/cura/Settings/DatabaseHandlers/VariantDatabaseHandler.py
@@ -6,7 +6,14 @@ class VariantDatabaseHandler(DatabaseMetadataContainerController):
     def __init__(self) -> None:
         super().__init__(
             insert_query= "INSERT INTO variants (id, name, hardware_type, definition, version, setting_version) VALUES (?, ?, ?, ?, ?, ?)",
-            update_query= "",
+            update_query="""UPDATE variants
+                            SET name = ?,
+                                hardware_type = ?,
+                                definition = ?,
+                                version = ?,
+                                setting_version = ?
+                            WHERE id = ?
+                        """,
             select_query= "SELECT * FROM variants where id = ?",
             table_query="""CREATE TABLE variants
                 (
@@ -20,9 +27,11 @@ class VariantDatabaseHandler(DatabaseMetadataContainerController):
                 CREATE UNIQUE INDEX idx_variants_id on variants (id);"""
         )
 
+    def _convertMetadataToUpdateBatch(self, metadata):
+        return self._convertMetadataToInsertBatch(metadata)[1:]
+
     def _convertRawDataToMetadata(self, data):
         return {"id": data[0], "name": data[1], "hardware_type": data[2], "definition": data[3], "container_type": InstanceContainer, "version": data[4], "setting_version": data[5], "type": "variant"}
-
 
     def _convertMetadataToInsertBatch(self, metadata):
         return metadata["id"], metadata["name"], metadata["hardware_type"], metadata["definition"], metadata["version"], \


### PR DESCRIPTION
Instead of re-reading the metadata from the files on every boot, which is pretty slow on windows (10+ seconds, even on machines with a fast SSD), we store the profiles in a database. By using the modified time of the files, we can check if the database needs updating.

Creating the database is about as fast as what it used to do, but every subsequent run, it knocked my boot time from 10s on windows to 0.6s. It also increases the booting time on Linux, but there it's only 300ms faster.

CURA-6096

Needs to be combined with https://github.com/Ultimaker/Uranium/pull/729