### PR TITLE
CURA-7976: Combing strategy to avoid top and bottom most surface skins

### DIFF
--- a/resources/definitions/anycubic_mega_zero.def.json
+++ b/resources/definitions/anycubic_mega_zero.def.json
@@ -92,7 +92,7 @@
 
         "retraction_hop_enabled": { "value": "True" },
         "retraction_hop": { "value": 0.2 },
-        "retraction_combing": { "value": "noskin" },
+        "retraction_combing": { "value": "'noskin'" },
         "retraction_combing_max_distance": { "value": 30 },
 
         "travel_avoid_other_parts": { "value": true },

--- a/resources/definitions/anycubic_mega_zero.def.json
+++ b/resources/definitions/anycubic_mega_zero.def.json
@@ -92,7 +92,7 @@
 
         "retraction_hop_enabled": { "value": "True" },
         "retraction_hop": { "value": 0.2 },
-        "retraction_combing": { "default_value": "noskin" },
+        "retraction_combing": { "value": "noskin" },
         "retraction_combing_max_distance": { "value": 30 },
 
         "travel_avoid_other_parts": { "value": true },

--- a/resources/definitions/atmat_signal_pro_base.def.json
+++ b/resources/definitions/atmat_signal_pro_base.def.json
@@ -225,7 +225,7 @@
         "retraction_prime_speed":                       { "value": "math.ceil(retraction_speed * 0.4)", "maximum_value_warning": "130" },
         "retraction_hop_enabled":                       { "value": "True" },
         "retraction_hop":                               { "value": "0.5" },
-        "retraction_combing":                           { "default_value": "noskin" },
+        "retraction_combing":                           { "value": "noskin" },
         "retraction_combing_max_distance":              { "value": "10" },
         "travel_avoid_other_parts":                     { "value": "True" },
         "travel_avoid_supports":                        { "value": "True" },

--- a/resources/definitions/atmat_signal_pro_base.def.json
+++ b/resources/definitions/atmat_signal_pro_base.def.json
@@ -225,7 +225,7 @@
         "retraction_prime_speed":                       { "value": "math.ceil(retraction_speed * 0.4)", "maximum_value_warning": "130" },
         "retraction_hop_enabled":                       { "value": "True" },
         "retraction_hop":                               { "value": "0.5" },
-        "retraction_combing":                           { "value": "noskin" },
+        "retraction_combing":                           { "value": "'noskin'" },
         "retraction_combing_max_distance":              { "value": "10" },
         "travel_avoid_other_parts":                     { "value": "True" },
         "travel_avoid_supports":                        { "value": "True" },

--- a/resources/definitions/creatable_d3.def.json
+++ b/resources/definitions/creatable_d3.def.json
@@ -27,7 +27,7 @@
         "gantry_height": {"value": "43"},
         "layer_height": { "default_value": 0.1 },
         "relative_extrusion": { "value": "False" },
-        "retraction_combing": { "value": "off" },
+        "retraction_combing": { "value": "'off'" },
         "retraction_hop_enabled": { "default_value": true },
         "retraction_hop_only_when_collides": { "default_value": false },
         "retraction_speed": { "default_value": 100 },

--- a/resources/definitions/creatable_d3.def.json
+++ b/resources/definitions/creatable_d3.def.json
@@ -27,7 +27,7 @@
         "gantry_height": {"value": "43"},
         "layer_height": { "default_value": 0.1 },
         "relative_extrusion": { "value": "False" },
-        "retraction_combing": { "default_value": "off" },
+        "retraction_combing": { "value": "off" },
         "retraction_hop_enabled": { "default_value": true },
         "retraction_hop_only_when_collides": { "default_value": false },
         "retraction_speed": { "default_value": 100 },

--- a/resources/definitions/deltacomb_base.def.json
+++ b/resources/definitions/deltacomb_base.def.json
@@ -64,7 +64,7 @@
         "retraction_hop":                    { "default_value": 1.0 },
         "retraction_amount" :                { "default_value": 3.5 },
         "retraction_speed" :                 { "default_value": 40 },
-        "retraction_combing" :               { "value": "noskin" },
+        "retraction_combing" :               { "value": "'noskin'" },
         "travel_avoid_distance":             { "value": "1" },
         "travel_avoid_supports":             { "value": "True" },
         "retraction_hop_only_when_collides": { "value": "1" },

--- a/resources/definitions/deltacomb_base.def.json
+++ b/resources/definitions/deltacomb_base.def.json
@@ -64,7 +64,7 @@
         "retraction_hop":                    { "default_value": 1.0 },
         "retraction_amount" :                { "default_value": 3.5 },
         "retraction_speed" :                 { "default_value": 40 },
-        "retraction_combing" :               { "default_value": "noskin" },
+        "retraction_combing" :               { "value": "noskin" },
         "travel_avoid_distance":             { "value": "1" },
         "travel_avoid_supports":             { "value": "True" },
         "retraction_hop_only_when_collides": { "value": "1" },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -3855,6 +3855,7 @@
                         "infill": "Within Infill"
                     },
                     "default_value": "all",
+                    "value": "'no_outer_surfaces' if (any(extruderValues('skin_monotonic')) or any(extruderValues('ironing_enabled')) or (any(extruderValues('roofing_monotonic')) and any(extruderValues('roofing_layer_count')))) else 'all'",
                     "resolve": "'noskin' if 'noskin' in extruderValues('retraction_combing') else ('infill' if 'infill' in extruderValues('retraction_combing') else ('all' if 'all' in extruderValues('retraction_combing') else ('no_outer_surfaces' if 'no_outer_surfaces' in extruderValues('retraction_combing') else 'off')))",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -3850,11 +3850,12 @@
                     {
                         "off": "Off",
                         "all": "All",
+                        "no_outer_surfaces": "Not on Outer Surface",
                         "noskin": "Not in Skin",
                         "infill": "Within Infill"
                     },
                     "default_value": "all",
-                    "resolve": "'noskin' if 'noskin' in extruderValues('retraction_combing') else ('infill' if 'infill' in extruderValues('retraction_combing') else ('all' if 'all' in extruderValues('retraction_combing') else 'off'))",
+                    "resolve": "'noskin' if 'noskin' in extruderValues('retraction_combing') else ('infill' if 'infill' in extruderValues('retraction_combing') else ('all' if 'all' in extruderValues('retraction_combing') else ('no_outer_surfaces' if 'no_outer_surfaces' in extruderValues('retraction_combing') else 'off')))",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },

--- a/resources/definitions/inat_base.def.json
+++ b/resources/definitions/inat_base.def.json
@@ -369,7 +369,7 @@
             "value": 45
         },
         "retraction_combing": {
-            "value": "infill"
+            "value": "'infill'"
         },
         "retraction_hop_enabled": {
             "value": true

--- a/resources/definitions/julia.def.json
+++ b/resources/definitions/julia.def.json
@@ -30,7 +30,7 @@
         "support_pattern": { "default_value": "grid" },
         "infill_sparse_density": { "default_value": 10 },
         "machine_extruder_count": { "default_value": 1 },
-        "retraction_combing": { "value": "off" },
+        "retraction_combing": { "value": "'off'" },
         "machine_heated_bed": { "default_value": true },
         "machine_center_is_zero": { "default_value": false },
         "machine_height": { "default_value": 260 },

--- a/resources/definitions/julia.def.json
+++ b/resources/definitions/julia.def.json
@@ -30,7 +30,7 @@
         "support_pattern": { "default_value": "grid" },
         "infill_sparse_density": { "default_value": 10 },
         "machine_extruder_count": { "default_value": 1 },
-        "retraction_combing": { "default_value": "off" },
+        "retraction_combing": { "value": "off" },
         "machine_heated_bed": { "default_value": true },
         "machine_center_is_zero": { "default_value": false },
         "machine_height": { "default_value": 260 },

--- a/resources/definitions/leapfrog_bolt_pro.def.json
+++ b/resources/definitions/leapfrog_bolt_pro.def.json
@@ -97,7 +97,7 @@
 		"material_final_print_temperature": {"value": "default_material_print_temperature" },
 		"material_initial_print_temperature": {"value": "default_material_print_temperature" },
         "gantry_height": {"value": "20"},
-        "retraction_combing": { "default_value": "all" },
+        "retraction_combing": { "value": "all" },
         "retraction_amount": {"default_value": 2},
         "adhesion_type": {"default_value": "skirt"},
         "skirt_line_count": {"default_value": 3},

--- a/resources/definitions/leapfrog_bolt_pro.def.json
+++ b/resources/definitions/leapfrog_bolt_pro.def.json
@@ -97,7 +97,7 @@
 		"material_final_print_temperature": {"value": "default_material_print_temperature" },
 		"material_initial_print_temperature": {"value": "default_material_print_temperature" },
         "gantry_height": {"value": "20"},
-        "retraction_combing": { "value": "all" },
+        "retraction_combing": { "value": "'all'" },
         "retraction_amount": {"default_value": 2},
         "adhesion_type": {"default_value": "skirt"},
         "skirt_line_count": {"default_value": 3},

--- a/resources/definitions/liquid.def.json
+++ b/resources/definitions/liquid.def.json
@@ -172,7 +172,7 @@
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 100" },
         "meshfix_maximum_deviation": { "value": "layer_height / 4" },
         "optimize_wall_printing_order": { "value": "True" },
-        "retraction_combing": { "default_value": "all" },
+        "retraction_combing": { "value": "all" },
         "initial_layer_line_width_factor": { "value": "120" },
         "zig_zaggify_infill": { "value": "gradual_infill_steps == 0" }
     }

--- a/resources/definitions/liquid.def.json
+++ b/resources/definitions/liquid.def.json
@@ -172,7 +172,7 @@
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 100" },
         "meshfix_maximum_deviation": { "value": "layer_height / 4" },
         "optimize_wall_printing_order": { "value": "True" },
-        "retraction_combing": { "value": "all" },
+        "retraction_combing": { "value": "'all'" },
         "initial_layer_line_width_factor": { "value": "120" },
         "zig_zaggify_infill": { "value": "gradual_infill_steps == 0" }
     }

--- a/resources/definitions/maker_made_300x.def.json
+++ b/resources/definitions/maker_made_300x.def.json
@@ -101,7 +101,7 @@
         "acceleration_enabled": {"value": false },
         "acceleration_roofing":  {"value": 3000 },
         "jerk_enabled":  {"value": false },
-        "retraction_combing":  {"value": "'within infill'" },
+        "retraction_combing":  {"value": "'infill'" },
         "travel_retract_before_outer_wall": {"value": false },
         "travel_avoid_other_parts": {"value": true },
         "retraction_hop_enabled": {"value": false },

--- a/resources/definitions/malyan_m200.def.json
+++ b/resources/definitions/malyan_m200.def.json
@@ -76,7 +76,7 @@
         "raft_surface_layers": { "default_value": 1 },
         "skirt_line_count": { "default_value": 2},
         "brim_width" : { "default_value": 5},
-        "retraction_combing": { "default_value": "noskin" },
+        "retraction_combing": { "value": "noskin" },
         "retraction_amount" : { "default_value": 4.5},
         "retraction_speed" : { "default_value": 40},
         "coasting_enable": { "default_value": true },

--- a/resources/definitions/malyan_m200.def.json
+++ b/resources/definitions/malyan_m200.def.json
@@ -76,7 +76,7 @@
         "raft_surface_layers": { "default_value": 1 },
         "skirt_line_count": { "default_value": 2},
         "brim_width" : { "default_value": 5},
-        "retraction_combing": { "value": "noskin" },
+        "retraction_combing": { "value": "'noskin'" },
         "retraction_amount" : { "default_value": 4.5},
         "retraction_speed" : { "default_value": 40},
         "coasting_enable": { "default_value": true },

--- a/resources/definitions/monoprice_select_mini_v2.def.json
+++ b/resources/definitions/monoprice_select_mini_v2.def.json
@@ -23,7 +23,7 @@
             "default_value": "G0 X0 Y120;(Stick out the part)\nM190 S0;(Turn off heat bed, don't wait.)\nG92 E10;(Set extruder to 10)\nG1 E7 F200;(retract 3mm)\nM104 S0;(Turn off nozzle, don't wait)\nG4 S300;(Delay 5 minutes)\nM107;(Turn off part fan)\nM84;(Turn off stepper motors.)"
         },
         "adhesion_type": { "default_value": "brim" },
-        "retraction_combing": { "value": "noskin" },
+        "retraction_combing": { "value": "'noskin'" },
         "retraction_amount" : { "default_value": 2.5},
         "retraction_speed" : { "default_value": 40},
         "material_print_temperature_layer_0": { "value": "material_print_temperature + 5" }

--- a/resources/definitions/monoprice_select_mini_v2.def.json
+++ b/resources/definitions/monoprice_select_mini_v2.def.json
@@ -23,7 +23,7 @@
             "default_value": "G0 X0 Y120;(Stick out the part)\nM190 S0;(Turn off heat bed, don't wait.)\nG92 E10;(Set extruder to 10)\nG1 E7 F200;(retract 3mm)\nM104 S0;(Turn off nozzle, don't wait)\nG4 S300;(Delay 5 minutes)\nM107;(Turn off part fan)\nM84;(Turn off stepper motors.)"
         },
         "adhesion_type": { "default_value": "brim" },
-        "retraction_combing": { "default_value": "noskin" },
+        "retraction_combing": { "value": "noskin" },
         "retraction_amount" : { "default_value": 2.5},
         "retraction_speed" : { "default_value": 40},
         "material_print_temperature_layer_0": { "value": "material_print_temperature + 5" }

--- a/resources/definitions/renkforce_rf100.def.json
+++ b/resources/definitions/renkforce_rf100.def.json
@@ -153,7 +153,7 @@
             "value": "5.0"
         },
         "retraction_combing": {
-            "value": "all"
+            "value": "'all'"
         },
         "retraction_enable": {
             "value": "True"

--- a/resources/definitions/renkforce_rf100.def.json
+++ b/resources/definitions/renkforce_rf100.def.json
@@ -153,7 +153,7 @@
             "value": "5.0"
         },
         "retraction_combing": {
-            "default_value": "all"
+            "value": "all"
         },
         "retraction_enable": {
             "value": "True"

--- a/resources/definitions/renkforce_rf100_v2.def.json
+++ b/resources/definitions/renkforce_rf100_v2.def.json
@@ -153,7 +153,7 @@
             "value": "5.0"
         },
         "retraction_combing": {
-            "value": "all"
+            "value": "'all'"
         },
         "retraction_enable": {
             "value": "True"

--- a/resources/definitions/renkforce_rf100_v2.def.json
+++ b/resources/definitions/renkforce_rf100_v2.def.json
@@ -153,7 +153,7 @@
             "value": "5.0"
         },
         "retraction_combing": {
-            "default_value": "all"
+            "value": "all"
         },
         "retraction_enable": {
             "value": "True"

--- a/resources/definitions/renkforce_rf100_xl.def.json
+++ b/resources/definitions/renkforce_rf100_xl.def.json
@@ -141,7 +141,7 @@
             "value": "5.0"
         },
         "retraction_combing": {
-            "value": "all"
+            "value": "'all'"
         },
         "retraction_enable": {
             "value": "True"

--- a/resources/definitions/renkforce_rf100_xl.def.json
+++ b/resources/definitions/renkforce_rf100_xl.def.json
@@ -141,7 +141,7 @@
             "value": "5.0"
         },
         "retraction_combing": {
-            "default_value": "all"
+            "value": "all"
         },
         "retraction_enable": {
             "value": "True"

--- a/resources/definitions/robo_3d_r1.def.json
+++ b/resources/definitions/robo_3d_r1.def.json
@@ -36,7 +36,7 @@
         "layer_height": { "default_value": 0.2 },
         "speed_print": { "default_value": 40 },
         "machine_extruder_count": { "default_value": 1 },
-        "retraction_combing": { "default_value": "off" },
+        "retraction_combing": { "value": "off" },
         "machine_heated_bed": { "default_value": true },
         "machine_center_is_zero": { "default_value": false },
         "machine_height": { "default_value": 210 },

--- a/resources/definitions/robo_3d_r1.def.json
+++ b/resources/definitions/robo_3d_r1.def.json
@@ -36,7 +36,7 @@
         "layer_height": { "default_value": 0.2 },
         "speed_print": { "default_value": 40 },
         "machine_extruder_count": { "default_value": 1 },
-        "retraction_combing": { "value": "off" },
+        "retraction_combing": { "value": "'off'" },
         "machine_heated_bed": { "default_value": true },
         "machine_center_is_zero": { "default_value": false },
         "machine_height": { "default_value": 210 },

--- a/resources/definitions/seemecnc_artemis.def.json
+++ b/resources/definitions/seemecnc_artemis.def.json
@@ -29,7 +29,7 @@
         "machine_width": { "default_value": 290 },
         "relative_extrusion": { "value": "False" },
         "retraction_amount": { "default_value": 3.2 },
-        "retraction_combing": { "value": "off" },
+        "retraction_combing": { "value": "'off'" },
         "retraction_hop_enabled": { "default_value": true },
         "retraction_hop_only_when_collides": { "default_value": false },
         "retraction_speed": { "default_value": 45 },

--- a/resources/definitions/seemecnc_artemis.def.json
+++ b/resources/definitions/seemecnc_artemis.def.json
@@ -29,7 +29,7 @@
         "machine_width": { "default_value": 290 },
         "relative_extrusion": { "value": "False" },
         "retraction_amount": { "default_value": 3.2 },
-        "retraction_combing": { "default_value": "off" },
+        "retraction_combing": { "value": "off" },
         "retraction_hop_enabled": { "default_value": true },
         "retraction_hop_only_when_collides": { "default_value": false },
         "retraction_speed": { "default_value": 45 },

--- a/resources/definitions/seemecnc_v32.def.json
+++ b/resources/definitions/seemecnc_v32.def.json
@@ -29,7 +29,7 @@
         "machine_width": { "default_value": 265 },
         "relative_extrusion": { "value": "False" },
         "retraction_amount": { "default_value": 3.2 },
-        "retraction_combing": { "value": "off" },
+        "retraction_combing": { "value": "'off'" },
         "retraction_hop_enabled": { "default_value": true },
         "retraction_hop_only_when_collides": { "default_value": false },
         "retraction_speed": { "default_value": 45 },

--- a/resources/definitions/seemecnc_v32.def.json
+++ b/resources/definitions/seemecnc_v32.def.json
@@ -29,7 +29,7 @@
         "machine_width": { "default_value": 265 },
         "relative_extrusion": { "value": "False" },
         "retraction_amount": { "default_value": 3.2 },
-        "retraction_combing": { "default_value": "off" },
+        "retraction_combing": { "value": "off" },
         "retraction_hop_enabled": { "default_value": true },
         "retraction_hop_only_when_collides": { "default_value": false },
         "retraction_speed": { "default_value": 45 },

--- a/resources/definitions/skriware_2.def.json
+++ b/resources/definitions/skriware_2.def.json
@@ -417,7 +417,7 @@
       "value": "1"
     },
     "retraction_combing": {
-      "default_value": "infill"
+      "value": "infill"
     },
     "acceleration_prime_tower": {
       "value": "250"

--- a/resources/definitions/skriware_2.def.json
+++ b/resources/definitions/skriware_2.def.json
@@ -417,7 +417,7 @@
       "value": "1"
     },
     "retraction_combing": {
-      "value": "infill"
+      "value": "'infill'"
     },
     "acceleration_prime_tower": {
       "value": "250"

--- a/resources/definitions/strateo3d.def.json
+++ b/resources/definitions/strateo3d.def.json
@@ -116,7 +116,7 @@
             "prime_tower_position_x": { "value": "machine_width/2 + prime_tower_size/2" },
             "prime_tower_position_y": { "value": "machine_depth - prime_tower_size - max(extruderValue(adhesion_extruder_nr, 'brim_width') * extruderValue(adhesion_extruder_nr, 'initial_layer_line_width_factor') / 100 if adhesion_type == 'brim' else (extruderValue(adhesion_extruder_nr, 'raft_margin') if adhesion_type == 'raft' else (extruderValue(adhesion_extruder_nr, 'skirt_gap') if adhesion_type == 'skirt' else 0)), max(extruderValues('travel_avoid_distance'))) - max(extruderValues('support_offset')) - sum(extruderValues('skirt_brim_line_width')) * extruderValue(adhesion_extruder_nr, 'initial_layer_line_width_factor') / 100 - (resolveOrValue('draft_shield_dist') if resolveOrValue('draft_shield_enabled') else 0) - 1" },
             "retraction_amount": { "default_value": 1.5 },
-            "retraction_combing": { "value": "all" },
+            "retraction_combing": { "value": "'all'" },
             "retraction_combing_max_distance": { "default_value": 5 },
             "retraction_count_max": { "default_value": 15 },
             "retraction_hop": { "value": "2" },

--- a/resources/definitions/strateo3d.def.json
+++ b/resources/definitions/strateo3d.def.json
@@ -116,7 +116,7 @@
             "prime_tower_position_x": { "value": "machine_width/2 + prime_tower_size/2" },
             "prime_tower_position_y": { "value": "machine_depth - prime_tower_size - max(extruderValue(adhesion_extruder_nr, 'brim_width') * extruderValue(adhesion_extruder_nr, 'initial_layer_line_width_factor') / 100 if adhesion_type == 'brim' else (extruderValue(adhesion_extruder_nr, 'raft_margin') if adhesion_type == 'raft' else (extruderValue(adhesion_extruder_nr, 'skirt_gap') if adhesion_type == 'skirt' else 0)), max(extruderValues('travel_avoid_distance'))) - max(extruderValues('support_offset')) - sum(extruderValues('skirt_brim_line_width')) * extruderValue(adhesion_extruder_nr, 'initial_layer_line_width_factor') / 100 - (resolveOrValue('draft_shield_dist') if resolveOrValue('draft_shield_enabled') else 0) - 1" },
             "retraction_amount": { "default_value": 1.5 },
-            "retraction_combing": { "default_value": "all" },
+            "retraction_combing": { "value": "all" },
             "retraction_combing_max_distance": { "default_value": 5 },
             "retraction_count_max": { "default_value": 15 },
             "retraction_hop": { "value": "2" },

--- a/resources/definitions/tizyx_evy.def.json
+++ b/resources/definitions/tizyx_evy.def.json
@@ -70,6 +70,6 @@
         "z_seam_type": {"default_value": "back"},
         "z_seam_x": {"value": "127.5"},
         "z_seam_y": {"value": "250"},
-        "retraction_combing": {"value": "off"}
+        "retraction_combing": {"value": "'off'"}
     }
 }

--- a/resources/definitions/tizyx_evy.def.json
+++ b/resources/definitions/tizyx_evy.def.json
@@ -70,6 +70,6 @@
         "z_seam_type": {"default_value": "back"},
         "z_seam_x": {"value": "127.5"},
         "z_seam_y": {"value": "250"},
-        "retraction_combing": {"default_value": "off"}
+        "retraction_combing": {"value": "off"}
     }
 }

--- a/resources/definitions/tizyx_evy_dual.def.json
+++ b/resources/definitions/tizyx_evy_dual.def.json
@@ -58,6 +58,6 @@
         "z_seam_type": {"default_value": "back"},
         "z_seam_x": {"value": "127.5"},
         "z_seam_y": {"value": "250"},
-        "retraction_combing": {"value": "off"}
+        "retraction_combing": {"value": "'off'"}
     }
 }

--- a/resources/definitions/tizyx_evy_dual.def.json
+++ b/resources/definitions/tizyx_evy_dual.def.json
@@ -58,6 +58,6 @@
         "z_seam_type": {"default_value": "back"},
         "z_seam_x": {"value": "127.5"},
         "z_seam_y": {"value": "250"},
-        "retraction_combing": {"default_value": "off"}
+        "retraction_combing": {"value": "off"}
     }
 }

--- a/resources/definitions/tizyx_k25.def.json
+++ b/resources/definitions/tizyx_k25.def.json
@@ -55,6 +55,6 @@
         "z_seam_type": {"default_value": "back"},
         "z_seam_x": {"value": "127.5"},
         "z_seam_y": {"value": "250"},
-        "retraction_combing": {"value": "off"}
+        "retraction_combing": {"value": "'off'"}
     }
 }

--- a/resources/definitions/tizyx_k25.def.json
+++ b/resources/definitions/tizyx_k25.def.json
@@ -55,6 +55,6 @@
         "z_seam_type": {"default_value": "back"},
         "z_seam_x": {"value": "127.5"},
         "z_seam_y": {"value": "250"},
-        "retraction_combing": {"default_value": "off"}
+        "retraction_combing": {"value": "off"}
     }
 }

--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -158,7 +158,7 @@
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 60" },
         "meshfix_maximum_deviation": { "value": "layer_height / 4" },
         "optimize_wall_printing_order": { "value": "True" },
-        "retraction_combing": { "default_value": "all" },
+        "retraction_combing": { "value": "all" },
         "initial_layer_line_width_factor": { "value": "120" },
         "zig_zaggify_infill": { "value": "gradual_infill_steps == 0" }
     }

--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -158,7 +158,6 @@
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 60" },
         "meshfix_maximum_deviation": { "value": "layer_height / 4" },
         "optimize_wall_printing_order": { "value": "True" },
-        "retraction_combing": { "value": "all" },
         "initial_layer_line_width_factor": { "value": "120" },
         "zig_zaggify_infill": { "value": "gradual_infill_steps == 0" }
     }

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -160,7 +160,6 @@
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 60" },
         "meshfix_maximum_deviation": { "value": "layer_height / 4" },
         "optimize_wall_printing_order": { "value": "True" },
-        "retraction_combing": { "value": "all" },
         "initial_layer_line_width_factor": { "value": "120" },
         "zig_zaggify_infill": { "value": "gradual_infill_steps == 0" },
         "build_volume_temperature": { "maximum_value": 50 }

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -160,7 +160,7 @@
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 60" },
         "meshfix_maximum_deviation": { "value": "layer_height / 4" },
         "optimize_wall_printing_order": { "value": "True" },
-        "retraction_combing": { "default_value": "all" },
+        "retraction_combing": { "value": "all" },
         "initial_layer_line_width_factor": { "value": "120" },
         "zig_zaggify_infill": { "value": "gradual_infill_steps == 0" },
         "build_volume_temperature": { "maximum_value": 50 }

--- a/resources/definitions/voron2_base.def.json
+++ b/resources/definitions/voron2_base.def.json
@@ -104,7 +104,7 @@
         "retraction_prime_speed":                       { "value": "math.ceil(retraction_speed * 0.4)", "maximum_value_warning": 130 },
         "retraction_hop_enabled":                       { "default_value": true },
         "retraction_hop":                               { "default_value": 0.2 },
-        "retraction_combing":                           { "default_value": "noskin" },
+        "retraction_combing":                           { "value": "noskin" },
         "retraction_combing_max_distance":              { "default_value": 10 },
         "travel_avoid_other_parts":                     { "default_value": false },
         "speed_travel":                                 { "maximum_value": 300, "value": 300, "maximum_value_warning": 501 },

--- a/resources/definitions/voron2_base.def.json
+++ b/resources/definitions/voron2_base.def.json
@@ -104,7 +104,7 @@
         "retraction_prime_speed":                       { "value": "math.ceil(retraction_speed * 0.4)", "maximum_value_warning": 130 },
         "retraction_hop_enabled":                       { "default_value": true },
         "retraction_hop":                               { "default_value": 0.2 },
-        "retraction_combing":                           { "value": "noskin" },
+        "retraction_combing":                           { "value": "'noskin'" },
         "retraction_combing_max_distance":              { "default_value": 10 },
         "travel_avoid_other_parts":                     { "default_value": false },
         "speed_travel":                                 { "maximum_value": 300, "value": 300, "maximum_value_warning": 501 },


### PR DESCRIPTION
New combing mode "Not in Outer Surfaces" to avoid going through the skin, only on the bottom-most and too-most outer surfaces. Compared to the "Not in Skin" option, which avoids combing through all the skin surfaces regardless if they are visible, the "Not in Outer Surfaces" avoids only the skin surfaces that are actually exposed and will be visible in the printed model. This has the added benefit that it saves time while preserving visual quality.

The "Not in Outer Surfaces" option will be enabled by default in the following cases:
1. Monotonic Top/Bottom Order is enabled (in any extruder)
2. Ironing is enabled (in any extruder)
3. Top Surface Skin Layers > 0 and Monotonic Top Surface Order is enabled (in any extruder)

Requires https://github.com/Ultimaker/CuraEngine/pull/1505.

CURA-7976