### PR TITLE
Fix visualisation of layer view with pause at height enabled

### DIFF
--- a/plugins/GCodeReader/FlavorParser.py
+++ b/plugins/GCodeReader/FlavorParser.py
@@ -198,7 +198,7 @@ class FlavorParser:
 
             # Only when extruding we can determine the latest known "layer height" which is the difference in height between extrusions
             # Also, 1.5 is a heuristic for any priming or whatsoever, we skip those.
-            if z > self._previous_z and (z - self._previous_z < 1.5):
+            if z > self._previous_z and (z - self._previous_z < 1.5) and (params.x is not None or params.y is not None):
                 self._current_layer_thickness = z - self._previous_z # allow a tiny overlap
                 self._previous_z = z
         elif self._previous_extrusion_value > e[self._extruder_number]:

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -489,18 +489,17 @@ class PauseAtHeight(Script):
                         # Set extruder resume temperature
                         prepend_gcode += self.putValue(M = 109, S = int(target_temperature.get(current_t, 0))) + " ; resume temperature\n"
 
-                    # Push the filament back,
-                    if retraction_amount != 0:
-                        prepend_gcode += self.putValue(G = 1, E = retraction_amount, F = retraction_speed * 60) + "\n"
+                    if extrude_amount != 0:  # Need to prime after the pause.
+                        # Push the filament back.
+                        if retraction_amount != 0:
+                            prepend_gcode += self.putValue(G = 1, E = retraction_amount, F = retraction_speed * 60) + "\n"
 
-                    # Optionally extrude material
-                    if extrude_amount != 0:
+                        # Prime the material.
                         prepend_gcode += self.putValue(G = 1, E = extrude_amount, F = extrude_speed * 60) + "; Extra extrude after the unpause\n"
 
-                    # and retract again, the properly primes the nozzle
-                    # when changing filament.
-                    if retraction_amount != 0:
-                        prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = retraction_speed * 60) + "\n"
+                        # And retract again to make the movements back to the starting position.
+                        if retraction_amount != 0:
+                            prepend_gcode += self.putValue(G = 1, E = -retraction_amount, F = retraction_speed * 60) + "\n"
 
                     # Move the head back
                     if park_enabled:


### PR DESCRIPTION
We do retracts/unretracts on different heights sometimes, for instance after a pause. This would get seen as a new layer. It's quite safe to say that purely retracts and unretracts on a different height do not constitute a layer in a normal g-code file. There would be nothing to draw anyway.

There was also an unnecessary unretract/retract introduced by the Pause At Height script sometimes. The unretract/retract is only necessary if it's priming some extra material. Fixing that up should reduce ooze for those who don't need to prime.

Fixes #10282. Fixes CURA-8522.