### PR TITLE
Marketplace navigation improvements

### DIFF
--- a/plugins/Marketplace/resources/qml/ManagePackagesButton.qml
+++ b/plugins/Marketplace/resources/qml/ManagePackagesButton.qml
@@ -20,7 +20,6 @@ Button
         color: backgroundColor
         border.color: transparent
         radius: Math.round(width * 0.5)
-
     }
 
     Cura.ToolTip

--- a/plugins/Marketplace/resources/qml/ManagePackagesButton.qml
+++ b/plugins/Marketplace/resources/qml/ManagePackagesButton.qml
@@ -7,18 +7,21 @@ import Cura 1.6 as Cura
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 
-Button
+TabButton
 {
     id: root
-    width: UM.Theme.getSize("button_icon").width
+    width: UM.Theme.getSize("button_icon").width+UM.Theme.getSize("narrow_margin").width
     height: UM.Theme.getSize("button_icon").height
     hoverEnabled: true
-    property color backgroundColor: hovered ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("action_button")
+    property color inactiveBackgroundColor : hovered ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("detail_background")
+    property color activeBackgroundColor : UM.Theme.getColor("main_background")
+    leftInset: UM.Theme.getSize("narrow_margin").width
 
     background: Rectangle
     {
-        color: backgroundColor
-        border.color: transparent
+        color: parent.checked ? activeBackgroundColor : inactiveBackgroundColor
+        border.color: parent.checked ? UM.Theme.getColor("detail_background") : "transparent"
+        border.width: UM.Theme.getSize("thick_lining").width
         radius: Math.round(width * 0.5)
     }
 
@@ -39,7 +42,8 @@ Button
   
         color: UM.Theme.getColor("icon")
         source: UM.Theme.getIcon("Settings")
-        anchors.centerIn: parent
-
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.horizontalCenterOffset: Math.round(UM.Theme.getSize("narrow_margin").width /2) 
+        anchors.verticalCenter: parent.verticalCenter
     }
 }

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -75,24 +75,11 @@ Window
                 Layout.preferredWidth: parent.width
                 Layout.preferredHeight: childrenRect.height
 
-                ManagePackagesButton
-                {
-                    id: managePackagesButton
-
-                    anchors.right: parent.right
-                    anchors.rightMargin: UM.Theme.getSize("default_margin").width
-
-                    onClicked:
-                    {
-                        content.source = "ManagedPackages.qml"
-                    }
-                }
-
                 // Page selection.
                 TabBar
                 {
                     id: pageSelectionTabBar
-                    anchors.right: managePackagesButton.left
+                    anchors.right: parent.right
                     anchors.rightMargin: UM.Theme.getSize("default_margin").width
                     height: UM.Theme.getSize("button_icon").height
                     spacing: 0
@@ -108,6 +95,10 @@ Window
                         width: implicitWidth
                         text: catalog.i18nc("@button", "Materials")
                         onClicked: content.source = "Materials.qml"
+                    }
+                    ManagePackagesButton
+                    {
+                        onClicked: content.source = "ManagedPackages.qml"
                     }
                 }
             }

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -100,14 +100,12 @@ Window
                     PackageTypeTab
                     {
                         width: implicitWidth
-                        padding: UM.Theme.getSize("default_margin").width/2
                         text: catalog.i18nc("@button", "Plugins")
                         onClicked: content.source = "Plugins.qml"
                     }
                     PackageTypeTab
                     {
                         width: implicitWidth
-                        padding: Math.round(UM.Theme.getSize("default_margin").width / 2)
                         text: catalog.i18nc("@button", "Materials")
                         onClicked: content.source = "Materials.qml"
                     }

--- a/plugins/Marketplace/resources/qml/PackageTypeTab.qml
+++ b/plugins/Marketplace/resources/qml/PackageTypeTab.qml
@@ -8,6 +8,7 @@ import UM 1.0 as UM
 TabButton
 {
     property string pageTitle
+    padding: UM.Theme.getSize("narrow_margin").width
 
     background: Rectangle
     {

--- a/plugins/Marketplace/resources/qml/PackageTypeTab.qml
+++ b/plugins/Marketplace/resources/qml/PackageTypeTab.qml
@@ -9,6 +9,7 @@ TabButton
 {
     property string pageTitle
     padding: UM.Theme.getSize("narrow_margin").width
+    horizontalPadding: UM.Theme.getSize("default_margin").width
     hoverEnabled: true
     property color inactiveBackgroundColor : hovered ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("detail_background")
     property color activeBackgroundColor : UM.Theme.getColor("main_background")

--- a/plugins/Marketplace/resources/qml/PackageTypeTab.qml
+++ b/plugins/Marketplace/resources/qml/PackageTypeTab.qml
@@ -9,11 +9,15 @@ TabButton
 {
     property string pageTitle
     padding: UM.Theme.getSize("narrow_margin").width
+    hoverEnabled: true
+    property color inactiveBackgroundColor : hovered ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("detail_background")
+    property color activeBackgroundColor : UM.Theme.getColor("main_background")
+
 
     background: Rectangle
     {
         anchors.fill: parent
-        color: parent.checked ? UM.Theme.getColor("main_background") : UM.Theme.getColor("detail_background")
+        color: parent.checked ? activeBackgroundColor : inactiveBackgroundColor
         border.color: UM.Theme.getColor("detail_background")
         border.width: UM.Theme.getSize("thick_lining").width
     }

--- a/plugins/Marketplace/resources/qml/PackageTypeTab.qml
+++ b/plugins/Marketplace/resources/qml/PackageTypeTab.qml
@@ -13,7 +13,6 @@ TabButton
     property color inactiveBackgroundColor : hovered ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("detail_background")
     property color activeBackgroundColor : UM.Theme.getColor("main_background")
 
-
     background: Rectangle
     {
         anchors.fill: parent
@@ -25,7 +24,7 @@ TabButton
     contentItem: Label
     {
         text: parent.text
-        font: UM.Theme.getFont("medium")
+        font: UM.Theme.getFont("medium_bold")
         color: UM.Theme.getColor("text")
         width: contentWidth
         anchors.centerIn: parent


### PR DESCRIPTION
In the current implementation of the marketplace navigation, clicking the manage plugins icon would not disable the previously active tab. Moreover the styles of the active, inactive and hover buttons where not aligned which might have led to confusion. 
![current](https://user-images.githubusercontent.com/2944758/141991363-a97df3e1-5bf7-4526-a1e5-decf88a23825.gif)

I moved the manage packages buttons inside the tabview and style all the buttons to look similar when active, inactive and hovered. I also addressed some other comments I got from @Ghostkeeper in the previous PR

![improved](https://user-images.githubusercontent.com/2944758/141991374-4c745e83-9b03-47e5-aa03-aa7fae7817d6.gif)

