### PR TITLE
Fix shader compilation on some GPUs

### DIFF
--- a/plugins/SimulationView/layers3d.shader
+++ b/plugins/SimulationView/layers3d.shader
@@ -111,7 +111,7 @@ vertex41core =
 
     float clamp(float v)
     {
-        float t = v < 0 ? 0 : v;
+        float t = v < 0.0 ? 0.0 : v;
         return t > 1.0 ? 1.0 : t;
     }
 


### PR DESCRIPTION
This PR fixes a compilation error of the shader used to render the simulation view. Some GPUs (rightly) complain about the difference between a float and an int. 

Fixes #10837