### PR TITLE
[CURA-9214] Can't export profiles, also fixes exporting materials

### DIFF
--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -246,7 +246,7 @@ UM.ManagementPage
                         break;
                 }
                 messageDialog.open();
-                CuraApplication.setDefaultPath("dialog_material_path", folder);
+                CuraApplication.setDefaultPath("dialog_material_path", currentFolder);
             }
         }
 
@@ -259,7 +259,9 @@ UM.ManagementPage
             currentFolder: CuraApplication.getDefaultPath("dialog_material_path")
             onAccepted:
             {
-                const result = Cura.ContainerManager.exportContainer(base.currentItem.root_material_id, selectedNameFilter, selectedFile);
+                var nameFilterString = selectedNameFilter.index >= 0 ? nameFilters[selectedNameFilter.index] : nameFilters[0]
+
+                const result = Cura.ContainerManager.exportContainer(base.currentItem.root_material_id, nameFilterString, selectedFile);
 
                 const messageDialog = Qt.createQmlObject("import Cura 1.5 as Cura; Cura.MessageDialog { onClosed: destroy() }", base);
                 messageDialog.title = catalog.i18nc("@title:window", "Export Material");
@@ -275,7 +277,7 @@ UM.ManagementPage
                 }
                 messageDialog.open();
 
-                CuraApplication.setDefaultPath("dialog_material_path", folder);
+                CuraApplication.setDefaultPath("dialog_material_path", currentFolder);
             }
         }
     }

--- a/resources/qml/Preferences/Materials/MaterialsPage.qml
+++ b/resources/qml/Preferences/Materials/MaterialsPage.qml
@@ -259,7 +259,7 @@ UM.ManagementPage
             currentFolder: CuraApplication.getDefaultPath("dialog_material_path")
             onAccepted:
             {
-                var nameFilterString = selectedNameFilter.index >= 0 ? nameFilters[selectedNameFilter.index] : nameFilters[0]
+                const nameFilterString = selectedNameFilter.index >= 0 ? nameFilters[selectedNameFilter.index] : nameFilters[0];
 
                 const result = Cura.ContainerManager.exportContainer(base.currentItem.root_material_id, nameFilterString, selectedFile);
 

--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -354,8 +354,13 @@ UM.ManagementPage
             currentFolder: CuraApplication.getDefaultPath("dialog_profile_path")
             onAccepted:
             {
+
+                // If nameFilters contains only 1 item, the index of selectedNameFilter will always be -1
+                // This fetches the nameFilter at index selectedNameFilter.index if it is positive
+                var nameFilterString = selectedNameFilter.index >= 0 ? nameFilters[selectedNameFilter.index] : nameFilters[0]
+
                 var result = Cura.ContainerManager.exportQualityChangesGroup(base.currentItem.quality_changes_group,
-                                                                             selectedFile, selectedNameFilter);
+                                                                             selectedFile, nameFilterString);
 
                 if (result && result.status == "error")
                 {
@@ -365,7 +370,7 @@ UM.ManagementPage
                 }
 
                 // else pop-up Message thing from python code
-                CuraApplication.setDefaultPath("dialog_profile_path", folder);
+                CuraApplication.setDefaultPath("dialog_profile_path", currentFolder);
             }
         }
 

--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -357,7 +357,7 @@ UM.ManagementPage
 
                 // If nameFilters contains only 1 item, the index of selectedNameFilter will always be -1
                 // This fetches the nameFilter at index selectedNameFilter.index if it is positive
-                var nameFilterString = selectedNameFilter.index >= 0 ? nameFilters[selectedNameFilter.index] : nameFilters[0]
+                const nameFilterString = selectedNameFilter.index >= 0 ? nameFilters[selectedNameFilter.index] : nameFilters[0];
 
                 var result = Cura.ContainerManager.exportQualityChangesGroup(base.currentItem.quality_changes_group,
                                                                              selectedFile, nameFilterString);


### PR DESCRIPTION
selectedNameFilter is now an object instead of a string. The nameFilter has to be manually pulled out using the index in selectedNameFilter.

If only one filter is supplied to nameFilters, the index will always be -1. I assume this is because we are not selecting the file type in the Dialog, it just defaults to the only item. The workaround I've written will work even if this behaviour changes. 

FileDialog now uses currentFolder instead of folder.

CURA-9214