### PR TITLE
[5.0b1] Fix creating a single copy of a model

### DIFF
--- a/resources/qml/Menus/ContextMenu.qml
+++ b/resources/qml/Menus/ContextMenu.qml
@@ -134,6 +134,7 @@ Cura.Menu
                 from: 1
                 to: 99
                 width: 2 * UM.Theme.getSize("button").width
+                value: 1
             }
         }
     }


### PR DESCRIPTION
This PR fixes the Multiply selected models when the number of copies is left to 1. The `value` of the spinbox does not get initialised to 1, so even though the label says 1, the value is 0. The command was making 0 copies.

Fixes #11897