### PR TITLE
Raft Middle Layers

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -601,6 +601,7 @@ class BuildVolume(SceneNode):
         if self._adhesion_type == "raft":
             self._raft_thickness = (
                 self._global_container_stack.getProperty("raft_base_thickness", "value") +
+                self._global_container_stack.getProperty("raft_interface_layers", "value") *
                 self._global_container_stack.getProperty("raft_interface_thickness", "value") +
                 self._global_container_stack.getProperty("raft_surface_layers", "value") *
                 self._global_container_stack.getProperty("raft_surface_thickness", "value") +
@@ -1214,7 +1215,7 @@ class BuildVolume(SceneNode):
 
     _machine_settings = ["machine_width", "machine_depth", "machine_height", "machine_shape", "machine_center_is_zero"]
     _skirt_settings = ["adhesion_type", "skirt_gap", "skirt_line_count", "skirt_brim_line_width", "brim_width", "brim_line_count", "raft_margin", "draft_shield_enabled", "draft_shield_dist", "initial_layer_line_width_factor"]
-    _raft_settings = ["adhesion_type", "raft_base_thickness", "raft_interface_thickness", "raft_surface_layers", "raft_surface_thickness", "raft_airgap", "layer_0_z_overlap"]
+    _raft_settings = ["adhesion_type", "raft_base_thickness", "raft_interface_layers", "raft_interface_thickness", "raft_surface_layers", "raft_surface_thickness", "raft_airgap", "layer_0_z_overlap"]
     _extra_z_settings = ["retraction_hop_enabled", "retraction_hop"]
     _prime_settings = ["extruder_prime_pos_x", "extruder_prime_pos_y", "prime_blob_enable"]
     _tower_settings = ["prime_tower_enable", "prime_tower_size", "prime_tower_position_x", "prime_tower_position_y", "prime_tower_brim_enable"]

--- a/cura/Settings/ExtruderManager.py
+++ b/cura/Settings/ExtruderManager.py
@@ -268,7 +268,8 @@ class ExtruderManager(QObject):
             used_adhesion_extruders.add("skirt_brim_extruder_nr")  # There's a brim or prime tower brim.
         if adhesion_type == "raft":
             used_adhesion_extruders.add("raft_base_extruder_nr")
-            used_adhesion_extruders.add("raft_interface_extruder_nr")
+            if global_stack.getProperty("raft_interface_layers", "value") > 0:
+                used_adhesion_extruders.add("raft_interface_extruder_nr")
             if global_stack.getProperty("raft_surface_layers", "value") > 0:
                 used_adhesion_extruders.add("raft_surface_extruder_nr")
         for extruder_setting in used_adhesion_extruders:

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5642,7 +5642,7 @@
                     "enabled": "resolveOrValue('adhesion_type') == 'raft'",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
-                    "limit_to_extruder": "raft_interface_extruder_nr"
+                    "limit_to_extruder": "raft_surface_extruder_nr"
                 },
                 "raft_surface_thickness":
                 {
@@ -5692,6 +5692,19 @@
                     "settable_per_extruder": true,
                     "limit_to_extruder": "raft_surface_extruder_nr"
                 },
+                "raft_interface_layers":
+                {
+                    "label": "Raft Middle Layers",
+                    "description": "The number of layers between the base and the surface of the raft. These comprise the main thickness of the raft. Increasing this creates a thicker, sturdier raft.",
+                    "type": "int",
+                    "default_value": 1,
+                    "minimum_value": "0",
+                    "maximum_value_warning": "10",
+                    "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true,
+                    "limit_to_extruder": "raft_interface_extruder_nr"
+                },
                 "raft_interface_thickness":
                 {
                     "label": "Raft Middle Thickness",
@@ -5703,7 +5716,7 @@
                     "minimum_value": "0.001",
                     "minimum_value_warning": "0.04",
                     "maximum_value_warning": "0.75 * machine_nozzle_size",
-                    "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                    "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
                     "limit_to_extruder": "raft_interface_extruder_nr"
@@ -5719,7 +5732,7 @@
                     "minimum_value": "0.001",
                     "minimum_value_warning": "machine_nozzle_size * 0.5",
                     "maximum_value_warning": "machine_nozzle_size * 3",
-                    "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                    "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
                     "limit_to_extruder": "raft_interface_extruder_nr"
@@ -5735,7 +5748,7 @@
                     "minimum_value": "0",
                     "minimum_value_warning": "raft_interface_line_width",
                     "maximum_value_warning": "15.0",
-                    "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                    "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
                     "limit_to_extruder": "raft_interface_extruder_nr"

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5845,7 +5845,7 @@
                             "minimum_value": "0.1",
                             "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                             "maximum_value_warning": "150",
-                            "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                             "settable_per_mesh": false,
                             "settable_per_extruder": true,
                             "limit_to_extruder": "raft_interface_extruder_nr"
@@ -5910,7 +5910,7 @@
                             "minimum_value": "0.1",
                             "minimum_value_warning": "100",
                             "maximum_value_warning": "10000",
-                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and resolveOrValue('acceleration_enabled')",
+                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and resolveOrValue('acceleration_enabled') and raft_interface_layers > 0",
                             "settable_per_mesh": false,
                             "limit_to_extruder": "raft_interface_extruder_nr"
                         },
@@ -5973,7 +5973,7 @@
                             "minimum_value": "0",
                             "minimum_value_warning": "5",
                             "maximum_value_warning": "50",
-                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and resolveOrValue('jerk_enabled')",
+                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and resolveOrValue('jerk_enabled') and raft_interface_layers > 0",
                             "settable_per_mesh": false,
                             "limit_to_extruder": "raft_interface_extruder_nr"
                         },
@@ -6034,7 +6034,7 @@
                             "maximum_value": "100",
                             "default_value": 0,
                             "value": "raft_fan_speed",
-                            "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                             "settable_per_mesh": false,
                             "settable_per_extruder": true,
                             "limit_to_extruder": "raft_interface_extruder_nr"

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5655,7 +5655,7 @@
                     "minimum_value": "0.001",
                     "minimum_value_warning": "0.04",
                     "maximum_value_warning": "0.75 * machine_nozzle_size",
-                    "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                    "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_surface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
                     "limit_to_extruder": "raft_surface_extruder_nr"
@@ -5671,7 +5671,7 @@
                     "minimum_value": "0.001",
                     "minimum_value_warning": "machine_nozzle_size * 0.1",
                     "maximum_value_warning": "machine_nozzle_size * 2",
-                    "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                    "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_surface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
                     "limit_to_extruder": "raft_surface_extruder_nr"
@@ -5686,7 +5686,7 @@
                     "minimum_value": "0",
                     "minimum_value_warning": "raft_surface_line_width",
                     "maximum_value_warning": "raft_surface_line_width * 3",
-                    "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                    "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_surface_layers > 0",
                     "value": "raft_surface_line_width",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5457,7 +5457,7 @@
                             "type": "extruder",
                             "default_value": "0",
                             "value": "adhesion_extruder_nr",
-                            "enabled": "extruders_enabled_count > 1 and resolveOrValue('adhesion_type') == 'raft' and raft_surface_layers > 0",
+                            "enabled": "extruders_enabled_count > 1 and resolveOrValue('adhesion_type') == 'raft'",
                             "settable_per_mesh": false,
                             "settable_per_extruder": false
                         }
@@ -5828,7 +5828,7 @@
                             "minimum_value": "0.1",
                             "maximum_value": "math.sqrt(machine_max_feedrate_x ** 2 + machine_max_feedrate_y ** 2)",
                             "maximum_value_warning": "100",
-                            "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_surface_layers > 0",
                             "value": "raft_speed",
                             "settable_per_mesh": false,
                             "settable_per_extruder": true,
@@ -5895,7 +5895,7 @@
                             "minimum_value": "0.1",
                             "minimum_value_warning": "100",
                             "maximum_value_warning": "10000",
-                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and resolveOrValue('acceleration_enabled')",
+                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and resolveOrValue('acceleration_enabled') and raft_surface_layers > 0",
                             "settable_per_mesh": false,
                             "limit_to_extruder": "raft_surface_extruder_nr"
                         },
@@ -5958,7 +5958,7 @@
                             "minimum_value": "0",
                             "minimum_value_warning": "5",
                             "maximum_value_warning": "100",
-                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and resolveOrValue('jerk_enabled')",
+                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and resolveOrValue('jerk_enabled') and raft_surface_layers > 0",
                             "settable_per_mesh": false,
                             "limit_to_extruder": "raft_surface_extruder_nr"
                         },
@@ -6019,7 +6019,7 @@
                             "maximum_value": "100",
                             "default_value": 0,
                             "value": "raft_fan_speed",
-                            "enabled": "resolveOrValue('adhesion_type') == 'raft'",
+                            "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_surface_layers > 0",
                             "settable_per_mesh": false,
                             "settable_per_extruder": true,
                             "limit_to_extruder": "raft_surface_extruder_nr"

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -304,6 +304,7 @@ raft_surface_layers
 raft_surface_thickness
 raft_surface_line_width
 raft_surface_line_spacing
+raft_interface_layers
 raft_interface_thickness
 raft_interface_line_width
 raft_interface_line_spacing

--- a/tests/TestBuildVolume.py
+++ b/tests/TestBuildVolume.py
@@ -165,7 +165,7 @@ class TestUpdateRaftThickness:
     setting_property_dict = {"raft_base_thickness": {"value": 1},
                              "raft_interface_layers": {"value": 2},
                              "raft_interface_thickness": {"value": 1},
-                             "raft_surface_layers": {"value": 1},
+                             "raft_surface_layers": {"value": 3},
                              "raft_surface_thickness": {"value": 1},
                              "raft_airgap": {"value": 1},
                              "layer_0_z_overlap": {"value": 1},
@@ -194,7 +194,7 @@ class TestUpdateRaftThickness:
 
         assert build_volume.getRaftThickness() == 0
         build_volume._updateRaftThickness()
-        assert build_volume.getRaftThickness() == 4  # 1 base layer of 1mm, 2 interface layers of 1mm each, 1 top layer of 1mm.
+        assert build_volume.getRaftThickness() == 6  # 1 base layer of 1mm, 2 interface layers of 1mm each, 3 surface layer of 1mm.
         assert build_volume.raftThicknessChanged.emit.call_count == 1
 
     def test_adhesionIsNotRaft(self, build_volume: BuildVolume):

--- a/tests/TestBuildVolume.py
+++ b/tests/TestBuildVolume.py
@@ -163,6 +163,7 @@ class TestComputeDisallowedAreasStatic:
 
 class TestUpdateRaftThickness:
     setting_property_dict = {"raft_base_thickness": {"value": 1},
+                             "raft_interface_layers": {"value": 2},
                              "raft_interface_thickness": {"value": 1},
                              "raft_surface_layers": {"value": 1},
                              "raft_surface_thickness": {"value": 1},
@@ -193,7 +194,7 @@ class TestUpdateRaftThickness:
 
         assert build_volume.getRaftThickness() == 0
         build_volume._updateRaftThickness()
-        assert build_volume.getRaftThickness() == 3
+        assert build_volume.getRaftThickness() == 4  # 1 base layer of 1mm, 2 interface layers of 1mm each, 1 top layer of 1mm.
         assert build_volume.raftThicknessChanged.emit.call_count == 1
 
     def test_adhesionIsNotRaft(self, build_volume: BuildVolume):


### PR DESCRIPTION
This feature adds a setting by which the user can change the number of middle layers to print in the raft.

See https://github.com/Ultimaker/CuraEngine/pull/1572 for a more complete description.