### PR TITLE
Pp 77 shrinkage compensation for pla tpla petg

### DIFF
--- a/cura/Scene/ConvexHullDecorator.py
+++ b/cura/Scene/ConvexHullDecorator.py
@@ -383,7 +383,7 @@ class ConvexHullDecorator(SceneNodeDecorator):
         # Shrinkage compensation.
         if not self._global_stack:  # Should never happen.
             return convex_hull
-        scale_factor = self._global_stack.getProperty("material_shrinkage_percentage_xy", "value") / 100.0
+        scale_factor = self._global_stack.getProperty("material_shrinkage_percentage", "value") / 100.0
         result = convex_hull
         if scale_factor != 1.0 and not self.getNode().callDecoration("isGroup"):
             center = None

--- a/cura/Scene/ConvexHullDecorator.py
+++ b/cura/Scene/ConvexHullDecorator.py
@@ -383,7 +383,7 @@ class ConvexHullDecorator(SceneNodeDecorator):
         # Shrinkage compensation.
         if not self._global_stack:  # Should never happen.
             return convex_hull
-        scale_factor = self._global_stack.getProperty("material_shrinkage_percentage", "value") / 100.0
+        scale_factor = self._global_stack.getProperty("material_shrinkage_percentage_xy", "value") / 100.0
         result = convex_hull
         if scale_factor != 1.0 and not self.getNode().callDecoration("isGroup"):
             center = None

--- a/plugins/ModelChecker/ModelChecker.py
+++ b/plugins/ModelChecker/ModelChecker.py
@@ -139,4 +139,4 @@ class ModelChecker(QObject, Extension):
         global_container_stack = Application.getInstance().getGlobalContainerStack()
         if global_container_stack is None:
             return 100
-        return max(global_container_stack.getProperty("material_shrinkage_percentage_xy", "value"), global_container_stack.getProperty("material_shrinkage_percentage_z", "value"))
+        return global_container_stack.getProperty("material_shrinkage_percentage", "value")

--- a/plugins/ModelChecker/ModelChecker.py
+++ b/plugins/ModelChecker/ModelChecker.py
@@ -139,4 +139,4 @@ class ModelChecker(QObject, Extension):
         global_container_stack = Application.getInstance().getGlobalContainerStack()
         if global_container_stack is None:
             return 100
-        return global_container_stack.getProperty("material_shrinkage_percentage", "value")
+        return max(global_container_stack.getProperty("material_shrinkage_percentage_xy", "value"), global_container_stack.getProperty("material_shrinkage_percentage_z", "value"))

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2527,35 +2527,55 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
-                "material_shrinkage_percentage_xy":
+                "material_shrinkage_percentage":
                 {
-                    "label": "Horizontal Scaling Factor Shrinkage Compensation",
-                    "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the XY-direction (horizontally).",
+                    "label": "Scaling Factor Shrinkage Compensation",
+                    "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor.",
                     "unit": "%",
                     "type": "float",
-                    "default_value": null,
+                    "default_value": 100.0,
                     "enabled": true,
                     "minimum_value": "0.001",
                     "minimum_value_warning": "100",
                     "maximum_value_warning": "120",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
-                    "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy'))"
-                },
-                "material_shrinkage_percentage_z":
-                {
-                    "label": "Vertical Scaling Factor Shrinkage Compensation",
-                    "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the Z-direction (vertically).",
-                    "unit": "%",
-                    "type": "float",
-                    "default_value": null,
-                    "enabled": true,
-                    "minimum_value": "0.001",
-                    "minimum_value_warning": "100",
-                    "maximum_value_warning": "120",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": false,
-                    "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z'))"
+                    "resolve": "sum(extruderValues(\"material_shrinkage_percentage\")) / len(extruderValues(\"material_shrinkage_percentage\"))",
+                    "children":
+                    {
+                        "material_shrinkage_percentage_xy":
+                        {
+                            "label": "Horizontal Scaling Factor Shrinkage Compensation",
+                            "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the XY-direction (horizontally).",
+                            "unit": "%",
+                            "type": "float",
+                            "default_value": 100.0,
+                            "enabled": true,
+                            "minimum_value": "0.001",
+                            "minimum_value_warning": "100",
+                            "maximum_value_warning": "120",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": false,
+                            "resolve": "sum(extruderValues(\"material_shrinkage_percentage_xy\")) / len(extruderValues(\"material_shrinkage_percentage_xy\"))",
+                            "value": "material_shrinkage_percentage"
+                        },
+                        "material_shrinkage_percentage_z":
+                        {
+                            "label": "Vertical Scaling Factor Shrinkage Compensation",
+                            "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the Z-direction (vertically).",
+                            "unit": "%",
+                            "type": "float",
+                            "default_value": 100.0,
+                            "enabled": true,
+                            "minimum_value": "0.001",
+                            "minimum_value_warning": "100",
+                            "maximum_value_warning": "120",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": false,
+                            "resolve": "sum(extruderValues(\"material_shrinkage_percentage_z\")) / len(extruderValues(\"material_shrinkage_percentage_z\"))",
+                            "value": "material_shrinkage_percentage"
+                        }
+                    }
                 },
                 "material_crystallinity":
                 {

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2527,10 +2527,10 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
-                "material_shrinkage_percentage":
+                "material_shrinkage_percentage_xy":
                 {
-                    "label": "Scaling Factor Shrinkage Compensation",
-                    "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor.",
+                    "label": "Horizontal Scaling Factor Shrinkage Compensation",
+                    "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the XY-direction (horizontally).",
                     "unit": "%",
                     "type": "float",
                     "default_value": null,
@@ -2540,42 +2540,22 @@
                     "maximum_value_warning": "120",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
-                    "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage'))",
-                    "children":
-                    {
-                        "material_shrinkage_percentage_xy":
-                        {
-                            "label": "Horizontal Scaling Factor Shrinkage Compensation",
-                            "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the XY-direction (horizontally).",
-                            "unit": "%",
-                            "type": "float",
-                            "default_value": null,
-                            "enabled": true,
-                            "minimum_value": "0.001",
-                            "minimum_value_warning": "100",
-                            "maximum_value_warning": "120",
-                            "settable_per_mesh": false,
-                            "settable_per_extruder": false,
-                            "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy'))",
-                            "value": "material_shrinkage_percentage"
-                        },
-                        "material_shrinkage_percentage_z":
-                        {
-                            "label": "Vertical Scaling Factor Shrinkage Compensation",
-                            "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the Z-direction (vertically).",
-                            "unit": "%",
-                            "type": "float",
-                            "default_value": null,
-                            "enabled": true,
-                            "minimum_value": "0.001",
-                            "minimum_value_warning": "100",
-                            "maximum_value_warning": "120",
-                            "settable_per_mesh": false,
-                            "settable_per_extruder": false,
-                            "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z'))",
-                            "value": "material_shrinkage_percentage"
-                        }
-                    }
+                    "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy'))"
+                },
+                "material_shrinkage_percentage_z":
+                {
+                    "label": "Vertical Scaling Factor Shrinkage Compensation",
+                    "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the Z-direction (vertically).",
+                    "unit": "%",
+                    "type": "float",
+                    "default_value": null,
+                    "enabled": true,
+                    "minimum_value": "0.001",
+                    "minimum_value_warning": "100",
+                    "maximum_value_warning": "120",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z'))"
                 },
                 "material_crystallinity":
                 {

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2533,14 +2533,14 @@
                     "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor.",
                     "unit": "%",
                     "type": "float",
-                    "default_value": 100.0,
-                    "enabled": false,
+                    "default_value": null,
+                    "enabled": true,
                     "minimum_value": "0.001",
                     "minimum_value_warning": "100",
                     "maximum_value_warning": "120",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
-                    "resolve": "sum(extruderValues(\"material_shrinkage_percentage\")) / len(extruderValues(\"material_shrinkage_percentage\"))",
+                    "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage'))",
                     "children":
                     {
                         "material_shrinkage_percentage_xy":
@@ -2549,14 +2549,14 @@
                             "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the XY-direction (horizontally).",
                             "unit": "%",
                             "type": "float",
-                            "default_value": 100.0,
-                            "enabled": false,
+                            "default_value": null,
+                            "enabled": true,
                             "minimum_value": "0.001",
                             "minimum_value_warning": "100",
                             "maximum_value_warning": "120",
                             "settable_per_mesh": false,
                             "settable_per_extruder": false,
-                            "resolve": "sum(extruderValues(\"material_shrinkage_percentage_xy\")) / len(extruderValues(\"material_shrinkage_percentage_xy\"))",
+                            "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_xy'))",
                             "value": "material_shrinkage_percentage"
                         },
                         "material_shrinkage_percentage_z":
@@ -2565,14 +2565,14 @@
                             "description": "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the Z-direction (vertically).",
                             "unit": "%",
                             "type": "float",
-                            "default_value": 100.0,
-                            "enabled": false,
+                            "default_value": null,
+                            "enabled": true,
                             "minimum_value": "0.001",
                             "minimum_value_warning": "100",
                             "maximum_value_warning": "120",
                             "settable_per_mesh": false,
                             "settable_per_extruder": false,
-                            "resolve": "sum(extruderValues(\"material_shrinkage_percentage_z\")) / len(extruderValues(\"material_shrinkage_percentage_z\"))",
+                            "resolve": "100 if sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z')) == 0 else sum(s if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z'))/sum(1 if s != None else 0 for s in extruderValues('material_shrinkage_percentage_z'))",
                             "value": "material_shrinkage_percentage"
                         }
                     }

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_PETG_Normal_Quality.inst.cfg
@@ -20,3 +20,5 @@ top_bottom_thickness = 0.8
 initial_layer_line_width_factor = 100
 
 material_print_temperature = =default_material_print_temperature - 5
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -22,6 +22,8 @@ machine_nozzle_heat_up_speed = 1.4
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = 190
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 retraction_hop = 0.2
 skin_overlap = 5
 speed_layer_0 = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_TPLA_Normal_Quality.inst.cfg
@@ -22,6 +22,8 @@ machine_nozzle_heat_up_speed = 1.4
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature - 15
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 skin_overlap = 5
 speed_layer_0 = =math.ceil(speed_print * 30 / 30)
 speed_print = 30

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Draft_Print.inst.cfg
@@ -15,6 +15,8 @@ variant = AA 0.4
 material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature - 5
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 skin_overlap = 20
 speed_print = 60

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Fast_Print.inst.cfg
@@ -16,6 +16,8 @@ cool_min_speed = 7
 material_print_temperature = =default_material_print_temperature
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_High_Quality.inst.cfg
@@ -18,6 +18,8 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 10
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 50
 speed_layer_0 = =math.ceil(speed_print * 20 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Normal_Quality.inst.cfg
@@ -17,6 +17,8 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 55
 speed_layer_0 = =math.ceil(speed_print * 20 / 55)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print.inst.cfg
@@ -18,6 +18,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print.inst.cfg
@@ -17,6 +17,8 @@ cool_fan_speed_max = =cool_fan_speed
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_print = 70

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_High_Quality.inst.cfg
@@ -19,6 +19,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -18,6 +18,8 @@ cool_min_speed = 7
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_VeryDraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_VeryDraft_Print.inst.cfg
@@ -32,6 +32,8 @@ material_print_temperature = =default_material_print_temperature + 10
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -22,6 +22,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -19,6 +19,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_layer_0 = =math.ceil(speed_print * 20 / 45)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_High_Quality.inst.cfg
@@ -19,6 +19,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -20,6 +20,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_VeryDraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_VeryDraft_Print.inst.cfg
@@ -32,6 +32,8 @@ material_print_temperature = =default_material_print_temperature - 5
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Draft_Print.inst.cfg
@@ -16,6 +16,8 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 40

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Superdraft_Print.inst.cfg
@@ -16,6 +16,8 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Verydraft_Print.inst.cfg
@@ -16,6 +16,8 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 40

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Draft_Print.inst.cfg
@@ -21,6 +21,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 support_angle = 70
 support_xy_distance = =wall_line_width_0 * 1.5

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -21,6 +21,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 15
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 raft_margin = 10
 support_angle = 70

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -21,6 +21,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 support_angle = 70
 support_xy_distance = =wall_line_width_0 * 1.5

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Draft_Print.inst.cfg
@@ -23,6 +23,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 0
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Superdraft_Print.inst.cfg
@@ -23,6 +23,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 5
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 raft_margin = 10
 retract_at_layer_change = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Verydraft_Print.inst.cfg
@@ -25,6 +25,8 @@ material_initial_print_temperature = =max(-273.15, material_print_temperature - 
 material_print_temperature = =default_material_print_temperature + 5
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retract_at_layer_change = False
 speed_infill = =math.ceil(speed_print * 30 / 35)

--- a/resources/quality/ultimaker_s3/um_s3_cc0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.4_PLA_Draft_Print.inst.cfg
@@ -24,6 +24,8 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_cc0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.4_PLA_Fast_Print.inst.cfg
@@ -24,6 +24,8 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Draft_Print.inst.cfg
@@ -24,6 +24,8 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Fast_Print.inst.cfg
@@ -24,6 +24,8 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PETG_Normal_Quality.inst.cfg
@@ -20,3 +20,5 @@ top_bottom_thickness = 0.8
 initial_layer_line_width_factor = 100
 
 material_print_temperature = =default_material_print_temperature - 5
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -22,6 +22,8 @@ machine_nozzle_heat_up_speed = 1.4
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = 190
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 retraction_hop = 0.2
 skin_overlap = 5
 speed_layer_0 = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_TPLA_Normal_Quality.inst.cfg
@@ -22,6 +22,8 @@ machine_nozzle_heat_up_speed = 1.4
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature - 15
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 skin_overlap = 5
 speed_layer_0 = =math.ceil(speed_print * 30 / 30)
 speed_print = 30

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Draft_Print.inst.cfg
@@ -15,6 +15,8 @@ variant = AA 0.4
 material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature - 5
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 skin_edge_support_thickness = =0.8 if infill_sparse_density < 30 else 0
 skin_overlap = 20

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Fast_Print.inst.cfg
@@ -16,6 +16,8 @@ cool_min_speed = 7
 material_print_temperature = =default_material_print_temperature
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_High_Quality.inst.cfg
@@ -18,6 +18,8 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 10
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 50
 speed_layer_0 = =math.ceil(speed_print * 20 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Normal_Quality.inst.cfg
@@ -17,6 +17,8 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 55
 speed_layer_0 = =math.ceil(speed_print * 20 / 55)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
@@ -18,6 +18,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_edge_support_thickness = =0.8 if infill_sparse_density < 30 else 0

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
@@ -17,6 +17,8 @@ cool_fan_speed_max = =cool_fan_speed
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_print = 70

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
@@ -19,6 +19,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -18,6 +18,8 @@ cool_min_speed = 7
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_VeryDraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_VeryDraft_Print.inst.cfg
@@ -32,6 +32,8 @@ material_print_temperature = =default_material_print_temperature + 10
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -22,6 +22,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -19,6 +19,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_layer_0 = =math.ceil(speed_print * 20 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_High_Quality.inst.cfg
@@ -19,6 +19,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -20,6 +20,8 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_VeryDraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_VeryDraft_Print.inst.cfg
@@ -32,6 +32,8 @@ material_print_temperature = =default_material_print_temperature - 5
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Draft_Print.inst.cfg
@@ -16,6 +16,8 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 40

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Superdraft_Print.inst.cfg
@@ -16,6 +16,8 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Verydraft_Print.inst.cfg
@@ -16,6 +16,8 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.5
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 40

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Draft_Print.inst.cfg
@@ -21,6 +21,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 support_angle = 70
 support_xy_distance = =wall_line_width_0 * 1.5

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -21,6 +21,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 15
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 raft_margin = 10
 support_angle = 70

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -21,6 +21,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 support_angle = 70
 support_xy_distance = =wall_line_width_0 * 1.5

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Draft_Print.inst.cfg
@@ -23,6 +23,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 0
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Superdraft_Print.inst.cfg
@@ -23,6 +23,8 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 5
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 raft_margin = 10
 retract_at_layer_change = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Verydraft_Print.inst.cfg
@@ -25,6 +25,8 @@ material_initial_print_temperature = =max(-273.15, material_print_temperature - 
 material_print_temperature = =default_material_print_temperature + 5
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retract_at_layer_change = False
 speed_infill = =math.ceil(speed_print * 30 / 35)

--- a/resources/quality/ultimaker_s5/um_s5_cc0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.4_PLA_Draft_Print.inst.cfg
@@ -24,6 +24,8 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_cc0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.4_PLA_Fast_Print.inst.cfg
@@ -24,6 +24,8 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Draft_Print.inst.cfg
@@ -24,6 +24,8 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Fast_Print.inst.cfg
@@ -24,6 +24,8 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
+material_shrinkage_percentage_xy = 100.2
+material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/setting_visibility/advanced.cfg
+++ b/resources/setting_visibility/advanced.cfg
@@ -57,6 +57,7 @@ retract_at_layer_change
 retraction_amount
 retraction_speed
 material_standby_temperature
+material_shrinkage_percentage
 
 [speed]
 speed_print

--- a/resources/setting_visibility/advanced.cfg
+++ b/resources/setting_visibility/advanced.cfg
@@ -57,7 +57,6 @@ retract_at_layer_change
 retraction_amount
 retraction_speed
 material_standby_temperature
-material_shrinkage_percentage
 
 [speed]
 speed_print

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -133,6 +133,9 @@ prime_tower_flow
 material_flow_layer_0
 material_standby_temperature
 material_alternate_walls
+material_shrinkage_percentage
+material_shrinkage_percentage_xy
+material_shrinkage_percentage_z
 
 [speed]
 speed_print

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -117,6 +117,7 @@ material_bed_temperature
 material_bed_temperature_layer_0
 material_adhesion_tendency
 material_surface_energy
+material_shrinkage_percentage
 material_shrinkage_percentage_xy
 material_shrinkage_percentage_z
 material_flow

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -117,6 +117,8 @@ material_bed_temperature
 material_bed_temperature_layer_0
 material_adhesion_tendency
 material_surface_energy
+material_shrinkage_percentage_xy
+material_shrinkage_percentage_z
 material_flow
 wall_material_flow
 wall_0_material_flow
@@ -133,9 +135,7 @@ prime_tower_flow
 material_flow_layer_0
 material_standby_temperature
 material_alternate_walls
-material_shrinkage_percentage
-material_shrinkage_percentage_xy
-material_shrinkage_percentage_z
+
 
 [speed]
 speed_print


### PR DESCRIPTION
This PR enables the shrinkage compensation for PLA, T-PLA and PETG.
For this feature to work properly I had to remove the old shrinkage factor only the xy and z variants remain in this PR.
Materials with no shrinkage set will default to None which means their value is not taken into account in the averaging of the shrinkage factor. 