### PR TITLE
Fix toolbar positioning when the toolbar is taller than its parent

### DIFF
--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -309,10 +309,13 @@ UM.MainWindow
 
                 property int mouseX: base.mouseX
                 property int mouseY: base.mouseY
+                property bool tallerThanParent: height > parent.height
+
+                z: 1 // Ensure toolbar and toolpanels are drawn on top
 
                 anchors
                 {
-                    verticalCenter: parent.verticalCenter
+                    verticalCenter: tallerThanParent ? undefined : parent.verticalCenter
                     left: parent.left
                 }
                 visible: CuraApplication.platformActivity && !PrintInformation.preSliced


### PR DESCRIPTION
This PR fixes the z-order of toolpanels and the placement of the toolbar when the toolbar becomes longer than the window permits (eg through multiple additional tool-plugins and/or many extruders).

Fixes #11990