### PR TITLE
Render labels using `Text.QtRendering` on OSX

### DIFF
--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -437,7 +437,6 @@ UM.Dialog
                 {
                     id: warningLabel
                     text: catalog.i18nc("@action:warning", "Loading a project will clear all models on the build plate.")
-                    wrapMode: Text.Wrap
                 }
             }
         }

--- a/plugins/CuraDrive/src/qml/pages/BackupsPage.qml
+++ b/plugins/CuraDrive/src/qml/pages/BackupsPage.qml
@@ -5,7 +5,7 @@ import QtQuick 2.7
 import QtQuick.Controls 2.1
 import QtQuick.Layouts 1.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 import "../components"
@@ -22,28 +22,23 @@ Item
         width: parent.width
         anchors.fill: parent
 
-        Label
+        UM.Label
         {
             id: backupTitle
             text: catalog.i18nc("@title", "My Backups")
             font: UM.Theme.getFont("large")
-            color: UM.Theme.getColor("text")
             Layout.fillWidth: true
-            renderType: Text.NativeRendering
         }
 
-        Label
+        UM.Label
         {
             text: catalog.i18nc("@empty_state",
                 "You don't have any backups currently. Use the 'Backup Now' button to create one.")
             width: parent.width
-            font: UM.Theme.getFont("default")
-            color: UM.Theme.getColor("text")
             wrapMode: Label.WordWrap
             visible: backupList.model.length == 0
             Layout.fillWidth: true
             Layout.fillHeight: true
-            renderType: Text.NativeRendering
         }
 
         BackupList
@@ -54,16 +49,13 @@ Item
             Layout.fillHeight: true
         }
 
-        Label
+        UM.Label
         {
             text: catalog.i18nc("@backup_limit_info",
                 "During the preview phase, you'll be limited to 5 visible backups. Remove a backup to see older ones.")
             width: parent.width
-            font: UM.Theme.getFont("default")
-            color: UM.Theme.getColor("text")
             wrapMode: Label.WordWrap
             visible: backupList.model.length > 4
-            renderType: Text.NativeRendering
         }
 
         BackupListFooter

--- a/plugins/DigitalLibrary/resources/qml/CreateNewProjectPopup.qml
+++ b/plugins/DigitalLibrary/resources/qml/CreateNewProjectPopup.qml
@@ -5,7 +5,7 @@ import QtQuick 2.15
 import QtQuick.Window 2.2
 import QtQuick.Controls 2.3
 
-import UM 1.2 as UM
+import UM 1.5 as UM
 import Cura 1.6 as Cura
 
 import DigitalFactory 1.0 as DF
@@ -64,12 +64,10 @@ Popup
         }
     }
 
-    Label
+    UM.Label
     {
         id: projectNameLabel
         text: "Project Name"
-        font: UM.Theme.getFont("default")
-        color: UM.Theme.getColor("text")
         anchors
         {
             top: createNewLibraryProjectLabel.bottom
@@ -107,13 +105,12 @@ Popup
         }
     }
 
-    Label
+    UM.Label
     {
         id: errorWhileCreatingProjectLabel
         text: manager.projectCreationErrorText
         width: parent.width
         wrapMode: Text.WordWrap
-        font: UM.Theme.getFont("default")
         color: UM.Theme.getColor("error")
         visible: manager.creatingNewProjectStatus == DF.RetrievalStatus.Failed
         anchors

--- a/plugins/DigitalLibrary/resources/qml/OpenProjectFilesPage.qml
+++ b/plugins/DigitalLibrary/resources/qml/OpenProjectFilesPage.qml
@@ -83,13 +83,12 @@ Item
             }
         }
 
-        Label
+        UM.Label
         {
             id: emptyProjectLabel
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
             text: "Select a project to view its files."
-            font: UM.Theme.getFont("default")
             color: UM.Theme.getColor("setting_category_text")
 
             Connections
@@ -102,14 +101,13 @@ Item
             }
         }
 
-        Label
+        UM.Label
         {
             id: noFilesInProjectLabel
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
             visible: (manager.digitalFactoryFileModel.count == 0 && !emptyProjectLabel.visible && !retrievingFilesBusyIndicator.visible)
             text: "No supported files in this project."
-            font: UM.Theme.getFont("default")
             color: UM.Theme.getColor("setting_category_text")
         }
 

--- a/plugins/DigitalLibrary/resources/qml/ProjectSummaryCard.qml
+++ b/plugins/DigitalLibrary/resources/qml/ProjectSummaryCard.qml
@@ -2,7 +2,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.2 as UM
+import UM 1.5 as UM
 import Cura 1.6 as Cura
 
 Cura.RoundedRectangle
@@ -58,34 +58,31 @@ Cura.RoundedRectangle
             width: parent.width - x - UM.Theme.getSize("default_margin").width
             anchors.verticalCenter: parent.verticalCenter
 
-            Label
+            UM.Label
             {
                 id: displayNameLabel
                 width: parent.width
                 height: Math.round(parent.height / 3)
                 elide: Text.ElideRight
-                color: UM.Theme.getColor("text")
                 font: UM.Theme.getFont("default_bold")
             }
 
-            Label
+            UM.Label
             {
                 id: usernameLabel
                 width: parent.width
                 height: Math.round(parent.height / 3)
                 elide: Text.ElideRight
                 color: UM.Theme.getColor("small_button_text")
-                font: UM.Theme.getFont("default")
             }
 
-            Label
+            UM.Label
             {
                 id: lastUpdatedLabel
                 width: parent.width
                 height: Math.round(parent.height / 3)
                 elide: Text.ElideRight
                 color: UM.Theme.getColor("small_button_text")
-                font: UM.Theme.getFont("default")
             }
         }
     }

--- a/plugins/DigitalLibrary/resources/qml/SaveProjectFilesPage.qml
+++ b/plugins/DigitalLibrary/resources/qml/SaveProjectFilesPage.qml
@@ -44,14 +44,13 @@ Item
         cardMouseAreaEnabled: false
     }
 
-    Label
+    UM.Label
     {
         id: fileNameLabel
         anchors.top: projectSummaryCard.bottom
         anchors.topMargin: UM.Theme.getSize("default_margin").height
         text: "Cura project name"
         font: UM.Theme.getFont("medium")
-        color: UM.Theme.getColor("text")
     }
 
 
@@ -110,13 +109,12 @@ Item
             }
         }
 
-        Label
+        UM.Label
         {
             id: emptyProjectLabel
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
             text: "Select a project to view its files."
-            font: UM.Theme.getFont("default")
             color: UM.Theme.getColor("setting_category_text")
 
             Connections
@@ -129,14 +127,13 @@ Item
             }
         }
 
-        Label
+        UM.Label
         {
             id: noFilesInProjectLabel
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
             visible: (manager.digitalFactoryFileModel.count == 0 && !emptyProjectLabel.visible && !retrievingFilesBusyIndicator.visible)
             text: "No supported files in this project."
-            font: UM.Theme.getFont("default")
             color: UM.Theme.getColor("setting_category_text")
         }
 

--- a/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
+++ b/plugins/DigitalLibrary/resources/qml/SelectProjectPage.qml
@@ -104,13 +104,12 @@ Item
                 width: parent.width - 2 * UM.Theme.getSize("thick_margin").width
             }
 
-            Label
+            UM.Label
             {
                 id: noLibraryProjectsLabel
                 anchors.horizontalCenter: parent.horizontalCenter
                 text: searchBar.text === "" ? "It appears that you don't have any projects in the Library yet." : "No projects found that match the search query."
                 font: UM.Theme.getFont("medium")
-                color: UM.Theme.getColor("text")
             }
 
             Cura.TertiaryButton

--- a/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml
+++ b/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml
@@ -147,8 +147,6 @@ Cura.MachineAction
                             return catalog.i18nc("@label","Firmware update failed due to missing firmware.");
                     }
                 }
-
-                wrapMode: Text.Wrap
             }
 
             UM.ProgressBar

--- a/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 
@@ -58,11 +58,10 @@ Item
 
             spacing: base.columnSpacing
 
-            Label   // Title Label
+            UM.Label   // Title Label
             {
                 text: catalog.i18nc("@title:label", "Nozzle Settings")
                 font: UM.Theme.getFont("medium_bold")
-                renderType: Text.NativeRendering
             }
 
             Cura.NumericTextFieldWithUnit  // "Nozzle size"

--- a/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml
@@ -5,7 +5,7 @@ import QtQuick 2.10
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 
@@ -51,12 +51,10 @@ Item
 
             spacing: base.columnSpacing
 
-            Label   // Title Label
+            UM.Label   // Title Label
             {
                 text: catalog.i18nc("@title:label", "Printer Settings")
                 font: UM.Theme.getFont("medium_bold")
-                color: UM.Theme.getColor("text")
-                renderType: Text.NativeRendering
                 width: parent.width
                 elide: Text.ElideRight
             }
@@ -182,12 +180,10 @@ Item
 
             spacing: base.columnSpacing
 
-            Label   // Title Label
+            UM.Label   // Title Label
             {
                 text: catalog.i18nc("@title:label", "Printhead Settings")
                 font: UM.Theme.getFont("medium_bold")
-                color: UM.Theme.getColor("text")
-                renderType: Text.NativeRendering
                 width: parent.width
                 elide: Text.ElideRight
             }

--- a/plugins/Marketplace/resources/qml/LicenseDialog.qml
+++ b/plugins/Marketplace/resources/qml/LicenseDialog.qml
@@ -42,16 +42,13 @@ UM.Dialog
                 source: UM.Theme.getIcon("Certificate", "high")
             }
 
-            Label
+            UM.Label
             {
                 text: catalog.i18nc("@text", "Please read and agree with the plugin licence.")
-                color: UM.Theme.getColor("text")
                 font: UM.Theme.getFont("large")
                 anchors.verticalCenter: icon.verticalCenter
                 height: UM.Theme.getSize("marketplace_large_icon").height
                 verticalAlignment: Qt.AlignmentFlag.AlignVCenter
-                wrapMode: Text.Wrap
-                renderType: Text.NativeRendering
             }
         }
 

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -6,7 +6,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window 2.2
 
-import UM 1.2 as UM
+import UM 1.5 as UM
 import Cura 1.6 as Cura
 
 Window
@@ -67,7 +67,7 @@ Window
                 Layout.preferredWidth: parent.width
                 Layout.preferredHeight: childrenRect.height + UM.Theme.getSize("default_margin").height
 
-                Label
+                UM.Label
                 {
                     id: pageTitle
                     anchors
@@ -80,7 +80,6 @@ Window
                     }
 
                     font: UM.Theme.getFont("large")
-                    color: UM.Theme.getColor("text")
                     text: content.item ? content.item.pageTitle: catalog.i18nc("@title", "Loading...")
                 }
             }

--- a/plugins/Marketplace/resources/qml/PackageCard.qml
+++ b/plugins/Marketplace/resources/qml/PackageCard.qml
@@ -29,16 +29,13 @@ Rectangle
 
             anchors.fill: parent
 
-            Label
+            UM.Label
             {
                 id: descriptionLabel
                 width: parent.width
 
                 text: packageData.description
-                font: UM.Theme.getFont("default")
-                color: UM.Theme.getColor("text")
                 maximumLineCount: 2
-                wrapMode: Text.Wrap
                 elide: Text.ElideRight
                 visible: text !== ""
             }

--- a/plugins/Marketplace/resources/qml/PackageCardHeader.qml
+++ b/plugins/Marketplace/resources/qml/PackageCardHeader.qml
@@ -87,11 +87,10 @@ Item
             Layout.preferredWidth: parent.width
             Layout.preferredHeight: childrenRect.height
 
-            Label
+            UM.Label
             {
                 text: packageData.displayName
                 font: UM.Theme.getFont("medium_bold")
-                color: UM.Theme.getColor("text")
                 verticalAlignment: Text.AlignTop
             }
             VerifiedIcon
@@ -100,12 +99,10 @@ Item
                 visible: packageData.isCheckedByUltimaker
             }
 
-            Label
+            UM.Label
             {
                 id: packageVersionLabel
                 text: packageData.packageVersion
-                font: UM.Theme.getFont("default")
-                color: UM.Theme.getColor("text")
                 Layout.fillWidth: true
             }
 
@@ -155,14 +152,11 @@ Item
             spacing: UM.Theme.getSize("narrow_margin").width
 
             // label "By"
-            Label
+            UM.Label
             {
                 id: authorBy
                 Layout.alignment: Qt.AlignCenter
-
                 text: catalog.i18nc("@label", "By")
-                font: UM.Theme.getFont("default")
-                color: UM.Theme.getColor("text")
             }
 
             // clickable author name

--- a/plugins/Marketplace/resources/qml/PackageDetails.qml
+++ b/plugins/Marketplace/resources/qml/PackageDetails.qml
@@ -45,14 +45,13 @@ Item
             iconSize: height - leftPadding * 2
         }
 
-        Label
+        UM.Label
         {
             Layout.alignment: Qt.AlignmentFlag.AlignVCenter
             Layout.fillWidth: true
 
             text: detailPage.title
             font: UM.Theme.getFont("large")
-            color: UM.Theme.getColor("text")
         }
     }
 

--- a/plugins/Marketplace/resources/qml/PackagePage.qml
+++ b/plugins/Marketplace/resources/qml/PackagePage.qml
@@ -56,13 +56,9 @@ Rectangle
                         color: UM.Theme.getColor("text")
                     }
 
-                    Label
+                    UM.Label
                     {
-
                         anchors.verticalCenter: downloadsIcon.verticalCenter
-
-                        color: UM.Theme.getColor("text")
-                        font: UM.Theme.getFont("default")
                         text: packageData.downloadCount
                     }
                 }
@@ -78,25 +74,22 @@ Rectangle
             topPadding: 0
             spacing: UM.Theme.getSize("default_margin").height
 
-            Label
+            UM.Label
             {
                 width: parent.width - parent.padding * 2
 
                 text: catalog.i18nc("@header", "Description")
                 font: UM.Theme.getFont("medium_bold")
-                color: UM.Theme.getColor("text")
                 elide: Text.ElideRight
             }
 
-            Label
+            UM.Label
             {
                 width: parent.width - parent.padding * 2
 
                 text: packageData.formattedDescription
                 font: UM.Theme.getFont("medium")
-                color: UM.Theme.getColor("text")
                 linkColor: UM.Theme.getColor("text_link")
-                wrapMode: Text.Wrap
                 textFormat: Text.RichText
 
                 onLinkActivated: UM.UrlUtil.openUrl(link, ["http", "https"])
@@ -110,13 +103,12 @@ Rectangle
                 visible: packageData.packageType === "material"
                 spacing: 0
 
-                Label
+                UM.Label
                 {
                     width: parent.width
 
                     text: catalog.i18nc("@header", "Compatible printers")
                     font: UM.Theme.getFont("medium_bold")
-                    color: UM.Theme.getColor("text")
                     elide: Text.ElideRight
                 }
 
@@ -124,25 +116,23 @@ Rectangle
                 {
                     model: packageData.compatiblePrinters
 
-                    Label
+                    UM.Label
                     {
                         width: compatiblePrinterColumn.width
 
                         text: modelData
                         font: UM.Theme.getFont("medium")
-                        color: UM.Theme.getColor("text")
                         elide: Text.ElideRight
                     }
                 }
 
-                Label
+                UM.Label
                 {
                     width: parent.width
 
                     visible: packageData.compatiblePrinters.length == 0
                     text: "(" + catalog.i18nc("@info", "No compatibility information") + ")"
                     font: UM.Theme.getFont("medium")
-                    color: UM.Theme.getColor("text")
                     elide: Text.ElideRight
                 }
             }
@@ -155,13 +145,12 @@ Rectangle
                 visible: packageData.packageType === "material"
                 spacing: 0
 
-                Label
+                UM.Label
                 {
                     width: parent.width
 
                     text: catalog.i18nc("@header", "Compatible support materials")
                     font: UM.Theme.getFont("medium_bold")
-                    color: UM.Theme.getColor("text")
                     elide: Text.ElideRight
                 }
 
@@ -169,25 +158,23 @@ Rectangle
                 {
                     model: packageData.compatibleSupportMaterials
 
-                    Label
+                    UM.Label
                     {
                         width: compatibleSupportMaterialColumn.width
 
                         text: modelData
                         font: UM.Theme.getFont("medium")
-                        color: UM.Theme.getColor("text")
                         elide: Text.ElideRight
                     }
                 }
 
-                Label
+                UM.Label
                 {
                     width: parent.width
 
                     visible: packageData.compatibleSupportMaterials.length == 0
                     text: "(" + catalog.i18nc("@info No materials", "None") + ")"
                     font: UM.Theme.getFont("medium")
-                    color: UM.Theme.getColor("text")
                     elide: Text.ElideRight
                 }
             }
@@ -199,23 +186,21 @@ Rectangle
                 visible: packageData.packageType === "material"
                 spacing: 0
 
-                Label
+                UM.Label
                 {
                     width: parent.width
 
                     text: catalog.i18nc("@header", "Compatible with Material Station")
                     font: UM.Theme.getFont("medium_bold")
-                    color: UM.Theme.getColor("text")
                     elide: Text.ElideRight
                 }
 
-                Label
+                UM.Label
                 {
                     width: parent.width
 
                     text: packageData.isCompatibleMaterialStation ? catalog.i18nc("@info", "Yes") : catalog.i18nc("@info", "No")
                     font: UM.Theme.getFont("medium")
-                    color: UM.Theme.getColor("text")
                     elide: Text.ElideRight
                 }
             }
@@ -227,23 +212,21 @@ Rectangle
                 visible: packageData.packageType === "material"
                 spacing: 0
 
-                Label
+                UM.Label
                 {
                     width: parent.width
 
                     text: catalog.i18nc("@header", "Optimized for Air Manager")
                     font: UM.Theme.getFont("medium_bold")
-                    color: UM.Theme.getColor("text")
                     elide: Text.ElideRight
                 }
 
-                Label
+                UM.Label
                 {
                     width: parent.width
 
                     text: packageData.isCompatibleAirManager ? catalog.i18nc("@info", "Yes") : catalog.i18nc("@info", "No")
                     font: UM.Theme.getFont("medium")
-                    color: UM.Theme.getColor("text")
                     elide: Text.ElideRight
                 }
             }

--- a/plugins/Marketplace/resources/qml/PackageTypeTab.qml
+++ b/plugins/Marketplace/resources/qml/PackageTypeTab.qml
@@ -3,7 +3,7 @@
 
 import QtQuick 2.15
 import QtQuick.Controls 2.15
-import UM 1.0 as UM
+import UM 1.5 as UM
 
 TabButton
 {
@@ -22,11 +22,10 @@ TabButton
         border.width: UM.Theme.getSize("thick_lining").width
     }
 
-    contentItem: Label
+    contentItem: UM.Label
     {
         text: parent.text
         font: UM.Theme.getFont("medium_bold")
-        color: UM.Theme.getColor("text")
         width: contentWidth
         anchors.centerIn: parent
     }

--- a/plugins/Marketplace/resources/qml/Packages.qml
+++ b/plugins/Marketplace/resources/qml/Packages.qml
@@ -40,7 +40,7 @@ ListView
 
         color: UM.Theme.getColor("detail_background")
 
-        Label
+        UM.Label
         {
             id: sectionHeaderText
             anchors.verticalCenter: parent.verticalCenter
@@ -48,7 +48,6 @@ ListView
 
             text: section
             font: UM.Theme.getFont("large")
-            color: UM.Theme.getColor("text")
         }
     }
 

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -132,7 +132,7 @@ Rectangle
                 width: UM.Theme.getSize("icon_indicator").width
                 height: UM.Theme.getSize("icon_indicator").height
             }
-            Label
+            UM.Label
             {
                 id: manageQueueText
                 anchors
@@ -144,7 +144,6 @@ Rectangle
                 color: UM.Theme.getColor("text_link")
                 font: UM.Theme.getFont("medium")
                 text: catalog.i18nc("@label link to technical assistance", "View user manuals online")
-                renderType: Text.NativeRendering
             }
             MouseArea
             {
@@ -155,14 +154,13 @@ Rectangle
                 onExited: manageQueueText.font.underline = false
             }
         }
-        Label
+        UM.Label
         {
             id: noConnectionLabel
             anchors.horizontalCenter: parent.horizontalCenter
             visible: !isNetworkConfigurable
             text: catalog.i18nc("@info", "In order to monitor your print from Cura, please connect the printer.")
             font: UM.Theme.getFont("medium")
-            color: UM.Theme.getColor("text")
             wrapMode: Text.WordWrap
             width: contentWidth
         }

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -245,7 +245,7 @@ UM.Dialog
             height: parent.height
             id: settingsPanel
 
-            Label
+            UM.Label
             {
                 id: scriptSpecsHeader
                 text: manager.selectedScriptIndex == -1 ? catalog.i18nc("@label", "Settings") : base.activeScriptName
@@ -262,7 +262,6 @@ UM.Dialog
                 elide: Text.ElideRight
                 height: 20 * screenScaleFactor
                 font: UM.Theme.getFont("large_bold")
-                color: UM.Theme.getColor("text")
             }
 
             ListView

--- a/plugins/SimulationView/SimulationViewMenuComponent.qml
+++ b/plugins/SimulationView/SimulationViewMenuComponent.qml
@@ -286,9 +286,7 @@ Cura.ExpandableComponent
                 UM.Label
                 {
                     text: label
-                    font: UM.Theme.getFont("default")
                     elide: Text.ElideRight
-                    renderType: Text.NativeRendering
                     color: UM.Theme.getColor("setting_control_text")
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.left: legendModelCheckBox.left

--- a/plugins/SliceInfoPlugin/MoreInfoWindow.qml
+++ b/plugins/SliceInfoPlugin/MoreInfoWindow.qml
@@ -61,7 +61,7 @@ Window
                 right: parent.right
             }
 
-            Label
+            UM.Label
             {
                 id: headerText
                 anchors
@@ -71,9 +71,7 @@ Window
                     right: parent.right
                 }
                 text: catalog.i18nc("@text:window", "Ultimaker Cura collects anonymous data in order to improve the print quality and user experience. Below is an example of all the data that is shared:")
-                color: UM.Theme.getColor("text")
                 wrapMode: Text.WordWrap
-                renderType: Text.NativeRendering
             }
 
             Cura.ScrollableTextArea

--- a/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml
@@ -295,7 +295,6 @@ Cura.MachineAction
             UM.Label
             {
                 text: catalog.i18nc("@label", "Enter the IP address of your printer on the network.")
-                renderType: Text.NativeRendering
             }
 
             Cura.TextField

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorExtruderConfiguration.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorExtruderConfiguration.qml
@@ -3,7 +3,7 @@
 
 import QtQuick 2.2
 import QtQuick.Controls 2.0
-import UM 1.3 as UM
+import UM 1.5 as UM
 
 import Cura 1.6 as Cura
 
@@ -57,32 +57,25 @@ Item
         width: Math.max(materialLabel.contentWidth, 60 * screenScaleFactor) // TODO: Theme!
         radius: 2 * screenScaleFactor // TODO: Theme!
 
-        Label
+        UM.Label
         {
             id: materialLabel
             anchors.top: parent.top
 
-            color: UM.Theme.getColor("text")
             elide: Text.ElideRight
-            font: UM.Theme.getFont("default") // 12pt, regular
             text: ""
             visible: text !== ""
-
-            renderType: Text.NativeRendering
         }
 
-        Label
+        UM.Label
         {
             id: printCoreLabel
             anchors.top: materialLabel.bottom
 
-            color: UM.Theme.getColor("text")
             elide: Text.ElideRight
             font: UM.Theme.getFont("default_bold") // 12pt, bold
             text: ""
             visible: text !== ""
-
-            renderType: Text.NativeRendering
         }
     }
 }

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorInfoBlurb.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorInfoBlurb.qml
@@ -3,7 +3,7 @@
 
 import QtQuick 2.3
 import QtQuick.Controls 2.0
-import UM 1.3 as UM
+import UM 1.5 as UM
 
 /**
  * A MonitorInfoBlurb is an extension of the GenericPopUp used to show static information (vs. interactive context
@@ -31,7 +31,7 @@ Item
             id: contentWrapper
             implicitWidth: childrenRect.width
             implicitHeight: innerLabel.contentHeight + 2 * innerLabel.padding
-            Label
+            UM.Label
             {
                 id: innerLabel
                 padding: 12 * screenScaleFactor // TODO: Theme!
@@ -39,7 +39,6 @@ Item
                 wrapMode: Text.WordWrap
                 width: 240 * screenScaleFactor // TODO: Theme!
                 color: UM.Theme.getColor("monitor_tooltip_text")
-                font: UM.Theme.getFont("default")
             }
         }
     }

--- a/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml
@@ -4,7 +4,7 @@ import QtQuick 2.2
 import QtQuick.Window 2.2
 import QtQuick.Controls 2.15
 
-import UM 1.1 as UM
+import UM 1.5 as UM
 
 UM.Dialog {
 
@@ -70,7 +70,7 @@ UM.Dialog {
             name: "cura";
         }
 
-        Label {
+        UM.Label {
             id: manualPrinterSelectionLabel;
             anchors {
                 left: parent.left;
@@ -79,8 +79,6 @@ UM.Dialog {
             }
             height: 20 * screenScaleFactor;
             text: catalog.i18nc("@label", "Printer selection");
-            wrapMode: Text.Wrap;
-            renderType: Text.NativeRendering;
         }
 
         ComboBox {

--- a/plugins/UltimakerMachineActions/BedLevelMachineAction.qml
+++ b/plugins/UltimakerMachineActions/BedLevelMachineAction.qml
@@ -5,7 +5,7 @@ import QtQuick 2.10
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 
@@ -23,18 +23,16 @@ Cura.MachineAction
         anchors.horizontalCenter: parent.horizontalCenter
         width: parent.width * 3 / 4
 
-        Label
+        UM.Label
         {
             id: pageTitle
             width: parent.width
             text: catalog.i18nc("@title", "Build Plate Leveling")
             wrapMode: Text.WordWrap
             font: UM.Theme.getFont("medium")
-            color: UM.Theme.getColor("text")
-            renderType: Text.NativeRendering
         }
 
-        Label
+        UM.Label
         {
             id: pageDescription
             anchors.top: pageTitle.bottom
@@ -42,12 +40,9 @@ Cura.MachineAction
             width: parent.width
             wrapMode: Text.WordWrap
             text: catalog.i18nc("@label", "To make sure your prints will come out great, you can now adjust your buildplate. When you click 'Move to Next Position' the nozzle will move to the different positions that can be adjusted.")
-            font: UM.Theme.getFont("default")
-            color: UM.Theme.getColor("text")
-            renderType: Text.NativeRendering
         }
 
-        Label
+        UM.Label
         {
             id: bedlevelingText
             anchors.top: pageDescription.bottom
@@ -55,9 +50,6 @@ Cura.MachineAction
             width: parent.width
             wrapMode: Text.WordWrap
             text: catalog.i18nc("@label", "For every position; insert a piece of paper under the nozzle and adjust the print build plate height. The print build plate height is right when the paper is slightly gripped by the tip of the nozzle.")
-            font: UM.Theme.getFont("default")
-            color: UM.Theme.getColor("text")
-            renderType: Text.NativeRendering
         }
 
         Row

--- a/plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml
+++ b/plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml
@@ -20,7 +20,7 @@ Cura.MachineAction
         anchors.topMargin: UM.Theme.getSize("default_margin").width * 5
         anchors.leftMargin: UM.Theme.getSize("default_margin").width * 4
 
-        Label
+        UM.Label
         {
             id: pageDescription
             anchors.top: parent.top
@@ -29,8 +29,6 @@ Cura.MachineAction
             wrapMode: Text.WordWrap
             text: catalog.i18nc("@label","Please select any upgrades made to this Ultimaker Original")
             font: UM.Theme.getFont("medium")
-            color: UM.Theme.getColor("text")
-            renderType: Text.NativeRendering
         }
 
         UM.CheckBox

--- a/resources/qml/ActionPanel/PrintJobInformation.qml
+++ b/resources/qml/ActionPanel/PrintJobInformation.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.1
 
-import UM 1.1 as UM
+import UM 1.5 as UM
 import Cura 1.0 as Cura
 
 Column
@@ -26,15 +26,14 @@ Column
         leftPadding: UM.Theme.getSize("default_margin").width
         rightPadding: UM.Theme.getSize("default_margin").width
 
-        Label
+        UM.Label
         {
             text: catalog.i18nc("@label", "Time estimation").toUpperCase()
             color: UM.Theme.getColor("primary")
             font: UM.Theme.getFont("default_bold")
-            renderType: Text.NativeRendering
         }
 
-        Label
+        UM.Label
         {
             id: byLineType
 
@@ -76,16 +75,13 @@ Column
                         Repeater
                         {
                             model: modelData
-                            Label
+                            UM.Label
                             {
                                 width: Math.round(byLineType.width * byLineType.columnWidthMultipliers[index])
                                 height: contentHeight
                                 horizontalAlignment: byLineType.columnHorizontalAligns[index]
-                                color: UM.Theme.getColor("text")
-                                font: UM.Theme.getFont("default")
                                 wrapMode: Text.WrapAnywhere
                                 text: modelData
-                                renderType: Text.NativeRendering
                             }
                         }
                     }
@@ -94,9 +90,6 @@ Column
 
             width: parent.width - 2 * UM.Theme.getSize("default_margin").width
             height: childrenRect.height
-            color: UM.Theme.getColor("text")
-            font: UM.Theme.getFont("default")
-            renderType: Text.NativeRendering
             textFormat: Text.RichText
         }
     }
@@ -109,15 +102,14 @@ Column
         leftPadding: UM.Theme.getSize("default_margin").width
         rightPadding: UM.Theme.getSize("default_margin").width
 
-        Label
+        UM.Label
         {
             text: catalog.i18nc("@label", "Material estimation").toUpperCase()
             color: UM.Theme.getColor("primary")
             font: UM.Theme.getFont("default_bold")
-            renderType: Text.NativeRendering
         }
         
-        Label
+        UM.Label
         {
             id: byMaterialType
 
@@ -180,16 +172,13 @@ Column
                         Repeater
                         {
                             model: modelData
-                            Label
+                            UM.Label
                             {
                                 width: Math.round(byMaterialType.width * byMaterialType.columnWidthMultipliers[index])
                                 height: contentHeight
                                 horizontalAlignment: byMaterialType.columnHorizontalAligns[index]
-                                color: UM.Theme.getColor("text")
-                                font: UM.Theme.getFont("default")
                                 wrapMode: Text.WrapAnywhere
                                 text: modelData
-                                renderType: Text.NativeRendering
                             }
                         }
                     }
@@ -198,9 +187,6 @@ Column
 
             width: parent.width - 2 * UM.Theme.getSize("default_margin").width
             height: childrenRect.height
-            color: UM.Theme.getColor("text")
-            font: UM.Theme.getFont("default")
-            renderType: Text.NativeRendering
             textFormat: Text.RichText
         }
     }

--- a/resources/qml/ActionPanel/SliceProcessWidget.qml
+++ b/resources/qml/ActionPanel/SliceProcessWidget.qml
@@ -5,7 +5,7 @@ import QtQuick 2.7
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.3
 
-import UM 1.4 as UM
+import UM 1.5 as UM
 import Cura 1.0 as Cura
 
 
@@ -45,16 +45,13 @@ Column
         }
     }
 
-    Label
+    UM.Label
     {
         id: autoSlicingLabel
         width: parent.width
         visible: progressBar.visible
 
         text: catalog.i18nc("@label:PrintjobStatus", "Slicing...")
-        color: UM.Theme.getColor("text")
-        font: UM.Theme.getFont("default")
-        renderType: Text.NativeRendering
     }
     Item
     {
@@ -71,7 +68,7 @@ Column
             height: width
             status: UM.StatusIcon.Status.WARNING
         }
-        Label
+        UM.Label
         {
             id: label
             anchors.left: warningIcon.right
@@ -79,9 +76,6 @@ Column
             anchors.verticalCenter: parent.verticalCenter
             anchors.leftMargin: UM.Theme.getSize("default_margin").width
             text: catalog.i18nc("@label:PrintjobStatus", "Unable to slice")
-            color: UM.Theme.getColor("text")
-            font: UM.Theme.getFont("default")
-            renderType: Text.NativeRendering
             wrapMode: Text.WordWrap
         }
     }

--- a/resources/qml/ApplicationSwitcher/ApplicationButton.qml
+++ b/resources/qml/ApplicationSwitcher/ApplicationButton.qml
@@ -82,7 +82,6 @@ Button
 
             height: base.height - applicationIcon.height - 2 * UM.Theme.getSize("default_margin").width  // Account for the top and bottom margins
             horizontalAlignment: Text.AlignHCenter
-            wrapMode: Text.Wrap
             elide: Text.ElideRight
         }
     }

--- a/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml
+++ b/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml
@@ -81,7 +81,6 @@ UM.Dialog
             id: questionText
             width: parent.width
             text: catalog.i18nc("@text:window", "This is a Cura project file. Would you like to open it as a project or import the models from it?")
-            font: UM.Theme.getFont("default")
             wrapMode: Text.WordWrap
         }
 

--- a/resources/qml/MachineSettings/ComboBoxWithOptions.qml
+++ b/resources/qml/MachineSettings/ComboBoxWithOptions.qml
@@ -5,7 +5,7 @@ import QtQuick 2.10
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 import "../Widgets"
@@ -52,15 +52,13 @@ UM.TooltipArea
         watchedProperties: [ "value", "options", "description" ]
     }
 
-    Label
+    UM.Label
     {
         id: fieldLabel
         anchors.left: parent.left
         anchors.verticalCenter: comboBox.verticalCenter
         visible: text != ""
         font: UM.Theme.getFont("medium")
-        color: UM.Theme.getColor("text")
-        renderType: Text.NativeRendering
     }
 
     ListModel

--- a/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
+++ b/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
@@ -62,15 +62,12 @@ UM.TooltipArea
         watchedProperties: [ "value", "description" ]
     }
 
-    Label
+    UM.Label
     {
         id: fieldLabel
         anchors.left: parent.left
         anchors.verticalCenter: textFieldWithUnit.verticalCenter
         visible: text != ""
-        font: UM.Theme.getFont("default")
-        color: UM.Theme.getColor("text")
-        renderType: Text.NativeRendering
     }
 
     TextField

--- a/resources/qml/MachineSettings/SimpleCheckBox.qml
+++ b/resources/qml/MachineSettings/SimpleCheckBox.qml
@@ -46,15 +46,13 @@ UM.TooltipArea
         watchedProperties: [ "value", "description" ]
     }
 
-    Label
+    UM.Label
     {
         id: fieldLabel
         anchors.left: parent.left
         anchors.verticalCenter: checkBox.verticalCenter
         visible: text != ""
         font: UM.Theme.getFont("medium")
-        color: UM.Theme.getColor("text")
-        renderType: Text.NativeRendering
     }
 
     UM.CheckBox

--- a/resources/qml/Menus/ConfigurationMenu/AutoConfiguration.qml
+++ b/resources/qml/Menus/ConfigurationMenu/AutoConfiguration.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.0 as Cura
 
 Item
@@ -12,14 +12,13 @@ Item
     width: parent.width
     height: childrenRect.height
 
-    Label
+    UM.Label
     {
         id: header
         text: catalog.i18nc("@header", "Configurations")
         font: UM.Theme.getFont("medium")
         color: UM.Theme.getColor("small_button_text")
         height: contentHeight
-        renderType: Text.NativeRendering
 
         anchors
         {

--- a/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml
+++ b/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml
@@ -39,7 +39,7 @@ Item
             anchors.verticalCenter: parent.verticalCenter
             status: UM.StatusIcon.Status.WARNING
         }
-        Label
+        UM.Label
         {
             id: label
             anchors.left: icon.right
@@ -51,9 +51,6 @@ Item
             text: Cura.MachineManager.printerConnected ?
                     catalog.i18nc("@label", "Loading available configurations from the printer...") :
                     catalog.i18nc("@label", "The configurations are not available because the printer is disconnected.")
-            color: UM.Theme.getColor("text")
-            font: UM.Theme.getFont("default")
-            renderType: Text.NativeRendering
             wrapMode: Text.WordWrap
         }
     }

--- a/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml
+++ b/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml
@@ -231,7 +231,6 @@ Window
                     {
                         id: syncStatusLabel
                         anchors.left: parent.left
-                        wrapMode: Text.Wrap
                         elide: Text.ElideRight
                         visible: text !== ""
                         font: UM.Theme.getFont("medium")
@@ -559,7 +558,6 @@ Window
                     text: catalog.i18nc("@text", "It seems like you don't have any compatible printers connected to Digital Factory. Make sure your printer is connected and it's running the latest firmware.")
                     Layout.fillWidth: true
                     horizontalAlignment: Text.AlignHCenter
-                    wrapMode: Text.Wrap
                 }
 
                 Item
@@ -633,7 +631,6 @@ Window
                 {
                     text: catalog.i18nc("@text In the UI this is followed by a list of steps the user needs to take.", "Follow the following steps to load the new material profiles to your printer.")
                     font: UM.Theme.getFont("medium")
-                    wrapMode: Text.Wrap
                     Layout.fillWidth: true
                 }
 

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml
@@ -133,7 +133,6 @@ Item
                             visible: (index % 20) == 0 // Only show steps of 20%
                             anchors.horizontalCenter: parent.horizontalCenter
                             y: UM.Theme.getSize("thin_margin").height
-                            renderType: Text.NativeRendering
                             color: UM.Theme.getColor("quality_slider_available")
                         }
                     }

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelector.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.2 as UM
+import UM 1.5 as UM
 import Cura 1.6 as Cura
 import ".."
 
@@ -111,7 +111,7 @@ Item
                 }
                 height: intentCategoryLabel.height
 
-                Label
+                UM.Label
                 {
                     id: intentCategoryLabel
                     text: model.name
@@ -119,8 +119,6 @@ Item
                     anchors.left: parent.left
                     anchors.leftMargin: UM.Theme.getSize("section_icon").width + UM.Theme.getSize("narrow_margin").width
                     font: UM.Theme.getFont("medium")
-                    color: UM.Theme.getColor("text")
-                    renderType: Text.NativeRendering
                     elide: Text.ElideRight
                 }
 

--- a/resources/qml/PrintSetupTooltip.qml
+++ b/resources/qml/PrintSetupTooltip.qml
@@ -90,7 +90,6 @@ UM.PointingRectangle
             y: UM.Theme.getSize("tooltip_margins").height
             width: textScroll.width - 2 * UM.Theme.getSize("tooltip_margins").width
 
-            wrapMode: Text.Wrap
             textFormat: Text.RichText
             color: UM.Theme.getColor("tooltip_text")
         }

--- a/resources/qml/PrinterOutput/OutputDeviceHeader.qml
+++ b/resources/qml/PrinterOutput/OutputDeviceHeader.qml
@@ -33,7 +33,6 @@ Item
         {
             id: outputDeviceNameLabel
             font: UM.Theme.getFont("large_bold")
-            color: UM.Theme.getColor("text")
             anchors.left: parent.left
             anchors.top: parent.top
             anchors.margins: UM.Theme.getSize("default_margin").width

--- a/resources/qml/PrinterTypeLabel.qml
+++ b/resources/qml/PrinterTypeLabel.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.7
 import QtQuick.Controls 2.1
 
-import UM 1.1 as UM
+import UM 1.5 as UM
 
 // This component creates a label with the abbreviated name of a printer, with a rectangle surrounding the label.
 // It is created in a separated place in order to be reused whenever needed.
@@ -24,14 +24,11 @@ Item
         radius: UM.Theme.getSize("checkbox_radius").width
     }
 
-    Label
+    UM.Label
     {
         id: printerTypeLabel
         text: "CFFFP" // As an abbreviated name of the Custom FFF Printer
         anchors.verticalCenter: parent.verticalCenter
         anchors.horizontalCenter: parent.horizontalCenter
-        renderType: Text.NativeRendering
-        font: UM.Theme.getFont("default")
-        color: UM.Theme.getColor("text")
     }
 }

--- a/resources/qml/Settings/SettingItem.qml
+++ b/resources/qml/Settings/SettingItem.qml
@@ -5,7 +5,7 @@ import QtQuick 2.7
 import QtQuick.Layouts 1.2
 import QtQuick.Controls 2.0
 
-import UM 1.1 as UM
+import UM 1.5 as UM
 import Cura 1.0 as Cura
 
 import "."
@@ -135,7 +135,7 @@ Item
             }
         }
 
-        Label
+        UM.Label
         {
             id: label
 
@@ -146,7 +146,6 @@ Item
 
             text: definition.label
             elide: Text.ElideMiddle
-            renderType: Text.NativeRendering
             textFormat: Text.PlainText
 
             color: UM.Theme.getColor("setting_control_text")

--- a/resources/qml/Toolbar.qml
+++ b/resources/qml/Toolbar.qml
@@ -210,12 +210,11 @@ Item
         width: toolHint.width + UM.Theme.getSize("default_margin").width
         height: toolHint.height;
         color: UM.Theme.getColor("tooltip")
-        Label
+        UM.Label
         {
             id: toolHint
             text: UM.ActiveTool.properties.getValue("ToolHint") != undefined ? UM.ActiveTool.properties.getValue("ToolHint") : ""
             color: UM.Theme.getColor("tooltip_text")
-            font: UM.Theme.getFont("default")
             anchors.horizontalCenter: parent.horizontalCenter
         }
 

--- a/resources/qml/WelcomePages/AddCloudPrintersView.qml
+++ b/resources/qml/WelcomePages/AddCloudPrintersView.qml
@@ -38,7 +38,7 @@ Item
             bottomMargin: UM.Theme.getSize("default_margin").height
         }
 
-        Label
+        UM.Label
         {
             id: titleLabel
             anchors.top: parent.top
@@ -47,7 +47,6 @@ Item
             text: catalog.i18nc("@label", "Add a Cloud printer")
             color: UM.Theme.getColor("primary_button")
             font: UM.Theme.getFont("huge")
-            renderType: Text.NativeRendering
         }
 
         // Component that contains a busy indicator and a message, while it waits for Cura to discover a cloud printer
@@ -65,7 +64,7 @@ Item
                 running: searchingForCloudPrinters
                 palette.dark: UM.Theme.getColor("text")
             }
-            Label
+            UM.Label
             {
                 id: waitingLabel
                 anchors.top: waitingIndicator.bottom
@@ -73,10 +72,8 @@ Item
                 horizontalAlignment: Text.AlignHCenter
                 text: catalog.i18nc("@label", "Waiting for Cloud response")
                 font: UM.Theme.getFont("large")
-                renderType: Text.NativeRendering
-                color: UM.Theme.getColor("text")
             }
-            Label
+            UM.Label
             {
                 id: noPrintersFoundLabel
                 anchors.top: waitingLabel.bottom
@@ -85,9 +82,8 @@ Item
                 horizontalAlignment: Text.AlignHCenter
                 text: catalog.i18nc("@label", "No printers found in your account?")
                 font: UM.Theme.getFont("medium")
-                color: UM.Theme.getColor("text")
             }
-            Label
+            UM.Label
             {
                 text: "Sign in with a different account"
                 anchors.top: noPrintersFoundLabel.bottom
@@ -112,7 +108,7 @@ Item
         }
 
         // Label displayed when a new cloud printer is discovered
-        Label
+        UM.Label
         {
             anchors.top: titleLabel.bottom
             anchors.topMargin: 2 * UM.Theme.getSize("default_margin").height
@@ -121,7 +117,6 @@ Item
             text: catalog.i18nc("@label", "The following printers in your account have been added in Cura:")
             height: contentHeight + 2 * UM.Theme.getSize("default_margin").height
             visible: discoveredCloudPrintersModel.count > 0
-            color: UM.Theme.getColor("text")
         }
 
         // The scrollView that contains the list of newly discovered Ultimaker Cloud printers. Visible only when
@@ -153,32 +148,29 @@ Item
                 Column
                 {
                     id: contentColumn
-                    Label
+                    UM.Label
                     {
                         id: cloudPrinterNameLabel
                         leftPadding: UM.Theme.getSize("default_margin").width
                         text: model.name ? model.name : ""
                         font: UM.Theme.getFont("large_bold")
-                        color: UM.Theme.getColor("text")
                         elide: Text.ElideRight
                     }
-                    Label
+                    UM.Label
                     {
                         id: cloudPrinterTypeLabel
                         leftPadding: 2 * UM.Theme.getSize("default_margin").width
                         topPadding: UM.Theme.getSize("thin_margin").height
-                        text: {"Type: " + model.machine_type}
+                        text: "Type: " + model.machine_type
                         font: UM.Theme.getFont("medium")
-                        color: UM.Theme.getColor("text")
                         elide: Text.ElideRight
                     }
-                    Label
+                    UM.Label
                     {
                         id: cloudPrinterFirmwareVersionLabel
                         leftPadding: 2 * UM.Theme.getSize("default_margin").width
-                        text: {"Firmware version: " + model.firmware_version}
+                        text: "Firmware version: " + model.firmware_version
                         font: UM.Theme.getFont("medium")
-                        color: UM.Theme.getColor("text")
                         elide: Text.ElideRight
                     }
                 }

--- a/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
+++ b/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml
@@ -183,7 +183,6 @@ Item
             UM.Label
             {
                 width: parent.width - (2 * UM.Theme.getSize("default_margin").width)
-                wrapMode: Text.Wrap
                 text: base.getMachineName()
                 color: UM.Theme.getColor("primary_button")
                 font: UM.Theme.getFont("huge")

--- a/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml
+++ b/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 
@@ -15,7 +15,7 @@ Item
 {
     UM.I18nCatalog { id: catalog; name: "cura" }
 
-    Label
+    UM.Label
     {
         id: titleLabel
         anchors.top: parent.top
@@ -24,7 +24,6 @@ Item
         text: catalog.i18nc("@label", "Add a printer")
         color: UM.Theme.getColor("primary_button")
         font: UM.Theme.getFont("huge")
-        renderType: Text.NativeRendering
     }
 
     DropDownWidget

--- a/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml
+++ b/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml
@@ -218,7 +218,6 @@ Item
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
                 text: catalog.i18nc("@label", "Troubleshooting")
-                font: UM.Theme.getFont("default")
                 color: UM.Theme.getColor("text_link")
             }
 

--- a/resources/qml/WelcomePages/AddPrinterByIpContent.qml
+++ b/resources/qml/WelcomePages/AddPrinterByIpContent.qml
@@ -5,7 +5,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.5 as Cura
 
 
@@ -61,7 +61,7 @@ Item
         }
     }
 
-    Label
+    UM.Label
     {
         id: titleLabel
         anchors.top: parent.top
@@ -70,7 +70,6 @@ Item
         text: catalog.i18nc("@label", "Add printer by IP address")
         color: UM.Theme.getColor("primary_button")
         font: UM.Theme.getFont("huge")
-        renderType: Text.NativeRendering
     }
 
     Item
@@ -88,17 +87,13 @@ Item
             anchors.right: parent.right
             anchors.margins: UM.Theme.getSize("default_margin").width
 
-            Label
+            UM.Label
             {
                 id: explainLabel
                 height: contentHeight
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.top: parent.top
-
-                font: UM.Theme.getFont("default")
-                color: UM.Theme.getColor("text")
-                renderType: Text.NativeRendering
                 text: catalog.i18nc("@label", "Enter the IP address of your printer on the network.")
             }
 
@@ -136,7 +131,7 @@ Item
                     onAccepted: addPrinterButton.clicked()
                 }
 
-                Label
+                UM.Label
                 {
                     id: invalidInputLabel
                     anchors.top: hostnameField.bottom
@@ -144,9 +139,6 @@ Item
                     anchors.left: parent.left
                     visible: false
                     text: catalog.i18nc("@text", "Please enter a valid IP address.")
-                    font: UM.Theme.getFont("default")
-                    color: UM.Theme.getColor("text")
-                    renderType: Text.NativeRendering
                 }
 
                 Cura.SecondaryButton
@@ -188,14 +180,11 @@ Item
                 anchors.top: userInputFields.bottom
                 anchors.margins: UM.Theme.getSize("default_margin").width
 
-                Label
+                UM.Label
                 {
                     id: waitResponseLabel
                     anchors.top: parent.top
                     anchors.margins: UM.Theme.getSize("default_margin").width
-                    font: UM.Theme.getFont("default")
-                    color: UM.Theme.getColor("text")
-                    renderType: Text.NativeRendering
 
                     visible: addPrinterByIpScreen.hasRequestInProgress || (addPrinterByIpScreen.hasRequestFinished && !addPrinterByIpScreen.isPrinterDiscovered)
                     textFormat: Text.RichText
@@ -225,18 +214,15 @@ Item
 
                     visible: addPrinterByIpScreen.isPrinterDiscovered
 
-                    Label
+                    UM.Label
                     {
                         id: printerNameLabel
                         anchors.top: parent.top
                         font: UM.Theme.getFont("large")
-                        color: UM.Theme.getColor("text")
-                        renderType: Text.NativeRendering
-
                         text: !addPrinterByIpScreen.isPrinterDiscovered ? "???" : addPrinterByIpScreen.discoveredPrinter.name
                     }
 
-                    Label
+                    UM.Label
                     {
                         id: printerCannotBeAddedLabel
                         width: parent.width
@@ -245,8 +231,6 @@ Item
                         text: catalog.i18nc("@label", "This printer cannot be added because it's an unknown printer or it's not the host of a group.")
                         visible: addPrinterByIpScreen.hasRequestFinished && !addPrinterByIpScreen.canAddPrinter
                         font: UM.Theme.getFont("default_bold")
-                        color: UM.Theme.getColor("text")
-                        renderType: Text.NativeRendering
                         wrapMode: Text.WordWrap
                     }
 
@@ -258,52 +242,33 @@ Item
                         columns: 2
                         columnSpacing: UM.Theme.getSize("default_margin").width
 
-                        Label
+                        UM.Label
                         {
                             text: catalog.i18nc("@label", "Type")
-                            font: UM.Theme.getFont("default")
-                            color: UM.Theme.getColor("text")
-                            renderType: Text.NativeRendering
                         }
-                        Label
+                        UM.Label
                         {
                             id: typeText
                             text: !addPrinterByIpScreen.isPrinterDiscovered ? "?" : addPrinterByIpScreen.discoveredPrinter.readableMachineType
-                            font: UM.Theme.getFont("default")
-                            color: UM.Theme.getColor("text")
-                            renderType: Text.NativeRendering
                         }
-
-                        Label
+                        UM.Label
                         {
                             text: catalog.i18nc("@label", "Firmware version")
-                            font: UM.Theme.getFont("default")
-                            color: UM.Theme.getColor("text")
-                            renderType: Text.NativeRendering
                         }
-                        Label
+                        UM.Label
                         {
                             id: firmwareText
                             text: !addPrinterByIpScreen.isPrinterDiscovered ? "0.0.0.0" : addPrinterByIpScreen.discoveredPrinter.device.getProperty("firmware_version")
-                            font: UM.Theme.getFont("default")
-                            color: UM.Theme.getColor("text")
-                            renderType: Text.NativeRendering
                         }
 
-                        Label
+                        UM.Label
                         {
                             text: catalog.i18nc("@label", "Address")
-                            font: UM.Theme.getFont("default")
-                            color: UM.Theme.getColor("text")
-                            renderType: Text.NativeRendering
                         }
-                        Label
+                        UM.Label
                         {
                             id: addressText
                             text: !addPrinterByIpScreen.isPrinterDiscovered ? "0.0.0.0" : addPrinterByIpScreen.discoveredPrinter.address
-                            font: UM.Theme.getFont("default")
-                            color: UM.Theme.getColor("text")
-                            renderType: Text.NativeRendering
                         }
                     }
 

--- a/resources/qml/WelcomePages/CloudContent.qml
+++ b/resources/qml/WelcomePages/CloudContent.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 
@@ -56,7 +56,7 @@ Item
 
             spacing: UM.Theme.getSize("thick_margin").height
 
-            Label
+            UM.Label
             {
                 id: titleLabel
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -64,7 +64,6 @@ Item
                 text: catalog.i18nc("@label", "Sign in to the Ultimaker platform")
                 color: UM.Theme.getColor("primary_button")
                 font: UM.Theme.getFont("huge")
-                renderType: Text.NativeRendering
             }
 
             // Filler item
@@ -116,17 +115,13 @@ Item
                         sourceSize.width: width
                         sourceSize.height: height
                     }
-                    Label
+                    UM.Label
                     {
                         id: marketplaceTextLabel
                         anchors.horizontalCenter: parent.horizontalCenter
                         width: parent.width
                         text: catalog.i18nc("@text", "Add material settings and plugins from the Marketplace")
-                        wrapMode: Text.Wrap
                         horizontalAlignment: Text.AlignHCenter
-                        color: UM.Theme.getColor("text")
-                        font: UM.Theme.getFont("default")
-                        renderType: Text.NativeRendering
                     }
                 }
 
@@ -146,17 +141,13 @@ Item
                         sourceSize.width: width
                         sourceSize.height: height
                     }
-                    Label
+                    UM.Label
                     {
                         id: syncTextLabel
                         anchors.horizontalCenter: parent.horizontalCenter
                         width: parent.width
                         text: catalog.i18nc("@text", "Backup and sync your material settings and plugins")
-                        wrapMode: Text.Wrap
                         horizontalAlignment: Text.AlignHCenter
-                        color: UM.Theme.getColor("text")
-                        font: UM.Theme.getFont("default")
-                        renderType: Text.NativeRendering
                     }
                 }
 
@@ -176,17 +167,13 @@ Item
                         sourceSize.width: width
                         sourceSize.height: height
                     }
-                    Label
+                    UM.Label
                     {
                         id: communityTextLabel
                         anchors.horizontalCenter: communityColumn.horizontalCenter
                         width: parent.width
                         text: catalog.i18nc("@text", "Share ideas and get help from 48,000+ users in the Ultimaker Community")
-                        wrapMode: Text.Wrap
                         horizontalAlignment: Text.AlignHCenter
-                        color: UM.Theme.getColor("text")
-                        font: UM.Theme.getFont("default")
-                        renderType: Text.NativeRendering
                     }
                 }
             }

--- a/resources/qml/WelcomePages/DataCollectionsContent.qml
+++ b/resources/qml/WelcomePages/DataCollectionsContent.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 
@@ -15,7 +15,7 @@ Item
 {
     UM.I18nCatalog { id: catalog; name: "cura" }
 
-    Label
+    UM.Label
     {
         id: titleLabel
         anchors.top: parent.top
@@ -24,7 +24,6 @@ Item
         text: catalog.i18nc("@label", "Help us to improve Ultimaker Cura")
         color: UM.Theme.getColor("primary_button")
         font: UM.Theme.getFont("huge")
-        renderType: Text.NativeRendering
     }
 
     // Area where the cloud contents can be put. Pictures, texts and such.
@@ -48,7 +47,7 @@ Item
 
             spacing: UM.Theme.getSize("wide_margin").height
 
-            Label
+            UM.Label
             {
                 id: topLabel
                 width: parent.width
@@ -57,8 +56,6 @@ Item
                 text: catalog.i18nc("@text", "Ultimaker Cura collects anonymous data to improve print quality and user experience, including:")
                 wrapMode: Text.WordWrap
                 font: UM.Theme.getFont("medium")
-                color: UM.Theme.getColor("text")
-                renderType: Text.NativeRendering
             }
 
             Grid {
@@ -91,7 +88,7 @@ Item
                 }
             }
 
-            Label
+            UM.Label
             {
                 id: bottomLabel
                 width: parent.width
@@ -107,10 +104,8 @@ Item
                 textFormat: Text.RichText
                 wrapMode: Text.WordWrap
                 font: UM.Theme.getFont("medium")
-                color: UM.Theme.getColor("text")
                 linkColor: UM.Theme.getColor("text_link")
                 onLinkActivated: CuraApplication.showMoreInformationDialogForAnonymousDataCollection()
-                renderType: Text.NativeRendering
             }
         }
     }

--- a/resources/qml/WelcomePages/FirstStartMachineActionsContent.qml
+++ b/resources/qml/WelcomePages/FirstStartMachineActionsContent.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 
@@ -36,7 +36,7 @@ Item
         }
     }
 
-    Label
+    UM.Label
     {
         id: titleLabel
         anchors.top: parent.top
@@ -45,7 +45,6 @@ Item
         text: machineActionsModel.currentItem.title == undefined ? "" : machineActionsModel.currentItem.title
         color: UM.Theme.getColor("primary_button")
         font: UM.Theme.getFont("huge")
-        renderType: Text.NativeRendering
     }
 
     Item

--- a/resources/qml/WelcomePages/ImageTile.qml
+++ b/resources/qml/WelcomePages/ImageTile.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 
 
 //
@@ -18,7 +18,7 @@ Column
     property alias text: label.text
     property alias imageSource: image.source
 
-    Label
+    UM.Label
     {
         id: label
         width: image.width
@@ -26,9 +26,6 @@ Column
         horizontalAlignment: Text.AlignHCenter
         text: ""
         wrapMode: Text.WordWrap
-        font: UM.Theme.getFont("default")
-        color: UM.Theme.getColor("text")
-        renderType: Text.NativeRendering
     }
 
     Image

--- a/resources/qml/WelcomePages/WelcomeContent.qml
+++ b/resources/qml/WelcomePages/WelcomeContent.qml
@@ -4,7 +4,7 @@
 import QtQuick 2.10
 import QtQuick.Controls 2.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 //
@@ -48,7 +48,7 @@ Item
             width: parent.width
         }
 
-        Label
+        UM.Label
         {
             id: titleLabel
             anchors.horizontalCenter: parent.horizontalCenter
@@ -56,20 +56,16 @@ Item
             text: catalog.i18nc("@label", "Welcome to Ultimaker Cura")
             color: UM.Theme.getColor("primary_button")
             font: UM.Theme.getFont("huge_bold")
-            renderType: Text.NativeRendering
         }
 
-        Label
+        UM.Label
         {
             id: textLabel
             anchors.horizontalCenter: parent.horizontalCenter
             horizontalAlignment: Text.AlignHCenter
             width: titleLabel.width + 2 * UM.Theme.getSize("thick_margin").width
             text: catalog.i18nc("@text", "Please follow these steps to set up Ultimaker Cura. This will only take a few moments.")
-            wrapMode: Text.Wrap
             font: UM.Theme.getFont("medium")
-            color: UM.Theme.getColor("text")
-            renderType: Text.NativeRendering
         }
 
         // Filler item

--- a/resources/qml/WelcomePages/WhatsNewContent.qml
+++ b/resources/qml/WelcomePages/WhatsNewContent.qml
@@ -5,7 +5,7 @@ import QtQuick 2.10
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 
-import UM 1.3 as UM
+import UM 1.5 as UM
 import Cura 1.1 as Cura
 
 
@@ -19,7 +19,7 @@ Item
 
     UM.I18nCatalog { id: catalog; name: "cura" }
 
-    Label
+    UM.Label
     {
         id: titleLabel
         anchors.top: parent.top
@@ -28,7 +28,6 @@ Item
         text: catalog.i18nc("@label", "What's New")
         color: UM.Theme.getColor("primary_button")
         font: UM.Theme.getFont("huge")
-        renderType: Text.NativeRendering
     }
 
     Rectangle


### PR DESCRIPTION
Fonts were looking a bit to thick on when using `Text.NativeRendering`, so using `Text.QtRendering` instead. After this the font weight looks identical to figma (as far as I can see).

In this commit I also changed all `Label`'s to `UM.Label`'s and removed default properties where I could.

CURA-9154