### PR TITLE
Make Wall Ordering option Center Last into its own setting

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1212,10 +1212,18 @@
                     "type": "enum",
                     "options": {
                         "inside_out": "Inside To Outside",
-                        "outside_in": "Outside To Inside",
-                        "center_last": "Center Last"
+                        "outside_in": "Outside To Inside"
                     },
                     "default_value": "center_last",
+                    "settable_per_mesh": true
+                },
+                "wall_order_center_last":
+                {
+                    "label": "Delay Middle Lines Until After All Walls",
+                    "description": "For thin geometry Cura might generate an odd number of walls smaller than the Wall Line Count. This setting control whether the middle line is printed after all even walls, rather than interspersed with the even walls. Depending on the Middle Line Threshold values the middle lines might have more width variation, which could cause issues for the even walls if printed interspersed. Disabling this setting reduces the travel time slightly.",
+                    "type": "bool",
+                    "default_value": false,
+                    "limit_to_extruder": "wall_x_extruder_nr",
                     "settable_per_mesh": true
                 },
                 "alternate_extra_perimeter":


### PR DESCRIPTION
It's called "Middle Last" rather than "Center Last" in order to be consistent with the Middle Line Threshold settings.

See backend PR: https://github.com/Ultimaker/CuraEngine/pull/1597