### PR TITLE
[CURA-9232] Fix menubar not catching events

### DIFF
--- a/resources/qml/PrintSetupTooltip.qml
+++ b/resources/qml/PrintSetupTooltip.qml
@@ -17,6 +17,8 @@ UM.PointingRectangle
     arrowSize: UM.Theme.getSize("default_arrow").width
 
     opacity: 0
+    // This should be disabled when invisible, otherwise it will catch mouse events.
+    enabled: false
 
     Behavior on opacity
     {
@@ -52,11 +54,13 @@ UM.PointingRectangle
         }
         base.opacity = 1;
         target = Qt.point(position.x + 1, position.y + Math.round(UM.Theme.getSize("tooltip_arrow_margins").height / 2))
+        enabled = true
     }
 
     function hide()
     {
         base.opacity = 0;
+        enabled = false
     }
 
     ScrollView

--- a/resources/qml/PrintSetupTooltip.qml
+++ b/resources/qml/PrintSetupTooltip.qml
@@ -18,7 +18,7 @@ UM.PointingRectangle
 
     opacity: 0
     // This should be disabled when invisible, otherwise it will catch mouse events.
-    enabled: false
+    enabled: opacity > 0
 
     Behavior on opacity
     {
@@ -54,13 +54,11 @@ UM.PointingRectangle
         }
         base.opacity = 1;
         target = Qt.point(position.x + 1, position.y + Math.round(UM.Theme.getSize("tooltip_arrow_margins").height / 2))
-        enabled = true
     }
 
     function hide()
     {
         base.opacity = 0;
-        enabled = false
     }
 
     ScrollView


### PR DESCRIPTION
The PrintSetupTooltip was catching events while invisible on the top left of the screen. This was causing the menubar not to be clickable.

I've disabled PrintSetupTooltip when not visible so that it does not catch events.

CURA-9232