### PR TITLE
adjusted buildplate grid color

### DIFF
--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -388,8 +388,8 @@
         "viewport_background": [250, 250, 250, 255],
         "volume_outline": [50, 130, 255, 255],
         "buildplate": [244, 244, 244, 255],
-        "buildplate_grid": [129, 131, 134, 255],
-        "buildplate_grid_minor": [230, 230, 231, 255],
+        "buildplate_grid": [180, 180, 180, 255],
+        "buildplate_grid_minor": [228, 228, 228, 255],
 
         "convex_hull": [35, 35, 35, 127],
         "disallowed_area": [0, 0, 0, 40],


### PR DESCRIPTION
Just a very small PR to look of the build plate grid. 
I reduced the line contrast while keeping the grid still very visible. 

old
![old](https://user-images.githubusercontent.com/2944758/154094068-c9e4a128-05a5-4eb3-ba69-89e309637ee2.png)
new
![new](https://user-images.githubusercontent.com/2944758/154094046-a75b31e0-8db9-4052-afc2-4eee875dda14.png)

