### PR TITLE
Pp 55 reduce cross3 d top layer bridge distance  - update after V&V testing

### DIFF
--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -48,7 +48,9 @@ skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
+skin_line_width = =round(line_width * 0.48 / 0.38, 2)
 
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -48,7 +48,9 @@ skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
+skin_line_width = =round(line_width * 0.48 / 0.38, 2)
 
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -47,7 +47,9 @@ skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
+skin_line_width = =round(line_width * 0.48 / 0.38, 2)
 
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Draft_Print.inst.cfg
@@ -48,7 +48,9 @@ skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
+skin_line_width = =round(line_width * 0.48 / 0.38, 2)
 
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Fast_Print.inst.cfg
@@ -48,7 +48,9 @@ skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
+skin_line_width = =round(line_width * 0.48 / 0.38, 2)
 
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -47,7 +47,9 @@ skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+
+speed_topbottom = =math.ceil(speed_print * 20 / 25)
+skin_line_width = =round(line_width * 0.48 / 0.38, 2)
 
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)


### PR DESCRIPTION
Increased the linewidth from 0.38mm to 0.48mm and reduced the speed from 25mm/s to 20mm/s for the skin layers of the TPU profiles (flow remains the same with this change). This reduced the pillowing effect on the TPU top layers.