### PR TITLE
[5.0b1] Fix material "Print Settings" tab

### DIFF
--- a/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
+++ b/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
@@ -38,6 +38,7 @@ UM.TooltipArea
 
     property alias textField: textFieldWithUnit
     property alias valueText: textFieldWithUnit.text
+    property alias enabled: textFieldWithUnit.enabled
     property alias editingFinishedFunction: textFieldWithUnit.editingFinishedFunction
 
     property string tooltipText: propertyProvider.properties.description ? propertyProvider.properties.description : ""

--- a/resources/qml/Preferences/Materials/MaterialsView.qml
+++ b/resources/qml/Preferences/Materials/MaterialsView.qml
@@ -601,6 +601,7 @@ Item
                     maximum: 99999
                     unitText: model.unit
                     decimals: model.unit == "mm" ? 2 : 0
+                    enabled: base.editingEnabled
 
                     editingFinishedFunction: materialPropertyProvider.setPropertyValue("value", value)
                 }

--- a/resources/qml/Preferences/Materials/MaterialsView.qml
+++ b/resources/qml/Preferences/Materials/MaterialsView.qml
@@ -603,7 +603,10 @@ Item
                     decimals: model.unit == "mm" ? 2 : 0
                     enabled: base.editingEnabled
 
-                    editingFinishedFunction: materialPropertyProvider.setPropertyValue("value", value)
+                    editingFinishedFunction: function()
+                    {
+                        materialPropertyProvider.setPropertyValue("value", parseFloat(valueText.replace(",", ".")))
+                    }
                 }
 
                 UM.ContainerPropertyProvider


### PR DESCRIPTION
This PR fixes setting values on the Print Settings tab of the Materials pane of the preferences. Without this PR, changes will not be saved at all. This PR also disables the input fields on the Print Settings tab for "read-only" materials.

Fixes https://github.com/Ultimaker/Cura/issues/12155