### PR TITLE
[CURA-8959] Add "Ok" button in export/import materials popup dialog

### DIFF
--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -335,16 +335,19 @@ Item
         folder: CuraApplication.getDefaultPath("dialog_material_path")
         onAccepted:
         {
-            var result = Cura.ContainerManager.importMaterialContainer(fileUrl);
+            const result = Cura.ContainerManager.importMaterialContainer(fileUrl);
 
+            const messageDialog = Qt.createQmlObject("import UM 1.5 as UM; UM.MessageDialog { onClosed: destroy() }", base);
+            messageDialog.standardButtons = Dialog.Ok;
             messageDialog.title = catalog.i18nc("@title:window", "Import Material");
-            if(result.status == "success")
+            switch (result.status)
             {
-                messageDialog.text = catalog.i18nc("@info:status Don't translate the XML tag <filename>!", "Successfully imported material <filename>%1</filename>").arg(fileUrl);
-            }
-            else
-            {
-                messageDialog.text = catalog.i18nc("@info:status Don't translate the XML tags <filename> or <message>!", "Could not import material <filename>%1</filename>: <message>%2</message>").arg(fileUrl).arg(result.message);
+                case "success":
+                    messageDialog.text = catalog.i18nc("@info:status Don't translate the XML tag <filename>!", "Successfully imported material <filename>%1</filename>").arg(fileUrl);
+                    break;
+                default:
+                    messageDialog.text = catalog.i18nc("@info:status Don't translate the XML tags <filename> or <message>!", "Could not import material <filename>%1</filename>: <message>%2</message>").arg(fileUrl).arg(result.message);
+                    break;
             }
             messageDialog.open();
             CuraApplication.setDefaultPath("dialog_material_path", folder);
@@ -360,25 +363,23 @@ Item
         folder: CuraApplication.getDefaultPath("dialog_material_path")
         onAccepted:
         {
-            var result = Cura.ContainerManager.exportContainer(base.currentItem.root_material_id, selectedNameFilter, fileUrl);
+            const result = Cura.ContainerManager.exportContainer(base.currentItem.root_material_id, selectedNameFilter, fileUrl);
 
+            const messageDialog = Qt.createQmlObject("import UM 1.5 as UM; UM.MessageDialog { onClosed: destroy() }", base);
             messageDialog.title = catalog.i18nc("@title:window", "Export Material");
-            if(result.status == "error")
+            messageDialog.standardButtons = Dialog.Ok;
+            switch (result.status)
             {
-                messageDialog.text = catalog.i18nc("@info:status Don't translate the XML tags <filename> and <message>!", "Failed to export material to <filename>%1</filename>: <message>%2</message>").arg(fileUrl).arg(result.message);
-                messageDialog.open();
+                case "error":
+                    messageDialog.text = catalog.i18nc("@info:status Don't translate the XML tags <filename> and <message>!", "Failed to export material to <filename>%1</filename>: <message>%2</message>").arg(fileUrl).arg(result.message);
+                    break;
+                case "success":
+                    messageDialog.text = catalog.i18nc("@info:status Don't translate the XML tag <filename>!", "Successfully exported material to <filename>%1</filename>").arg(result.path);
+                    break;
             }
-            else if(result.status == "success")
-            {
-                messageDialog.text = catalog.i18nc("@info:status Don't translate the XML tag <filename>!", "Successfully exported material to <filename>%1</filename>").arg(result.path);
-                messageDialog.open();
-            }
+            messageDialog.open();
+
             CuraApplication.setDefaultPath("dialog_material_path", folder);
         }
-    }
-
-    UM.MessageDialog
-    {
-        id: messageDialog
     }
 }


### PR DESCRIPTION
Proposed solution takes a different approach compared to the previous solution. Previously there was one message dialog that was hidden by default. When the import/export material confirm dialog was triggered the text and body of this message dialog would change.

I did deviate from this pattern as this might introduce hard to debug issues when a property would be set on this dialog. As this dialog is used for various instances every instance should update the same properties. If one property is missed then the popup might show unwanted information.

I propose a different solution instead. Here a popup is created dynamically. This way the properties used for each instance is clear. This might add a delay when showing the popup as the whole component needs to be created when called. 

CURA-8959