### PR TITLE
OAuth via HttpRequestManager

### DIFF
--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -1,15 +1,15 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2021 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
-from datetime import datetime
-from typing import Any, Optional, Dict, TYPE_CHECKING, Callable
 
+from datetime import datetime
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, pyqtProperty, QTimer, Q_ENUMS
+from typing import Any, Optional, Dict, TYPE_CHECKING, Callable
 
 from UM.Logger import Logger
 from UM.Message import Message
 from UM.i18n import i18nCatalog
 from cura.OAuth2.AuthorizationService import AuthorizationService
-from cura.OAuth2.Models import OAuth2Settings
+from cura.OAuth2.Models import OAuth2Settings, UserProfile
 from cura.UltimakerCloud import UltimakerCloudConstants
 
 if TYPE_CHECKING:
@@ -46,6 +46,9 @@ class Account(QObject):
     loginStateChanged = pyqtSignal(bool)
     """Signal emitted when user logged in or out"""
 
+    userProfileChanged = pyqtSignal()
+    """Signal emitted when new account information is available."""
+
     additionalRightsChanged = pyqtSignal("QVariantMap")
     """Signal emitted when a users additional rights change"""
 
@@ -73,6 +76,7 @@ class Account(QObject):
 
         self._error_message = None  # type: Optional[Message]
         self._logged_in = False
+        self._user_profile = None
         self._additional_rights: Dict[str, Any] = {}
         self._sync_state = SyncState.IDLE
         self._manual_sync_enabled = False
@@ -196,11 +200,16 @@ class Account(QObject):
             self._logged_in = logged_in
             self.loginStateChanged.emit(logged_in)
             if logged_in:
+                self._authorization_service.getUserProfile(self._onProfileChanged)
                 self._setManualSyncEnabled(False)
                 self._sync()
             else:
                 if self._update_timer.isActive():
                     self._update_timer.stop()
+
+    def _onProfileChanged(self, profile: UserProfile):
+        self._user_profile = profile
+        self.userProfileChanged.emit(profile)
 
     def _sync(self) -> None:
         """Signals all sync services to start syncing
@@ -243,32 +252,28 @@ class Account(QObject):
                 return
         self._authorization_service.startAuthorizationFlow(force_logout_before_login)
 
-    @pyqtProperty(str, notify=loginStateChanged)
+    @pyqtProperty(str, notify = userProfileChanged)
     def userName(self):
-        user_profile = self._authorization_service.getUserProfile()
-        if not user_profile:
-            return None
-        return user_profile.username
+        if not self._user_profile:
+            return ""
+        return self._user_profile.username
 
-    @pyqtProperty(str, notify = loginStateChanged)
+    @pyqtProperty(str, notify = userProfileChanged)
     def profileImageUrl(self):
-        user_profile = self._authorization_service.getUserProfile()
-        if not user_profile:
-            return None
-        return user_profile.profile_image_url
+        if not self._user_profile:
+            return ""
+        return self._user_profile.profile_image_url
 
     @pyqtProperty(str, notify=accessTokenChanged)
     def accessToken(self) -> Optional[str]:
         return self._authorization_service.getAccessToken()
 
-    @pyqtProperty("QVariantMap", notify = loginStateChanged)
+    @pyqtProperty("QVariantMap", notify = userProfileChanged)
     def userProfile(self) -> Optional[Dict[str, Optional[str]]]:
         """None if no user is logged in otherwise the logged in  user as a dict containing containing user_id, username and profile_image_url """
-
-        user_profile = self._authorization_service.getUserProfile()
-        if not user_profile:
+        if not self._user_profile:
             return None
-        return user_profile.__dict__
+        return self._user_profile.__dict__
 
     @pyqtProperty(str, notify=lastSyncDateTimeChanged)
     def lastSyncDateTime(self) -> str:

--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -74,14 +74,14 @@ class Account(QObject):
         self._application = application
         self._new_cloud_printers_detected = False
 
-        self._error_message = None  # type: Optional[Message]
+        self._error_message: Optional[Message] = None
         self._logged_in = False
-        self._user_profile = None  # type: Optional[UserProfile]
+        self._user_profile: Optional[UserProfile] = None
         self._additional_rights: Dict[str, Any] = {}
         self._sync_state = SyncState.IDLE
         self._manual_sync_enabled = False
         self._update_packages_enabled = False
-        self._update_packages_action = None  # type: Optional[Callable]
+        self._update_packages_action: Optional[Callable] = None
         self._last_sync_str = "-"
 
         self._callback_port = 32118
@@ -107,7 +107,7 @@ class Account(QObject):
         self._update_timer.setSingleShot(True)
         self._update_timer.timeout.connect(self.sync)
 
-        self._sync_services = {}  # type: Dict[str, int]
+        self._sync_services: Dict[str, int] = {}
         """contains entries "service_name" : SyncState"""
 
     def initialize(self) -> None:

--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -207,7 +207,7 @@ class Account(QObject):
                 if self._update_timer.isActive():
                     self._update_timer.stop()
 
-    def _onProfileChanged(self, profile: UserProfile) -> None:
+    def _onProfileChanged(self, profile: Optional[UserProfile]) -> None:
         self._user_profile = profile
         self.userProfileChanged.emit()
 

--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -76,7 +76,7 @@ class Account(QObject):
 
         self._error_message = None  # type: Optional[Message]
         self._logged_in = False
-        self._user_profile = None
+        self._user_profile = None  # type: Optional[UserProfile]
         self._additional_rights: Dict[str, Any] = {}
         self._sync_state = SyncState.IDLE
         self._manual_sync_enabled = False
@@ -207,7 +207,7 @@ class Account(QObject):
                 if self._update_timer.isActive():
                     self._update_timer.stop()
 
-    def _onProfileChanged(self, profile: UserProfile):
+    def _onProfileChanged(self, profile: UserProfile) -> None:
         self._user_profile = profile
         self.userProfileChanged.emit()
 

--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -209,7 +209,7 @@ class Account(QObject):
 
     def _onProfileChanged(self, profile: UserProfile):
         self._user_profile = profile
-        self.userProfileChanged.emit(profile)
+        self.userProfileChanged.emit()
 
     def _sync(self) -> None:
         """Signals all sync services to start syncing

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -94,12 +94,12 @@ class AuthorizationHelpers:
             return
 
         callback(AuthenticationResponse(success = True,
-            token_type = token_data["token_type"],
-            access_token = token_data["access_token"],
-            refresh_token = token_data["refresh_token"],
-            expires_in = token_data["expires_in"],
-            scope = token_data["scope"],
-            received_at = datetime.now().strftime(TOKEN_TIMESTAMP_FORMAT)))
+                                        token_type = token_data["token_type"],
+                                        access_token = token_data["access_token"],
+                                        refresh_token = token_data["refresh_token"],
+                                        expires_in = token_data["expires_in"],
+                                        scope = token_data["scope"],
+                                        received_at = datetime.now().strftime(TOKEN_TIMESTAMP_FORMAT)))
         return
 
     def checkToken(self, access_token: str, success_callback: Optional[Callable[[UserProfile], None]] = None, failed_callback: Optional[Callable[[], None]] = None) -> None:

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -51,7 +51,8 @@ class AuthorizationHelpers:
             self._token_url,
             data = urllib.parse.urlencode(data).encode("UTF-8"),
             headers_dict = headers,
-            callback = lambda response: self.parseTokenResponse(response, callback)
+            callback = lambda response: self.parseTokenResponse(response, callback),
+            error_callback = lambda response, _: self.parseTokenResponse(response, callback)
         )
 
     def getAccessTokenUsingRefreshToken(self, refresh_token: str, callback: Callable[[AuthenticationResponse], None]) -> None:
@@ -74,7 +75,7 @@ class AuthorizationHelpers:
             data = urllib.parse.urlencode(data).encode("UTF-8"),
             headers_dict = headers,
             callback = lambda response: self.parseTokenResponse(response, callback),
-            error_callback = lambda response: self.parseTokenResponse(response, callback)
+            error_callback = lambda response, _: self.parseTokenResponse(response, callback)
         )
 
     def parseTokenResponse(self, token_response: QNetworkReply, callback: Callable[[AuthenticationResponse], None]) -> None:

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -73,7 +73,8 @@ class AuthorizationHelpers:
             self._token_url,
             data = urllib.parse.urlencode(data).encode("UTF-8"),
             headers_dict = headers,
-            callback = lambda response: self.parseTokenResponse(response, callback)
+            callback = lambda response: self.parseTokenResponse(response, callback),
+            error_callback = lambda response: self.parseTokenResponse(response, callback)
         )
 
     def parseTokenResponse(self, token_response: QNetworkReply, callback: Callable[[AuthenticationResponse], None]) -> None:

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -118,7 +118,7 @@ class AuthorizationHelpers:
             check_token_url,
             headers_dict = headers,
             callback = lambda reply: self._parseUserProfile(reply, success_callback, failed_callback),
-            error_callback = lambda _: failed_callback()
+            error_callback = lambda _, _2: failed_callback() if failed_callback is not None else None
         )
 
     def _parseUserProfile(self, reply: QNetworkReply, success_callback: Optional[Callable[[UserProfile], None]], failed_callback: Optional[Callable[[], None]] = None) -> None:

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -132,20 +132,23 @@ class AuthorizationHelpers:
         """
         if reply.error() != QNetworkReply.NetworkError.NoError:
             Logger.warning(f"Could not access account information. QNetworkError {reply.errorString()}")
-            failed_callback()
+            if failed_callback is not None:
+                failed_callback()
             return
 
         profile_data = HttpRequestManager.getInstance().readJSON(reply)
         if profile_data is None or "data" not in profile_data:
             Logger.warning("Could not parse user data from token.")
-            failed_callback()
+            if failed_callback is not None:
+                failed_callback()
             return
         profile_data = profile_data["data"]
 
         required_fields = {"user_id", "username"}
         if "user_id" not in profile_data or "username" not in profile_data:
             Logger.warning(f"User data missing required field(s): {required_fields - set(profile_data.keys())}")
-            failed_callback()
+            if failed_callback is not None:
+                failed_callback()
             return
 
         success_callback(UserProfile(

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -153,13 +153,14 @@ class AuthorizationHelpers:
                 failed_callback()
             return
 
-        success_callback(UserProfile(
-            user_id = profile_data["user_id"],
-            username = profile_data["username"],
-            profile_image_url = profile_data.get("profile_image_url", ""),
-            organization_id = profile_data.get("organization", {}).get("organization_id"),
-            subscriptions = profile_data.get("subscriptions", [])
-        ))
+        if success_callback is not None:
+            success_callback(UserProfile(
+                user_id = profile_data["user_id"],
+                username = profile_data["username"],
+                profile_image_url = profile_data.get("profile_image_url", ""),
+                organization_id = profile_data.get("organization", {}).get("organization_id"),
+                subscriptions = profile_data.get("subscriptions", [])
+            ))
 
     @staticmethod
     def generateVerificationCode(code_length: int = 32) -> str:

--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -8,7 +8,6 @@ from PyQt5.QtNetwork import QNetworkReply
 import secrets
 from threading import Lock
 from typing import Callable, Optional
-import requests
 import urllib.parse
 
 from UM.i18n import i18nCatalog

--- a/cura/OAuth2/AuthorizationRequestHandler.py
+++ b/cura/OAuth2/AuthorizationRequestHandler.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 catalog = i18nCatalog("cura")
 
+
 class AuthorizationRequestHandler(BaseHTTPRequestHandler):
     """This handler handles all HTTP requests on the local web server.
 

--- a/cura/OAuth2/AuthorizationRequestHandler.py
+++ b/cura/OAuth2/AuthorizationRequestHandler.py
@@ -25,11 +25,11 @@ class AuthorizationRequestHandler(BaseHTTPRequestHandler):
         super().__init__(request, client_address, server)
 
         # These values will be injected by the HTTPServer that this handler belongs to.
-        self.authorization_helpers = None  # type: Optional[AuthorizationHelpers]
-        self.authorization_callback = None  # type: Optional[Callable[[AuthenticationResponse], None]]
-        self.verification_code = None  # type: Optional[str]
+        self.authorization_helpers: Optional[AuthorizationHelpers] = None
+        self.authorization_callback: Optional[Callable[[AuthenticationResponse], None]] = None
+        self.verification_code: Optional[str] = None
 
-        self.state = None  # type: Optional[str]
+        self.state: Optional[str] = None
 
     # CURA-6609: Some browser seems to issue a HEAD instead of GET request as the callback.
     def do_HEAD(self) -> None:

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -42,13 +42,13 @@ class AuthorizationService:
         self._settings = settings
         self._auth_helpers = AuthorizationHelpers(settings)
         self._auth_url = "{}/authorize".format(self._settings.OAUTH_SERVER_URL)
-        self._auth_data = None  # type: Optional[AuthenticationResponse]
-        self._user_profile = None  # type: Optional["UserProfile"]
+        self._auth_data: Optional[AuthenticationResponse] = None
+        self._user_profile: Optional["UserProfile"] = None
         self._preferences = preferences
         self._server = LocalAuthorizationServer(self._auth_helpers, self._onAuthStateChanged, daemon=True)
         self._currently_refreshing_token = False  # Whether we are currently in the process of refreshing auth. Don't make new requests while busy.
 
-        self._unable_to_get_data_message = None  # type: Optional[Message]
+        self._unable_to_get_data_message: Optional[Message] = None
 
         self.onAuthStateChanged.connect(self._authChanged)
 

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -134,7 +134,7 @@ class AuthorizationService:
 
             self._auth_helpers.getAccessTokenUsingRefreshToken(self._auth_data.refresh_token, process_auth_data)
 
-        self._auth_helpers.checkToken(self._auth_data.access_token, check_user_profile, lambda: callback(None))
+        self._auth_helpers.checkToken(self._auth_data.access_token, check_user_profile, lambda: check_user_profile(None))
 
     def getAccessToken(self) -> Optional[str]:
         """Get the access token as provided by the response data."""

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -74,19 +74,22 @@ class AuthorizationService:
         """
         if self._user_profile:
             # We already obtained the profile. No need to make another request for it.
-            callback(self._user_profile)
+            if callback is not None:
+                callback(self._user_profile)
             return
 
         # If no user profile was stored locally, we try to get it from JWT.
         def store_profile(profile: Optional["UserProfile"]):
             if profile is not None:
                 self._user_profile = profile
-                callback(profile)
+                if callback is not None:
+                    callback(profile)
             elif self._auth_data:
                 # If there is no user profile from the JWT, we have to log in again.
                 Logger.warning("The user profile could not be loaded. The user must log in again!")
                 self.deleteAuthData()
-                callback(None)
+                if callback is not None:
+                    callback(None)
 
         self._parseJWT(callback = store_profile)
 

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -89,6 +89,9 @@ class AuthorizationService:
                 self.deleteAuthData()
                 if callback is not None:
                     callback(None)
+            else:
+                if callback is not None:
+                    callback(None)
 
         self._parseJWT(callback = store_profile)
 

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -134,7 +134,7 @@ class AuthorizationService:
 
             self._auth_helpers.getAccessTokenUsingRefreshToken(self._auth_data.refresh_token, process_auth_data)
 
-        self._auth_helpers.checkToken(self._auth_data.access_token, check_user_profile)
+        self._auth_helpers.checkToken(self._auth_data.access_token, check_user_profile, lambda: callback(None))
 
     def getAccessToken(self) -> Optional[str]:
         """Get the access token as provided by the response data."""

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 MYCLOUD_LOGOFF_URL = "https://account.ultimaker.com/logoff?utm_source=cura&utm_medium=software&utm_campaign=change-account-before-adding-printers"
 
+
 class AuthorizationService:
     """The authorization service is responsible for handling the login flow, storing user credentials and providing
     account information.
@@ -62,7 +63,7 @@ class AuthorizationService:
         if self._preferences:
             self._preferences.addPreference(self._settings.AUTH_DATA_PREFERENCE_KEY, "{}")
 
-    def getUserProfile(self, callback: Callable[[Optional["UserProfile"]], None] = None) -> None:
+    def getUserProfile(self, callback: Optional[Callable[[Optional["UserProfile"]], None]] = None) -> None:
         """
         Get the user profile as obtained from the JWT (JSON Web Token).
 
@@ -79,7 +80,7 @@ class AuthorizationService:
             return
 
         # If no user profile was stored locally, we try to get it from JWT.
-        def store_profile(profile: Optional["UserProfile"]):
+        def store_profile(profile: Optional["UserProfile"]) -> None:
             if profile is not None:
                 self._user_profile = profile
                 if callback is not None:
@@ -110,7 +111,7 @@ class AuthorizationService:
             return
 
         # When we checked the token we may get a user profile. This callback checks if that is a valid one and tries to refresh the token if it's not.
-        def check_user_profile(user_profile):
+        def check_user_profile(user_profile: Optional["UserProfile"]) -> None:
             if user_profile:
                 # If the profile was found, we call it back immediately.
                 callback(user_profile)
@@ -121,7 +122,7 @@ class AuthorizationService:
                 callback(None)
                 return
 
-            def process_auth_data(auth_data: AuthenticationResponse):
+            def process_auth_data(auth_data: AuthenticationResponse) -> None:
                 if auth_data.access_token is None:
                     Logger.warning("Unable to use the refresh token to get a new access token.")
                     callback(None)
@@ -161,7 +162,7 @@ class AuthorizationService:
             Logger.log("w", "Unable to refresh access token, since there is no refresh token.")
             return
 
-        def process_auth_data(response: AuthenticationResponse):
+        def process_auth_data(response: AuthenticationResponse) -> None:
             if response.success:
                 self._storeAuthData(response)
                 self.onAuthStateChanged.emit(logged_in = True)
@@ -264,7 +265,7 @@ class AuthorizationService:
                 self._auth_data = AuthenticationResponse(**preferences_data)
 
                 # Also check if we can actually get the user profile information.
-                def callback(profile: Optional["UserProfile"]):
+                def callback(profile: Optional["UserProfile"]) -> None:
                     if profile is not None:
                         self.onAuthStateChanged.emit(logged_in = True)
                         Logger.debug("Auth data was successfully loaded")
@@ -272,7 +273,8 @@ class AuthorizationService:
                         if self._unable_to_get_data_message is not None:
                             self._unable_to_get_data_message.show()
                         else:
-                            self._unable_to_get_data_message = Message(i18n_catalog.i18nc("@info", "Unable to reach the Ultimaker account server."),
+                            self._unable_to_get_data_message = Message(i18n_catalog.i18nc("@info",
+                                                                                          "Unable to reach the Ultimaker account server."),
                                                                        title = i18n_catalog.i18nc("@info:title", "Log-in failed"),
                                                                        message_type = Message.MessageType.ERROR)
                             Logger.warning("Unable to get user profile using auth data from preferences.")

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -249,7 +249,7 @@ class AuthorizationService:
                 self._auth_data = AuthenticationResponse(**preferences_data)
 
                 # Also check if we can actually get the user profile information.
-                def callback(profile: Optional[UserProfile]):
+                def callback(profile: Optional["UserProfile"]):
                     if profile is not None:
                         self.onAuthStateChanged.emit(logged_in = True)
                         Logger.debug("Auth data was successfully loaded")

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -103,6 +103,7 @@ class AuthorizationService:
             # If no auth data exists, we should always log in again.
             Logger.debug("There was no auth data or access token")
             callback(None)
+            return
 
         # When we checked the token we may get a user profile. This callback checks if that is a valid one and tries to refresh the token if it's not.
         def check_user_profile(user_profile):

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -3,7 +3,7 @@
 
 import json
 from datetime import datetime, timedelta
-from typing import Callable, Dict, Optional, TYPE_CHECKING
+from typing import Callable, Dict, Optional, TYPE_CHECKING, Union
 from urllib.parse import urlencode, quote_plus
 
 from PyQt5.QtCore import QUrl
@@ -15,7 +15,7 @@ from UM.Signal import Signal
 from UM.i18n import i18nCatalog
 from cura.OAuth2.AuthorizationHelpers import AuthorizationHelpers, TOKEN_TIMESTAMP_FORMAT
 from cura.OAuth2.LocalAuthorizationServer import LocalAuthorizationServer
-from cura.OAuth2.Models import AuthenticationResponse
+from cura.OAuth2.Models import AuthenticationResponse, BaseModel
 
 i18n_catalog = i18nCatalog("cura")
 
@@ -117,7 +117,7 @@ class AuthorizationService:
                 callback(user_profile)
                 return
             # The JWT was expired or invalid and we should request a new one.
-            if self._auth_data.refresh_token is None:
+            if self._auth_data is None or self._auth_data.refresh_token is None:
                 Logger.warning("There was no refresh token in the auth data.")
                 callback(None)
                 return

--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 from typing import Callable, Dict, Optional, TYPE_CHECKING
 from urllib.parse import urlencode, quote_plus
 
-import requests.exceptions
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QDesktopServices
 

--- a/plugins/Toolbox/src/CloudSync/CloudPackageChecker.py
+++ b/plugins/Toolbox/src/CloudSync/CloudPackageChecker.py
@@ -66,7 +66,7 @@ class CloudPackageChecker(QObject):
         self._application.getHttpRequestManager().get(url,
                                                       callback = self._onUserPackagesRequestFinished,
                                                       error_callback = self._onUserPackagesRequestFinished,
-                                                      timeout=10,
+                                                      timeout = 10,
                                                       scope = self._scope)
 
     def _onUserPackagesRequestFinished(self, reply: "QNetworkReply", error: Optional["QNetworkReply.NetworkError"] = None) -> None:

--- a/tests/API/TestAccount.py
+++ b/tests/API/TestAccount.py
@@ -80,46 +80,6 @@ def test_errorLoginState(application):
     account._onLoginStateChanged(False, "OMGZOMG!")
     account.loginStateChanged.emit.called_with(False)
 
-
-def test_userName(user_profile):
-    account = Account(MagicMock())
-    mocked_auth_service = MagicMock()
-    account._authorization_service = mocked_auth_service
-    mocked_auth_service.getUserProfile = MagicMock(return_value = user_profile)
-
-    assert account.userName == "username!"
-
-    mocked_auth_service.getUserProfile = MagicMock(return_value=None)
-    assert account.userName is None
-
-
-def test_profileImageUrl(user_profile):
-    account = Account(MagicMock())
-    mocked_auth_service = MagicMock()
-    account._authorization_service = mocked_auth_service
-    mocked_auth_service.getUserProfile = MagicMock(return_value = user_profile)
-
-    assert account.profileImageUrl == "profile_image_url!"
-
-    mocked_auth_service.getUserProfile = MagicMock(return_value=None)
-    assert account.profileImageUrl is None
-
-
-def test_userProfile(user_profile):
-    account = Account(MagicMock())
-    mocked_auth_service = MagicMock()
-    account._authorization_service = mocked_auth_service
-    mocked_auth_service.getUserProfile = MagicMock(return_value=user_profile)
-
-    returned_user_profile = account.userProfile
-    assert returned_user_profile["username"] == "username!"
-    assert returned_user_profile["profile_image_url"] == "profile_image_url!"
-    assert returned_user_profile["user_id"] == "user_id!"
-
-    mocked_auth_service.getUserProfile = MagicMock(return_value=None)
-    assert account.userProfile is None
-
-
 def test_sync_success():
     account = Account(MagicMock())
 

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -50,7 +50,9 @@ MALFORMED_AUTH_RESPONSE = AuthenticationResponse(success=False)
 
 
 def test_cleanAuthService() -> None:
-    # Ensure that when setting up an AuthorizationService, no data is set.
+    """
+    Ensure that when setting up an AuthorizationService, no data is set.
+    """
     authorization_service = AuthorizationService(OAUTH_SETTINGS, Preferences())
     authorization_service.initialize()
 

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -217,7 +217,7 @@ def test_failedLogin() -> None:
     assert authorization_service.getUserProfile() is None
     assert authorization_service.getAccessToken() is None
 
-@patch.object(AuthorizationService, "getUserProfile", return_value=UserProfile())
+@patch.object(AuthorizationService, "getUserProfile")
 def test_storeAuthData(get_user_profile) -> None:
     preferences = Preferences()
     authorization_service = AuthorizationService(OAUTH_SETTINGS, preferences)

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -120,9 +120,11 @@ def test__parseJWTFailOnRefresh():
     mock_reply.error = Mock(return_value = QNetworkReply.NetworkError.AuthenticationRequiredError)  # The reply is 403: Authentication required, meaning the server responded with a "Can't do that, Dave".
     http_mock = Mock()
     http_mock.get = lambda url, headers_dict, callback, error_callback: callback(mock_reply)
+    http_mock.post = lambda url, data, headers_dict, callback, error_callback: callback(mock_reply)
 
-    with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.getInstance", MagicMock(return_value = http_mock)):
-        authorization_service._parseJWT(mock_callback)
+    with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.readJSON", Mock(return_value = {"error_description": "Mock a failed request!"})):
+        with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.getInstance", MagicMock(return_value = http_mock)):
+            authorization_service._parseJWT(mock_callback)
     mock_callback.assert_called_once_with(None)
 
 def test__parseJWTSucceedOnRefresh():

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -1,7 +1,8 @@
+# Copyright (c) 2021 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
 from datetime import datetime
 from unittest.mock import MagicMock, Mock, patch
-
-import requests
 
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtNetwork import QNetworkReply

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import requests
 
@@ -53,7 +53,11 @@ def test_cleanAuthService() -> None:
     # Ensure that when setting up an AuthorizationService, no data is set.
     authorization_service = AuthorizationService(OAUTH_SETTINGS, Preferences())
     authorization_service.initialize()
-    assert authorization_service.getUserProfile() is None
+
+    mock_callback = Mock()
+    authorization_service.getUserProfile(mock_callback)
+    mock_callback.assert_called_once_with(None)
+
     assert authorization_service.getAccessToken() is None
 
 

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -199,12 +199,6 @@ def test_refreshAccesTokenWithoutData():
     authorization_service.refreshAccessToken()
     authorization_service.onAuthStateChanged.emit.assert_not_called()
 
-def test_userProfileException():
-    authorization_service = AuthorizationService(OAUTH_SETTINGS, Preferences())
-    authorization_service.initialize()
-    authorization_service._parseJWT = MagicMock(side_effect=requests.exceptions.ConnectionError)
-    assert authorization_service.getUserProfile() is None
-
 def test_failedLogin() -> None:
     authorization_service = AuthorizationService(OAUTH_SETTINGS, Preferences())
     authorization_service.onAuthenticationError.emit = MagicMock()

--- a/tests/TestOAuth2.py
+++ b/tests/TestOAuth2.py
@@ -297,9 +297,11 @@ def test_loginAndLogout() -> None:
 def test_wrongServerResponses() -> None:
     authorization_service = AuthorizationService(OAUTH_SETTINGS, Preferences())
     authorization_service.initialize()
-    with patch.object(AuthorizationHelpers, "parseJWT", return_value=UserProfile()):
-        authorization_service._onAuthStateChanged(MALFORMED_AUTH_RESPONSE)
-    assert authorization_service.getUserProfile() is None
+    authorization_service._onAuthStateChanged(MALFORMED_AUTH_RESPONSE)
+
+    def callback(profile):
+        assert profile is None
+    authorization_service.getUserProfile(callback)
 
 def test__generate_auth_url() -> None:
     preferences = Preferences()


### PR DESCRIPTION
The OAuth log-in flow was using the `requests` library. This was a problem for us for three reasons:
* The `requests` library doesn't properly use the desktop integrations of network requests, like the OS-provided local SSL certificate roots.
* The `requests` library is blocking, including blocking the main thread at start-up.
* The `requests` library is another attack vector for security issues. While there are no known issues with the current version, using a single library for all network requests reduces the attack surface.

This is a series of refactors to change that to use the HttpRequestManager, which uses the QNetworkManager under water. This does properly use local certificate roots and is not blocking. With this, we are no longer impacted by security issues in `requests` if any arise.

We cannot drop `requests` from our build environment until a major SDK increment. This means that plug-ins could still be using `requests` and be prone to not using those SSL certificate roots or security issues in `requests`.

The refactors below mostly have to do with becoming non-blocking. The HttpRequestManager is not blocking, and furthermore cannot be used in a blocking way unless it is certain that it is called from a different thread than the main thread. This is because the HttpRequestManager always executes some of its work on the main (Qt) thread due to usage of QTimers. If a function blocks the main thread while waiting for a request to finish from the HttpRequestManager, this results in a deadlock because the HttpRequestManager needs the Qt (main) thread to process its requests.
As a result of becoming asynchronous, the nested calls become a bit of a callback hell. Any feedback on how this can be improved is welcome.

Implements CURA-8539.