### PR TITLE
[5.0b1] Remove "phantom menu" when there is only a single FileProvider

### DIFF
--- a/resources/qml/Menus/FileMenu.qml
+++ b/resources/qml/Menus/FileMenu.qml
@@ -33,6 +33,7 @@ Cura.Menu
         id: openFilesMenu
 
         shouldBeVisible: base.fileProviderModel.count > 1
+        enabled: shouldBeVisible
     }
 
     RecentFilesMenu { }


### PR DESCRIPTION
This PR removes a "phantom menu" that is only accessible when navigating the File menu with the keyboard, by moving "between" the `Open Files...` and `Open Recent` options and pressing the right cursor key. In the screenshot below, note how there is no parent menuitem visible for the submenu that opened, and the submenu that opened is not the submenu for the `Open Recent` menu.

![image](https://user-images.githubusercontent.com/143551/166219716-d47ba31d-db57-4eb5-b30f-bd9bb305727c.png)

This PR solves a cosmetic issue, but the fix is fairly trivial.