### PR TITLE
Ender5 Fixed Extruder hitting frame after print

### DIFF
--- a/resources/definitions/creality_ender5.def.json
+++ b/resources/definitions/creality_ender5.def.json
@@ -4,7 +4,7 @@
     "inherits": "creality_base",
     "overrides": {
         "machine_name": { "default_value": "Creality Ender-5" },
-        "machine_end_gcode": { "default_value": "G91 ;Relative positioning\nG1 E-2 F2700 ;Retract a bit\nG1 E-2 Z0.2 F2400 ;Retract and raise Z\nG1 X5 Y5 F3000 ;Wipe out\nG1 Z10 ;Raise Z more\nG90 ;Absolute positioning\n\nG28 ;Present print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\n\nM84 X Y E ;Disable all steppers but Z\n" },
+        "machine_end_gcode": { "default_value": "G91 ;Relative positioning\nG1 E-2 F2700 ;Retract a bit\nG1 E-2 Z0.2 F2400 ;Retract and raise Z\nG1 X5 Y5 F3000 ;Wipe out\nG1 Z10 ;Raise Z more\nG90 ;Absolute positioning\n\nG28 X0 Y0 ;Present print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\n\nM84 X Y E ;Disable all steppers but Z\n" },
         "machine_width": { "default_value": 220 },
         "machine_depth": { "default_value": 220 },
         "machine_height": { "default_value": 300 },

--- a/resources/definitions/creality_ender5.def.json
+++ b/resources/definitions/creality_ender5.def.json
@@ -4,7 +4,7 @@
     "inherits": "creality_base",
     "overrides": {
         "machine_name": { "default_value": "Creality Ender-5" },
-        "machine_end_gcode": { "default_value": "G91 ;Relative positioning\nG1 E-2 F2700 ;Retract a bit\nG1 E-2 Z0.2 F2400 ;Retract and raise Z\nG1 X5 Y5 F3000 ;Wipe out\nG1 Z10 ;Raise Z more\nG90 ;Absolute positioning\n\nG1 X0 Y0 ;Present print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\n\nM84 X Y E ;Disable all steppers but Z\n" },
+        "machine_end_gcode": { "default_value": "G91 ;Relative positioning\nG1 E-2 F2700 ;Retract a bit\nG1 E-2 Z0.2 F2400 ;Retract and raise Z\nG1 X5 Y5 F3000 ;Wipe out\nG1 Z10 ;Raise Z more\nG90 ;Absolute positioning\n\nG28 ;Present print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\n\nM84 X Y E ;Disable all steppers but Z\n" },
         "machine_width": { "default_value": 220 },
         "machine_depth": { "default_value": 220 },
         "machine_height": { "default_value": 300 },


### PR DESCRIPTION
Using G28 to fix the orientation of homing & the speed after the print.