### PR TITLE
[CURA-8955] Ip adress dialog

### DIFF
--- a/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
@@ -333,18 +333,16 @@ Cura.MachineAction
             }
         }
 
-        onRejected:
-        {
-            manualPrinterDialog.reject()
-            manualPrinterDialog.hide()
-        }
         onAccepted:
         {
             // Validate the input first
             if (!networkingUtil.isValidIP(manualPrinterDialog.addressText))
             {
-                invalidIPAddressMessageDialog.open()
-                return
+                // prefent closing of element, as we want to keep the dialog active after a wrongly entered IP adress
+                manualPrinterDialog.open()
+                // show invalid ip warning
+                invalidIPAddressMessageDialog.open();
+                return;
             }
 
             // if the entered IP address has already been discovered, switch the current item to that item
@@ -354,14 +352,12 @@ Cura.MachineAction
                 var device = manager.foundDevices[i]
                 if (device.address == manualPrinterDialog.addressText)
                 {
-                    currentItemIndex = i
-                    manualPrinterDialog.hide()
-                    return
+                    currentItemIndex = i;
+                    return;
                 }
             }
 
-            manager.setManualDevice(manualPrinterDialog.printerKey, manualPrinterDialog.addressText)
-            manualPrinterDialog.hide()
+            manager.setManualDevice(manualPrinterDialog.printerKey, manualPrinterDialog.addressText);
         }
     }
 }


### PR DESCRIPTION
In component discover um 3 dialog. After a "complete" action the dialog will immediately close. This was undesired behaviour as we want to keep the dialog active if an IP address is wrongly added.

Additionally, it is no longer necessary to close/hide the dialog after a reject/accept as this is done by default.

CURA-8955