### PR TITLE
CURA-8496: Account for the width of the arrow in the Extruders row

### DIFF
--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml
@@ -40,7 +40,10 @@ Cura.ExpandablePopup
         // Horizontal list that shows the extruders and their materials
         RowLayout
         {
-            anchors.fill: parent
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            width: parent.width - UM.Theme.getSize("standard_arrow").width
             visible: Cura.MachineManager.activeMachine ? Cura.MachineManager.activeMachine.hasMaterials : false
             Repeater
             {


### PR DESCRIPTION
Although the ExpandablePopup already sets the anchors of the `headerItem` to account for the arrow icon on the right side, the ConfigurationMenu's extruder row was ignoring it, thus making the elided text of the last extruder to overlap with the arrow icon a bit.

This commit fixes that by explicitly accounting for the width of the arrow in the extruders row.

**Note:** if the Cura window gets resized way too much, the extruder icons will still overlap with the arrow, since there is no space to fit everything.

CURA-8496