### PR TITLE
[5.0b1] Fix missing icons since move to PyQt6

### DIFF
--- a/plugins/CuraDrive/src/qml/pages/WelcomePage.qml
+++ b/plugins/CuraDrive/src/qml/pages/WelcomePage.qml
@@ -23,7 +23,7 @@ Column
     {
         id: profileImage
         fillMode: Image.PreserveAspectFit
-        source: "../images/backup.svg"
+        source: Qt.resolvedUrl("../images/backup.svg")
         anchors.horizontalCenter: parent.horizontalCenter
         width: Math.round(parent.width / 4)
     }

--- a/plugins/DigitalLibrary/resources/qml/LoadMoreProjectsCard.qml
+++ b/plugins/DigitalLibrary/resources/qml/LoadMoreProjectsCard.qml
@@ -37,7 +37,7 @@ Cura.RoundedRectangle
             width: UM.Theme.getSize("section").height
             height: width
             color: UM.Theme.getColor("text_link")
-            source: "../images/arrow_down.svg"
+            source: Qt.resolvedUrl("../images/arrow_down.svg")
         }
 
         Label
@@ -65,7 +65,7 @@ Cura.RoundedRectangle
             {
                 target: projectImage
                 color: UM.Theme.getColor("text_link")
-                source: "../images/arrow_down.svg"
+                source: Qt.resolvedUrl("../images/arrow_down.svg")
             }
             PropertyChanges
             {
@@ -88,7 +88,7 @@ Cura.RoundedRectangle
             {
                 target: projectImage
                 color: UM.Theme.getColor("text_link")
-                source: "../images/arrow_down.svg"
+                source: Qt.resolvedUrl("../images/arrow_down.svg")
             }
             PropertyChanges
             {
@@ -111,7 +111,7 @@ Cura.RoundedRectangle
             {
                 target: projectImage
                 color: UM.Theme.getColor("action_button_disabled_text")
-                source: "../images/update.svg"
+                source: Qt.resolvedUrl("../images/update.svg")
             }
             PropertyChanges
             {

--- a/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
+++ b/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
@@ -99,7 +99,7 @@ Item
             {
                 id: digitalFactoryImage
                 anchors.horizontalCenter: parent.horizontalCenter
-                source: searchBar.text === "" ? "../images/digital_factory.svg" : "../images/projects_not_found.svg"
+                source: Qt.resolvedUrl(searchBar.text === "" ? "../images/digital_factory.svg" : "../images/projects_not_found.svg")
                 fillMode: Image.PreserveAspectFit
                 width: parent.width - 2 * UM.Theme.getSize("thick_margin").width
             }

--- a/plugins/ModelChecker/ModelChecker.qml
+++ b/plugins/ModelChecker/ModelChecker.qml
@@ -14,7 +14,7 @@ UM.SimpleButton
 
     width: UM.Theme.getSize("save_button_specs_icons").width
     height: UM.Theme.getSize("save_button_specs_icons").height
-    iconSource: "model_checker.svg"
+    iconSource: Qt.resolvedUrl("model_checker.svg")
     anchors.verticalCenter: parent ? parent.verticalCenter : undefined
     color: UM.Theme.getColor("text_scene")
     hoverColor: UM.Theme.getColor("text_scene_hover")

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -475,7 +475,7 @@ UM.Dialog
             }
             toolTipContentAlignment: UM.Enums.ContentAlignment.AlignLeft
             onClicked: dialog.show()
-//            iconSource: Qt.resolvedUrl("Script.svg")
+            iconSource: Qt.resolvedUrl("Script.svg")
             fixedWidthMode: false
         }
 

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -475,7 +475,7 @@ UM.Dialog
             }
             toolTipContentAlignment: UM.Enums.ContentAlignment.AlignLeft
             onClicked: dialog.show()
-//            iconSource: "Script.svg"
+//            iconSource: Qt.resolvedUrl("Script.svg")
             fixedWidthMode: false
         }
 

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorIconExtruder.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorIconExtruder.qml
@@ -22,7 +22,7 @@ Item
     property int size: 32 * screenScaleFactor // TODO: Theme!
 
     // THe extruder icon source; NOTE: This shouldn't need to be changed
-    property string iconSource: "../svg/icons/Extruder.svg"
+    property string iconSource: Qt.resolvedUrl("../svg/icons/Extruder.svg")
 
     height: size
     width: size

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobPreview.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobPreview.qml
@@ -45,7 +45,7 @@ Item
         anchors.centerIn: printJobPreview
         color: UM.Theme.getColor("monitor_placeholder_image")
         height: printJobPreview.height
-        source: "../svg/ultibot.svg"
+        source: Qt.resolvedUrl("../svg/ultibot.svg")
         /* Since print jobs ALWAYS have an image url, we have to check if that image URL errors or
             not in order to determine if we show the placeholder (ultibot) image instead. */
         visible: printJob && previewImage.status == Image.Error

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
@@ -252,7 +252,7 @@ Item
                 bottom: parent.bottom
                 bottomMargin: 20 * screenScaleFactor // TODO: Theme!
             }
-            iconSource: "../svg/icons/CameraPhoto.svg"
+            iconSource: Qt.resolvedUrl("../svg/icons/CameraPhoto.svg")
             enabled: !cloudConnection
             visible: printer
         }

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -61,7 +61,7 @@ Item
                     left: parent.left
                     leftMargin: UM.Theme.getSize("default_margin").width
                 }
-                source: UM.Theme.getIcon("search")
+                source: UM.Theme.getIcon("Magnifier")
                 height: UM.Theme.getSize("small_button_icon").height
                 width: height
                 color: UM.Theme.getColor("text")


### PR DESCRIPTION
This PR fixes some missing icons in the Cura 5.0 UI. In Qt6, the source of an image needs to be a resolved URL, whereas in Qt5 it could be a relative path string. This PR also fixes a "deprecated theme icon" warning.

After fixing this for the missing camera icon in the monitor page, I found the rest via a search in the source.

Fixes #11884, CURA-9117, CURA-9195