### PR TITLE
Flow equalization width factor as percentage

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -3230,10 +3230,10 @@
                     "label": "Flow Equalization Width Factor",
                     "description": "Extrusion width based correction factor on the equalized flow. The target flow (in mm³/s) is reduced by the percentual difference in line width multiplied by this factor. A factor above zero means that thin lines are adjusted to be even faster than simple flow equalization would speed them up to. Conversely, wider lines are slowed down more. A positive value can help to compensate for the width depended back pressure the previous layer exterts on the line.",
                     "type": "float",
-                    "unit": "mm³/s",
+                    "unit": "%",
                     "default_value": 0.0,
-                    "minimum_value_warning": "0.0",
-                    "maximum_value_warning": "3.0",
+                    "minimum_value": "0",
+                    "maximum_value_warning": "200.0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },

--- a/resources/definitions/ultimaker2.def.json
+++ b/resources/definitions/ultimaker2.def.json
@@ -91,7 +91,7 @@
             "value": "False"
         },
         "speed_equalize_flow_width_factor": {
-            "value": "0.5"
+            "value": "50.0"
         },
         "retraction_combing": {
             "value": "'no_outer_surfaces'"

--- a/resources/definitions/ultimaker3.def.json
+++ b/resources/definitions/ultimaker3.def.json
@@ -154,7 +154,7 @@
         "roofing_layer_count": { "value": "1" },
         "roofing_monotonic": { "value": "True" },
         "skin_overlap": { "value": "10" },
-        "speed_equalize_flow_width_factor": { "value": "0.5" },
+        "speed_equalize_flow_width_factor": { "value": "50.0" },
         "skin_monotonic" : { "value": true },
         "speed_layer_0": { "value": "20" },
         "speed_prime_tower": { "value": "speed_topbottom" },

--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -141,7 +141,7 @@
         "retraction_prime_speed": { "value": "15" },
         "skin_monotonic" : { "value": true },
         "skin_overlap": { "value": "10" },
-        "speed_equalize_flow_width_factor": { "value": "0.5" },
+        "speed_equalize_flow_width_factor": { "value": "50.0" },
         "speed_layer_0": { "value": "20" },
         "speed_prime_tower": { "value": "speed_topbottom" },
         "speed_print": { "value": "35" },

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -145,7 +145,7 @@
         "retraction_prime_speed": { "value": "15" },
         "skin_monotonic" : { "value": true },
         "skin_overlap": { "value": "10" },
-        "speed_equalize_flow_width_factor": { "value": "0.5" },
+        "speed_equalize_flow_width_factor": { "value": "50.0" },
         "speed_layer_0": { "value": "20" },
         "speed_prime_tower": { "value": "speed_topbottom" },
         "speed_print": { "value": "35" },


### PR DESCRIPTION
This variable makes more sense to as a Ratio.
This was discussed during the eCCB 12/11/21
and implemented as a 5 min fix.

Note: The current default values were 0.5 there
is a new PR which change these 1.0. These values
should be multiplied with a 100

See also PR Ultimaker/CuraEngine#1529