### PR TITLE
Retain the last saved filename after saving a file

### DIFF
--- a/cura/UI/PrintInformation.py
+++ b/cura/UI/PrintInformation.py
@@ -67,7 +67,7 @@ class PrintInformation(QObject):
         self._application.globalContainerStackChanged.connect(self._updateJobName)
         self._application.globalContainerStackChanged.connect(self.setToZeroPrintInformation)
         self._application.fileLoaded.connect(self.setBaseName)
-        self._application.workspaceLoaded.connect(self.setProjectName)
+        self._application.workspaceLoaded.connect(self._onWorkspaceLoaded)
         self._application.getMachineManager().rootMaterialChanged.connect(self._onActiveMaterialsChanged)
         self._application.getInstance().getPreferences().preferenceChanged.connect(self._onPreferencesChanged)
 
@@ -439,3 +439,7 @@ class PrintInformation(QObject):
         """Listen to scene changes to check if we need to reset the print information"""
 
         self.setToZeroPrintInformation(self._active_build_plate)
+
+    def _onWorkspaceLoaded(self, new_name: str) -> None:
+        """Update the job name whenever a new workspace is loaded."""
+        self.setJobName(os.path.splitext(os.path.basename(new_name))[0])

--- a/cura/UI/PrintInformation.py
+++ b/cura/UI/PrintInformation.py
@@ -13,7 +13,8 @@ from UM.Qt.Duration import Duration
 from UM.Scene.SceneNode import SceneNode
 from UM.i18n import i18nCatalog
 from UM.MimeTypeDatabase import MimeTypeDatabase, MimeTypeNotFoundError
-from UM.OutputDevice import OutputDevice
+from UM.OutputDevice.OutputDevice import OutputDevice
+from UM.OutputDevice.ProjectOutputDevice import ProjectOutputDevice
 
 if TYPE_CHECKING:
     from cura.CuraApplication import CuraApplication
@@ -445,9 +446,10 @@ class PrintInformation(QObject):
     def _onOutputStart(self, output_device: OutputDevice) -> None:
         """If this is the sort of output 'device' (like local or online file storage, rather than a printer),
            the user could have altered the file-name, and thus the project name should be altered as well."""
-        new_name = output_device.getLastOutputName()
-        if new_name is not None:
-            if len(os.path.dirname(new_name)) > 0:
-                self.setProjectName(new_name)
-            else:
-                self.setJobName(new_name)
+        if isinstance(output_device, ProjectOutputDevice):
+            new_name = output_device.getLastOutputName()
+            if new_name is not None:
+                if len(os.path.dirname(new_name)) > 0:
+                    self.setProjectName(new_name)
+                else:
+                    self.setJobName(new_name)

--- a/plugins/DigitalLibrary/src/DigitalFactoryController.py
+++ b/plugins/DigitalLibrary/src/DigitalFactoryController.py
@@ -603,8 +603,8 @@ class DigitalFactoryController(QObject):
         self._saveFileToSelectedProjectHelper(filename, formats)
 
     def _saveFileToSelectedProjectHelper(self, filename: str, formats: List[str]) -> None:
-        # Indicate we have started sending a job.
-        self.uploadStarted.emit()
+        # Indicate we have started sending a job (and propagate any user file name changes back to the open project)
+        self.uploadStarted.emit(filename)
 
         library_project_id = self._project_model.items[self._selected_project_idx]["libraryProjectId"]
         library_project_name = self._project_model.items[self._selected_project_idx]["displayName"]

--- a/plugins/DigitalLibrary/src/DigitalFactoryController.py
+++ b/plugins/DigitalLibrary/src/DigitalFactoryController.py
@@ -604,7 +604,7 @@ class DigitalFactoryController(QObject):
 
     def _saveFileToSelectedProjectHelper(self, filename: str, formats: List[str]) -> None:
         # Indicate we have started sending a job (and propagate any user file name changes back to the open project)
-        self.uploadStarted.emit(filename)
+        self.uploadStarted.emit(filename if "3mf" in formats else None)
 
         library_project_id = self._project_model.items[self._selected_project_idx]["libraryProjectId"]
         library_project_name = self._project_model.items[self._selected_project_idx]["displayName"]

--- a/plugins/DigitalLibrary/src/DigitalFactoryOutputDevice.py
+++ b/plugins/DigitalLibrary/src/DigitalFactoryOutputDevice.py
@@ -105,8 +105,10 @@ class DigitalFactoryOutputDevice(ProjectOutputDevice):
         self.enabled = logged_in and self._controller.userAccountHasLibraryAccess()
         self.enabledChanged.emit()
 
-    def _onWriteStarted(self) -> None:
+    def _onWriteStarted(self, new_name: Optional[str] = None) -> None:
         self._writing = True
+        if new_name:
+            self.setLastOutputName(new_name)  # On saving, the user can change the name, this should propagate.
         self.writeStarted.emit(self)
 
     def _onWriteFinished(self) -> None:


### PR DESCRIPTION
Cura was not retaining the last saved filename selected by the user after they were saving their file. This PR fixes that by making sure that the filename selected by the user in the save file dialog will update the name of the workspace (project) all around Cura.

**Note:** The stored filename is forgotten when the user loads another project file, creates a new project (Ctrl+N) or clears the buildplate (Ctrl+D).

Requires https://github.com/Ultimaker/Uranium/pull/728

CURA-8358