### PR TITLE
Fix missing "star" icon in Cura 4.11

### DIFF
--- a/resources/themes/cura-light/icons/deprecated_icons.json
+++ b/resources/themes/cura-light/icons/deprecated_icons.json
@@ -167,6 +167,10 @@
         "new_icon": "Check",
         "size": "default"
     },
+    "star": {
+        "new_icon": "StarFilled",
+        "size": "default"
+    },
     "pencil": {
         "new_icon": "Pen",
         "size": "default"


### PR DESCRIPTION
This PR adds an alias for the previously existing "star" icon that was used in the header for the profile dropdown to show a profile had changed settings.

The PR is against version 4.11, because if the alias is not there in Cura 4.11 then it makes little sense to add it back to the next version of Cura.