### PR TITLE
CURA-8496: Fix showing only the material type after resizing Cura's window

### DIFF
--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -60,7 +60,7 @@ Cura.ExpandablePopup
                         anchors.verticalCenter: parent.verticalCenter
                     }
 
-                    ColumnLayout
+                    Column
                     {
                         opacity: model.enabled ? 1 : UM.Theme.getColor("extruder_disabled").a
                         spacing: 0
@@ -83,7 +83,7 @@ Cura.ExpandablePopup
                             font: UM.Theme.getFont("default")
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
-                            Layout.preferredWidth: parent.width
+                            width: parent.width
                             visible: !truncated
                         }
 
@@ -96,7 +96,7 @@ Cura.ExpandablePopup
                             font: UM.Theme.getFont("default")
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
-                            Layout.preferredWidth: parent.width
+                            width: parent.width
                             visible: !materialBrandColorTypeLabel.visible && !truncated
                         }
 
@@ -109,7 +109,7 @@ Cura.ExpandablePopup
                             font: UM.Theme.getFont("default")
                             color: UM.Theme.getColor("text")
                             renderType: Text.NativeRendering
-                            Layout.preferredWidth: parent.width
+                            width: parent.width
                             visible: !materialBrandColorTypeLabel.visible && !materialColorTypeLabel.visible
                         }
                         // Label that shows the name of the variant


### PR DESCRIPTION
When the labels were getting truncated and invisible after reducing the width of Cura's window, their visibility wasn't being restored back and, as a result, the `materialTypeLabel` was the only one that was remaining visible, even if there was enough space for the full `materialBrandColorTypeLabel`.

Changing the ColumnLayout to a Column, where the width is inherited from the parent, fixes that issue.

**Before:** After resizing from a small Cura window to a very wide one, the material color is not restored even though there is enough space
![image](https://user-images.githubusercontent.com/19388042/130585779-8f8a1b67-6a33-42d4-8aad-e1661cc000c0.png)

**After:** The material colors are restored as expected when there is enough space
![image](https://user-images.githubusercontent.com/19388042/130585964-0413662b-d89c-41b5-a3b9-90437cb751fd.png)


CURA-8496