### PR TITLE
[CURA-9010] adjust text highlight color of textfield when changing project name

### DIFF
--- a/resources/qml/JobSpecs.qml
+++ b/resources/qml/JobSpecs.qml
@@ -58,7 +58,7 @@ Item
             }
         }
 
-        TextField
+        Cura.TextField
         {
             id: printJobTextfield
             anchors.left: printJobPencilIcon.right


### PR DESCRIPTION
Swap TextField for Cura.TextField so it has the same styling as the rest of text fields.

CURA-9010