### PR TITLE
Fix translation for 'nozzle'.

### DIFF
--- a/resources/i18n/ru_RU/fdmprinter.def.json.po
+++ b/resources/i18n/ru_RU/fdmprinter.def.json.po
@@ -108,12 +108,12 @@ msgstr "Следует ли добавлять команду ожидания �
 #: fdmprinter.def.json
 msgctxt "material_print_temp_wait label"
 msgid "Wait for Nozzle Heatup"
-msgstr "Ожидать пока прогреется голова"
+msgstr "Ожидать пока прогреется сопло"
 
 #: fdmprinter.def.json
 msgctxt "material_print_temp_wait description"
 msgid "Whether to wait until the nozzle temperature is reached at the start."
-msgstr "Следует ли добавлять команду ожидания прогрева головы перед началом печати."
+msgstr "Следует ли добавлять команду ожидания прогрева сопла перед началом печати."
 
 #: fdmprinter.def.json
 msgctxt "material_print_temp_prepend label"
@@ -7177,7 +7177,7 @@ msgstr "Матрица преобразования, применяемая к �
 
 #~ msgctxt "material_print_temp_wait label"
 #~ msgid "Wait for nozzle heatup"
-#~ msgstr "Ожидать пока прогреется голова"
+#~ msgstr "Ожидать пока прогреется сопло"
 
 #~ msgctxt "material_print_temp_prepend label"
 #~ msgid "Include material temperatures"


### PR DESCRIPTION
Update strings having 'nozzle' translated as 'head' and make them more consistent with others where translation is correct.