### PR TITLE
Fix initial layer bed and print head temperature for Snapmaker profile

### DIFF
--- a/resources/definitions/snapmaker2.def.json
+++ b/resources/definitions/snapmaker2.def.json
@@ -26,7 +26,7 @@
             "default_value": true
         },
         "machine_start_gcode": {
-            "default_value": "M104 S{material_print_temperature} ;Set Hotend Temperature\nM140 S{material_bed_temperature} ;Set Bed Temperature\nG28 ;home\nG90 ;absolute positioning\nG1 X-10 Y-10 F3000 ;Move to corner \nG1 Z0 F1800 ;Go to zero offset\nM109 S{material_print_temperature} ;Wait for Hotend Temperature\nM190 S{material_bed_temperature} ;Wait for Bed Temperature\nG92 E0 ;Zero set extruder position\nG1 E20 F200 ;Feed filament to clear nozzle\nG92 E0 ;Zero set extruder position"
+            "default_value": "M104 S{material_print_temperature_layer_0} ;Set Hotend Temperature\nM140 S{material_bed_temperature_layer_0} ;Set Bed Temperature\nG28 ;home\nG90 ;absolute positioning\nG1 X-10 Y-10 F3000 ;Move to corner \nG1 Z0 F1800 ;Go to zero offset\nM109 S{material_print_temperature_layer_0} ;Wait for Hotend Temperature\nM190 S{material_bed_temperature_layer_0} ;Wait for Bed Temperature\nG92 E0 ;Zero set extruder position\nG1 E20 F200 ;Feed filament to clear nozzle\nG92 E0 ;Zero set extruder position"
         },
         "machine_end_gcode": {
             "default_value": "M104 S0 ;Extruder heater off\nM140 S0 ;Heated bed heater off\nG90 ;absolute positioning\nG92 E0 ;Retract the filament\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z{machine_width} E-1 F3000 ;move Z up a bit and retract filament even more\nG1 X0 F3000 ;move X to min endstops, so the head is out of the way\nG1 Y{machine_depth} F3000 ;so the head is out of the way and Plate is moved forward"


### PR DESCRIPTION
Fixing the initial print temperature for print head and bed for the Snapmaker profile so that users can set the "Printing Temperature Initial Layer" and "Build Plate Temperature Initial Layer" properties and they actually do something.