### PR TITLE
Add a default value to spool cost if defined in fdm material profile

### DIFF
--- a/resources/qml/Preferences/Materials/MaterialsView.qml
+++ b/resources/qml/Preferences/Materials/MaterialsView.qml
@@ -261,7 +261,7 @@ TabView
                 {
                     id: spoolCostSpinBox
                     width: scrollView.columnWidth
-                    value: base.getMaterialPreferenceValue(properties.guid, "spool_cost")
+                    value: base.getMaterialPreferenceValue(properties.guid, "spool_cost", Cura.ContainerManager.getContainerMetaDataEntry(properties.container_id, "properties/cost"))
                     prefix: base.currency + " "
                     decimals: 2
                     maximumValue: 100000000


### PR DESCRIPTION
Hello everyone,

This PR just adds a default value to the spool cost if defined in material profile.
It is just the very same behavior as for the spool weight.

Regards,
Orel