### PR TITLE
Fix greyed out cluster printers

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml
@@ -2,7 +2,8 @@
 // Cura is released under the terms of the LGPLv3 or higher.
 import QtQuick 2.2
 import QtQuick.Window 2.2
-import QtQuick.Controls 1.2
+import QtQuick.Controls 2.15
+
 import UM 1.1 as UM
 
 UM.Dialog {
@@ -84,6 +85,7 @@ UM.Dialog {
 
         ComboBox {
             id: printerComboBox;
+            currentIndex: 0;
             Behavior on height { NumberAnimation { duration: 100 } }
             height: 40 * screenScaleFactor;
             model: ListModel {

--- a/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml
@@ -2,7 +2,8 @@
 // Cura is released under the terms of the LGPLv3 or higher.
 import QtQuick 2.2
 import QtQuick.Window 2.2
-import QtQuick.Controls 2.15
+import QtQuick.Controls 1.1
+import QtQuick.Controls 2.15 as NewControls
 
 import UM 1.1 as UM
 
@@ -83,7 +84,7 @@ UM.Dialog {
             renderType: Text.NativeRendering;
         }
 
-        ComboBox {
+        NewControls.ComboBox {
             id: printerComboBox;
             currentIndex: 0;
             Behavior on height { NumberAnimation { duration: 100 } }

--- a/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml
+++ b/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml
@@ -3,6 +3,7 @@
 
 import QtQuick 2.1
 import QtQuick.Controls 1.1
+import QtQuick.Controls 2.15 as NewControls
 import QtQuick.Dialogs 1.2
 import QtQuick.Window 2.1
 
@@ -145,10 +146,11 @@ UM.Dialog
         anchors.margins: UM.Theme.getSize("default_margin").width
         height: childrenRect.height
 
-        ComboBox
+        NewControls.ComboBox
         {
             id: discardOrKeepProfileChangesDropDownButton
             width: 300
+            textRole: "text"
 
             model: ListModel
             {


### PR DESCRIPTION
The PrintWindow still used an old style combobox.
This resulted in a Mac user not being able to specify
which clustered printer he wanted to send a slice to.

Using the new QtQuick.Controls and specifically setting
the currentIndex fixed it for Mac.

Contributes to CURA-8214
![image](https://user-images.githubusercontent.com/8535734/131334253-bc722575-878a-4da5-ae35-434617b67349.png)

![image](https://user-images.githubusercontent.com/8535734/131334173-9f579c01-0616-47b7-b365-1c7966f42aae.png)
