### PR TITLE
CURA-8254: Trigger material profile sync with printer

### DIFF
--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -73,6 +73,8 @@ class MaterialManagementModel(QObject):
                 button_style = Message.ActionButtonStyle.LINK
         )
         sync_materials_message.actionTriggered.connect(self._onSyncMaterialsMessageActionTriggered)
+
+        # Show the message only if there are printers that support material export
         container_registry = cura.CuraApplication.CuraApplication.getInstance().getContainerRegistry()
         global_stacks = container_registry.findContainerStacks(type = "machine")
         if any([stack.supportsMaterialExport for stack in global_stacks]):

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 import uuid  # To generate new GUIDs for new materials.
 import zipfile  # To export all materials in a .zip archive.
 
+from PyQt5.QtGui import QDesktopServices
+
 from UM.i18n import i18nCatalog
 from UM.Logger import Logger
 from UM.Message import Message
@@ -21,12 +23,63 @@ if TYPE_CHECKING:
 
 catalog = i18nCatalog("cura")
 
+
 class MaterialManagementModel(QObject):
     favoritesChanged = pyqtSignal(str)
     """Triggered when a favorite is added or removed.
 
     :param The base file of the material is provided as parameter when this emits
     """
+
+    def __init__(self, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent = parent)
+        self._checkIfNewMaterialsWereInstalled()
+
+    def _checkIfNewMaterialsWereInstalled(self):
+        application = cura.CuraApplication.CuraApplication.getInstance()
+        new_materials_installed = False
+        print(application.getPackageManager().installed_packages)
+        for package_id, package_info in application.getPackageManager().installed_packages.items():
+            new_materials_installed = package_info["package_info"]["package_type"] == "material"
+        if new_materials_installed:
+            self._showSyncNewMaterialsMessage()
+
+    def _showSyncNewMaterialsMessage(self):
+        sync_materials_message = Message(
+                text = catalog.i18nc("@action:button",
+                                     "Please sync the material profiles with your pinter before starting to print."),
+                title = catalog.i18nc("@action:button", "New materials installed"),
+                message_type = Message.MessageType.WARNING,
+                lifetime = 0
+        )
+
+        sync_materials_message.addAction(
+                "sync",
+                name = catalog.i18nc("@action:button", "Sync materials with printers"),
+                icon = "",
+                description = "Sync your newly installed materials with your printers.",
+                button_align = Message.ActionButtonAlignment.ALIGN_RIGHT
+        )
+
+        sync_materials_message.addAction(
+                "learn_more",
+                name = catalog.i18nc("@action:button", "Learn more"),
+                icon = "",
+                description = "Learn more.",
+                button_align = Message.ActionButtonAlignment.ALIGN_LEFT,
+                button_style = Message.ActionButtonStyle.LINK
+        )
+        sync_materials_message.actionTriggered.connect(self._onSyncMaterialsMessageActionTriggered)
+        sync_materials_message.show()
+
+    @staticmethod
+    def _onSyncMaterialsMessageActionTriggered(sync_message: Optional[Message], sync_message_action: Optional[str]):
+        if sync_message_action == "sync":
+            QDesktopServices.openUrl(QUrl("https://example.com/sync"))
+            if sync_message is not None:
+                sync_message.hide()
+        elif sync_message_action == "learn_more":
+            QDesktopServices.openUrl(QUrl("https://example.com/learn_more"))
 
     @pyqtSlot("QVariant", result = bool)
     def canMaterialBeRemoved(self, material_node: "MaterialNode") -> bool:

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -41,11 +41,11 @@ class MaterialManagementModel(QObject):
         a message prompting the user to sync the materials with their printers.
         """
         application = cura.CuraApplication.CuraApplication.getInstance()
-        new_materials_installed = False
-        for package_id, package_info in application.getPackageManager().installed_packages.items():
-            new_materials_installed = package_info["package_info"]["package_type"] == "material"
-        if new_materials_installed:
-            self._showSyncNewMaterialsMessage()
+        for package_id, package_data in application.getPackageManager().installed_packages.items():
+            if package_data["package_info"]["package_type"] == "material":
+                # At least one new material was installed
+                self._showSyncNewMaterialsMessage()
+                break
 
     def _showSyncNewMaterialsMessage(self):
         sync_materials_message = Message(

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -82,7 +82,7 @@ class MaterialManagementModel(QObject):
             if sync_message is not None:
                 sync_message.hide()
         elif sync_message_action == "learn_more":
-            QDesktopServices.openUrl(QUrl("https://support.ultimaker.com/hc/en-us/articles/360013137919?utm_source=cura&utm_medium=software&utm_campaign=sync-material-printer"))
+            QDesktopServices.openUrl(QUrl("https://support.ultimaker.com/hc/en-us/articles/360013137919?utm_source=cura&utm_medium=software&utm_campaign=sync-material-printer-message"))
 
     @pyqtSlot("QVariant", result = bool)
     def canMaterialBeRemoved(self, material_node: "MaterialNode") -> bool:

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -35,7 +35,7 @@ class MaterialManagementModel(QObject):
         super().__init__(parent = parent)
         self._checkIfNewMaterialsWereInstalled()
 
-    def _checkIfNewMaterialsWereInstalled(self):
+    def _checkIfNewMaterialsWereInstalled(self) -> None:
         """
         Checks whether new material packages were installed in the latest startup. If there were, then it shows
         a message prompting the user to sync the materials with their printers.
@@ -47,7 +47,7 @@ class MaterialManagementModel(QObject):
                 self._showSyncNewMaterialsMessage()
                 break
 
-    def _showSyncNewMaterialsMessage(self):
+    def _showSyncNewMaterialsMessage(self) -> None:
         sync_materials_message = Message(
                 text = catalog.i18nc("@action:button",
                                      "Please sync the material profiles with your printers before starting to print."),
@@ -80,12 +80,11 @@ class MaterialManagementModel(QObject):
         if any([stack.supportsMaterialExport for stack in global_stacks]):
             sync_materials_message.show()
 
-    def _onSyncMaterialsMessageActionTriggered(self, sync_message: Optional[Message], sync_message_action: Optional[str]):
+    def _onSyncMaterialsMessageActionTriggered(self, sync_message: Message, sync_message_action: str):
         if sync_message_action == "sync":
             QDesktopServices.openUrl(QUrl("https://example.com/openSyncAllWindow"))
             # self.openSyncAllWindow()
-            if sync_message is not None:
-                sync_message.hide()
+            sync_message.hide()
         elif sync_message_action == "learn_more":
             QDesktopServices.openUrl(QUrl("https://support.ultimaker.com/hc/en-us/articles/360013137919?utm_source=cura&utm_medium=software&utm_campaign=sync-material-printer-message"))
 

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -41,7 +41,7 @@ class MaterialManagementModel(QObject):
         a message prompting the user to sync the materials with their printers.
         """
         application = cura.CuraApplication.CuraApplication.getInstance()
-        for package_id, package_data in application.getPackageManager().installed_packages.items():
+        for package_id, package_data in application.getPackageManager().getPackagesInstalledOnStartup().items():
             if package_data["package_info"]["package_type"] == "material":
                 # At least one new material was installed
                 self._showSyncNewMaterialsMessage()

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -50,7 +50,7 @@ class MaterialManagementModel(QObject):
     def _showSyncNewMaterialsMessage(self):
         sync_materials_message = Message(
                 text = catalog.i18nc("@action:button",
-                                     "Please sync the material profiles with your printer before starting to print."),
+                                     "Please sync the material profiles with your printers before starting to print."),
                 title = catalog.i18nc("@action:button", "New materials installed"),
                 message_type = Message.MessageType.WARNING,
                 lifetime = 0

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -73,7 +73,10 @@ class MaterialManagementModel(QObject):
                 button_style = Message.ActionButtonStyle.LINK
         )
         sync_materials_message.actionTriggered.connect(self._onSyncMaterialsMessageActionTriggered)
-        sync_materials_message.show()
+        container_registry = cura.CuraApplication.CuraApplication.getInstance().getContainerRegistry()
+        global_stacks = container_registry.findContainerStacks(type = "machine")
+        if any([stack.supportsMaterialExport for stack in global_stacks]):
+            sync_materials_message.show()
 
     def _onSyncMaterialsMessageActionTriggered(self, sync_message: Optional[Message], sync_message_action: Optional[str]):
         if sync_message_action == "sync":

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -36,9 +36,12 @@ class MaterialManagementModel(QObject):
         self._checkIfNewMaterialsWereInstalled()
 
     def _checkIfNewMaterialsWereInstalled(self):
+        """
+        Checks whether new material packages were installed in the latest startup. If there were, then it shows
+        a message prompting the user to sync the materials with their printers.
+        """
         application = cura.CuraApplication.CuraApplication.getInstance()
         new_materials_installed = False
-        print(application.getPackageManager().installed_packages)
         for package_id, package_info in application.getPackageManager().installed_packages.items():
             new_materials_installed = package_info["package_info"]["package_type"] == "material"
         if new_materials_installed:
@@ -57,6 +60,7 @@ class MaterialManagementModel(QObject):
                 "sync",
                 name = catalog.i18nc("@action:button", "Sync materials with printers"),
                 icon = "",
+                description = "Sync your newly installed materials with your printers.",
                 button_align = Message.ActionButtonAlignment.ALIGN_RIGHT
         )
 
@@ -64,6 +68,7 @@ class MaterialManagementModel(QObject):
                 "learn_more",
                 name = catalog.i18nc("@action:button", "Learn more"),
                 icon = "",
+                description = "Learn more about syncing your newly installed materials with your printers.",
                 button_align = Message.ActionButtonAlignment.ALIGN_LEFT,
                 button_style = Message.ActionButtonStyle.LINK
         )

--- a/cura/Machines/Models/MaterialManagementModel.py
+++ b/cura/Machines/Models/MaterialManagementModel.py
@@ -47,7 +47,7 @@ class MaterialManagementModel(QObject):
     def _showSyncNewMaterialsMessage(self):
         sync_materials_message = Message(
                 text = catalog.i18nc("@action:button",
-                                     "Please sync the material profiles with your pinter before starting to print."),
+                                     "Please sync the material profiles with your printer before starting to print."),
                 title = catalog.i18nc("@action:button", "New materials installed"),
                 message_type = Message.MessageType.WARNING,
                 lifetime = 0
@@ -57,7 +57,6 @@ class MaterialManagementModel(QObject):
                 "sync",
                 name = catalog.i18nc("@action:button", "Sync materials with printers"),
                 icon = "",
-                description = "Sync your newly installed materials with your printers.",
                 button_align = Message.ActionButtonAlignment.ALIGN_RIGHT
         )
 
@@ -65,21 +64,20 @@ class MaterialManagementModel(QObject):
                 "learn_more",
                 name = catalog.i18nc("@action:button", "Learn more"),
                 icon = "",
-                description = "Learn more.",
                 button_align = Message.ActionButtonAlignment.ALIGN_LEFT,
                 button_style = Message.ActionButtonStyle.LINK
         )
         sync_materials_message.actionTriggered.connect(self._onSyncMaterialsMessageActionTriggered)
         sync_materials_message.show()
 
-    @staticmethod
-    def _onSyncMaterialsMessageActionTriggered(sync_message: Optional[Message], sync_message_action: Optional[str]):
+    def _onSyncMaterialsMessageActionTriggered(self, sync_message: Optional[Message], sync_message_action: Optional[str]):
         if sync_message_action == "sync":
-            QDesktopServices.openUrl(QUrl("https://example.com/sync"))
+            QDesktopServices.openUrl(QUrl("https://example.com/openSyncAllWindow"))
+            # self.openSyncAllWindow()
             if sync_message is not None:
                 sync_message.hide()
         elif sync_message_action == "learn_more":
-            QDesktopServices.openUrl(QUrl("https://example.com/learn_more"))
+            QDesktopServices.openUrl(QUrl("https://support.ultimaker.com/hc/en-us/articles/360013137919?utm_source=cura&utm_medium=software&utm_campaign=sync-material-printer"))
 
     @pyqtSlot("QVariant", result = bool)
     def canMaterialBeRemoved(self, material_node: "MaterialNode") -> bool:


### PR DESCRIPTION
This PR adds a message on startup which will appear if the user has just installed or updated material packages. The message will only show if the user has printers which support material export.

![image](https://user-images.githubusercontent.com/19388042/136001805-b972955b-906e-494e-9c70-f38cfcbb3ea5.png)

Requires https://github.com/Ultimaker/Uranium/pull/743.

CURA-8254