### PR TITLE
CURA-8380: Align link style among os in whats new

### DIFF
--- a/plugins/Toolbox/resources/qml/components/ToolboxDownloadsShowcase.qml
+++ b/plugins/Toolbox/resources/qml/components/ToolboxDownloadsShowcase.qml
@@ -8,7 +8,7 @@ import UM 1.1 as UM
 
 Rectangle
 {
-    color: UM.Theme.getColor("secondary")
+    color: UM.Theme.getColor("toolbox_premium_packages_background")
     height: childrenRect.height
     width: parent.width
     Column

--- a/plugins/Toolbox/resources/qml/pages/ToolboxInstalledPage.qml
+++ b/plugins/Toolbox/resources/qml/pages/ToolboxInstalledPage.qml
@@ -71,6 +71,7 @@ ScrollView
                 padding: UM.Theme.getSize("default_margin").width
                 text: catalog.i18nc("@info", "No plugin has been installed.")
                 font: UM.Theme.getFont("medium")
+                color: UM.Theme.getColor("lining")
                 renderType: Text.NativeRendering
             }
         }
@@ -123,6 +124,7 @@ ScrollView
                 visible: toolbox.materialsInstalledModel.count < 1
                 padding: UM.Theme.getSize("default_margin").width
                 text: catalog.i18nc("@info", "No material has been installed.")
+                color: UM.Theme.getColor("lining")
                 font: UM.Theme.getFont("medium")
                 renderType: Text.NativeRendering
             }

--- a/resources/qml/WelcomePages/WhatsNewContent.qml
+++ b/resources/qml/WelcomePages/WhatsNewContent.qml
@@ -119,7 +119,7 @@ Item
                         do_borders: false
 
                         textArea.wrapMode: TextEdit.Wrap
-                        textArea.text: manager.getSubpageText(index)
+                        textArea.text: "<style>a:link { color: " + UM.Theme.getColor("text_link") + "; text-decoration: underline; }</style>" + manager.getSubpageText(index)
                         textArea.textFormat: Text.RichText
                         textArea.readOnly: true
                         textArea.font: UM.Theme.getFont("default")

--- a/resources/themes/cura-dark/theme.json
+++ b/resources/themes/cura-dark/theme.json
@@ -177,6 +177,7 @@
 
         "toolbox_header_button_text_active": [255, 255, 255, 255],
         "toolbox_header_button_text_inactive": [128, 128, 128, 255],
+        "toolbox_premium_packages_background": [57, 57, 57, 255],
 
         "monitor_printer_family_tag": [86, 86, 106, 255],
         "monitor_text_disabled": [102, 102, 102, 255],

--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -428,6 +428,7 @@
         "printer_config_mismatch": [127, 127, 127, 255],
 
         "toolbox_header_button_text_inactive": [0, 0, 0, 255],
+        "toolbox_premium_packages_background": [240, 240, 240, 255],
 
         "favorites_header_bar": [245, 245, 245, 255],
         "favorites_header_hover": [245, 245, 245, 255],


### PR DESCRIPTION
The following things are fixed by this PR:

1. The links in the What's new pages were using the OS-style links and they were inconsistent between OS. In addition to the inconsistency, the OS-styled link in Windows was hard to see in the dark theme. This is now fixed by making the links in that text area use a specific style. 
**Note: ** The style is applied by prepending the CSS style, since the text in the What's new pages is retrieved from html files.

![link_visibility](https://user-images.githubusercontent.com/19388042/130615007-3d374c84-a5c8-4f37-8143-10be729cc941.jpg)


2. The background color of premium plugins and materials was making the "Search materials" link very hard to see in the dark theme. This is now changed to a darked shade of grey

![premium_background](https://user-images.githubusercontent.com/19388042/130615642-febe3bdd-fb90-4761-bed5-a031d2a8e3a8.jpg)

3. The "No plugins/materials installed" text in the Installed tab in the Marketplace was invisible in the dark theme. This is now changed so that the text color will be consistend with the disabled plugins' text color

![label_visibility](https://user-images.githubusercontent.com/19388042/130615873-1862a2a6-2a84-4784-b1f8-1548f96f773f.jpg)

CURA-8380