### PR TITLE
Remove reference to Cura in UM component

### DIFF
--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -48,6 +48,17 @@ UM.ManagementPage
 
     onHamburgeButtonClicked: menu.popup(content_item, content_item.width - menu.width, hamburger_button.height)
 
+    isActiveModelFunction: function(model, id) {
+        if (model.is_read_only)
+        {
+            return (model.name == Cura.MachineManager.activeQualityOrQualityChangesName) && (model.intent_category == Cura.MachineManager.activeIntentCategory);
+        }
+        else
+        {
+            return model.name == Cura.MachineManager.activeQualityOrQualityChangesName;
+        }
+    }
+
     onCreateProfile:
     {
         createQualityDialog.object = Cura.ContainerManager.makeUniqueName(Cura.MachineManager.activeQualityOrQualityChangesName);


### PR DESCRIPTION
Add isActiveModelFunction that can be overwritten in inheriting components

Override isActiveModelFunction in Profiles page, this is done because quality models do not have a unique id that can be assigned to activeId

CURA-9044
https://github.com/Ultimaker/Uranium/pull/798/