### PR TITLE
[CURA-8031] Modifier meshes in one at a time mode

### DIFF
--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -208,7 +208,8 @@ class StartSliceJob(Job):
             modifier_mesh_nodes = []
 
             for node in DepthFirstIterator(self._scene.getRoot()):
-                if node.callDecoration("isNonPrintingMesh"):
+                build_plate_number = node.callDecoration("getBuildPlateNumber")
+                if node.callDecoration("isNonPrintingMesh") and build_plate_number == self._build_plate_number:
                     modifier_mesh_nodes.append(node)
 
             for node in OneAtATimeIterator(self._scene.getRoot()):

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -205,6 +205,12 @@ class StartSliceJob(Job):
         # Get the objects in their groups to print.
         object_groups = []
         if stack.getProperty("print_sequence", "value") == "one_at_a_time":
+            modifier_mesh_nodes = []
+
+            for node in DepthFirstIterator(self._scene.getRoot()):
+                if node.callDecoration("isNonPrintingMesh"):
+                    modifier_mesh_nodes.append(node)
+
             for node in OneAtATimeIterator(self._scene.getRoot()):
                 temp_list = []
 
@@ -221,7 +227,7 @@ class StartSliceJob(Job):
                         temp_list.append(child_node)
 
                 if temp_list:
-                    object_groups.append(temp_list)
+                    object_groups.append(temp_list + modifier_mesh_nodes)
                 Job.yieldThread()
             if len(object_groups) == 0:
                 Logger.log("w", "No objects suitable for one at a time found, or no correct order found")


### PR DESCRIPTION
Modifier meshes were not being included in object groups in one at a time mode. 

This change adds all modifier meshes to each object group in one at a time mode

<img width="631" alt="Screenshot 2022-02-16 at 16 09 52" src="https://user-images.githubusercontent.com/23387864/154294027-0a4706d1-06c7-48d8-a9ae-111e2b1e6647.png">
.