### PR TITLE
[CURA-8945] odd spinbox behaviour when typing

### DIFF
--- a/resources/qml/SpinBox.qml
+++ b/resources/qml/SpinBox.qml
@@ -72,6 +72,18 @@ Item
             base.value = value * base.stepSize;
         }
 
+        // This forces TextField to commit typed values before incrementing with buttons.
+        // This fixes the typed value not being incremented when the textField has active focus.
+        up.onPressedChanged:
+        {
+            base.forceActiveFocus()
+        }
+
+        down.onPressedChanged:
+        {
+            base.forceActiveFocus()
+        }
+
         background: Item {}
 
         contentItem: Cura.TextField


### PR DESCRIPTION
This fixes the issue where the value that was in the textfield before typing would be incremented instead, if the textField had active focus.

CURA-8945