### PR TITLE
[CURA-8539] HTTP Request Manager Login

### DIFF
--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -70,7 +70,8 @@ class AuthorizationHelpers:
             "refresh_token": refresh_token,
             "scope": self._settings.CLIENT_SCOPES if self._settings.CLIENT_SCOPES is not None else "",
         }
-        HttpRequestManager.getInstance().post(self._token_url, data = json.dumps(data).encode("UTF-8"), callback = lambda reply: self.parseTokenResponse(reply, response_callback))
+        headers = {"Content-type": "application/x-www-form-urlencoded"}
+        HttpRequestManager.getInstance().post(self._token_url, data = urllib.parse.urlencode(data).encode("UTF-8"), headers_dict = headers, callback = lambda reply: self.parseTokenResponse(reply, response_callback))
 
     @staticmethod
     def parseTokenResponse(token_response: QNetworkReply, response_callback: Callable[[AuthenticationResponse], None]) -> None:

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -55,12 +55,13 @@ class AuthorizationHelpers:
         headers = {"Content-type": "application/x-www-form-urlencoded"}
         HttpRequestManager.getInstance().post(self._token_url, data = urllib.parse.urlencode(data).encode("UTF-8"), headers_dict = headers, callback = lambda reply: self.parseTokenResponse(reply, response_callback))
 
-    def getAccessTokenUsingRefreshToken(self, refresh_token: str) -> None:
+    def getAccessTokenUsingRefreshToken(self, refresh_token: str, response_callback: Callable[[AuthenticationResponse], None]) -> None:
         """
         Request the access token from the authorization server using a refresh token.
         :param refresh_token: A valid encoded refresh key to get new access with.
+        :param response_callback: When the token has been obtained, call this function to communicate the token to the
+        caller. This will be responding asynchronously.
         """
-
         Logger.log("d", "Refreshing the access token for [%s]", self._settings.OAUTH_SERVER_URL)
         data = {
             "client_id": self._settings.CLIENT_ID if self._settings.CLIENT_ID is not None else "",
@@ -69,7 +70,7 @@ class AuthorizationHelpers:
             "refresh_token": refresh_token,
             "scope": self._settings.CLIENT_SCOPES if self._settings.CLIENT_SCOPES is not None else "",
         }
-        HttpRequestManager.getInstance().post(self._token_url, data = json.dumps(data).encode("UTF-8"), callback = self.parseTokenResponse)
+        HttpRequestManager.getInstance().post(self._token_url, data = json.dumps(data).encode("UTF-8"), callback = lambda reply: self.parseTokenResponse(reply, response_callback))
 
     @staticmethod
     def parseTokenResponse(token_response: QNetworkReply, response_callback: Callable[[AuthenticationResponse], None]) -> None:

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -53,7 +53,12 @@ class AuthorizationHelpers:
             "scope": self._settings.CLIENT_SCOPES if self._settings.CLIENT_SCOPES is not None else "",
             }
         headers = {"Content-type": "application/x-www-form-urlencoded"}
-        HttpRequestManager.getInstance().post(self._token_url, data = urllib.parse.urlencode(data).encode("UTF-8"), headers_dict = headers, callback = lambda reply: self.parseTokenResponse(reply, response_callback))
+        HttpRequestManager.getInstance().post(
+            self._token_url,
+            data = urllib.parse.urlencode(data).encode("UTF-8"),
+            headers_dict = headers,
+            callback = lambda reply: self.parseTokenResponse(reply, response_callback)
+        )
 
     def getAccessTokenUsingRefreshToken(self, refresh_token: str, response_callback: Callable[[AuthenticationResponse], None]) -> None:
         """
@@ -71,7 +76,12 @@ class AuthorizationHelpers:
             "scope": self._settings.CLIENT_SCOPES if self._settings.CLIENT_SCOPES is not None else "",
         }
         headers = {"Content-type": "application/x-www-form-urlencoded"}
-        HttpRequestManager.getInstance().post(self._token_url, data = urllib.parse.urlencode(data).encode("UTF-8"), headers_dict = headers, callback = lambda reply: self.parseTokenResponse(reply, response_callback))
+        HttpRequestManager.getInstance().post(
+            self._token_url,
+            data = urllib.parse.urlencode(data).encode("UTF-8"),
+            headers_dict = headers,
+            callback = lambda reply: self.parseTokenResponse(reply, response_callback)
+        )
 
     @staticmethod
     def parseTokenResponse(token_response: QNetworkReply, response_callback: Callable[[AuthenticationResponse], None]) -> None:

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -50,7 +50,8 @@ class AuthorizationHelpers:
             "code_verifier": verification_code,
             "scope": self._settings.CLIENT_SCOPES if self._settings.CLIENT_SCOPES is not None else "",
             }
-        HttpRequestManager.getInstance().post(self._token_url, data = urllib.parse.urlencode(data).encode("UTF-8"), callback = lambda reply: self.parseTokenResponse(reply, response_callback))
+        headers = {"Content-type": "application/x-www-form-urlencoded"}
+        HttpRequestManager.getInstance().post(self._token_url, data = urllib.parse.urlencode(data).encode("UTF-8"), headers_dict = headers, callback = lambda reply: self.parseTokenResponse(reply, response_callback))
 
     def getAccessTokenUsingRefreshToken(self, refresh_token: str) -> None:
         """Request the access token from the authorization server using a refresh token.

--- a/cura/OAuth2/AuthorizationRequestHandler.py
+++ b/cura/OAuth2/AuthorizationRequestHandler.py
@@ -68,6 +68,7 @@ class AuthorizationRequestHandler(BaseHTTPRequestHandler):
             self._responseCallback(server_response, token_response)
         elif code and self.authorization_helpers is not None and self.verification_code is not None:
             # If the code was returned we get the access token.
+            server_response.redirect_uri = self.authorization_helpers.settings.AUTH_SUCCESS_REDIRECT
             self.authorization_helpers.getAccessTokenUsingAuthorizationCode(code, self.verification_code, lambda token: self._responseCallback(server_response, token))
 
         elif self._queryGet(query, "error_code") == "user_denied":

--- a/cura/OAuth2/LocalAuthorizationServer.py
+++ b/cura/OAuth2/LocalAuthorizationServer.py
@@ -1,10 +1,11 @@
-# Copyright (c) 2020 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
-import sys
+
 import threading
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
 from UM.Logger import Logger
+from UM.Platform import Platform
 
 got_server_type = False
 try:
@@ -100,7 +101,7 @@ class LocalAuthorizationServer:
         """
         Logger.log("d", "Local web server for authorization has started")
         if self._web_server:
-            if sys.platform == "win32":
+            if Platform.isWindows():
                 try:
                     self._web_server.serve_forever()
                 except OSError:


### PR DESCRIPTION
I think someone forgot to make a pull, since the ticket is in review. Will make a t least a draft PR here.

> The OAuth flow is currently the only place where we still use requests. In all other places we have refactored the code to use HttpRequestManager instead.
We have found the following issues with requests;
Certain companies use ZScaler. This seems to install custom certificates on the machine, which isn't handled correctly by Requests. Qt does handle this correctly
Requests does not support OCSP stapling, Qt does (needed for CURA-8402)
Furthermore, it's also just easier to not have to work with two different network libraries. Do note that our current network implementation does not have blocking network requests and requests does. Although it should make certain things run a bit smoother, it might cause issues when refactoring this.