### PR TITLE
Use the correct function parameters when removing objects in menu

### DIFF
--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -232,7 +232,7 @@ UM.Dialog
                 }
 
                 onObjectAdded: function(index, object) { scriptsMenu.insertItem(index, object)}
-                onObjectRemoved: function(object) {  scriptsMenu.removeItem(object) }
+                onObjectRemoved: function(index, object) {  scriptsMenu.removeItem(object) }
             }
         }
 

--- a/resources/qml/Menus/ContextMenu.qml
+++ b/resources/qml/Menus/ContextMenu.qml
@@ -46,7 +46,7 @@ Cura.Menu
         }
         // Add it to the fifth position (and above) as we want it to be added after the extruder header.
         onObjectAdded: function(index, object) { base.insertItem(index + 5, object) }
-        onObjectRemoved: function(object) {  base.removeItem(object) }
+        onObjectRemoved: function(index, object) {  base.removeItem(object) }
     }
 
     // Global actions

--- a/resources/qml/Menus/ExtensionMenu.qml
+++ b/resources/qml/Menus/ExtensionMenu.qml
@@ -54,11 +54,11 @@ Cura.Menu
                 }
 
                 onObjectAdded: function(index, object) { sub_menu.insertItem(index, object.item)}
-                onObjectRemoved: function(object) { sub_menu.removeItem(object.item)}
+                onObjectRemoved: function(index, object) { sub_menu.removeItem(object.item)}
             }
         }
 
         onObjectAdded: function(index, object) { extensionMenu.insertMenu(index, object) }
-        onObjectRemoved: function(object) { extensionMenu.removeMenu(object)}
+        onObjectRemoved: function(index, object) { extensionMenu.removeMenu(object)}
     }
 }

--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -67,7 +67,7 @@ Cura.Menu
             onTriggered: Cura.MachineManager.setMaterial(extruderIndex, model.container_node)
         }
         onObjectAdded: function(index, object) { materialMenu.insertItem(index + 1, object) }
-        onObjectRemoved: function(object) { materialMenu.removeItem(index) }
+        onObjectRemoved: function(index, object) { materialMenu.removeItem(index) }
     }
 
     Cura.MenuSeparator { visible: favoriteMaterialsModel.items.length > 0}
@@ -89,7 +89,7 @@ Cura.Menu
                 onTriggered: Cura.MachineManager.setMaterial(extruderIndex, model.container_node)
             }
             onObjectAdded: function(index, object) { genericMenu.insertItem(index, object)}
-            onObjectRemoved: function(object) {genericMenu.removeItem(index) }
+            onObjectRemoved: function(index, object) {genericMenu.removeItem(index) }
         }
     }
 
@@ -103,7 +103,7 @@ Cura.Menu
             materialTypesModel: model
         }
         onObjectAdded: function(index, object) { materialMenu.insertItem(index + 4, object)}
-        onObjectRemoved: function(object) { materialMenu.removeItem(index) }
+        onObjectRemoved: function(index, object) { materialMenu.removeItem(index) }
     }
 
     Cura.MenuSeparator {}

--- a/resources/qml/Menus/NozzleMenu.qml
+++ b/resources/qml/Menus/NozzleMenu.qml
@@ -50,7 +50,7 @@ Cura.Menu
         }
 
         onObjectAdded: function(index, object) { nozzleMenu.insertItem(index, object) }
-        onObjectRemoved: function(object) {nozzleMenu.removeItem(object)}
+        onObjectRemoved: function(index, object) {nozzleMenu.removeItem(object)}
     }
 
 }

--- a/resources/qml/Menus/OpenFilesMenu.qml
+++ b/resources/qml/Menus/OpenFilesMenu.qml
@@ -36,6 +36,6 @@ Cura.Menu
         }
         onObjectAdded: function(index, object) { openFilesMenu.insertItem(index, object)}
 
-        onObjectRemoved: function(object) { openFilesMenu.removeItem(object) }
+        onObjectRemoved: function(index, object) { openFilesMenu.removeItem(object) }
     }
 }

--- a/resources/qml/Menus/PrinterMenu.qml
+++ b/resources/qml/Menus/PrinterMenu.qml
@@ -39,7 +39,7 @@ Cura.Menu
             onTriggered: Cura.MachineManager.setActiveMachine(model.id)
         }
         onObjectAdded: function(index, object) { menu.insertItem(2, object)}
-        onObjectRemoved: function(object) {  menu.removeItem(object)}
+        onObjectRemoved: function(index, object) {  menu.removeItem(object)}
     }
 
     Cura.MenuSeparator { visible: networKPrinterInstantiator.count > 0 }
@@ -67,7 +67,7 @@ Cura.Menu
         }
         // A bit hackish, but we have 2 items at the end, put them before that
         onObjectAdded: function(index, object) { menu.insertItem(menu.count - 2, object) }
-        onObjectRemoved: function(object) {  menu.removeItem(object) }
+        onObjectRemoved: function(index, object) {  menu.removeItem(object) }
     }
 
     Cura.MenuSeparator { visible: localPrinterInstantiator.count > 0 }

--- a/resources/qml/Menus/PrinterTypeMenu.qml
+++ b/resources/qml/Menus/PrinterTypeMenu.qml
@@ -29,6 +29,6 @@ Cura.Menu
             }
         }
         onObjectAdded: function(index, object) { return menu.insertItem(index, object); }
-        onObjectRemoved: function(object) { return menu.removeItem(object); }
+        onObjectRemoved: function(index, object) { return menu.removeItem(object); }
     }
 }

--- a/resources/qml/Menus/SaveProjectMenu.qml
+++ b/resources/qml/Menus/SaveProjectMenu.qml
@@ -44,7 +44,7 @@ Cura.Menu
             enabled: saveProjectMenu.shouldBeVisible
         }
         onObjectAdded: function(index, object) {  saveProjectMenu.insertItem(index, object)}
-        onObjectRemoved: function(object) {  saveProjectMenu.removeItem(object)}
+        onObjectRemoved: function(index, object) {  saveProjectMenu.removeItem(object)}
     }
 
     WorkspaceSummaryDialog

--- a/resources/qml/Menus/SettingVisibilityPresetsMenu.qml
+++ b/resources/qml/Menus/SettingVisibilityPresetsMenu.qml
@@ -33,7 +33,7 @@ Cura.Menu
         }
 
         onObjectAdded: function(index, object) { menu.insertItem(index, object) }
-        onObjectRemoved: function(object) { menu.removeItem(object)}
+        onObjectRemoved: function(index, object) { menu.removeItem(object)}
     }
 
     Cura.MenuSeparator {}

--- a/resources/qml/Menus/SettingsMenu.qml
+++ b/resources/qml/Menus/SettingsMenu.qml
@@ -68,7 +68,7 @@ Cura.Menu
             }
         }
         onObjectAdded: function(index, object) {  base.insertMenu(index, object) }
-        onObjectRemoved:function(object) {  base.removeMenu(object)}
+        onObjectRemoved: function(index, object) {  base.removeMenu(object);}
     }
 
     Cura.MenuSeparator { }


### PR DESCRIPTION
It turns out that the order of these functions matters. So when we created a function with only one param, it would actually give it the index. Removing with the index didn't work, so the object would still be there. The Qt objects would already be deleted which caused segfaults

CURA-9222