### PR TITLE
[PP-168] [CURA-9293] Fix UM2+C buffer underruns

### DIFF
--- a/resources/definitions/ultimaker2_plus_connect.def.json
+++ b/resources/definitions/ultimaker2_plus_connect.def.json
@@ -81,7 +81,7 @@
         "material_bed_temperature_layer_0": { "maximum_value": 110 },
         "material_print_temperature": { "maximum_value": 260 },
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 60" },
-        "meshfix_maximum_deviation": { "value": "layer_height / 3" },
+        "meshfix_maximum_deviation": { "value": "layer_height / 3 if magic_spiralize else layer_height / 4" },
         "meshfix_maximum_travel_resolution": { "value": 0.5 },
         "prime_blob_enable": { "enabled": true, "default_value": true, "value": "resolveOrValue('print_sequence') != 'one_at_a_time'" },
         "retraction_prime_speed": { "value": "15" },

--- a/resources/definitions/ultimaker2_plus_connect.def.json
+++ b/resources/definitions/ultimaker2_plus_connect.def.json
@@ -81,7 +81,7 @@
         "material_bed_temperature_layer_0": { "maximum_value": 110 },
         "material_print_temperature": { "maximum_value": 260 },
         "meshfix_maximum_resolution": { "value": "(speed_wall_0 + speed_wall_x) / 60" },
-        "meshfix_maximum_deviation": { "value": "layer_height / 4" },
+        "meshfix_maximum_deviation": { "value": "layer_height / 3" },
         "meshfix_maximum_travel_resolution": { "value": 0.5 },
         "prime_blob_enable": { "enabled": true, "default_value": true, "value": "resolveOrValue('print_sequence') != 'one_at_a_time'" },
         "retraction_prime_speed": { "value": "15" },


### PR DESCRIPTION
Blobs were observed on the spiralized vase print on the UM2+C. After analysis we increased the resolution deviation to prevent microsegments. We found out that this is only needed for the spiralize mode, the quality was decreased for normal prints.

For details see: PP-168  