### PR TITLE
adjusted style of hover and button sizes

### DIFF
--- a/plugins/Marketplace/resources/qml/ManagePackagesButton.qml
+++ b/plugins/Marketplace/resources/qml/ManagePackagesButton.qml
@@ -12,7 +12,6 @@ Button
     id: root
     width: UM.Theme.getSize("button_icon").width
     height: UM.Theme.getSize("button_icon").height
-
     hoverEnabled: true
     property color backgroundColor: hovered ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("action_button")
 

--- a/plugins/Marketplace/resources/qml/ManagePackagesButton.qml
+++ b/plugins/Marketplace/resources/qml/ManagePackagesButton.qml
@@ -10,18 +10,18 @@ import QtQuick.Controls 2.15
 Button
 {
     id: root
-    width: childrenRect.width
-    height: childrenRect.height
+    width: UM.Theme.getSize("button_icon").width
+    height: UM.Theme.getSize("button_icon").height
 
     hoverEnabled: true
-    property color borderColor: hovered ? UM.Theme.getColor("primary") : "transparent"
     property color backgroundColor: hovered ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("action_button")
 
     background: Rectangle
     {
         color: backgroundColor
-        border.color: borderColor
-        border.width: UM.Theme.getSize("default_lining").width
+        border.color: transparent
+        radius: Math.round(width * 0.5)
+
     }
 
     Cura.ToolTip
@@ -38,8 +38,10 @@ Button
 
         width: UM.Theme.getSize("section_icon").width
         height: UM.Theme.getSize("section_icon").height
-
+  
         color: UM.Theme.getColor("icon")
         source: UM.Theme.getIcon("Settings")
+        anchors.centerIn: parent
+
     }
 }

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -100,7 +100,7 @@ Window
                     PackageTypeTab
                     {
                         width: implicitWidth
-                        padding:UM.Theme.getSize("default_margin").width/2
+                        padding: UM.Theme.getSize("default_margin").width/2
                         text: catalog.i18nc("@button", "Plugins")
                         onClicked: content.source = "Plugins.qml"
                     }

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -94,18 +94,20 @@ Window
                     id: pageSelectionTabBar
                     anchors.right: managePackagesButton.left
                     anchors.rightMargin: UM.Theme.getSize("default_margin").width
-
+                    height:UM.Theme.getSize("button_icon").height
                     spacing: 0
 
                     PackageTypeTab
                     {
                         width: implicitWidth
+                        padding:UM.Theme.getSize("default_margin").width/2
                         text: catalog.i18nc("@button", "Plugins")
                         onClicked: content.source = "Plugins.qml"
                     }
                     PackageTypeTab
                     {
                         width: implicitWidth
+                        padding:UM.Theme.getSize("default_margin").width/2
                         text: catalog.i18nc("@button", "Materials")
                         onClicked: content.source = "Materials.qml"
                     }

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -94,7 +94,7 @@ Window
                     id: pageSelectionTabBar
                     anchors.right: managePackagesButton.left
                     anchors.rightMargin: UM.Theme.getSize("default_margin").width
-                    height:UM.Theme.getSize("button_icon").height
+                    height: UM.Theme.getSize("button_icon").height
                     spacing: 0
 
                     PackageTypeTab

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -107,7 +107,7 @@ Window
                     PackageTypeTab
                     {
                         width: implicitWidth
-                        padding:UM.Theme.getSize("default_margin").width/2
+                        padding: Math.round(UM.Theme.getSize("default_margin").width / 2)
                         text: catalog.i18nc("@button", "Materials")
                         onClicked: content.source = "Materials.qml"
                     }


### PR DESCRIPTION
I updated the styling of the hover state for the manage plugins button to match the styling of the buttons in the toolbar. and adjusted some sizes and paddings of the tabs button. 
![Peek 2021-11-04 14-30](https://user-images.githubusercontent.com/2944758/140322196-cfe10d72-a06c-43f0-9c9a-389355e1eff0.gif)


