### PR TITLE
voron2_base.def.json: Do not limit travel speeds to 300mm/s

### DIFF
--- a/resources/definitions/voron2_base.def.json
+++ b/resources/definitions/voron2_base.def.json
@@ -107,7 +107,7 @@
         "retraction_combing":                           { "value": "'noskin'" },
         "retraction_combing_max_distance":              { "default_value": 10 },
         "travel_avoid_other_parts":                     { "default_value": false },
-        "speed_travel":                                 { "maximum_value": 300, "value": 300, "maximum_value_warning": 501 },
+        "speed_travel":                                 { "value": 300, "maximum_value_warning": 501 },
         "speed_travel_layer_0":                         { "value": "math.ceil(speed_travel * 0.4)" },
         "speed_layer_0":                                { "value": "math.ceil(speed_print * 0.25)" },
         "speed_wall":                                   { "value": "math.ceil(speed_print * 0.33)" },


### PR DESCRIPTION
VORON V2.4 is an fast machine. There is no reason to limit
the user to 300mm/s. Unlock these speeds by removing maximum_value
which makes cura fallback to machine_max_feedrate_x/y which are
set to the C (299,792,458).

Also set the warning to 301 (As requested by Fulg) as
anything above 300 means beyond the "standarts".