### PR TITLE
Fix "double"/non-functional scrollbars on ScrollViews

### DIFF
--- a/resources/qml/Dialogs/WorkspaceSummaryDialog.qml
+++ b/resources/qml/Dialogs/WorkspaceSummaryDialog.qml
@@ -67,7 +67,7 @@ UM.Dialog
 
             ScrollBar.vertical: UM.ScrollBar
             {
-                parent: scroll
+                parent: scroll.parent
                 anchors
                 {
                     top: parent.top

--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml
@@ -68,7 +68,7 @@ Item
         clip: true
 
         ScrollBar.vertical: UM.ScrollBar {
-            parent: container
+            parent: container.parent
             anchors
             {
                 top: parent.top

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -141,7 +141,7 @@ UM.PreferencesPage
         ScrollBar.vertical: UM.ScrollBar
         {
             id: preferencesScrollBar
-            parent: preferencesScrollView
+            parent: preferencesScrollView.parent
             anchors
             {
                 top: parent.top

--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -126,7 +126,7 @@ UM.ManagementPage
         ScrollBar.vertical: UM.ScrollBar
         {
             id: materialScrollBar
-            parent: materialScrollView
+            parent: materialScrollView.parent
             anchors
             {
                 top: parent.top

--- a/resources/qml/Preferences/Materials/MaterialsView.qml
+++ b/resources/qml/Preferences/Materials/MaterialsView.qml
@@ -94,7 +94,7 @@ Item
             ScrollBar.vertical: UM.ScrollBar
             {
                 id: scrollBar
-                parent: informationPage
+                parent: informationPage.parent
                 anchors
                 {
                     top: parent.top
@@ -536,7 +536,7 @@ Item
             ScrollBar.vertical: UM.ScrollBar
             {
                 id: settingScrollBar
-                parent: settingsPage
+                parent: settingsPage.parent
                 anchors
                 {
                     top: parent.top

--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -21,7 +21,7 @@ ScrollView
     ScrollBar.vertical: UM.ScrollBar
     {
         id: scrollbar
-        parent: base
+        parent: base.parent
         anchors
         {
             right: parent.right


### PR DESCRIPTION
This PR fixes what looks like a vestigial "double" scrollbar in some places. The mechanism seems to be that even though a custom scrollbar is provided, the "default" scrollbar is not hidden because it has a parent outside the scrollview (and the custom scrollbar is inside the scrollview). The resulting "default" scrollbar is non-functional, but its hitarea overlaps the custom scrollview so that one has a very small hit-area.

![scrollbar](https://user-images.githubusercontent.com/143551/159497761-6e70fdcc-88b8-48b3-b725-7162825ff6b5.png)

Both scrollbars showing in the materials pane are affected:
![image](https://user-images.githubusercontent.com/143551/159498050-6508ab1b-a67a-432b-9666-d352e555e3c0.png)

The profile selector is also affected:
![image](https://user-images.githubusercontent.com/143551/159498103-09028b5e-769a-4998-9afd-1f21632e1b44.png)


For (some) details: https://doc.qt.io/qt-5/qml-qtquick-controls2-scrollbar.html#attaching-scrollbar-to-a-flickable