### PR TITLE
automatically remove all holes when spiralizing

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6361,6 +6361,7 @@
                     "description": "Remove the holes in each layer and keep only the outside shape. This will ignore any invisible internal geometry. However, it also ignores layer holes which can be viewed from above or below.",
                     "type": "bool",
                     "default_value": false,
+                    "value": "magic_spiralize",
                     "settable_per_mesh": true
                 },
                 "meshfix_extensive_stitching":


### PR DESCRIPTION
This PR automatically enables Remove All Holes when Spiralize Outer Contour is enabled.

Vase mode is meant for models which are solid, but many people don't know and model their things hollow.
With this automatic setting change these people won't notice that they have modeled it wrong.
Which means there are less times I need to explain stuff to users.
Profit.