### PR TITLE
Remove `material_diameter` from quality profiles

### DIFF
--- a/resources/quality/anycubic_chiron/anycubic_chiron_draft.inst.cfg
+++ b/resources/quality/anycubic_chiron/anycubic_chiron_draft.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.3
 layer_height_0 = 0.3
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/anycubic_chiron/anycubic_chiron_high.inst.cfg
+++ b/resources/quality/anycubic_chiron/anycubic_chiron_high.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.1
 layer_height_0 = 0.1
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/anycubic_chiron/anycubic_chiron_normal.inst.cfg
+++ b/resources/quality/anycubic_chiron/anycubic_chiron_normal.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.2
 layer_height_0 = 0.2
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_draft.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_draft.inst.cfg
@@ -27,7 +27,6 @@ jerk_print = 8
 jerk_travel = 10
 layer_height = 0.3
 layer_height_0 = 0.3
-material_diameter = 1.75
 retract_at_layer_change = False
 retraction_amount = 6
 retraction_hop = 0.075

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_high.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_high.inst.cfg
@@ -27,7 +27,6 @@ jerk_print = 8
 jerk_travel = 10
 layer_height = 0.1
 layer_height_0 = 0.1
-material_diameter = 1.75
 retract_at_layer_change = False
 retraction_amount = 6
 retraction_hop = 0.075

--- a/resources/quality/anycubic_i3_mega/anycubic_i3_mega_normal.inst.cfg
+++ b/resources/quality/anycubic_i3_mega/anycubic_i3_mega_normal.inst.cfg
@@ -27,7 +27,6 @@ jerk_print = 8
 jerk_travel = 10
 layer_height = 0.2
 layer_height_0 = 0.2
-material_diameter = 1.75
 retract_at_layer_change = False
 retraction_amount = 6
 retraction_hop = 0.075

--- a/resources/quality/crazy3dprint/crazy3dprint_global_0.10_fine.inst.cfg
+++ b/resources/quality/crazy3dprint/crazy3dprint_global_0.10_fine.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.10
 layer_height_0 = 0.20
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 210
 material_print_temperature_layer_0 = 210
 speed_infill = =speed_print

--- a/resources/quality/crazy3dprint/crazy3dprint_global_0.20_normal.inst.cfg
+++ b/resources/quality/crazy3dprint/crazy3dprint_global_0.20_normal.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.2
 layer_height_0 = 0.3
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 210
 material_print_temperature_layer_0 = 210
 speed_infill = =speed_print

--- a/resources/quality/crazy3dprint/crazy3dprint_global_0.30_draft.inst.cfg
+++ b/resources/quality/crazy3dprint/crazy3dprint_global_0.30_draft.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.30
 layer_height_0 = 0.40
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 210
 material_print_temperature_layer_0 = 210
 speed_infill = =speed_print

--- a/resources/quality/crazy3dprint/crazy3dprint_global_0.40_coarse.inst.cfg
+++ b/resources/quality/crazy3dprint/crazy3dprint_global_0.40_coarse.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.4
 layer_height_0 = 0.4
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 210
 material_print_temperature_layer_0 = 210
 speed_infill = =speed_print

--- a/resources/quality/flashforge/flashforge_global_0.08_ultra.inst.cfg
+++ b/resources/quality/flashforge/flashforge_global_0.08_ultra.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.08
 layer_height_0 = 0.12
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 speed_infill = =speed_print

--- a/resources/quality/flashforge/flashforge_global_0.12_super.inst.cfg
+++ b/resources/quality/flashforge/flashforge_global_0.12_super.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.12
 layer_height_0 = 0.16
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 speed_infill = =speed_print

--- a/resources/quality/flashforge/flashforge_global_0.16_adaptive.inst.cfg
+++ b/resources/quality/flashforge/flashforge_global_0.16_adaptive.inst.cfg
@@ -19,7 +19,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.16
 layer_height_0 = 0.2
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 speed_infill = =speed_print

--- a/resources/quality/flashforge/flashforge_global_0.20_standard.inst.cfg
+++ b/resources/quality/flashforge/flashforge_global_0.20_standard.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.2
 layer_height_0 = 0.28
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 speed_infill = =speed_print

--- a/resources/quality/flashforge/flashforge_global_0.28_low.inst.cfg
+++ b/resources/quality/flashforge/flashforge_global_0.28_low.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.28
 layer_height_0 = 0.32
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 speed_infill = =speed_print

--- a/resources/quality/flashforge/flashforge_global_0.32_draft.inst.cfg
+++ b/resources/quality/flashforge/flashforge_global_0.32_draft.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.32
 layer_height_0 = 0.32
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 speed_infill = =speed_print

--- a/resources/quality/flashforge/flashforge_global_0.40_coarse.inst.cfg
+++ b/resources/quality/flashforge/flashforge_global_0.40_coarse.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.4
 layer_height_0 = 0.4
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 205
 material_print_temperature_layer_0 = 0
 speed_infill = =speed_print

--- a/resources/quality/flashforge/flashforge_global_0.48_extra_coarse.inst.cfg
+++ b/resources/quality/flashforge/flashforge_global_0.48_extra_coarse.inst.cfg
@@ -18,7 +18,6 @@ cool_fan_speed_0 = 0
 layer_height = 0.48
 layer_height_0 = 0.48
 material_bed_temperature = 40
-material_diameter = 1.75
 material_print_temperature = 205
 material_print_temperature_layer_0 = 0
 speed_infill = =speed_print

--- a/resources/quality/gmax15plus/gmax15plus_global_dual_normal.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_dual_normal.inst.cfg
@@ -30,7 +30,6 @@ retraction_combing = off
 retraction_amount = 0.75
 retraction_speed = 70
 material_flow = 98
-material_diameter = 1.75
 
 support_use_towers = False
 support_z_distance = 0.2

--- a/resources/quality/gmax15plus/gmax15plus_global_dual_thick.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_dual_thick.inst.cfg
@@ -30,7 +30,6 @@ retraction_combing = off
 retraction_amount = 0.75
 retraction_speed = 70
 material_flow = 98
-material_diameter = 1.75
 
 support_use_towers = False
 support_z_distance = 0.2

--- a/resources/quality/gmax15plus/gmax15plus_global_dual_thin.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_dual_thin.inst.cfg
@@ -30,7 +30,6 @@ retraction_combing = off
 retraction_amount = 0.75
 retraction_speed = 70
 material_flow = 98
-material_diameter = 1.75
 
 support_use_towers = False
 support_z_distance = 0.2

--- a/resources/quality/gmax15plus/gmax15plus_global_dual_very_thick.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_dual_very_thick.inst.cfg
@@ -29,7 +29,6 @@ retraction_combing = off
 retraction_amount = 0.75
 retraction_speed = 70
 material_flow = 98
-material_diameter = 1.75
 
 support_use_towers = False
 support_z_distance = 0.2

--- a/resources/quality/gmax15plus/gmax15plus_global_normal.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_normal.inst.cfg
@@ -30,7 +30,6 @@ retraction_combing = off
 retraction_amount = 0.75
 retraction_speed = 70
 material_flow = 98
-material_diameter = 1.75
 
 support_use_towers = False
 support_z_distance = 0.2

--- a/resources/quality/gmax15plus/gmax15plus_global_thick.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_thick.inst.cfg
@@ -30,7 +30,6 @@ retraction_combing = off
 retraction_amount = 0.75
 retraction_speed = 70
 material_flow = 98
-material_diameter = 1.75
 
 support_use_towers = False
 support_z_distance = 0.2

--- a/resources/quality/gmax15plus/gmax15plus_global_thin.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_thin.inst.cfg
@@ -30,7 +30,6 @@ retraction_combing = off
 retraction_amount = 0.75
 retraction_speed = 70
 material_flow = 98
-material_diameter = 1.75
 
 support_use_towers = False
 support_z_distance = 0.2

--- a/resources/quality/gmax15plus/gmax15plus_global_very_thick.inst.cfg
+++ b/resources/quality/gmax15plus/gmax15plus_global_very_thick.inst.cfg
@@ -29,7 +29,6 @@ retraction_combing = off
 retraction_amount = 0.75
 retraction_speed = 70
 material_flow = 98
-material_diameter = 1.75
 
 support_use_towers = False
 support_z_distance = 0.2

--- a/resources/quality/katihal/alya3dp_normal_generic_pla.inst.cfg
+++ b/resources/quality/katihal/alya3dp_normal_generic_pla.inst.cfg
@@ -11,7 +11,6 @@ weight = 3
 material = generic_pla
 
 [values]
-material_diameter = 1.75
 speed_print = 40
 speed_topbottom = 30
 speed_wall_0 = 35

--- a/resources/quality/katihal/alyanx3dp_normal_generic_pla.inst.cfg
+++ b/resources/quality/katihal/alyanx3dp_normal_generic_pla.inst.cfg
@@ -11,7 +11,6 @@ weight = 2
 material = generic_pla
 
 [values]
-material_diameter = 1.75
 speed_print = 40
 speed_topbottom = 30
 speed_wall_0 = 35

--- a/resources/quality/katihal/kupido_normal_generic_abs.inst.cfg
+++ b/resources/quality/katihal/kupido_normal_generic_abs.inst.cfg
@@ -11,7 +11,6 @@ weight = 3
 material = generic_abs
 
 [values]
-material_diameter = 1.75
 speed_print = 40
 speed_topbottom = 30
 speed_wall_0 = 35

--- a/resources/quality/katihal/kupido_normal_generic_pla.inst.cfg
+++ b/resources/quality/katihal/kupido_normal_generic_pla.inst.cfg
@@ -11,7 +11,6 @@ weight = 3
 material = generic_pla
 
 [values]
-material_diameter = 1.75
 speed_print = 40
 speed_topbottom = 30
 speed_wall_0 = 35

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_draft.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_draft.inst.cfg
@@ -24,7 +24,6 @@ speed_travel = 120
 
 material_print_temperature = 246
 material_bed_temperature = 85
-material_diameter = 1.75
 
 retraction_speed = 50
 retraction_amount = 1.5

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_extra_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_extra_fine.inst.cfg
@@ -24,7 +24,6 @@ speed_travel = 120
 
 material_print_temperature = 246
 material_bed_temperature = 85
-material_diameter = 1.75
 
 retraction_speed = 50
 retraction_amount = 1.5

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_fine.inst.cfg
@@ -24,7 +24,6 @@ speed_travel = 120
 
 material_print_temperature = 246
 material_bed_temperature = 85
-material_diameter = 1.75
 
 retraction_speed = 50
 retraction_amount = 1.5

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_low.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_low.inst.cfg
@@ -24,7 +24,6 @@ speed_travel = 120
 
 material_print_temperature = 246
 material_bed_temperature = 85
-material_diameter = 1.75
 
 retraction_speed = 50
 retraction_amount = 1.5

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_abs_normal.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_abs_normal.inst.cfg
@@ -24,7 +24,6 @@ speed_travel = 120
 
 material_print_temperature = 246
 material_bed_temperature = 85
-material_diameter = 1.75
 
 retraction_speed = 50
 retraction_amount = 1.5

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_draft.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_draft.inst.cfg
@@ -18,7 +18,6 @@ speed_print = 60
 
 material_print_temperature = 214
 material_bed_temperature = 60
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_extra_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_extra_fine.inst.cfg
@@ -18,7 +18,6 @@ speed_print = 30
 
 material_print_temperature = 214
 material_bed_temperature = 60
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_fine.inst.cfg
@@ -18,7 +18,6 @@ speed_print = 40
 
 material_print_temperature = 214
 material_bed_temperature = 60
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_low.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_low.inst.cfg
@@ -18,7 +18,6 @@ speed_print = 60
 
 material_print_temperature = 214
 material_bed_temperature = 60
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_beta_pla_normal.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_beta_pla_normal.inst.cfg
@@ -18,7 +18,6 @@ speed_print = 50
 
 material_print_temperature = 214
 material_bed_temperature = 60
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_draft.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_draft.inst.cfg
@@ -17,7 +17,6 @@ adhesion_type = raft
 speed_print = 60
 
 material_print_temperature = 214
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_extra_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_extra_fine.inst.cfg
@@ -23,7 +23,6 @@ speed_topbottom = =math.ceil(speed_print * 20 / 40)
 speed_travel = 120
 
 material_print_temperature = 214
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_fine.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_fine.inst.cfg
@@ -23,7 +23,6 @@ speed_topbottom = =math.ceil(speed_print * 30 / 50)
 speed_travel = 120
 
 material_print_temperature = 214
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_low.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_low.inst.cfg
@@ -17,7 +17,6 @@ adhesion_type = raft
 speed_print = 60
 
 material_print_temperature = 214
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/kemiq_q2/kemiq_q2_gama_pla_normal.inst.cfg
+++ b/resources/quality/kemiq_q2/kemiq_q2_gama_pla_normal.inst.cfg
@@ -23,7 +23,6 @@ speed_topbottom = =math.ceil(speed_print * 20 / 60)
 speed_travel = 120
 
 material_print_temperature = 214
-material_diameter = 1.75
 
 retraction_speed = 40
 retraction_amount = 2.15

--- a/resources/quality/key3d/key3d_tyro_best.inst.cfg
+++ b/resources/quality/key3d/key3d_tyro_best.inst.cfg
@@ -47,7 +47,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/key3d/key3d_tyro_fast.inst.cfg
+++ b/resources/quality/key3d/key3d_tyro_fast.inst.cfg
@@ -46,7 +46,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/key3d/key3d_tyro_normal.inst.cfg
+++ b/resources/quality/key3d/key3d_tyro_normal.inst.cfg
@@ -46,7 +46,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/nwa3d_a31/nwa3d_a31_best.inst.cfg
+++ b/resources/quality/nwa3d_a31/nwa3d_a31_best.inst.cfg
@@ -48,7 +48,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/nwa3d_a31/nwa3d_a31_e.inst.cfg
+++ b/resources/quality/nwa3d_a31/nwa3d_a31_e.inst.cfg
@@ -45,7 +45,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/nwa3d_a31/nwa3d_a31_fast.inst.cfg
+++ b/resources/quality/nwa3d_a31/nwa3d_a31_fast.inst.cfg
@@ -48,7 +48,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/nwa3d_a31/nwa3d_a31_normal.inst.cfg
+++ b/resources/quality/nwa3d_a31/nwa3d_a31_normal.inst.cfg
@@ -47,7 +47,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/nwa3d_a5/nwa3d_a5_best.inst.cfg
+++ b/resources/quality/nwa3d_a5/nwa3d_a5_best.inst.cfg
@@ -46,7 +46,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/nwa3d_a5/nwa3d_a5_fast.inst.cfg
+++ b/resources/quality/nwa3d_a5/nwa3d_a5_fast.inst.cfg
@@ -46,7 +46,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/nwa3d_a5/nwa3d_a5_normal.inst.cfg
+++ b/resources/quality/nwa3d_a5/nwa3d_a5_normal.inst.cfg
@@ -46,7 +46,6 @@ gradual_infill_steps = 0
 infill_before_walls = False
 infill_support_enabled = False
 max_skin_angle_for_expansion = 90
-material_diameter = 1.75
 default_material_print_temperature = 220
 material_print_temperature = 220
 material_print_temperature_layer_0 = 220

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_draft.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_draft.inst.cfg
@@ -14,7 +14,6 @@ global_quality = True
 brim_width = 4.0
 infill_pattern = zigzag
 layer_height = 0.3
-material_diameter = 1.75
 speed_infill = =speed_print
 speed_print = 50
 speed_support = 30

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_high.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_high.inst.cfg
@@ -14,7 +14,6 @@ global_quality = True
 brim_width = 4.0
 infill_pattern = zigzag
 layer_height = 0.1
-material_diameter = 1.75
 speed_infill = =speed_print
 speed_print = 50
 speed_support = 30

--- a/resources/quality/tevo_blackwidow/tevo_blackwidow_normal.inst.cfg
+++ b/resources/quality/tevo_blackwidow/tevo_blackwidow_normal.inst.cfg
@@ -14,7 +14,6 @@ global_quality = True
 brim_width = 4.0
 infill_pattern = zigzag
 layer_height = 0.2
-material_diameter = 1.75
 speed_infill = =math.ceil(speed_print * 60 / 50)
 speed_print = 50
 speed_support = 30

--- a/resources/quality/tinyboy/tinyboy_e10_draft.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_e10_draft.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.3
 layer_height_0 = 0.3
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tinyboy/tinyboy_e10_high.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_e10_high.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.1
 layer_height_0 = 0.1
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tinyboy/tinyboy_e10_normal.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_e10_normal.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.2
 layer_height_0 = 0.2
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tinyboy/tinyboy_e16_draft.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_e16_draft.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.3
 layer_height_0 = 0.3
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tinyboy/tinyboy_e16_high.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_e16_high.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.1
 layer_height_0 = 0.1
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tinyboy/tinyboy_e16_normal.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_e16_normal.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.2
 layer_height_0 = 0.2
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tinyboy/tinyboy_fabrikator15_draft.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_fabrikator15_draft.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.3
 layer_height_0 = 0.3
 material_bed_temperature = 60
-material_diameter = 1.75
 retract_at_layer_change = False
 retraction_amount = 6
 retraction_hop = 0.075

--- a/resources/quality/tinyboy/tinyboy_fabrikator15_high.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_fabrikator15_high.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.1
 layer_height_0 = 0.1
 material_bed_temperature = 60
-material_diameter = 1.75
 retract_at_layer_change = False
 retraction_amount = 6
 retraction_hop = 0.075

--- a/resources/quality/tinyboy/tinyboy_fabrikator15_normal.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_fabrikator15_normal.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.2
 layer_height_0 = 0.2
 material_bed_temperature = 60
-material_diameter = 1.75
 retract_at_layer_change = False
 retraction_amount = 6
 retraction_hop = 0.075

--- a/resources/quality/tinyboy/tinyboy_ra20_draft.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_ra20_draft.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.3
 layer_height_0 = 0.3
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tinyboy/tinyboy_ra20_high.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_ra20_high.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.1
 layer_height_0 = 0.1
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tinyboy/tinyboy_ra20_normal.inst.cfg
+++ b/resources/quality/tinyboy/tinyboy_ra20_normal.inst.cfg
@@ -29,7 +29,6 @@ jerk_travel = 10
 layer_height = 0.2
 layer_height_0 = 0.2
 material_bed_temperature = 60
-material_diameter = 1.75
 material_print_temperature = 200
 material_print_temperature_layer_0 = 0
 retract_at_layer_change = False

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Coarse_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Coarse_Quality.inst.cfg
@@ -29,7 +29,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Draft_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Draft_Quality.inst.cfg
@@ -29,7 +29,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Extra_Coarse_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Extra_Coarse_Quality.inst.cfg
@@ -29,7 +29,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_High_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_High_Quality.inst.cfg
@@ -29,7 +29,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Normal_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy/tizyx_evy_global_Normal_Quality.inst.cfg
@@ -29,7 +29,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_High_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_High_Quality.inst.cfg
@@ -38,7 +38,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_Normal_Quality.inst.cfg
+++ b/resources/quality/tizyx/tizyx_evy_dual/tizyx_evy_dual_global_Normal_Quality.inst.cfg
@@ -38,7 +38,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/tizyx/tizyx_k25/tizyx_k25_high.inst.cfg
+++ b/resources/quality/tizyx/tizyx_k25/tizyx_k25_high.inst.cfg
@@ -25,7 +25,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/tizyx/tizyx_k25/tizyx_k25_normal.inst.cfg
+++ b/resources/quality/tizyx/tizyx_k25/tizyx_k25_normal.inst.cfg
@@ -25,7 +25,6 @@ skirt_line_count = 2
 skirt_gap = 2
 fill_outline_gaps = True
 infill_sparse_density = 15
-material_diameter = 1.75
 retraction_min_travel = 2
 speed_print = 60
 cool_fan_speed_0 = 10

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_1p0_pro_copper_0.40_abs_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_1p0_pro_copper_0.40_abs_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_1p0_pro_copper_0.40_abs_draft.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_1p0_pro_copper_0.40_abs_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_1p0_pro_copper_0.40_abs_fine.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_1p0_pro_copper_0.40_abs_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_1p0_pro_copper_0.40_abs_normal.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_1p0_pro_copper_0.40_abs_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_abs_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_abs_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_abs_draft.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_abs_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_abs_fine.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_abs_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_abs_normal.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_abs_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_super_copper_0.40_abs_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_super_copper_0.40_abs_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_super_copper_0.40_abs_draft.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_super_copper_0.40_abs_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_super_copper_0.40_abs_fine.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_super_copper_0.40_abs_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_super_copper_0.40_abs_normal.inst.cfg
+++ b/resources/quality/xyzprinting/abs/xyzprinting_da_vinci_super_copper_0.40_abs_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_1p0_pro_copper_0.40_antibact_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_1p0_pro_copper_0.40_antibact_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_1p0_pro_copper_0.40_antibact_draft.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_1p0_pro_copper_0.40_antibact_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_1p0_pro_copper_0.40_antibact_fine.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_1p0_pro_copper_0.40_antibact_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_1p0_pro_copper_0.40_antibact_normal.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_1p0_pro_copper_0.40_antibact_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_antibact_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_antibact_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_antibact_draft.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_antibact_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_antibact_fine.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_antibact_fine.inst.cfg
@@ -13,7 +13,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_antibact_normal.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_antibact_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_antibact_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_antibact_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_antibact_draft.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_antibact_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_antibact_fine.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_antibact_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_antibact_normal.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_antibact_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_antibact_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_antibact_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_antibact_draft.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_antibact_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_antibact_fine.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_antibact_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_antibact_normal.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_antibact_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_w_pro_ss_0.40_antibact_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_w_pro_ss_0.40_antibact_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_w_pro_ss_0.40_antibact_draft.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_w_pro_ss_0.40_antibact_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_w_pro_ss_0.40_antibact_fine.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_w_pro_ss_0.40_antibact_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_w_pro_ss_0.40_antibact_normal.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_jr_w_pro_ss_0.40_antibact_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_super_copper_0.40_antibact_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_super_copper_0.40_antibact_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_super_copper_0.40_antibact_draft.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_super_copper_0.40_antibact_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_super_copper_0.40_antibact_fine.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_super_copper_0.40_antibact_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_super_copper_0.40_antibact_normal.inst.cfg
+++ b/resources/quality/xyzprinting/anti_bact/xyzprinting_da_vinci_super_copper_0.40_antibact_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_carbon_fiber_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_carbon_fiber_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_carbon_fiber_draft.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_carbon_fiber_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_carbon_fiber_fine.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_carbon_fiber_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_carbon_fiber_normal.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_carbon_fiber_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_carbon_fiber_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_carbon_fiber_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_carbon_fiber_draft.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_carbon_fiber_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_carbon_fiber_fine.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_carbon_fiber_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_carbon_fiber_normal.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_carbon_fiber_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_carbon_fiber_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_carbon_fiber_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_carbon_fiber_draft.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_carbon_fiber_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_carbon_fiber_fine.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_carbon_fiber_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_carbon_fiber_normal.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_carbon_fiber_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_w_pro_hs_0.40_carbon_fiber_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_w_pro_hs_0.40_carbon_fiber_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_w_pro_hs_0.40_carbon_fiber_draft.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_w_pro_hs_0.40_carbon_fiber_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_w_pro_hs_0.40_carbon_fiber_fine.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_w_pro_hs_0.40_carbon_fiber_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_w_pro_hs_0.40_carbon_fiber_normal.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_jr_w_pro_hs_0.40_carbon_fiber_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_super_hs_0.40_carbon_fiber_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_super_hs_0.40_carbon_fiber_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_super_hs_0.40_carbon_fiber_draft.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_super_hs_0.40_carbon_fiber_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_super_hs_0.40_carbon_fiber_fine.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_super_hs_0.40_carbon_fiber_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_super_hs_0.40_carbon_fiber_normal.inst.cfg
+++ b/resources/quality/xyzprinting/carbon_fiber/xyzprinting_da_vinci_super_hs_0.40_carbon_fiber_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_colorinkjet_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_colorinkjet_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_colorinkjet_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_colorinkjet_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_colorinkjet_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_colorinkjet_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_colorinkjet_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_colorinkjet_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_colorinkjet_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_colorinkjet_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_colorinkjet_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_colorinkjet_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_colorinkjet_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_colorinkjet_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_colorinkjet_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_colorinkjet_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_super_copper_0.40_colorinkjet_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_super_copper_0.40_colorinkjet_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_super_copper_0.40_colorinkjet_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_super_copper_0.40_colorinkjet_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_super_copper_0.40_colorinkjet_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_super_copper_0.40_colorinkjet_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_super_copper_0.40_colorinkjet_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/color_pla/xyzprinting_da_vinci_super_copper_0.40_colorinkjet_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/flexible/xyzprinting_da_vinci_super_copper_0.40_flexible_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/flexible/xyzprinting_da_vinci_super_copper_0.40_flexible_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/flexible/xyzprinting_da_vinci_super_copper_0.40_flexible_draft.inst.cfg
+++ b/resources/quality/xyzprinting/flexible/xyzprinting_da_vinci_super_copper_0.40_flexible_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/flexible/xyzprinting_da_vinci_super_copper_0.40_flexible_fine.inst.cfg
+++ b/resources/quality/xyzprinting/flexible/xyzprinting_da_vinci_super_copper_0.40_flexible_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/flexible/xyzprinting_da_vinci_super_copper_0.40_flexible_normal.inst.cfg
+++ b/resources/quality/xyzprinting/flexible/xyzprinting_da_vinci_super_copper_0.40_flexible_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_metallic_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_metallic_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_metallic_draft.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_metallic_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_metallic_fine.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_metallic_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_metallic_normal.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_1p0a_pro_hs_0.40_metallic_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_metallic_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_metallic_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_metallic_draft.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_metallic_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_metallic_fine.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_metallic_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_metallic_normal.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xeplus_hs_0.40_metallic_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_metallic_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_metallic_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_metallic_draft.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_metallic_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_metallic_fine.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_metallic_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_metallic_normal.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_pro_xplus_hs_0.40_metallic_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_w_pro_hs_0.40_metallic_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_w_pro_hs_0.40_metallic_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_w_pro_hs_0.40_metallic_draft.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_w_pro_hs_0.40_metallic_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_w_pro_hs_0.40_metallic_fine.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_w_pro_hs_0.40_metallic_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_w_pro_hs_0.40_metallic_normal.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_jr_w_pro_hs_0.40_metallic_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_super_hs_0.40_metallic_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_super_hs_0.40_metallic_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_super_hs_0.40_metallic_draft.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_super_hs_0.40_metallic_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_super_hs_0.40_metallic_fine.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_super_hs_0.40_metallic_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_super_hs_0.40_metallic_normal.inst.cfg
+++ b/resources/quality/xyzprinting/metallic_pla/xyzprinting_da_vinci_super_hs_0.40_metallic_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Hardened Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/nylon/xyzprinting_da_vinci_super_copper_0.40_nylon_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/nylon/xyzprinting_da_vinci_super_copper_0.40_nylon_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/nylon/xyzprinting_da_vinci_super_copper_0.40_nylon_draft.inst.cfg
+++ b/resources/quality/xyzprinting/nylon/xyzprinting_da_vinci_super_copper_0.40_nylon_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/nylon/xyzprinting_da_vinci_super_copper_0.40_nylon_fine.inst.cfg
+++ b/resources/quality/xyzprinting/nylon/xyzprinting_da_vinci_super_copper_0.40_nylon_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/nylon/xyzprinting_da_vinci_super_copper_0.40_nylon_normal.inst.cfg
+++ b/resources/quality/xyzprinting/nylon/xyzprinting_da_vinci_super_copper_0.40_nylon_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_1p0_pro_copper_0.40_petg_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_1p0_pro_copper_0.40_petg_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_1p0_pro_copper_0.40_petg_draft.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_1p0_pro_copper_0.40_petg_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_1p0_pro_copper_0.40_petg_fine.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_1p0_pro_copper_0.40_petg_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_1p0_pro_copper_0.40_petg_normal.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_1p0_pro_copper_0.40_petg_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_petg_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_petg_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_petg_draft.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_petg_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_petg_fine.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_petg_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_petg_normal.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_petg_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_petg_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_petg_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_petg_draft.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_petg_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_petg_fine.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_petg_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_petg_normal.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_petg_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_petg_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_petg_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_petg_draft.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_petg_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_petg_fine.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_petg_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_petg_normal.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_petg_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_w_pro_ss_0.40_petg_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_w_pro_ss_0.40_petg_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_w_pro_ss_0.40_petg_draft.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_w_pro_ss_0.40_petg_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_w_pro_ss_0.40_petg_fine.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_w_pro_ss_0.40_petg_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_w_pro_ss_0.40_petg_normal.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_jr_w_pro_ss_0.40_petg_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_super_copper_0.40_petg_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_super_copper_0.40_petg_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_super_copper_0.40_petg_draft.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_super_copper_0.40_petg_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_super_copper_0.40_petg_fine.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_super_copper_0.40_petg_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_super_copper_0.40_petg_normal.inst.cfg
+++ b/resources/quality/xyzprinting/petg/xyzprinting_da_vinci_super_copper_0.40_petg_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_super_copper_0.40_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_super_copper_0.40_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_super_copper_0.40_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_super_copper_0.40_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_super_copper_0.40_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_super_copper_0.40_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_super_copper_0.40_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/pla/xyzprinting_da_vinci_super_copper_0.40_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_tough_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_tough_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_tough_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_tough_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_tough_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_tough_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_tough_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_1p0_pro_copper_0.40_tough_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_tough_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_tough_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_tough_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_tough_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_tough_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_tough_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_tough_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_1p0a_pro_copper_0.40_tough_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_tough_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_tough_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_tough_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_tough_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_tough_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_tough_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_tough_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xeplus_copper_0.40_tough_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_tough_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_tough_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_tough_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_tough_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_tough_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_tough_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_tough_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_pro_xplus_copper_0.40_tough_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_tough_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_tough_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_tough_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_tough_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_tough_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_tough_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_tough_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_jr_w_pro_ss_0.40_tough_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Stainless Steel 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_super_copper_0.40_tough_pla_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_super_copper_0.40_tough_pla_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_super_copper_0.40_tough_pla_draft.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_super_copper_0.40_tough_pla_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_super_copper_0.40_tough_pla_fine.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_super_copper_0.40_tough_pla_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_super_copper_0.40_tough_pla_normal.inst.cfg
+++ b/resources/quality/xyzprinting/tough_pla/xyzprinting_da_vinci_super_copper_0.40_tough_pla_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tpu/xyzprinting_da_vinci_super_copper_0.40_tpu_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/tpu/xyzprinting_da_vinci_super_copper_0.40_tpu_coarse.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tpu/xyzprinting_da_vinci_super_copper_0.40_tpu_draft.inst.cfg
+++ b/resources/quality/xyzprinting/tpu/xyzprinting_da_vinci_super_copper_0.40_tpu_draft.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tpu/xyzprinting_da_vinci_super_copper_0.40_tpu_fine.inst.cfg
+++ b/resources/quality/xyzprinting/tpu/xyzprinting_da_vinci_super_copper_0.40_tpu_fine.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/tpu/xyzprinting_da_vinci_super_copper_0.40_tpu_normal.inst.cfg
+++ b/resources/quality/xyzprinting/tpu/xyzprinting_da_vinci_super_copper_0.40_tpu_normal.inst.cfg
@@ -14,7 +14,6 @@ variant = Copper 0.4mm Nozzle
 [values]
 layer_height = 0.2
 layer_height_0 = 0.35
-material_diameter = 1.75
 material_bed_temperature_layer_0 = =material_bed_temperature
 material_print_temperature_layer_0 = =material_print_temperature
 material_initial_print_temperature = =material_print_temperature

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_1p0_pro_global_0.10_fine.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_1p0_pro_global_0.10_fine.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_1p0_pro_global_0.20_normal.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_1p0_pro_global_0.20_normal.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_1p0_pro_global_0.30_draft.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_1p0_pro_global_0.30_draft.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_1p0_pro_global_0.40_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_1p0_pro_global_0.40_coarse.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_1p0a_pro_global_0.10_fine.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_1p0a_pro_global_0.10_fine.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_1p0a_pro_global_0.20_normal.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_1p0a_pro_global_0.20_normal.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_1p0a_pro_global_0.30_draft.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_1p0a_pro_global_0.30_draft.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_1p0a_pro_global_0.40_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_1p0a_pro_global_0.40_coarse.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xep_global_0.10_fine.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xep_global_0.10_fine.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xep_global_0.20_normal.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xep_global_0.20_normal.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xep_global_0.30_draft.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xep_global_0.30_draft.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xep_global_0.40_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xep_global_0.40_coarse.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xp_global_0.10_fine.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xp_global_0.10_fine.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xp_global_0.20_normal.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xp_global_0.20_normal.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xp_global_0.30_draft.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xp_global_0.30_draft.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xp_global_0.40_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_pro_xp_global_0.40_coarse.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_w_pro_global_0.10_fine.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_w_pro_global_0.10_fine.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_w_pro_global_0.20_normal.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_w_pro_global_0.20_normal.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_w_pro_global_0.30_draft.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_w_pro_global_0.30_draft.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_w_pro_global_0.40_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_jr_w_pro_global_0.40_coarse.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_super_global_0.10_fine.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_super_global_0.10_fine.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.1
 layer_height_0 = 0.2
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_super_global_0.20_normal.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_super_global_0.20_normal.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.2
 layer_height_0 = 0.3
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_super_global_0.30_draft.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_super_global_0.30_draft.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.3
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10

--- a/resources/quality/xyzprinting/xyzprinting_da_vinci_super_global_0.40_coarse.inst.cfg
+++ b/resources/quality/xyzprinting/xyzprinting_da_vinci_super_global_0.40_coarse.inst.cfg
@@ -13,5 +13,4 @@ global_quality = True
 [values]
 layer_height = 0.4
 layer_height_0 = 0.4
-material_diameter = 1.75
 infill_sparse_density = 10


### PR DESCRIPTION
This PR removes the `material_diameter` from quality profiles for several printers.

Setting the `material_diameter` in a quality profile overrides what is set in the material, and there is no way for the user to override this since `material_diameter` is a hidden "machine" setting. The `material_diameter` is still properly set in the printer definition and the used material, so functionally there is no difference.

(Doesn't) affect XYZ Da Vinci, Tinyboy, Tevo Blackwidow, Nwa3d, Key3d, Kemiq Q2, Katihal, Gmax15+, Flashforge, Crazy3dPrint and AnyCubic printers.

For more information, see https://community.ultimaker.com/topic/39974-solved-material-settings-diameter-could-be-ignored-with-bad-preset-print-setting-profiles-topic-regarding-anycubic-chiron