### PR TITLE
USBPrinterOutputDevice.py: Convert estimated time to int

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -398,7 +398,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
             line = line[:line.find(";")]
 
         line = line.strip()
-
+ 
         # Don't send empty lines. But we do have to send something, so send M105 instead.
         # Don't send the M0 or M1 to the machine, as M0 and M1 are handled as an LCD menu pause.
         if line == "" or line == "M0" or line == "M1":
@@ -429,7 +429,7 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
         print_job.updateTimeElapsed(elapsed_time)
         estimated_time = self._print_estimated_time
         if progress > .1:
-            estimated_time = self._print_estimated_time * (1 - progress) + elapsed_time
+            estimated_time = int(self._print_estimated_time * (1 - progress) + elapsed_time)
         print_job.updateTimeTotal(estimated_time)
 
         self._gcode_position += 1


### PR DESCRIPTION
PrintJobOutputModel.py requires timeElapsed be an int.  USBPrinterOutputDevice.py sets it to a float instead, which causes PILES of exception windows to open up, though Cura does not crash and the print continues fine (albeit displaying some nonsense values for percentage done, etc).  Simple fix.