### PR TITLE
[CURA-8666] Don't restore files ignored with current backup policy.

### DIFF
--- a/cura/Backups/Backup.py
+++ b/cura/Backups/Backup.py
@@ -181,8 +181,7 @@ class Backup:
 
         return extracted
 
-    @staticmethod
-    def _extractArchive(archive: "ZipFile", target_path: str) -> bool:
+    def _extractArchive(self, archive: "ZipFile", target_path: str) -> bool:
         """Extract the whole archive to the given target path.
 
         :param archive: The archive as ZipFile.
@@ -201,7 +200,11 @@ class Backup:
         Resources.factoryReset()
         Logger.log("d", "Extracting backup to location: %s", target_path)
         name_list = archive.namelist()
+        ignore_string = re.compile("|".join(self.IGNORED_FILES + self.IGNORED_FOLDERS))
         for archive_filename in name_list:
+            if ignore_string.search(archive_filename):
+                Logger.warning(f"File ({archive_filename}) in archive that doesn't fit current backup policy; ignored.")
+                continue
             try:
                 archive.extract(archive_filename, target_path)
             except (PermissionError, EnvironmentError):


### PR DESCRIPTION
Restoring plugins will cause a headache when (they are large and) the central storage was removed in the mean time. Since it's current policy to ignore plugins _anyway_ when backing up, the simple solution is to also just don't restore them, even if they where present to begin with. Of course this is also applied to other to-be-ignored files and folder types.
