### PR TITLE
Remove unused import of sentry_sdk

### DIFF
--- a/cura/CrashHandler.py
+++ b/cura/CrashHandler.py
@@ -12,8 +12,6 @@ import json
 import locale
 from typing import cast, Any
 
-import sentry_sdk
-
 try:
     from sentry_sdk.hub import Hub
     from sentry_sdk.utils import event_from_exception


### PR DESCRIPTION
This breaks builds without the Sentry SDK. The check below handles the missing library fine, but this line introduced in https://github.com/Ultimaker/Cura/commit/3bfea5b97094615753fccdb7d03be335417f3228 broke it.