### PR TITLE
[CURA-9039] combobox dropdown scrolls out of settingview

### DIFF
--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -193,6 +193,14 @@ Item
         cacheBuffer: 1000000   // Set a large cache to effectively just cache every list item.
         ScrollBar.vertical: UM.ScrollBar { id: scrollBar }
 
+        onContentYChanged: {
+        // This removes focus from SettingItems when scrolling.
+        // This fixes comboboxes staying open and scrolling out of the settingView.
+            if (!scrollBar.activeFocus) {
+                scrollBar.forceActiveFocus();
+            }
+        }
+
         model: UM.SettingDefinitionsModel
         {
             id: definitionsModel


### PR DESCRIPTION
This fixes the issue where you can scroll combobox dropdowns out of the settingView.

This change causes all setting inputs to loose focus when you scroll.

CURA-9039