### PR TITLE
[CURA-8541] Add handling of missing printJob status cases

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml
@@ -73,10 +73,6 @@ Item
             switch (printJob.state)
             {
                 case "wait_cleanup":
-                    if (printJob.timeTotal > printJob.timeElapsed)
-                    {
-                        return catalog.i18nc("@label:status", "Aborted");
-                    }
                     return catalog.i18nc("@label:status", "Finished");
                 case "finished":
                     return catalog.i18nc("@label:status", "Finished");
@@ -88,6 +84,20 @@ Item
                     return catalog.i18nc("@label:status", "Aborting...");
                 case "aborted": // NOTE: Unused, see above
                     return catalog.i18nc("@label:status", "Aborted");
+                case "aborted_post_print":
+                    return catalog.i18nc("@label:status", "Aborted");
+                case "aborted_wait_user_action":
+                    return catalog.i18nc("@label:status", "Aborted");
+                case "aborted_wait_cleanup":
+                    return catalog.i18nc("@label:status", "Aborted");
+                case "failed":
+                    return catalog.i18nc("@label:status", "Failed");
+                case "failed_post_print":
+                    return catalog.i18nc("@label:status", "Failed");
+                case "failed_wait_user_action":
+                    return catalog.i18nc("@label:status", "Failed");
+                case "failed_wait_cleanup":
+                    return catalog.i18nc("@label:status", "Failed");
                 case "pausing":
                     return catalog.i18nc("@label:status", "Pausing...");
                 case "paused":


### PR DESCRIPTION
The `printJob` now also contains a status for detecting aborted prints that were awaiting cleanup, preventing the need for the additional checks in the `await_cleanup` status.

Fixes CURA-8541