### PR TITLE
More intuitive line thresholds

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1226,8 +1226,6 @@
                             "unit": "mm",
                             "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
                             "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
-                            "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                            "maximum_value_warning_old": "2 * machine_nozzle_size",
                             "default_value": 0.3,
                             "value": "min_wall_line_width",
                             "type": "float",
@@ -1254,8 +1252,6 @@
                             "unit": "mm",
                             "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
                             "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
-                            "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                            "maximum_value_warning_old": "2 * machine_nozzle_size",
                             "default_value": 0.3,
                             "value": "min_wall_line_width",
                             "type": "float",
@@ -1269,7 +1265,6 @@
                                     "unit": "%",
                                     "default_value": 80,
                                     "value": "max(1, min(99, 100 * min_odd_wall_line_width / wall_line_width_x))",
-                                    "value_explicit": "100 * (2 * wall_line_width_0 + min_odd_wall_line_width - 2 * wall_line_width_0) / (2 * wall_line_width_0 + wall_line_width_x - 2 * wall_line_width_0)",
                                     "minimum_value": "1",
                                     "maximum_value": "99"
                                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1304,7 +1304,7 @@
                     "label": "Minimum Wall Line Width",
                     "description": "Width of the wall that will replace thin features (according to the Minimum Feature Size) of the model. If the Minimum Wall Line Width is thinner than the thickness of the feature, the wall will become as thick as the feature itself.",
                     "unit": "mm",
-                    "value": "wall_line_width_0 * (100.0 + wall_split_middle_threshold)/200",
+                    "value": "machine_nozzle_size * .75",
                     "default_value": 0.2,
                     "minimum_value": "0.001",
                     "minimum_value_warning": "min_feature_size",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1207,7 +1207,7 @@
                 "min_wall_line_width":
                 {
                     "label": "Minimum Wall Line Width",
-                    "description": "TODO. For thin structures. Max odd is 2x min even, max even is Outer wall line width + .5x min odd.",
+                    "description": "For thin structures around once or twice the nozzle size, the line widths need to be altered to adhere to the thickness of the model. This setting controls the minimum line width allowed for the walls. The minimum line widths inherently also determine the maximum line widths, since we transition from N to N+1 walls at some geometry thickness where the N walls are wide and the N+1 walls are narrow. The widest possible wall line is twice the Minimum Wall Line Width.",
                     "unit": "mm",
                     "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
                     "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
@@ -1222,7 +1222,7 @@
                         "min_even_wall_line_width":
                         {
                             "label": "Minimum Even Wall Line Width",
-                            "description": "TODO.",
+                            "description": "The minimum line width for normal polygonal walls. This setting determines at which model thickness we switch from printing a single thin wall line, to printing two wall lines. A higher Minimum Even Wall Line Width leads to a higher maximum odd wall line width. The maximum even wall line width is calculated as Outer Wall Line Width + 0.5 * Minimum Odd Wall Line Width.",
                             "unit": "mm",
                             "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
                             "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
@@ -1250,7 +1250,7 @@
                         "min_odd_wall_line_width":
                         {
                             "label": "Minimum Odd Wall Line Width",
-                            "description": "TODO.",
+                            "description": "The minimum line width for middle line gap filler polyline walls. This setting determines at which model thickness we switch from printing two wall lines, to printing two outer walls and a single central wall in the middle. A higher Minimum Odd Wall Line Width leads to a higher maximum even wall line width. The maximum odd wall line width is calculated as 2 * Minimum Even Wall Line Width,",
                             "unit": "mm",
                             "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
                             "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1092,35 +1092,91 @@
                     "default_value": "inward_distributed",
                     "limit_to_extruder": "wall_0_extruder_nr"
                 },
-                "wall_transition_threshold": {
-                    "label": "Middle Line Threshold",
-                    "description": "The smallest line width, as a factor of the normal line width, below which it will choose to use fewer, but wider lines to fill the available space the wall needs to occupy. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
+                "max_odd_wall_line_width":
+                {
+                    "label": "Maximum Wall Line Width of Middle Walls",
+                    "description": "TODO.",
+                    "unit": "mm",
+                    "minimum_value": "max(wall_line_width_0, wall_line_width_x)",
+                    "maximum_value": "2 * min(wall_line_width_0, wall_line_width_x)",
+                    "minimum_value_warning": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                    "maximum_value_warning": "2 * machine_nozzle_size",
+                    "default_value": 0.6,
+                    "value": "wall_line_width * 1.5",
                     "type": "float",
-                    "unit": "%",
-                    "default_value": 90,
-                    "minimum_value": "1",
-                    "maximum_value": "99",
+                    "settable_per_mesh": true,
                     "children":
                     {
-                        "wall_split_middle_threshold": {
-                            "label": "Split Middle Line Threshold",
-                            "description": "The smallest line width, as a factor of the normal line width, above which the middle line (if there is one) will be split into two. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
+                        "min_even_wall_line_width":
+                        {
+                            "label": "Minimum Wall Line Width of Even Walls",
+                            "description": "TODO.",
+                            "unit": "mm",
+                            "minimum_value": ".5 * max(wall_line_width_0, wall_line_width_x)",
+                            "maximum_value": "min(wall_line_width_0, wall_line_width_x)",
+                            "minimum_value_warning": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                            "maximum_value_warning": "2 * machine_nozzle_size",
+                            "default_value": 0.3,
+                            "value": "max_odd_wall_line_width / 2",
                             "type": "float",
-                            "unit": "%",
-                            "default_value": 90,
-                            "value": "wall_transition_threshold",
-                            "minimum_value": "1",
-                            "maximum_value": "99"
-                        },
-                        "wall_add_middle_threshold": {
-                            "label": "Add Middle Line Threshold",
-                            "description": "The smallest line width, as a factor of the normal line width, above which a middle line (if there wasn't one already) will be added. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
+                            "settable_per_mesh": true,
+                            "children":
+                            {
+                                "wall_split_middle_threshold": {
+                                    "label": "Split Middle Line Threshold",
+                                    "description": "The smallest line width, as a factor of the normal line width, above which the middle line (if there is one) will be split into two. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
+                                    "type": "float",
+                                    "unit": "%",
+                                    "default_value": 90,
+                                    "value": "100 * (2 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0",
+                                    "minimum_value": "1",
+                                    "maximum_value": "99"
+                                }
+                            }
+                        }
+                    }
+                },
+                "max_even_wall_line_width":
+                {
+                    "label": "Maximum Wall Line Width of Even Walls",
+                    "description": "TODO.",
+                    "unit": "mm",
+                    "minimum_value": "max(wall_line_width_0, wall_line_width_x)",
+                    "maximum_value": "2 * min(wall_line_width_0, wall_line_width_x)",
+                    "minimum_value_warning": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                    "maximum_value_warning": "2 * machine_nozzle_size",
+                    "default_value": 0.6,
+                    "value": "wall_line_width * 1.5",
+                    "type": "float",
+                    "settable_per_mesh": true,
+                    "children":
+                    {
+                        "min_odd_wall_line_width":
+                        {
+                            "label": "Minimum Wall Line Width of Odd Walls",
+                            "description": "TODO.",
+                            "unit": "mm",
+                            "minimum_value": ".5 * max(wall_line_width_0, wall_line_width_x)",
+                            "maximum_value": "min(wall_line_width_0, wall_line_width_x)",
+                            "minimum_value_warning": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                            "maximum_value_warning": "2 * machine_nozzle_size",
+                            "default_value": 0.3,
+                            "value": "max_even_wall_line_width * 2 - 2 * wall_line_width_0",
                             "type": "float",
-                            "unit": "%",
-                            "default_value": 80,
-                            "value": "wall_transition_threshold * 8 / 9",
-                            "minimum_value": "1",
-                            "maximum_value": "99"
+                            "settable_per_mesh": true,
+                            "children":
+                            {
+                                "wall_add_middle_threshold": {
+                                    "label": "Add Middle Line Threshold",
+                                    "description": "The smallest line width, as a factor of the normal line width, above which a middle line (if there wasn't one already) will be added. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
+                                    "type": "float",
+                                    "unit": "%",
+                                    "default_value": 80,
+                                    "value": "100 * min_odd_wall_line_width / wall_line_width_x",
+                                    "minimum_value": "1",
+                                    "maximum_value": "99"
+                                }
+                            }
                         }
                     }
                 },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1301,7 +1301,7 @@
                 },
                 "min_bead_width":
                 {
-                    "label": "Minimum Wall Line Width",
+                    "label": "Minimum Thin Wall Line Width",
                     "description": "Width of the wall that will replace thin features (according to the Minimum Feature Size) of the model. If the Minimum Wall Line Width is thinner than the thickness of the feature, the wall will become as thick as the feature itself.",
                     "unit": "mm",
                     "value": "machine_nozzle_size * .75",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1237,7 +1237,7 @@
                                     "description": "The smallest line width, as a factor of the normal line width, above which the middle line (if there is one) will be split into two. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
                                     "type": "float",
                                     "unit": "%",
-                                    "default_value": 90,
+                                    "default_value": 50,
                                     "value": "max(1, min(99, 100 * (2 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0))",
                                     "value_explicit": "100 * (2 * min_even_wall_line_width - wall_line_width_0) / (wall_line_width_0 + wall_line_width_x - wall_line_width_0)",
                                     "minimum_value": "1",
@@ -1263,7 +1263,7 @@
                                     "description": "The smallest line width, as a factor of the normal line width, above which a middle line (if there wasn't one already) will be added. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
                                     "type": "float",
                                     "unit": "%",
-                                    "default_value": 80,
+                                    "default_value": 75,
                                     "value": "max(1, min(99, 100 * min_odd_wall_line_width / wall_line_width_x))",
                                     "minimum_value": "1",
                                     "maximum_value": "99"

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1092,32 +1092,32 @@
                     "default_value": "inward_distributed",
                     "limit_to_extruder": "wall_0_extruder_nr"
                 },
-                "max_odd_wall_line_width":
+                "min_wall_line_width":
                 {
-                    "label": "Maximum Wall Line Width of Middle Walls",
-                    "description": "TODO.",
+                    "label": "Minimum Wall Line Width",
+                    "description": "TODO. For thin structures. Max odd is 2x min even, max even is Outer wall line width + .5x min odd.",
                     "unit": "mm",
-                    "minimum_value": "max(wall_line_width_0, wall_line_width_x)",
-                    "maximum_value": "2 * min(wall_line_width_0, wall_line_width_x)",
-                    "minimum_value_warning": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                    "maximum_value_warning": "2 * machine_nozzle_size",
-                    "default_value": 0.6,
-                    "value": "wall_line_width * 1.5",
+                    "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
+                    "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
+                    "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                    "maximum_value_warning_old": "2 * machine_nozzle_size",
+                    "default_value": 0.3,
+                    "value": "machine_nozzle_size * .75",
                     "type": "float",
                     "settable_per_mesh": true,
                     "children":
                     {
                         "min_even_wall_line_width":
                         {
-                            "label": "Minimum Wall Line Width of Even Walls",
+                            "label": "Minimum Even Wall Line Width",
                             "description": "TODO.",
                             "unit": "mm",
-                            "minimum_value": ".5 * max(wall_line_width_0, wall_line_width_x)",
-                            "maximum_value": "min(wall_line_width_0, wall_line_width_x)",
-                            "minimum_value_warning": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                            "maximum_value_warning": "2 * machine_nozzle_size",
+                            "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
+                            "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
+                            "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                            "maximum_value_warning_old": "2 * machine_nozzle_size",
                             "default_value": 0.3,
-                            "value": "max_odd_wall_line_width / 2",
+                            "value": "min_wall_line_width",
                             "type": "float",
                             "settable_per_mesh": true,
                             "children":
@@ -1128,40 +1128,24 @@
                                     "type": "float",
                                     "unit": "%",
                                     "default_value": 90,
-                                    "value": "100 * (2 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0",
+                                    "value": "max(1, min(99, 100 * (2 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0))",
+                                    "value_explicit": "100 * (2 * min_even_wall_line_width - wall_line_width_0) / (wall_line_width_0 + wall_line_width_x - wall_line_width_0)",
                                     "minimum_value": "1",
                                     "maximum_value": "99"
                                 }
                             }
-                        }
-                    }
-                },
-                "max_even_wall_line_width":
-                {
-                    "label": "Maximum Wall Line Width of Even Walls",
-                    "description": "TODO.",
-                    "unit": "mm",
-                    "minimum_value": "max(wall_line_width_0, wall_line_width_x)",
-                    "maximum_value": "2 * min(wall_line_width_0, wall_line_width_x)",
-                    "minimum_value_warning": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                    "maximum_value_warning": "2 * machine_nozzle_size",
-                    "default_value": 0.6,
-                    "value": "wall_line_width * 1.5",
-                    "type": "float",
-                    "settable_per_mesh": true,
-                    "children":
-                    {
+                        },
                         "min_odd_wall_line_width":
                         {
-                            "label": "Minimum Wall Line Width of Odd Walls",
+                            "label": "Minimum Odd Wall Line Width",
                             "description": "TODO.",
                             "unit": "mm",
-                            "minimum_value": ".5 * max(wall_line_width_0, wall_line_width_x)",
-                            "maximum_value": "min(wall_line_width_0, wall_line_width_x)",
-                            "minimum_value_warning": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                            "maximum_value_warning": "2 * machine_nozzle_size",
+                            "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
+                            "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
+                            "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                            "maximum_value_warning_old": "2 * machine_nozzle_size",
                             "default_value": 0.3,
-                            "value": "max_even_wall_line_width * 2 - 2 * wall_line_width_0",
+                            "value": "min_wall_line_width",
                             "type": "float",
                             "settable_per_mesh": true,
                             "children":
@@ -1172,7 +1156,8 @@
                                     "type": "float",
                                     "unit": "%",
                                     "default_value": 80,
-                                    "value": "100 * min_odd_wall_line_width / wall_line_width_x",
+                                    "value": "max(1, min(99, 100 * min_odd_wall_line_width / wall_line_width_x))",
+                                    "value_explicit": "100 * (2 * wall_line_width_0 + min_odd_wall_line_width - 2 * wall_line_width_0) / (2 * wall_line_width_0 + wall_line_width_x - 2 * wall_line_width_0)",
                                     "minimum_value": "1",
                                     "maximum_value": "99"
                                 }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1092,79 +1092,6 @@
                     "default_value": "inward_distributed",
                     "limit_to_extruder": "wall_0_extruder_nr"
                 },
-                "min_wall_line_width":
-                {
-                    "label": "Minimum Wall Line Width",
-                    "description": "TODO. For thin structures. Max odd is 2x min even, max even is Outer wall line width + .5x min odd.",
-                    "unit": "mm",
-                    "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
-                    "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
-                    "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                    "maximum_value_warning_old": "2 * machine_nozzle_size",
-                    "default_value": 0.3,
-                    "value": "machine_nozzle_size * .75",
-                    "type": "float",
-                    "settable_per_mesh": true,
-                    "children":
-                    {
-                        "min_even_wall_line_width":
-                        {
-                            "label": "Minimum Even Wall Line Width",
-                            "description": "TODO.",
-                            "unit": "mm",
-                            "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
-                            "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
-                            "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                            "maximum_value_warning_old": "2 * machine_nozzle_size",
-                            "default_value": 0.3,
-                            "value": "min_wall_line_width",
-                            "type": "float",
-                            "settable_per_mesh": true,
-                            "children":
-                            {
-                                "wall_split_middle_threshold": {
-                                    "label": "Split Middle Line Threshold",
-                                    "description": "The smallest line width, as a factor of the normal line width, above which the middle line (if there is one) will be split into two. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
-                                    "type": "float",
-                                    "unit": "%",
-                                    "default_value": 90,
-                                    "value": "max(1, min(99, 100 * (2 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0))",
-                                    "value_explicit": "100 * (2 * min_even_wall_line_width - wall_line_width_0) / (wall_line_width_0 + wall_line_width_x - wall_line_width_0)",
-                                    "minimum_value": "1",
-                                    "maximum_value": "99"
-                                }
-                            }
-                        },
-                        "min_odd_wall_line_width":
-                        {
-                            "label": "Minimum Odd Wall Line Width",
-                            "description": "TODO.",
-                            "unit": "mm",
-                            "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
-                            "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
-                            "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
-                            "maximum_value_warning_old": "2 * machine_nozzle_size",
-                            "default_value": 0.3,
-                            "value": "min_wall_line_width",
-                            "type": "float",
-                            "settable_per_mesh": true,
-                            "children":
-                            {
-                                "wall_add_middle_threshold": {
-                                    "label": "Add Middle Line Threshold",
-                                    "description": "The smallest line width, as a factor of the normal line width, above which a middle line (if there wasn't one already) will be added. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
-                                    "type": "float",
-                                    "unit": "%",
-                                    "default_value": 80,
-                                    "value": "max(1, min(99, 100 * min_odd_wall_line_width / wall_line_width_x))",
-                                    "value_explicit": "100 * (2 * wall_line_width_0 + min_odd_wall_line_width - 2 * wall_line_width_0) / (2 * wall_line_width_0 + wall_line_width_x - 2 * wall_line_width_0)",
-                                    "minimum_value": "1",
-                                    "maximum_value": "99"
-                                }
-                            }
-                        }
-                    }
-                },
                 "wall_transition_length":
                 {
                     "label": "Wall Transition Length",
@@ -1276,6 +1203,79 @@
                     "default_value": true,
                     "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true
+                },
+                "min_wall_line_width":
+                {
+                    "label": "Minimum Wall Line Width",
+                    "description": "TODO. For thin structures. Max odd is 2x min even, max even is Outer wall line width + .5x min odd.",
+                    "unit": "mm",
+                    "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
+                    "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
+                    "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                    "maximum_value_warning_old": "2 * machine_nozzle_size",
+                    "default_value": 0.3,
+                    "value": "machine_nozzle_size * .75",
+                    "type": "float",
+                    "settable_per_mesh": true,
+                    "children":
+                    {
+                        "min_even_wall_line_width":
+                        {
+                            "label": "Minimum Even Wall Line Width",
+                            "description": "TODO.",
+                            "unit": "mm",
+                            "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
+                            "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
+                            "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                            "maximum_value_warning_old": "2 * machine_nozzle_size",
+                            "default_value": 0.3,
+                            "value": "min_wall_line_width",
+                            "type": "float",
+                            "settable_per_mesh": true,
+                            "children":
+                            {
+                                "wall_split_middle_threshold": {
+                                    "label": "Split Middle Line Threshold",
+                                    "description": "The smallest line width, as a factor of the normal line width, above which the middle line (if there is one) will be split into two. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
+                                    "type": "float",
+                                    "unit": "%",
+                                    "default_value": 90,
+                                    "value": "max(1, min(99, 100 * (2 * min_even_wall_line_width - wall_line_width_0) / wall_line_width_0))",
+                                    "value_explicit": "100 * (2 * min_even_wall_line_width - wall_line_width_0) / (wall_line_width_0 + wall_line_width_x - wall_line_width_0)",
+                                    "minimum_value": "1",
+                                    "maximum_value": "99"
+                                }
+                            }
+                        },
+                        "min_odd_wall_line_width":
+                        {
+                            "label": "Minimum Odd Wall Line Width",
+                            "description": "TODO.",
+                            "unit": "mm",
+                            "minimum_value_warning": ".5 * max(wall_line_width_0, wall_line_width_x)",
+                            "maximum_value_warning": "min(wall_line_width_0, wall_line_width_x)",
+                            "minimum_value_warning_old": "(0.1 + 0.4 * machine_nozzle_size) if inset_direction == \"outside_in\" else 0.1 * machine_nozzle_size",
+                            "maximum_value_warning_old": "2 * machine_nozzle_size",
+                            "default_value": 0.3,
+                            "value": "min_wall_line_width",
+                            "type": "float",
+                            "settable_per_mesh": true,
+                            "children":
+                            {
+                                "wall_add_middle_threshold": {
+                                    "label": "Add Middle Line Threshold",
+                                    "description": "The smallest line width, as a factor of the normal line width, above which a middle line (if there wasn't one already) will be added. Reduce this setting to use more, thinner lines. Increase to use fewer, wider lines. Note that this applies -as if- the entire shape should be filled with wall, so the middle here refers to the middle of the object between two outer edges of the shape, even if there actually is fill or (other) skin in the print instead of wall.",
+                                    "type": "float",
+                                    "unit": "%",
+                                    "default_value": 80,
+                                    "value": "max(1, min(99, 100 * min_odd_wall_line_width / wall_line_width_x))",
+                                    "value_explicit": "100 * (2 * wall_line_width_0 + min_odd_wall_line_width - 2 * wall_line_width_0) / (2 * wall_line_width_0 + wall_line_width_x - 2 * wall_line_width_0)",
+                                    "minimum_value": "1",
+                                    "maximum_value": "99"
+                                }
+                            }
+                        }
+                    }
                 },
                 "fill_outline_gaps": {
                     "label": "Print Thin Walls",


### PR DESCRIPTION
This PR introduces Minimum Wall Line Width settings which control the Middle Line Thresholds in a more intuitive fashion.

Moreover, this PR includes the formulae which properly relate the Minimum Lien Width settings to the Threshold settings.

These formulae can be used to verify the current behavior of the threshold settings more easily.

![image](https://user-images.githubusercontent.com/8895761/157657014-9a58dff1-0f85-4a8a-a9eb-82eb468422a6.png)
