### PR TITLE
Fix show hidden settings

### DIFF
--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -340,7 +340,7 @@ Item
                     }
                     function onShowTooltip(text) { base.showTooltip(delegate, Qt.point(-settingsView.x - UM.Theme.getSize("default_margin").width, 0), text) }
                     function onHideTooltip() { base.hideTooltip() }
-                    function onShowAllHiddenInheritedSettings()
+                    function onShowAllHiddenInheritedSettings(category_id)
                     {
                         var children_with_override = Cura.SettingInheritanceManager.getChildrenKeysWithOverride(category_id)
                         for(var i = 0; i < children_with_override.length; i++)


### PR DESCRIPTION
In the Cura UI shows if there are hidding settings changed in the settings menu by showing an `i`-icon. Previously clicking this icon would show the hidden setting in the menu, this functionality broke over time. This PR re-enables that functionality. 