### PR TITLE
Correctly calculate the unreachable area for the extruders

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -952,20 +952,11 @@ class BuildVolume(SceneNode):
 
             # Only do nozzle offsetting if needed
             if nozzle_offsetting_for_disallowed_areas:
-                # The build volume is defined as the union of the area that all extruders can reach, so we need to know
-                # the relative offset to all extruders.
-                for other_extruder in ExtruderManager.getInstance().getActiveExtruderStacks():
-                    other_offset_x = other_extruder.getProperty("machine_nozzle_offset_x", "value")
-                    if other_offset_x is None:
-                        other_offset_x = 0
-                    other_offset_y = other_extruder.getProperty("machine_nozzle_offset_y", "value")
-                    if other_offset_y is None:
-                        other_offset_y = 0
-                    other_offset_y = -other_offset_y
-                    left_unreachable_border = min(left_unreachable_border, other_offset_x - offset_x)
-                    right_unreachable_border = max(right_unreachable_border, other_offset_x - offset_x)
-                    top_unreachable_border = min(top_unreachable_border, other_offset_y - offset_y)
-                    bottom_unreachable_border = max(bottom_unreachable_border, other_offset_y - offset_y)
+                    #Calculate the unreachable areas for this nozzle.
+                    left_unreachable_border = min(left_unreachable_border, - offset_x)
+                    right_unreachable_border = max(right_unreachable_border, - offset_x)
+                    top_unreachable_border = min(top_unreachable_border, - offset_y)
+                    bottom_unreachable_border = max(bottom_unreachable_border, - offset_y)
             half_machine_width = self._global_container_stack.getProperty("machine_width", "value") / 2
             half_machine_depth = self._global_container_stack.getProperty("machine_depth", "value") / 2
 


### PR DESCRIPTION
I have made a discussion on the issue linked below:

https://github.com/Ultimaker/Cura/issues/10354

Basically, by comparing nozzle offsets during this calculation, you wind up mirroring disallowed areas, restricting the build volume despite all nozzles being able to reach some locations. This is further discussed by my comments here:

https://github.com/Ultimaker/Cura/issues/10354#issuecomment-913214851

This is the changes requested in that issue.

Fixes #10354 