### PR TITLE
optimized skin orientation for cross infill pattern

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -40,6 +40,9 @@
         {
             "value": false,
             "enabled": false
+        },
+        "skin_angles": {
+            "value": "[] if infill_pattern not in ['cross', 'cross_3d'] else [20, 110]"
         }
     }
 }


### PR DESCRIPTION
The skin orientation is optimized for the cross (3d) infill pattern to reduce the bridge distance. For more information see PP-55.