### PR TITLE
Show install, uninstall & disable buttons in packages list

### DIFF
--- a/plugins/Marketplace/RemotePackageList.py
+++ b/plugins/Marketplace/RemotePackageList.py
@@ -117,9 +117,6 @@ class RemotePackageList(PackageList):
             return
 
         for package_data in response_data["data"]:
-            package_id = package_data["package_id"]
-            if package_id in self._package_manager.local_packages_ids:
-                continue  # We should only show packages which are not already installed
             try:
                 package = PackageModel(package_data, parent = self)
                 self._connectManageButtonSignals(package)

--- a/plugins/Marketplace/resources/qml/ManagedPackages.qml
+++ b/plugins/Marketplace/resources/qml/ManagedPackages.qml
@@ -19,7 +19,8 @@ Packages
         bannerVisible = false;
     }
     searchInBrowserUrl: "https://marketplace.ultimaker.com/app/cura/plugins?utm_source=cura&utm_medium=software&utm_campaign=marketplace-search-plugins-browser"
-    packagesManageableInListView: true
-
+    showUpdateButton: true
+    showInstallButton: true
+    showDisableButton: true
     model: manager.LocalPackageList
 }

--- a/plugins/Marketplace/resources/qml/Materials.qml
+++ b/plugins/Marketplace/resources/qml/Materials.qml
@@ -16,7 +16,8 @@ Packages
         bannerVisible = false;
     }
     searchInBrowserUrl: "https://marketplace.ultimaker.com/app/cura/materials?utm_source=cura&utm_medium=software&utm_campaign=marketplace-search-materials-browser"
-    packagesManageableInListView: false
+    showUpdateButton: true
+    showInstallButton: true
 
     model: manager.MaterialPackageList
 }

--- a/plugins/Marketplace/resources/qml/PackageCard.qml
+++ b/plugins/Marketplace/resources/qml/PackageCard.qml
@@ -11,7 +11,9 @@ import Cura 1.6 as Cura
 Rectangle
 {
     property alias packageData: packageCardHeader.packageData
-    property alias manageableInListView: packageCardHeader.showManageButtons
+    property alias showUpdateButton:  packageCardHeader.showUpdateButton
+    property alias showDisableButton:  packageCardHeader.showDisableButton
+    property alias showInstallButton: packageCardHeader.showInstallButton
 
     height: childrenRect.height
     color: UM.Theme.getColor("main_background")

--- a/plugins/Marketplace/resources/qml/PackageCardHeader.qml
+++ b/plugins/Marketplace/resources/qml/PackageCardHeader.qml
@@ -12,10 +12,13 @@ import Cura 1.6 as Cura
 // are combined into the reusable "PackageCardHeader" component
 Item
 {
-    default property alias contents: contentItem.children;
+    default property alias contents: contentItem.children
 
     property var packageData
-    property bool showManageButtons: false
+    property bool showDisableButton: false
+    property bool showInstallButton: false
+    property bool showUpdateButton: false
+
 
     width: parent.width
     height: UM.Theme.getSize("card").height
@@ -157,7 +160,7 @@ Item
             ManageButton
             {
                 id: enableManageButton
-                visible: showManageButtons && packageData.isInstalled && !packageData.isToBeInstalled && packageData.packageType != "material"
+                visible: showDisableButton && packageData.isInstalled && !packageData.isToBeInstalled && packageData.packageType != "material"
                 enabled: !packageData.busy
 
                 button_style: !packageData.isActive
@@ -171,7 +174,7 @@ Item
             ManageButton
             {
                 id: installManageButton
-                visible: showManageButtons && (packageData.canDowngrade || !packageData.isBundled)
+                visible: showInstallButton && (packageData.canDowngrade || !packageData.isBundled)
                 enabled: !packageData.busy
                 busy: packageData.busy
                 button_style: !(packageData.isInstalled || packageData.isToBeInstalled)
@@ -201,7 +204,7 @@ Item
             ManageButton
             {
                 id: updateManageButton
-                visible: showManageButtons && packageData.canUpdate
+                visible: showUpdateButton && packageData.canUpdate
                 enabled: !packageData.busy
                 busy: packageData.busy
                 Layout.alignment: Qt.AlignTop

--- a/plugins/Marketplace/resources/qml/PackagePage.qml
+++ b/plugins/Marketplace/resources/qml/PackagePage.qml
@@ -31,7 +31,9 @@ Rectangle
             PackageCardHeader
             {
                 id: packageCardHeader
-                showManageButtons: true
+                showUpdateButton: true
+                showInstallButton: true
+                showDisableButton: true
 
                 anchors.fill: parent
 

--- a/plugins/Marketplace/resources/qml/Packages.qml
+++ b/plugins/Marketplace/resources/qml/Packages.qml
@@ -19,7 +19,10 @@ ListView
     property string bannerText
     property string bannerReadMoreUrl
     property var onRemoveBanner
-    property bool packagesManageableInListView
+
+    property bool showUpdateButton
+    property bool showDisableButton
+    property bool showInstallButton
 
     clip: true
 
@@ -81,7 +84,9 @@ ListView
 
         PackageCard
         {
-            manageableInListView: packages.packagesManageableInListView
+            showUpdateButton: packages.showUpdateButton
+            showDisableButton: packages.showDisableButton
+            showInstallButton: packages.showInstallButton
             packageData: model.package
             width: parent.width - UM.Theme.getSize("default_margin").width - UM.Theme.getSize("narrow_margin").width
             color: cardMouseArea.containsMouse ? UM.Theme.getColor("action_button_hovered") : UM.Theme.getColor("main_background")

--- a/plugins/Marketplace/resources/qml/Plugins.qml
+++ b/plugins/Marketplace/resources/qml/Plugins.qml
@@ -16,7 +16,8 @@ Packages
         bannerVisible = false;
     }
     searchInBrowserUrl: "https://marketplace.ultimaker.com/app/cura/plugins?utm_source=cura&utm_medium=software&utm_campaign=marketplace-search-plugins-browser"
-    packagesManageableInListView: false
+    showUpdateButton: true
+    showInstallButton: true
 
     model: manager.PluginPackageList
 }


### PR DESCRIPTION
This splits up the single show controls property into three separate ones and no longer hides installed packages from the plugin & materials list

CURA-8834