### PR TITLE
Fix width of some drop-downs

### DIFF
--- a/plugins/PrepareStage/PrepareMenu.qml
+++ b/plugins/PrepareStage/PrepareMenu.qml
@@ -106,26 +106,34 @@ Item
                 {
                     id: openProviderColumn
 
-                    //The column doesn't automatically listen to its children rect if the children change internally, so we need to explicitly update the size.
-                    onChildrenRectChanged:
+                    // Automatically set the width to fit the widest MenuItem
+                    // Based on https://martin.rpdev.net/2018/03/13/qt-quick-controls-2-automatically-set-the-width-of-menus.html
+                    function setWidth()
                     {
-                        popup.implicitHeight = childrenRect.height
-                        popup.implicitWidth = childrenRect.width
+                        var result = 0;
+                        var padding = 0;
+                        for (var i = 0; i < fileProviderRepeater.count; ++i) {
+                            var item = fileProviderRepeater.itemAt(i);
+                            if (item.hasOwnProperty("implicitWidth"))
+                            {
+                                var itemWidth = item.implicitWidth;
+                                result = Math.max(itemWidth, result);
+                                padding = Math.max(item.padding, padding);
+                            }
+                        }
+                        return result + padding * 2;
                     }
-                    onPositioningComplete:
-                    {
-                        popup.implicitHeight = childrenRect.height
-                        popup.implicitWidth = childrenRect.width
-                    }
+                    width: setWidth()
 
                     Repeater
                     {
+                        id: fileProviderRepeater
                         model: prepareMenu.fileProviderModel
                         delegate: Button
                         {
                             leftPadding: UM.Theme.getSize("default_margin").width
                             rightPadding: UM.Theme.getSize("default_margin").width
-                            width: contentItem.width + leftPadding + rightPadding
+                            width: openProviderColumn.width
                             height: UM.Theme.getSize("action_button").height
                             hoverEnabled: true
 

--- a/resources/qml/Account/UserOperations.qml
+++ b/resources/qml/Account/UserOperations.qml
@@ -90,8 +90,9 @@ Column
     Cura.TertiaryButton
     {
         id: cloudButton
-        width: UM.Theme.getSize("account_button").width
+        width: parent.width
         height: UM.Theme.getSize("account_button").height
+
         text: "Ultimaker Digital Factory"
         onClicked: Qt.openUrlExternally(CuraApplication.ultimakerDigitalFactoryUrl + "?utm_source=cura&utm_medium=software&utm_campaign=menu-visit-DF")
         fixedWidthMode: false
@@ -100,8 +101,9 @@ Column
     Cura.TertiaryButton
     {
         id: accountButton
-        width: UM.Theme.getSize("account_button").width
+        width: parent.width
         height: UM.Theme.getSize("account_button").height
+
         text: catalog.i18nc("@button", "Ultimaker Account")
         onClicked: Qt.openUrlExternally(CuraApplication.ultimakerCloudAccountRootUrl + "?utm_source=cura&utm_medium=software&utm_campaign=menu-visit-account")
         fixedWidthMode: false
@@ -117,7 +119,11 @@ Column
     Cura.TertiaryButton
     {
         id: signOutButton
+        width: parent.width
+        height: UM.Theme.getSize("account_button").height
+
         onClicked: Cura.API.account.logout()
         text: catalog.i18nc("@button", "Sign Out")
+        fixedWidthMode: false
     }
 }


### PR DESCRIPTION
The drop-down to select where to open files from had a problem where the items inside had the necessary width to fit their text, but that left space if there were other items next to it.

![image](https://user-images.githubusercontent.com/2448634/167387775-996b3f33-213f-4f7d-bb7f-9c11518f2a6c.png)

This is now fixed. All items have their width adjusted to fit the width of the pop-up. The pop-up takes on the width of the widest item inside. The code is taken from UM.Menu and works similarly, but with a different width property.

Another issue was fixed where the buttons in the account profile menu weren't as wide as the parent, and the text was wider than the buttons. This made the hover area a bit weird. That's fixed by simply making the buttons as wide as their parent.