### PR TITLE
reduce top/bottom speed by 80%

### DIFF
--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -46,11 +46,12 @@ retraction_hop = 1.5
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_travel = 300
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -47,11 +47,12 @@ retraction_hop = 1.5
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_travel = 300
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)

--- a/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -44,11 +44,12 @@ retraction_hop = 1.5
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_travel = 300
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Draft_Print.inst.cfg
@@ -44,12 +44,12 @@ retraction_extrusion_window = 1
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
-
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
 support_angle = 50

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Fast_Print.inst.cfg
@@ -44,12 +44,12 @@ retraction_extrusion_window = 1
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
-
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
 support_angle = 50

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -43,12 +43,12 @@ retraction_extrusion_window = 1
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
-
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
 support_angle = 50

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Draft_Print.inst.cfg
@@ -44,12 +44,12 @@ retraction_extrusion_window = 1
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
-
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
 support_angle = 50

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Fast_Print.inst.cfg
@@ -44,12 +44,12 @@ retraction_extrusion_window = 1
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
-
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
 support_angle = 50

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPU_Normal_Quality.inst.cfg
@@ -43,12 +43,12 @@ retraction_extrusion_window = 1
 retraction_hop_only_when_collides = True
 retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
+skin_line_width = =round(line_width / 0.8, 2)
 skin_overlap = 5
 speed_equalize_flow_enabled = True
 speed_layer_0 = =math.ceil(speed_print * 18 / 25)
 speed_print = 25
-speed_topbottom = =math.ceil(speed_print * 25 / 25)
-
+speed_topbottom = =math.ceil(speed_print * 0.8)
 speed_wall = =math.ceil(speed_print * 25 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
 support_angle = 50


### PR DESCRIPTION
The top/bottom speed is reduced by 80% to allow for better cooling of the top layers. This reduces pillowing. The line width is increased by 80% to maintain the flow equalization. PP-95