### PR TITLE
Clarify the Simulation View plugin description

### DIFF
--- a/plugins/SimulationView/plugin.json
+++ b/plugins/SimulationView/plugin.json
@@ -2,7 +2,7 @@
     "name": "Simulation View",
     "author": "Ultimaker B.V.",
     "version": "1.0.1",
-    "description": "Provides the Simulation view.",
+    "description": "Provides the preview of sliced layerdata.",
     "api": 7,
     "i18n-catalog": "cura"
 }


### PR DESCRIPTION
This PR adds a more descriptive text to the Simulation View plugin explaining what it does. Twice now I have had to help people who complain that they no longer have a PREVIEW tab after having disabled the "Simulation View". In the UI, the term "Simulation View" is never mentioned, and apparently (rightfully) don't associate the "Simulation View" plugin with the Preview functionality in Cura.

The description of a plugin named "Simulation View" being "Provides the Simulation View" is not really all that descriptive. In the PR, I have changed it to "Provides the preview of sliced layerdata", which at least has the word "preview" in it.