### PR TITLE
Fix thumbnail format

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/CreateThumbnail.py
+++ b/plugins/PostProcessingPlugin/scripts/CreateThumbnail.py
@@ -37,7 +37,7 @@ class CreateThumbnail(Script):
 
         encoded_snapshot_length = len(encoded_snapshot)
         gcode.append(";")
-        gcode.append("; thumbnail begin {} {} {}".format(
+        gcode.append("; thumbnail begin {}x{} {}".format(
             width, height, encoded_snapshot_length))
 
         chunks = ["; {}".format(encoded_snapshot[i:i+chunk_size])


### PR DESCRIPTION
All slicers I have tried uses an "x" instead of space in between width and height.
Also DWC (Duet web control) can't view thumbnails without the "x" character.