### PR TITLE
new printer profiles for Monoprice MP10

### DIFF
--- a/resources/definitions/monoprice_mp10.def.json
+++ b/resources/definitions/monoprice_mp10.def.json
@@ -1,0 +1,107 @@
+{
+    "name": "Monoprice MP10",
+    "version": 2,
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": true,
+        "author": "Yongzong Lin",
+        "manufacturer": "Monoprice",
+        "file_formats": "text/x-gcode",
+        "preferred_quality_type": "draft",
+        "machine_extruder_trains":
+        {
+            "0": "monoprice_mp10_extruder_0"
+        }
+    },
+    "overrides": {
+        "machine_width": {
+            "default_value": 300
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_depth": {
+            "default_value": 300
+        },
+        "machine_head_polygon": {
+            "default_value": [
+                [-30, 34],
+                [-30, -32],
+                [30, -32],
+                [30, 34]
+            ]
+        },
+        "layer_height_0": {
+            "default_value": 0.2
+        },
+        "top_bottom_thickness": {
+            "default_value": 0.6
+        },
+        "top_bottom_pattern_0": {
+            "default_value": "concentric"
+        },
+        "infill_pattern": {
+            "value": "'triangles'"
+        },
+        "retraction_enable": {
+            "default_value": true
+        },
+        "retraction_amount": {
+            "default_value": 5
+        },
+        "retraction_speed": {
+            "default_value": 40
+        },
+        "cool_min_layer_time": {
+            "default_value": 10
+        },
+        "adhesion_type": {
+            "default_value": "raft"
+        },
+		"raft_margin": {
+            "default_value": 8
+        },
+		"raft_surface_layers": {
+            "default_value": 3
+        },
+		"support_bottom_distance": {
+            "default_value": 0.12
+        },
+		"support_top_distance": {
+            "default_value": 0.22
+        },
+        "skirt_line_count": {
+            "default_value": 4
+        },
+        "skirt_gap": {
+            "default_value": 5
+        },
+        "machine_end_gcode": {
+            "default_value": "G91\nG1 F1800 E-3\nG1 F3000 Z10\nG90\nG28 X0 Y0 ; home x and y axis\nM106 S0 ; turn off cooling fan\nM104 S0 ; turn off extruder\nM140 S0 ; turn off bed\nM84 ; disable motors"
+        },
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "gantry_height": {
+            "default_value": 30
+        },
+        "acceleration_enabled": {
+            "default_value": true
+        },
+        "acceleration_print": {
+            "default_value": 500
+        },
+        "acceleration_travel": {
+            "default_value": 500
+        },
+        "jerk_enabled": {
+            "default_value": true
+        },
+        "jerk_print": {
+            "default_value": 20
+        },
+        "jerk_travel": {
+            "default_value": 20
+        }
+    }
+}

--- a/resources/definitions/monoprice_mp10mini.def.json
+++ b/resources/definitions/monoprice_mp10mini.def.json
@@ -1,0 +1,107 @@
+{
+    "name": "Monoprice MP10 mini",
+    "version": 2,
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": true,
+        "author": "Yongzong Lin",
+        "manufacturer": "Monoprice",
+        "file_formats": "text/x-gcode",
+        "preferred_quality_type": "draft",
+        "machine_extruder_trains":
+        {
+            "0": "monoprice_mp10_extruder_0"
+        }
+    },
+    "overrides": {
+        "machine_width": {
+            "default_value": 200
+        },
+        "machine_height": {
+            "default_value": 180
+        },
+        "machine_depth": {
+            "default_value": 200
+        },
+        "machine_head_polygon": {
+            "default_value": [
+                [-30, 34],
+                [-30, -32],
+                [30, -32],
+                [30, 34]
+            ]
+        },
+        "layer_height_0": {
+            "default_value": 0.2
+        },
+        "top_bottom_thickness": {
+            "default_value": 0.6
+        },
+        "top_bottom_pattern_0": {
+            "default_value": "concentric"
+        },
+        "infill_pattern": {
+            "value": "'triangles'"
+        },
+        "retraction_enable": {
+            "default_value": true
+        },
+        "retraction_amount": {
+            "default_value": 5
+        },
+        "retraction_speed": {
+            "default_value": 40
+        },
+        "cool_min_layer_time": {
+            "default_value": 10
+        },
+        "adhesion_type": {
+            "default_value": "raft"
+        },
+		"raft_margin": {
+            "default_value": 8
+        },
+		"raft_surface_layers": {
+            "default_value": 3
+        },
+		"support_bottom_distance": {
+            "default_value": 0.12
+        },
+		"support_top_distance": {
+            "default_value": 0.22
+        },
+        "skirt_line_count": {
+            "default_value": 4
+        },
+        "skirt_gap": {
+            "default_value": 5
+        },
+        "machine_end_gcode": {
+            "default_value": "G91\nG1 F1800 E-3\nG1 F3000 Z10\nG90\nG28 X0 Y0 ; home x and y axis\nM106 S0 ; turn off cooling fan\nM104 S0 ; turn off extruder\nM140 S0 ; turn off bed\nM84 ; disable motors"
+        },
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "gantry_height": {
+            "default_value": 30
+        },
+        "acceleration_enabled": {
+            "default_value": true
+        },
+        "acceleration_print": {
+            "default_value": 500
+        },
+        "acceleration_travel": {
+            "default_value": 500
+        },
+        "jerk_enabled": {
+            "default_value": true
+        },
+        "jerk_print": {
+            "default_value": 20
+        },
+        "jerk_travel": {
+            "default_value": 20
+        }
+    }
+}

--- a/resources/extruders/monoprice_mp10_extruder_0.def.json
+++ b/resources/extruders/monoprice_mp10_extruder_0.def.json
@@ -1,0 +1,16 @@
+{
+    "id": "monoprice_mp10_extruder_0",
+    "version": 2,
+    "name": "Extruder 1",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "monoprice_mp10",
+        "position": "0"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 0 },
+        "machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 }
+    }
+}


### PR DESCRIPTION
added printer profiles and extruder definition for
* Monoprice MP10 (see https://www.monoprice.com/product?p_id=34437)
* Monoprice MP10 Mini (see https://www.monoprice.com/product?p_id=34438)