### PR TITLE
Fix search field losing focus when scrolling the setting list

### DIFF
--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -195,7 +195,7 @@ Item
             onPositionChanged: {
                 // This removes focus from items when scrolling.
                 // This fixes comboboxes staying open and scrolling container
-                if (!activeFocus) {
+                if (!activeFocus && !filter.activeFocus) {
                     forceActiveFocus();
                 }
             }


### PR DESCRIPTION
When scrolling the setting list, it was clearing the focus in order to close the pop-ups in the setting list. If pop-ups like for the infill pattern or extruder selection settings are not closed, the pop-up part is still rendered even if the user scrolls those settings out of view, causing the pop-up to appear somewhere on top of completely unrelated interface elements. It scrolls all the way to the top of the screen, effectively.

I couldn't find a way to cause pop-ups to be clipped with the rest of the contents of the ListView. They are always rendered on top due to the nature of the pop-up. I could find a way to trigger pop-ups to close upon changing the scrolled position without changing the focus, but that method was fairly complex with a bunch of `Connection`s and an extra signal. This is by far the simplest solution.

Contributes to issue CURA-9070.