### PR TITLE
Add Creality Ender 3 S1 profile - fixes #11512

### DIFF
--- a/resources/definitions/creality_ender3s1.def.json
+++ b/resources/definitions/creality_ender3s1.def.json
@@ -1,0 +1,38 @@
+{
+    "name": "Creality Ender-3 S1",
+    "version": 2,
+    "inherits": "creality_base",
+    "metadata": {
+        "quality_definition": "creality_base",
+        "visible": true
+    },
+    "overrides": {
+        "machine_name": { "default_value": "Creality Ender-3 S1" },
+        "machine_width": { "default_value": 220 },
+        "machine_depth": { "default_value": 220 },
+        "machine_height": { "default_value": 270 },
+        "machine_head_with_fans_polygon": { "default_value": [
+                [-26, 34],
+                [-26, -32],
+                [32, -32],
+                [32, 34]
+            ]
+        },
+
+        "gantry_height": { "value": 25 },
+        
+        "speed_print": {"value": 50},
+        "speed_layer_0": {"value": 25},
+        "speed_travel": { "value": 150 },
+        "retraction_amount": {"value":  0.8},
+        "retraction_speed": { "default_value": 40},
+
+        "acceleration_enabled": {"value":  true},
+        "acceleration_travel": {"value": 2000},
+        "retraction_extrusion_window": {"value": 1.5},
+        
+        "machine_start_gcode": {
+            "default_value": "; Ender 3 S1 Start G-code\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nG1 Z10.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0 Y0\n\nM104 S{material_print_temperature_layer_0}\nM190 S{material_bed_temperature_layer_0}\nM109 S{material_print_temperature_layer_0}\n\nG1 X0.1 Y20 Z0.3 F5000.0 ; Move to start position\nG1 X0.1 Y200.0 Z0.3 F1500.0 E15 ; Draw the first line\nG1 X0.4 Y200.0 Z0.3 F5000.0 ; Move to side a little\nG1 X0.4 Y20 Z0.3 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.3 F5000.0 ; Move over to prevent blob squish\n"
+        }
+    }
+}

--- a/resources/variants/creality_ender3s1_0.2.inst.cfg
+++ b/resources/variants/creality_ender3s1_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = creality_ender3s1
+
+[metadata]
+setting_version = 19
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/creality_ender3s1_0.3.inst.cfg
+++ b/resources/variants/creality_ender3s1_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = creality_ender3s1
+
+[metadata]
+setting_version = 19
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/creality_ender3s1_0.4.inst.cfg
+++ b/resources/variants/creality_ender3s1_0.4.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.4mm Nozzle
+version = 4
+definition = creality_ender3s1
+
+[metadata]
+setting_version = 19
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.4

--- a/resources/variants/creality_ender3s1_0.5.inst.cfg
+++ b/resources/variants/creality_ender3s1_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = creality_ender3s1
+
+[metadata]
+setting_version = 19
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/creality_ender3s1_0.6.inst.cfg
+++ b/resources/variants/creality_ender3s1_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = creality_ender3s1
+
+[metadata]
+setting_version = 19
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/creality_ender3s1_0.8.inst.cfg
+++ b/resources/variants/creality_ender3s1_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = creality_ender3s1
+
+[metadata]
+setting_version = 19
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/creality_ender3s1_1.0.inst.cfg
+++ b/resources/variants/creality_ender3s1_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = creality_ender3s1
+
+[metadata]
+setting_version = 19
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0


### PR DESCRIPTION
This adds a machine profile for the Ender 3 S1 as requested in #11512. I ported the settings from Creality Cura and made up-to-date Cura printer profiles.