### PR TITLE
Add Optional Filter to Removable Drive Output Device Plugin

### DIFF
--- a/plugins/RemovableDriveOutputDevice/DriveFilter.py
+++ b/plugins/RemovableDriveOutputDevice/DriveFilter.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2022 Ultimaker B.V.
+# Uranium is released under the terms of the LGPLv3 or higher.
+
+import re
+from typing import Dict, List
+
+
+class DriveFilter:
+    def __init__(self):
+        """Creates the filter.
+        """
+
+        self.filterSteps: List[Dict[str, str]] = []
+
+    def reload(self, filterSteps: List[Dict[str, str]]) -> None:
+        """Reloads the filter.
+
+        :param filterSteps: Steps in the filter to apply.
+        """
+
+        self.filterSteps = filterSteps
+
+    def passesFilter(self, string: str) -> bool:
+        """Returns if a string can pass the filter.
+        A string is considered passing the filter if:
+        1. It passes at least 1 whitelist condition.
+        2. It passes every blacklist condition.
+
+        :param string: String to test.
+        :return: Whether the string passes the filter.
+        """
+
+        # Iterate through the steps and determine if it passes the whitelist and blacklist.
+        stepsPassed = {
+            "whitelistregex": 0,
+            "blacklistregex": 0,
+        }
+        stepsAttempted = {
+            "whitelistregex": 0,
+            "blacklistregex": 0,
+        }
+        for filterStep in self.filterSteps:
+            # Add the base counters.
+            stepType = filterStep["type"].lower()
+            if stepType not in stepsAttempted:
+                stepsAttempted[stepType] = 0
+                stepsPassed[stepType] = 0
+            stepsAttempted[stepType] += 1
+
+            # Add the passed step.
+            stepPassed = False
+            if stepType == "whitelistregex":
+                regexPattern = re.compile(filterStep["pattern"])
+                if regexPattern.search(string) is not None:
+                    stepPassed = True
+            elif stepType == "blacklistregex":
+                regexPattern = re.compile(filterStep["pattern"])
+                if regexPattern.search(string) is not None:
+                    stepPassed = True
+            if stepPassed:
+                stepsPassed[stepType] += 1
+
+        # Return if the whitelist and blacklist pass.
+        return (stepsAttempted["whitelistregex"] == 0 or stepsPassed["whitelistregex"] > 0) and stepsPassed["blacklistregex"] == 0
+
+    def filterByValue(self, dictionary: Dict[str, str]) -> Dict[str, str]:
+        """Filters a dictionary of strings based ont the values.
+
+        :param dictionary: Input keys pairs to filter.
+        :return: The key pairs where the value passes the filter.
+        """
+
+        # Get the values that pass the filter.
+        filteredDictionary = {}
+        for key in dictionary.keys():
+            if self.passesFilter(dictionary[key]):
+                filteredDictionary[key] = dictionary[key]
+
+        # Return the filtered strings.
+        return filteredDictionary

--- a/plugins/RemovableDriveOutputDevice/RemovableDrivePlugin.py
+++ b/plugins/RemovableDriveOutputDevice/RemovableDrivePlugin.py
@@ -10,6 +10,7 @@ from UM.Logger import Logger
 
 # Uranium/IO
 from UM.OutputDevice.OutputDevicePlugin import OutputDevicePlugin
+from . import DriveFilter
 from . import RemovableDriveOutputDevice
 
 # Uranium/l18n
@@ -26,6 +27,7 @@ class RemovableDrivePlugin(OutputDevicePlugin):
         self._check_updates = True
 
         self._drives = {}
+        self._filter = DriveFilter.DriveFilter()
 
     def start(self):
         self._update_thread.start()
@@ -61,6 +63,8 @@ class RemovableDrivePlugin(OutputDevicePlugin):
             time.sleep(5)
 
     def _addRemoveDrives(self, drives):
+        drives = self._filter.filterByValue(drives)
+
         # First, find and add all new or changed keys
         for key, value in drives.items():
             if key not in self._drives:

--- a/plugins/RemovableDriveOutputDevice/tests/TestDriveFilter.py
+++ b/plugins/RemovableDriveOutputDevice/tests/TestDriveFilter.py
@@ -1,0 +1,80 @@
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+from DriveFilter import DriveFilter
+import pytest
+
+
+def test_defaultFilterAllowAll():
+    filter = DriveFilter()
+    assert filter.filterByValue({}) == {}
+    assert filter.filterByValue({"1": "Test1", "2": "Test2", "3": "Test3"}) == {"1": "Test1", "2": "Test2", "3": "Test3"}
+
+def test_whiteListRegexSimpleContains():
+    filter = DriveFilter()
+    filter.reload([
+        {
+            "type": "WhitelistRegex",
+            "pattern": "Test",
+        },
+    ])
+    assert filter.filterByValue({"1": "Test1", "2": "Test2", "3": "Test3", "4": "Invalid", "5": "Test"}) == {"1": "Test1", "2": "Test2", "3": "Test3", "5": "Test"}
+
+def test_whiteListRegexPattern():
+    filter = DriveFilter()
+    filter.reload([
+        {
+            "type": "WhitelistRegex",
+            "pattern": r"Test\d+",
+        },
+    ])
+    assert filter.filterByValue({"1": "Test1", "2": "Test2", "3": "Test3", "4": "Invalid", "5": "Test"}) == {"1": "Test1", "2": "Test2", "3": "Test3"}
+
+def test_blackListRegexSimpleContains():
+    filter = DriveFilter()
+    filter.reload([
+        {
+            "type": "BlacklistRegex",
+            "pattern": "Test",
+        },
+    ])
+    assert filter.filterByValue({"1": "Test1", "2": "Test2", "3": "Test3", "4": "Valid", "5": "Test"}) == {"4": "Valid"}
+
+def test_blackListRegexPattern():
+    filter = DriveFilter()
+    filter.reload([
+        {
+            "type": "BlacklistRegex",
+            "pattern": r"Test\d+",
+        },
+    ])
+    assert filter.filterByValue({"1": "Test1", "2": "Test2", "3": "Test3", "4": "Valid", "5": "Test"}) == {"4": "Valid", "5": "Test"}
+
+def test_multipleWhiteListRegexContains():
+    filter = DriveFilter()
+    filter.reload([
+        {
+            "type": "WhitelistRegex",
+            "pattern": "Test",
+        },
+        {
+            "type": "WhitelistRegex",
+            "pattern": "Valid",
+        },
+    ])
+    assert filter.filterByValue({"1": "Test1", "2": "Test2", "3": "Test3", "4": "Valid", "5": "Test"}) == {"1": "Test1", "2": "Test2", "3": "Test3", "4": "Valid", "5": "Test"}
+
+def test_whitelistBlacklistRegexContains():
+    filter = DriveFilter()
+    filter.reload([
+        {
+            "type": "WhitelistRegex",
+            "pattern": "Test",
+        },
+        {
+            "type": "BlacklistRegex",
+            "pattern": "Test2",
+        },
+    ])
+    assert filter.filterByValue({"1": "Test1", "2": "Test2", "3": "Test3", "4": "Test"}) == {"1": "Test1", "3": "Test3", "4": "Test"}


### PR DESCRIPTION
Resolves #10915, which is already closed.

This pull request adds an optional filter to the Removable Drive Output Device plugin for being able to whitelist or blacklist removable devices. To restate the initial issue, The Construct @ RIT has Cura installed on public desktops, where users typically transfer files using USB drives. We have standardized on PRINTER_SD and PRINTER_USB and currently use a modified version of the plugin to make sure only these devices appear instead of the user's devices. The changes made add a more generalized filter that is stored in the normal configuration. A blacklist option is also implemented, such as for those who have a removable hard drive always plugged in they want to be ignored.

A user interface for modifying the filter is not included. We do not need this for our use case and I am not a fan of doing user interfaces. In theory, a new plugin could exist just for this by changing the preferences directly, but it is not included.

**Edit:** The tests appeared to fail due to comment syntax issues for the version upgrade plugins, not the changes I made.