### PR TITLE
Add back missing translations

### DIFF
--- a/resources/i18n/cs_CZ/cura.po
+++ b/resources/i18n/cs_CZ/cura.po
@@ -6563,6 +6563,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB tisk"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Zjistit Více"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/cs_CZ/cura.po
+++ b/resources/i18n/cs_CZ/cura.po
@@ -6563,41 +6563,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB tisk"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "Pro instalaci balíčku musíte přijmout licenční ujednání"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Zjištěny změny z vašeho účtu Ultimaker"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Změny z vašeho účtu"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Schovat"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Odmítnout a odstranit z účtu"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Chcete synchronizovat materiálové a softwarové balíčky s vaším účtem?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Synchronizuji..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Následující balíčky byly přidány:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "Než se změny projeví, musíte ukončit a restartovat {}."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "Nepovedlo se stáhnout {} zásuvných modulů"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Licenční ujednání zásuvného modulu"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Synchronizovat materiály s tiskárnami"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "Než se změny projeví, musíte ukončit a restartovat {}."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Synchronizuji..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Zjištěny změny z vašeho účtu Ultimaker"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Chcete synchronizovat materiál a softwarové balíčky s vaším účtem?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Synchronizovat"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Odmítnout a odstranit z účtu"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "Nepovedlo se stáhnout {} zásuvných modulů"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Licenční ujednání zásuvného modulu"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -6786,22 +6814,6 @@ msgstr "USB tisk"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Nelze se připojit k databázi balíčku Cura. Zkontrolujte připojení."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "Pro instalaci balíčku musíte přijmout licenční ujednání"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Změny z vašeho účtu"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Schovat"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Následující balíčky byly přidány:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"
@@ -7232,22 +7244,6 @@ msgstr "USB tisk"
 #~ msgctxt "@button"
 #~ msgid "Create an account"
 #~ msgstr "Vytvořit účet"
-
-#~ msgctxt "@info:generic"
-#~ msgid ""
-#~ "\n"
-#~ "Do you want to sync material and software packages with your account?"
-#~ msgstr ""
-#~ "\n"
-#~ "Chcete synchronizovat materiálové a softwarové balíčky s vaším účtem?"
-
-#~ msgctxt "@info:generic"
-#~ msgid ""
-#~ "\n"
-#~ "Syncing..."
-#~ msgstr ""
-#~ "\n"
-#~ "Synchronizuji..."
 
 #~ msgctxt "@info:status"
 #~ msgid "Nothing to slice because none of the models fit the build volume or are assigned to a disabled extruder. Please scale or rotate models to fit, or enable an extruder."

--- a/resources/i18n/cura.pot
+++ b/resources/i18n/cura.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-13 10:49+0200\n"
+"POT-Creation-Date: 2022-05-10 17:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,1466 +18,133 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PrepareStage/__init__.py:12
-msgctxt "@item:inmenu"
-msgid "Prepare"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraProfileWriter/__init__.py:14
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraProfileReader/__init__.py:14
-msgctxt "@item:inlistbox"
-msgid "Cura Profile"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/TrimeshReader/__init__.py:15
-msgctxt "@item:inlistbox 'Open' is part of the name of this file format."
-msgid "Open Compressed Triangle Mesh"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/TrimeshReader/__init__.py:19
-msgctxt "@item:inlistbox"
-msgid "COLLADA Digital Asset Exchange"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/TrimeshReader/__init__.py:23
-msgctxt "@item:inlistbox"
-msgid "glTF Binary"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/TrimeshReader/__init__.py:27
-msgctxt "@item:inlistbox"
-msgid "glTF Embedded JSON"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/TrimeshReader/__init__.py:36
-msgctxt "@item:inlistbox"
-msgid "Stanford Triangle Format"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/TrimeshReader/__init__.py:40
-msgctxt "@item:inlistbox"
-msgid "Compressed COLLADA Digital Asset Exchange"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerJob.py:127
-msgctxt "@info"
-msgid "Could not access update information."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:17
-#, python-brace-format
-msgctxt ""
-"@info Don't translate {machine_name}, since it gets replaced by a printer "
-"name!"
-msgid ""
-"New features or bug-fixes may be available for your {machine_name}! If you "
-"haven't done so already, it is recommended to update the firmware on your "
-"printer to version {latest_version}."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:22
-#, python-format
-msgctxt "@info:title The %s gets replaced with the printer name."
-msgid "New %s stable firmware available"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:28
-msgctxt "@action:button"
-msgid "How to update"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MonitorStage/__init__.py:14
-msgctxt "@item:inmenu"
-msgid "Monitor"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:23
-msgctxt "@action:button Preceded by 'Ready to'."
-msgid "Save to Removable Drive"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:24
-#, python-brace-format
-msgctxt "@item:inlistbox"
-msgid "Save to Removable Drive {0}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:66
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/MeshFormatHandler.py:118
-msgctxt "@info:status"
-msgid "There are no file formats available to write with!"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:97
-#, python-brace-format
-msgctxt "@info:progress Don't translate the XML tags <filename>!"
-msgid "Saving to Removable Drive <filename>{0}</filename>"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:98
-msgctxt "@info:title"
-msgid "Saving"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:108
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:111
-#, python-brace-format
-msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
-msgid "Could not save to <filename>{0}</filename>: <message>{1}</message>"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:127
-#, python-brace-format
-msgctxt "@info:status Don't translate the tag {device}!"
-msgid "Could not find a file name when trying to write to {device}."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:140
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:159
-#, python-brace-format
-msgctxt "@info:status"
-msgid "Could not save to removable drive {0}: {1}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:141
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:161
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:1782
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:156
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:166
-msgctxt "@info:title"
-msgid "Error"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:150
-#, python-brace-format
-msgctxt "@info:status"
-msgid "Saved to Removable Drive {0} as {1}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:151
-msgctxt "@info:title"
-msgid "File Saved"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:153
-msgctxt "@action:button"
-msgid "Eject"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:153
-#, python-brace-format
-msgctxt "@action"
-msgid "Eject removable device {0}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:172
-#, python-brace-format
-msgctxt "@info:status"
-msgid "Ejected {0}. You can now safely remove the drive."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:173
-msgctxt "@info:title"
-msgid "Safely Remove Hardware"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:176
-#, python-brace-format
-msgctxt "@info:status"
-msgid "Failed to eject {0}. Another program may be using the drive."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:177
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:1770
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationService.py:217
-msgctxt "@info:title"
-msgid "Warning"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/RemovableDriveOutputDevice/WindowsRemovableDrivePlugin.py:76
-msgctxt "@item:intext"
-msgid "Removable Drive"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/AMFReader/__init__.py:15
-msgctxt "@item:inlistbox"
-msgid "AMF File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UFPReader/__init__.py:22
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UFPWriter/__init__.py:28
-msgctxt "@item:inlistbox"
-msgid "Ultimaker Format Package"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/__init__.py:14
-msgctxt "@label"
-msgid "Per Model Settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/__init__.py:15
-msgctxt "@info:tooltip"
-msgid "Configure Per Model Settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.py:27
-msgctxt "@action"
-msgid "Update Firmware"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/MaterialSyncMessage.py:24
-#, python-brace-format
-msgctxt "@info:status"
-msgid ""
-"Cura has detected material profiles that were not yet installed on the host "
-"printer of group {0}."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/MaterialSyncMessage.py:26
-msgctxt "@info:title"
-msgid "Sending materials to printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:27
-#, python-brace-format
-msgctxt "@info:status"
-msgid ""
-"You are attempting to connect to {0} but it is not the host of a group. You "
-"can visit the web page to configure it as a group host."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:30
-msgctxt "@info:title"
-msgid "Not a group host"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:36
-msgctxt "@action"
-msgid "Configure group"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadProgressMessage.py:15
-msgctxt "@info:status"
-msgid "Sending Print Job"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadProgressMessage.py:16
-msgctxt "@info:status"
-msgid "Uploading print job to printer."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadQueueFullMessage.py:16
-msgctxt "@info:status"
-msgid "Print job queue is full. The printer can't accept a new job."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadQueueFullMessage.py:17
-msgctxt "@info:title"
-msgid "Queue Full"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadBlockedMessage.py:15
-msgctxt "@info:status"
-msgid "Please wait until the current job has been sent."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadBlockedMessage.py:16
-msgctxt "@info:title"
-msgid "Print error"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadSuccessMessage.py:15
-msgctxt "@info:status"
-msgid "Print job was successfully sent to the printer."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadSuccessMessage.py:16
-msgctxt "@info:title"
-msgid "Data Sent"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:25
-#, python-brace-format
-msgctxt "@info:status"
-msgid ""
-"Your printer <b>{printer_name}</b> could be connected via cloud.\n"
-" Manage your print queue and monitor your prints from anywhere connecting "
-"your printer to Digital Factory"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:26
-msgctxt "@info:title"
-msgid "Are you ready for cloud printing?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:30
-msgctxt "@action"
-msgid "Get started"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:31
-msgctxt "@action"
-msgid "Learn more"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/LegacyDeviceNoLongerSupportedMessage.py:18
-msgctxt "@info:status"
-msgid ""
-"You are attempting to connect to a printer that is not running Ultimaker "
-"Connect. Please update the printer to the latest firmware."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/LegacyDeviceNoLongerSupportedMessage.py:21
-msgctxt "@info:title"
-msgid "Update your printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py:15
-msgctxt "@info:text"
-msgid "Could not upload the data to the printer."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py:16
-msgctxt "@info:title"
-msgid "Network error"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:58
-msgctxt "@action:button Preceded by 'Ready to'."
-msgid "Print over network"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:59
-msgctxt "@properties:tooltip"
-msgid "Print over network"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:60
-msgctxt "@info:status"
-msgid "Connected over the network"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Utils.py:27
-msgctxt "@info:status"
-msgid "tomorrow"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Utils.py:30
-msgctxt "@info:status"
-msgid "today"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterAction.py:28
-msgctxt "@action"
-msgid "Connect via Network"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:229
-msgctxt "info:status"
-msgid "New printer detected from your Ultimaker account"
-msgid_plural "New printers detected from your Ultimaker account"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:240
-#, python-brace-format
-msgctxt "info:status Filled in with printer name and printer model."
-msgid "Adding printer {name} ({model}) from your account"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:257
-#, python-brace-format
-msgctxt "info:{0} gets replaced by a number of printers"
-msgid "... and {0} other"
-msgid_plural "... and {0} others"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:262
-msgctxt "info:status"
-msgid "Printers added from Digital Factory:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:328
-msgctxt "info:status"
-msgid "A cloud connection is not available for a printer"
-msgid_plural "A cloud connection is not available for some printers"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:337
-msgctxt "info:status"
-msgid "This printer is not linked to the Digital Factory:"
-msgid_plural "These printers are not linked to the Digital Factory:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:342
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:432
-msgctxt "info:name"
-msgid "Ultimaker Digital Factory"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:346
-#, python-brace-format
-msgctxt "info:status"
-msgid "To establish a connection, please visit the {website_link}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:350
-msgctxt "@action:button"
-msgid "Keep printer configurations"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:355
-msgctxt "@action:button"
-msgid "Remove printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:434
-#, python-brace-format
-msgctxt "@message {printer_name} is replaced with the name of the printer"
-msgid "{printer_name} will be removed until the next account sync."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:435
-#, python-brace-format
-msgctxt "@message {printer_name} is replaced with the name of the printer"
-msgid "To remove {printer_name} permanently, visit {digital_factory_link}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:436
-#, python-brace-format
-msgctxt "@message {printer_name} is replaced with the name of the printer"
-msgid "Are you sure you want to remove {printer_name} temporarily?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:473
-msgctxt "@title:window"
-msgid "Remove printers?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:476
-#, python-brace-format
-msgctxt "@label"
-msgid ""
-"You are about to remove {0} printer from Cura. This action cannot be "
-"undone.\n"
-"Are you sure you want to continue?"
-msgid_plural ""
-"You are about to remove {0} printers from Cura. This action cannot be "
-"undone.\n"
-"Are you sure you want to continue?"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:481
-msgctxt "@label"
-msgid ""
-"You are about to remove all printers from Cura. This action cannot be "
-"undone.\n"
-"Are you sure you want to continue?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:154
-msgctxt "@action:button"
-msgid "Print via cloud"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:155
-msgctxt "@properties:tooltip"
-msgid "Print via cloud"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:156
-msgctxt "@info:status"
-msgid "Connected via cloud"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:261
-msgctxt "@action:button"
-msgid "Monitor print"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:263
-msgctxt "@action:tooltip"
-msgid "Track the print in Ultimaker Digital Factory"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:279
-#, python-brace-format
-msgctxt "@error:send"
-msgid "Unknown error code when uploading print job: {0}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ModelChecker/ModelChecker.py:31
-msgctxt "@info:title"
-msgid "3D Model Assistant"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ModelChecker/ModelChecker.py:97
-#, python-brace-format
-msgctxt "@info:status"
-msgid ""
-"<p>One or more 3D models may not print optimally due to the model size and "
-"material configuration:</p>\n"
-"<p>{model_names}</p>\n"
-"<p>Find out how to ensure the best possible print quality and reliability.</"
-"p>\n"
-"<p><a href=\"https://ultimaker.com/3D-model-assistant\">View print quality "
-"guide</a></p>"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationView.py:129
-msgctxt "@info:status"
-msgid "Cura does not accurately display layers when Wire Printing is enabled."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationView.py:130
-msgctxt "@info:title"
-msgid "Simulation View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationView.py:133
-msgctxt "@info:status"
-msgid "Nothing is shown because you need to slice first."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationView.py:134
-msgctxt "@info:title"
-msgid "No layers to show"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationView.py:136
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SolidView/SolidView.py:74
-msgctxt "@info:option_text"
-msgid "Do not show this message again"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/__init__.py:15
-msgctxt "@item:inlistbox"
-msgid "Layer view"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeWriter/GCodeWriter.py:74
-msgctxt "@error:not supported"
-msgid "GCodeWriter does not support non-text mode."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeWriter/GCodeWriter.py:80
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeWriter/GCodeWriter.py:96
-msgctxt "@warning:status"
-msgid "Please prepare G-code before exporting."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeWriter/__init__.py:16
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeProfileReader/__init__.py:14
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeReader/__init__.py:14
-msgctxt "@item:inlistbox"
-msgid "G-code File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFWriter/ThreeMFWriter.py:226
-msgctxt "@error:zip"
-msgid "Error writing 3mf file."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:31
-msgctxt "@error:zip"
-msgid "3MF Writer plug-in is corrupt."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:37
-msgctxt "@error"
-msgid "There is no workspace yet to write. Please add a printer first."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:64
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:97
-msgctxt "@error:zip"
-msgid "No permission to write the workspace here."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:101
-msgctxt "@error:zip"
-msgid ""
-"The operating system does not allow saving a project file to this location "
-"or with this file name."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFWriter/__init__.py:26
-msgctxt "@item:inlistbox"
-msgid "3MF file"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFWriter/__init__.py:34
-msgctxt "@item:inlistbox"
-msgid "Cura Project 3MF file"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeGzReader/__init__.py:17
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeGzWriter/__init__.py:17
-msgctxt "@item:inlistbox"
-msgid "Compressed G-code File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:161
-msgctxt "@message"
-msgid ""
-"Slicing failed with an unexpected error. Please consider reporting a bug on "
-"our issue tracker."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:162
-msgctxt "@message:title"
-msgid "Slicing failed"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:167
-msgctxt "@message:button"
-msgid "Report a bug"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:168
-msgctxt "@message:description"
-msgid "Report a bug on Ultimaker Cura's issue tracker."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:395
-msgctxt "@info:status"
-msgid ""
-"Unable to slice with the current material as it is incompatible with the "
-"selected machine or configuration."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:396
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:429
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:456
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:468
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:480
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:493
-msgctxt "@info:title"
-msgid "Unable to slice"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:428
-#, python-brace-format
-msgctxt "@info:status"
-msgid ""
-"Unable to slice with the current settings. The following settings have "
-"errors: {0}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:455
-#, python-brace-format
-msgctxt "@info:status"
-msgid ""
-"Unable to slice due to some per-model settings. The following settings have "
-"errors on one or more models: {error_labels}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:467
-msgctxt "@info:status"
-msgid ""
-"Unable to slice because the prime tower or prime position(s) are invalid."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:479
-#, python-format
-msgctxt "@info:status"
-msgid ""
-"Unable to slice because there are objects associated with disabled Extruder "
-"%s."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:489
-msgctxt "@info:status"
-msgid ""
-"Please review settings and check if your models:\n"
-"- Fit within the build volume\n"
-"- Are assigned to an enabled extruder\n"
-"- Are not all set as modifier meshes"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:52
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:260
-msgctxt "@info:status"
-msgid "Processing Layers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:261
-msgctxt "@info:title"
-msgid "Information"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/X3DReader/__init__.py:13
-msgctxt "@item:inlistbox"
-msgid "X3D File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/__init__.py:14
-msgctxt "@item:inlistbox"
-msgid "JPG Image"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/__init__.py:18
-msgctxt "@item:inlistbox"
-msgid "JPEG Image"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/__init__.py:22
-msgctxt "@item:inlistbox"
-msgid "PNG Image"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/__init__.py:26
-msgctxt "@item:inlistbox"
-msgid "BMP Image"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/__init__.py:30
-msgctxt "@item:inlistbox"
-msgid "GIF Image"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:218
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/MachineManager.py:713
-msgctxt "@label"
-msgid "Nozzle"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:544
-#, python-brace-format
-msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
-msgid ""
-"Project file <filename>{0}</filename> contains an unknown machine type "
-"<message>{1}</message>. Cannot import the machine. Models will be imported "
-"instead."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:547
-msgctxt "@info:title"
-msgid "Open Project File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:644
-#, python-brace-format
-msgctxt "@info:error Don't translate the XML tags <filename> or <message>!"
-msgid ""
-"Project file <filename>{0}</filename> is suddenly inaccessible: <message>{1}"
-"</message>."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:645
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:653
-msgctxt "@info:title"
-msgid "Can't Open Project File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:652
-#, python-brace-format
-msgctxt "@info:error Don't translate the XML tags <filename> or <message>!"
-msgid ""
-"Project file <filename>{0}</filename> is corrupt: <message>{1}</message>."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:705
-#, python-brace-format
-msgctxt "@info:error Don't translate the XML tag <filename>!"
-msgid ""
-"Project file <filename>{0}</filename> is made using profiles that are "
-"unknown to this version of Ultimaker Cura."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.py:203
-msgctxt "@title:tab"
-msgid "Recommended"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.py:205
-msgctxt "@title:tab"
-msgid "Custom"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/__init__.py:27
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/__init__.py:33
-msgctxt "@item:inlistbox"
-msgid "3MF File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UFPWriter/UFPWriter.py:57
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UFPWriter/UFPWriter.py:72
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UFPWriter/UFPWriter.py:94
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UFPWriter/UFPWriter.py:149
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UFPWriter/UFPWriter.py:159
-msgctxt "@info:error"
-msgid "Can't write to UFP file:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/LegacyProfileReader/__init__.py:14
-msgctxt "@item:inlistbox"
-msgid "Cura 15.04 profiles"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/CreateBackupJob.py:25
-msgctxt "@info:title"
-msgid "Backups"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/CreateBackupJob.py:26
-msgctxt "@info:backup_status"
-msgid "There was an error while uploading your backup."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/CreateBackupJob.py:46
-msgctxt "@info:backup_status"
-msgid "Creating your backup..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/CreateBackupJob.py:55
-msgctxt "@info:backup_status"
-msgid "There was an error while creating your backup."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/CreateBackupJob.py:59
-msgctxt "@info:backup_status"
-msgid "Uploading your backup..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/CreateBackupJob.py:69
-msgctxt "@info:backup_status"
-msgid "Your backup has finished uploading."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/CreateBackupJob.py:103
-msgctxt "@error:file_size"
-msgid "The backup exceeds the maximum file size."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:69
-msgctxt "@item:inmenu"
-msgid "Manage backups"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:118
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:126
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Backups/Backup.py:122
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Backups/Backup.py:159
-msgctxt "@info:title"
-msgid "Backup"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/DriveApiService.py:86
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/RestoreBackupJob.py:26
-msgctxt "@info:backup_status"
-msgid "There was an error trying to restore your backup."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SliceInfoPlugin/SliceInfo.py:95
-msgctxt "@text"
-msgid "Unable to read example data file."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeGzWriter/GCodeGzWriter.py:43
-msgctxt "@error:not supported"
-msgid "GCodeGzWriter does not support text mode."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:35
-msgctxt "@item:inmenu"
-msgid "Post Processing"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:36
-msgctxt "@item:inmenu"
-msgid "Modify G-Code"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SupportEraser/__init__.py:12
-msgctxt "@label"
-msgid "Support Blocker"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SupportEraser/__init__.py:13
-msgctxt "@info:tooltip"
-msgid "Create a volume in which supports are not printed."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PreviewStage/__init__.py:13
-msgctxt "@item:inmenu"
-msgid "Preview"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/XRayView/__init__.py:12
-msgctxt "@item:inlistbox"
-msgid "X-Ray view"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.py:24
-msgctxt "@action"
-msgid "Level build plate"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelection.py:21
-msgctxt "@action"
-msgid "Select upgrades"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/PackageModel.py:43
-msgctxt "@label:property"
-msgid "Unknown Package"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/PackageModel.py:66
-msgctxt "@label:property"
-msgid "Unknown Author"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/RemotePackageList.py:116
-msgctxt "@info:error"
-msgid "Could not interpret the server's response."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/RemotePackageList.py:146
-msgctxt "@info:error"
-msgid "Could not reach Marketplace."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/LocalPackageList.py:28
-msgctxt "@label"
-msgid "Installed Plugins"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/LocalPackageList.py:29
-msgctxt "@label"
-msgid "Installed Materials"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/LocalPackageList.py:33
-msgctxt "@label"
-msgid "Bundled Plugins"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/LocalPackageList.py:34
-msgctxt "@label"
-msgid "Bundled Materials"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SolidView/SolidView.py:71
-msgctxt "@info:status"
-msgid ""
-"The highlighted areas indicate either missing or extraneous surfaces. Fix "
-"your model and open it again into Cura."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SolidView/SolidView.py:73
-msgctxt "@info:title"
-msgid "Model Errors"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SolidView/SolidView.py:80
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/MaterialManagementModel.py:71
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UltimakerCloud/CloudMaterialSync.py:82
-msgctxt "@action:button"
-msgid "Learn more"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SolidView/__init__.py:12
-msgctxt "@item:inmenu"
-msgid "Solid view"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeReader/FlavorParser.py:350
-msgctxt "@info:status"
-msgid "Parsing G-code"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeReader/FlavorParser.py:352
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeReader/FlavorParser.py:506
-msgctxt "@info:title"
-msgid "G-code Details"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeReader/FlavorParser.py:504
-msgctxt "@info:generic"
-msgid ""
-"Make sure the g-code is suitable for your printer and printer configuration "
-"before sending the file to it. The g-code representation may not be accurate."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/GCodeReader/__init__.py:18
-msgctxt "@item:inlistbox"
-msgid "G File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsAction.py:32
-msgctxt "@action"
-msgid "Machine Settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:42
-msgctxt "@item:inmenu"
-msgid "USB printing"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:43
-msgctxt "@action:button Preceded by 'Ready to'."
-msgid "Print via USB"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:44
-msgctxt "@info:tooltip"
-msgid "Print via USB"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:80
-msgctxt "@info:status"
-msgid "Connected via USB"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:110
-msgctxt "@label"
-msgid ""
-"A USB print is in progress, closing Cura will stop this print. Are you sure?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:135
-msgctxt "@message"
-msgid ""
-"A print is still in progress. Cura cannot start another print via USB until "
-"the previous print has completed."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:136
-msgctxt "@message"
-msgid "Print in Progress"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:529
-msgctxt "@info:progress"
-msgid "Loading machines..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:536
-msgctxt "@info:progress"
-msgid "Setting up preferences..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:678
-msgctxt "@info:progress"
-msgid "Initializing Active Machine..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:802
-msgctxt "@info:progress"
-msgid "Initializing machine manager..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:816
-msgctxt "@info:progress"
-msgid "Initializing build volume..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:884
-msgctxt "@info:progress"
-msgid "Setting up scene..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:920
-msgctxt "@info:progress"
-msgid "Loading interface..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:925
-msgctxt "@info:progress"
-msgid "Initializing engine..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:1242
-#, python-format
-msgctxt ""
-"@info 'width', 'depth' and 'height' are variable names that must NOT be "
-"translated; just translate the format of ##x##x## mm."
-msgid "%(width).1f x %(depth).1f x %(height).1f mm"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:1768
-#, python-brace-format
-msgctxt "@info:status"
-msgid "Only one G-code file can be loaded at a time. Skipped importing {0}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CuraApplication.py:1780
-#, python-brace-format
-msgctxt "@info:status"
-msgid "Can't open any other file if G-code is loading. Skipped importing {0}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentCategoryModel.py:42
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/QualityManagementModel.py:338
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentTranslations.py:11
-msgctxt "@label"
-msgid "Default"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentCategoryModel.py:45
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentTranslations.py:14
-msgctxt "@label"
-msgid "Visual"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentCategoryModel.py:46
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentTranslations.py:15
-msgctxt "@text"
-msgid ""
-"The visual profile is designed to print visual prototypes and models with "
-"the intent of high visual and surface quality."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentCategoryModel.py:49
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentTranslations.py:18
-msgctxt "@label"
-msgid "Engineering"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentCategoryModel.py:50
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentTranslations.py:19
-msgctxt "@text"
-msgid ""
-"The engineering profile is designed to print functional prototypes and end-"
-"use parts with the intent of better accuracy and for closer tolerances."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentCategoryModel.py:53
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentTranslations.py:22
-msgctxt "@label"
-msgid "Draft"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentCategoryModel.py:54
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/IntentTranslations.py:23
-msgctxt "@text"
-msgid ""
-"The draft profile is designed to print initial prototypes and concept "
-"validation with the intent of significant print time reduction."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/ExtrudersModel.py:219
-msgctxt "@menuitem"
-msgid "Not overridden"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/GlobalStacksModel.py:143
-#, python-brace-format
-msgctxt "@label {0} is the name of a printer that's about to be deleted."
-msgid "Are you sure you wish to remove {0}? This cannot be undone!"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:83
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/QualityManagementModel.py:361
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/MachineManager.py:1614
-msgctxt "@label"
-msgid "Unknown"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:113
-msgctxt "@label"
-msgid ""
-"The printer(s) below cannot be connected because they are part of a group"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:115
-msgctxt "@label"
-msgid "Available networked printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/QualitySettingsModel.py:182
-msgctxt "@info:status"
-msgid "Calculated"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/MaterialManagementModel.py:55
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UltimakerCloud/CloudMaterialSync.py:66
-msgctxt "@action:button"
-msgid ""
-"Please sync the material profiles with your printers before starting to "
-"print."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/MaterialManagementModel.py:56
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UltimakerCloud/CloudMaterialSync.py:67
-msgctxt "@action:button"
-msgid "New materials installed"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/MaterialManagementModel.py:63
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UltimakerCloud/CloudMaterialSync.py:74
-msgctxt "@action:button"
-msgid "Sync materials"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/MaterialManagementModel.py:288
-msgctxt "@label"
-msgid "Custom Material"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/MaterialManagementModel.py:289
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:336
-msgctxt "@label"
-msgid "Custom"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/QualityManagementModel.py:390
-msgctxt "@label"
-msgid "Custom profiles"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/QualityManagementModel.py:425
-#, python-brace-format
-msgctxt "@item:inlistbox"
-msgid "All Supported Types ({0})"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Machines/Models/QualityManagementModel.py:426
-msgctxt "@item:inlistbox"
-msgid "All Files (*)"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:104
-msgctxt "@text:error"
-msgid "Failed to create archive of materials to sync with printers."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:111
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:165
-msgctxt "@text:error"
-msgid "Failed to load the archive of materials to sync it with printers."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:143
-msgctxt "@text:error"
-msgid "The response from Digital Factory appears to be corrupted."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:147
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:151
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:155
-msgctxt "@text:error"
-msgid "The response from Digital Factory is missing important information."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:218
-msgctxt "@text:error"
-msgid ""
-"Failed to connect to Digital Factory to sync materials with some of the "
-"printers."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/PrinterOutput/UploadMaterialsJob.py:232
-msgctxt "@text:error"
-msgid "Failed to connect to Digital Factory."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Backups/Backup.py:115
-msgctxt "@info:backup_failed"
-msgid "Could not create archive from user data directory: {}"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Backups/Backup.py:134
-msgctxt "@info:backup_failed"
-msgid "Tried to restore a Cura backup without having proper data or meta data."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Backups/Backup.py:145
-msgctxt "@info:backup_failed"
-msgid "Tried to restore a Cura backup that is higher than the current version."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Backups/Backup.py:158
-msgctxt "@info:backup_failed"
-msgid "The following error occurred while trying to restore a Cura backup:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Arranging/ArrangeObjectsJob.py:24
-msgctxt "@info:status"
-msgid "Finding new location for objects"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Arranging/ArrangeObjectsJob.py:28
-msgctxt "@info:title"
-msgid "Finding Location"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Arranging/ArrangeObjectsJob.py:41
-#: /home/remco/dev/code/ulti/trans/Cura/cura/MultiplyObjectsJob.py:99
-msgctxt "@info:status"
-msgid "Unable to find a location within the build volume for all objects"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Arranging/ArrangeObjectsJob.py:42
-msgctxt "@info:title"
-msgid "Can't Find Location"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/API/Account.py:190
-msgctxt "@info:title"
-msgid "Login failed"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:85
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:85
 msgctxt "@tooltip"
 msgid "Outer Wall"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:86
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:86
 msgctxt "@tooltip"
 msgid "Inner Walls"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:87
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:87
 msgctxt "@tooltip"
 msgid "Skin"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:88
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:88
 msgctxt "@tooltip"
 msgid "Infill"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:89
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:89
 msgctxt "@tooltip"
 msgid "Support Infill"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:90
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:90
 msgctxt "@tooltip"
 msgid "Support Interface"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:91
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:91
 msgctxt "@tooltip"
 msgid "Support"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:92
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:92
 msgctxt "@tooltip"
 msgid "Skirt"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:93
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:93
 msgctxt "@tooltip"
 msgid "Prime Tower"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:94
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:94
 msgctxt "@tooltip"
 msgid "Travel"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:95
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:95
 msgctxt "@tooltip"
 msgid "Retractions"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/PrintInformation.py:96
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/PrintInformation.py:96
 msgctxt "@tooltip"
 msgid "Other"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/ObjectsModel.py:69
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/TextManager.py:37
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/TextManager.py:63
+msgctxt "@text:window"
+msgid "The release notes could not be opened."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/ObjectsModel.py:69
 #, python-brace-format
 msgctxt "@label"
 msgid "Group #{group_nr}"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/TextManager.py:37
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/TextManager.py:63
-msgctxt "@text:window"
-msgid "The release notes could not be opened."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/WhatsNewPagesModel.py:67
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/WelcomePagesModel.py:286
-msgctxt "@action:button"
-msgid "Skip"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/WhatsNewPagesModel.py:72
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:135
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:178
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:450
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:172
-msgctxt "@action:button"
-msgid "Close"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/AddPrinterPagesModel.py:17
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:61
-msgctxt "@action:button"
-msgid "Add"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/AddPrinterPagesModel.py:26
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/WelcomePagesModel.py:290
-msgctxt "@action:button"
-msgid "Finish"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/AddPrinterPagesModel.py:33
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:27
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:43
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:323
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:451
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:150
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:284
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:59
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/RenameDialog.qml:74
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ColorDialog.qml:136
-msgctxt "@action:button"
-msgid "Cancel"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/WelcomePagesModel.py:57
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UI/WelcomePagesModel.py:277
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/WelcomePagesModel.py:57
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/WelcomePagesModel.py:277
 msgctxt "@action:button"
 msgid "Next"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/BuildVolume.py:100
-msgctxt "@info:status"
-msgid ""
-"The build volume height has been reduced due to the value of the \"Print "
-"Sequence\" setting to prevent the gantry from colliding with printed models."
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/WelcomePagesModel.py:286
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/WhatsNewPagesModel.py:67
+msgctxt "@action:button"
+msgid "Skip"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/BuildVolume.py:103
-msgctxt "@info:title"
-msgid "Build Volume"
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/WelcomePagesModel.py:290
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/AddPrinterPagesModel.py:26
+msgctxt "@action:button"
+msgid "Finish"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UltimakerCloud/CloudMaterialSync.py:135
-msgctxt "@message:text"
-msgid "Could not save material archive to {}:"
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/AddPrinterPagesModel.py:17
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:61
+msgctxt "@action:button"
+msgid "Add"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UltimakerCloud/CloudMaterialSync.py:136
-msgctxt "@message:title"
-msgid "Failed to save material archive"
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/AddPrinterPagesModel.py:33
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:323
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:43
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:27
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:149
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:451
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/RenameDialog.qml:74
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:59
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:291
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ColorDialog.qml:139
+msgctxt "@action:button"
+msgid "Cancel"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/UltimakerCloud/CloudMaterialSync.py:188
-msgctxt "@text"
-msgid "Unknown error."
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UI/WhatsNewPagesModel.py:72
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:444
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:135
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:177
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:172
+msgctxt "@action:button"
+msgid "Close"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/ContainerManager.py:207
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:140
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/ContainerManager.py:207
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:140
 msgctxt "@title:window"
 msgid "File Already Exists"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/ContainerManager.py:208
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:141
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/ContainerManager.py:208
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:141
 #, python-brace-format
 msgctxt "@label Don't translate the XML tag <filename>!"
 msgid ""
@@ -1485,46 +152,68 @@ msgid ""
 "overwrite it?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/ContainerManager.py:459
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/ContainerManager.py:462
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/ContainerManager.py:459
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/ContainerManager.py:462
 msgctxt "@info:status"
 msgid "Invalid file URL:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/cura_empty_instance_containers.py:36
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/cura_empty_instance_containers.py:36
 msgctxt "@info:not supported profile"
 msgid "Not supported"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/cura_empty_instance_containers.py:55
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/cura_empty_instance_containers.py:55
 msgctxt "@info:No intent profile selected"
 msgid "Default"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/MachineManager.py:857
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/MachineManager.py:713
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:218
+msgctxt "@label"
+msgid "Nozzle"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/MachineManager.py:857
 msgctxt "@info:message Followed by a list of settings."
 msgid ""
 "Settings have been changed to match the current availability of extruders:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/MachineManager.py:858
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/MachineManager.py:858
 msgctxt "@info:title"
 msgid "Settings updated"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/MachineManager.py:1480
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/MachineManager.py:1480
 msgctxt "@info:title"
 msgid "Extruder(s) Disabled"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:153
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/MachineManager.py:1614
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/QualityManagementModel.py:361
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:83
+msgctxt "@label"
+msgid "Unknown"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:153
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
 msgid ""
 "Failed to export profile to <filename>{0}</filename>: <message>{1}</message>"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:163
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:156
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:166
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:1807
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:141
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:161
+msgctxt "@info:title"
+msgid "Error"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:163
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid ""
@@ -1532,44 +221,44 @@ msgid ""
 "failure."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:171
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:171
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid "Exported profile to <filename>{0}</filename>"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:173
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:173
 msgctxt "@info:title"
 msgid "Export succeeded"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:205
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:205
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid "Failed to import profile from <filename>{0}</filename>: {1}"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:209
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:209
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid ""
 "Can't import profile from <filename>{0}</filename> before a printer is added."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:224
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:224
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid "No custom profile to import in file <filename>{0}</filename>"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:228
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:228
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid "Failed to import profile from <filename>{0}</filename>:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:252
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:262
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:252
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:262
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid ""
@@ -1577,51 +266,51 @@ msgid ""
 "import it."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:355
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:355
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid "Failed to import profile from <filename>{0}</filename>:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:359
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:359
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Successfully imported profile {0}."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:366
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:366
 #, python-brace-format
 msgctxt "@info:status"
 msgid "File {0} does not contain any valid profile."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:369
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:369
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Profile {0} has an unknown file type or is corrupted."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:443
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:443
 msgctxt "@label"
 msgid "Custom profile"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:459
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:459
 msgctxt "@info:status"
 msgid "Profile is missing a quality type."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:463
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:463
 msgctxt "@info:status"
 msgid "There is no active printer yet."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:469
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:469
 msgctxt "@info:status"
 msgid "Unable to add the profile."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:483
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:483
 #, python-brace-format
 msgctxt "@info:status"
 msgid ""
@@ -1629,7 +318,7 @@ msgid ""
 "definition '{1}'."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/Settings/CuraContainerRegistry.py:488
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Settings/CuraContainerRegistry.py:488
 #, python-brace-format
 msgctxt "@info:status"
 msgid ""
@@ -1638,69 +327,394 @@ msgid ""
 "combination that can use this quality type."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/MultiplyObjectsJob.py:30
+#: /Users/j.delarago/development/cura_installation/Cura/cura/MultiplyObjectsJob.py:30
 msgctxt "@info:status"
 msgid "Multiplying and placing objects"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/MultiplyObjectsJob.py:32
+#: /Users/j.delarago/development/cura_installation/Cura/cura/MultiplyObjectsJob.py:32
 msgctxt "@info:title"
 msgid "Placing Objects"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/MultiplyObjectsJob.py:100
+#: /Users/j.delarago/development/cura_installation/Cura/cura/MultiplyObjectsJob.py:99
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Arranging/ArrangeObjectsJob.py:41
+msgctxt "@info:status"
+msgid "Unable to find a location within the build volume for all objects"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/MultiplyObjectsJob.py:100
 msgctxt "@info:title"
 msgid "Placing Object"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationService.py:216
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:529
+msgctxt "@info:progress"
+msgid "Loading machines..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:536
+msgctxt "@info:progress"
+msgid "Setting up preferences..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:681
+msgctxt "@info:progress"
+msgid "Initializing Active Machine..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:821
+msgctxt "@info:progress"
+msgid "Initializing machine manager..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:835
+msgctxt "@info:progress"
+msgid "Initializing build volume..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:903
+msgctxt "@info:progress"
+msgid "Setting up scene..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:939
+msgctxt "@info:progress"
+msgid "Loading interface..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:944
+msgctxt "@info:progress"
+msgid "Initializing engine..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:1267
+#, python-format
+msgctxt ""
+"@info 'width', 'depth' and 'height' are variable names that must NOT be "
+"translated; just translate the format of ##x##x## mm."
+msgid "%(width).1f x %(depth).1f x %(height).1f mm"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:1793
+#, python-brace-format
+msgctxt "@info:status"
+msgid "Only one G-code file can be loaded at a time. Skipped importing {0}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:1795
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationService.py:217
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:177
+msgctxt "@info:title"
+msgid "Warning"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CuraApplication.py:1805
+#, python-brace-format
+msgctxt "@info:status"
+msgid "Can't open any other file if G-code is loading. Skipped importing {0}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationHelpers.py:89
+msgctxt "@message"
+msgid "Could not read response."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationRequestHandler.py:75
+msgctxt "@message"
+msgid "The provided state is not correct."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationRequestHandler.py:80
+msgctxt "@message"
+msgid "Timeout when authenticating with the account server."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationRequestHandler.py:97
+msgctxt "@message"
+msgid "Please give the required permissions when authorizing this application."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationRequestHandler.py:104
+msgctxt "@message"
+msgid "Something unexpected happened when trying to log in, please try again."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationService.py:216
 msgctxt "@info"
 msgid ""
 "Unable to start a new sign in process. Check if another sign in attempt is "
 "still active."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationService.py:277
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationService.py:277
 msgctxt "@info"
 msgid "Unable to reach the Ultimaker account server."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationService.py:278
+#: /Users/j.delarago/development/cura_installation/Cura/cura/OAuth2/AuthorizationService.py:278
 msgctxt "@info:title"
 msgid "Log-in failed"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationHelpers.py:89
-msgctxt "@message"
-msgid "Could not read response."
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Arranging/ArrangeObjectsJob.py:24
+msgctxt "@info:status"
+msgid "Finding new location for objects"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationRequestHandler.py:75
-msgctxt "@message"
-msgid "The provided state is not correct."
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Arranging/ArrangeObjectsJob.py:28
+msgctxt "@info:title"
+msgid "Finding Location"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationRequestHandler.py:80
-msgctxt "@message"
-msgid "Timeout when authenticating with the account server."
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Arranging/ArrangeObjectsJob.py:42
+msgctxt "@info:title"
+msgid "Can't Find Location"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationRequestHandler.py:97
-msgctxt "@message"
-msgid "Please give the required permissions when authorizing this application."
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/ExtrudersModel.py:219
+msgctxt "@menuitem"
+msgid "Not overridden"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationRequestHandler.py:104
-msgctxt "@message"
-msgid "Something unexpected happened when trying to log in, please try again."
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentTranslations.py:11
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentCategoryModel.py:42
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/QualityManagementModel.py:338
+msgctxt "@label"
+msgid "Default"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:107
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentTranslations.py:14
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentCategoryModel.py:45
+msgctxt "@label"
+msgid "Visual"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentTranslations.py:15
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentCategoryModel.py:46
+msgctxt "@text"
+msgid ""
+"The visual profile is designed to print visual prototypes and models with "
+"the intent of high visual and surface quality."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentTranslations.py:18
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentCategoryModel.py:49
+msgctxt "@label"
+msgid "Engineering"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentTranslations.py:19
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentCategoryModel.py:50
+msgctxt "@text"
+msgid ""
+"The engineering profile is designed to print functional prototypes and end-"
+"use parts with the intent of better accuracy and for closer tolerances."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentTranslations.py:22
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentCategoryModel.py:53
+msgctxt "@label"
+msgid "Draft"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentTranslations.py:23
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/IntentCategoryModel.py:54
+msgctxt "@text"
+msgid ""
+"The draft profile is designed to print initial prototypes and concept "
+"validation with the intent of significant print time reduction."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/QualitySettingsModel.py:182
+msgctxt "@info:status"
+msgid "Calculated"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/QualityManagementModel.py:390
+msgctxt "@label"
+msgid "Custom profiles"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/QualityManagementModel.py:425
+#, python-brace-format
+msgctxt "@item:inlistbox"
+msgid "All Supported Types ({0})"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/QualityManagementModel.py:426
+msgctxt "@item:inlistbox"
+msgid "All Files (*)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:113
+msgctxt "@label"
+msgid ""
+"The printer(s) below cannot be connected because they are part of a group"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:115
+msgctxt "@label"
+msgid "Available networked printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/GlobalStacksModel.py:138
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterSelector/MachineSelectorList.qml:24
+msgctxt "@label"
+msgid "Connected printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/GlobalStacksModel.py:138
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterSelector/MachineSelectorList.qml:24
+msgctxt "@label"
+msgid "Preset printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/GlobalStacksModel.py:143
+#, python-brace-format
+msgctxt "@label {0} is the name of a printer that's about to be deleted."
+msgid "Are you sure you wish to remove {0}? This cannot be undone!"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/MaterialManagementModel.py:55
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UltimakerCloud/CloudMaterialSync.py:66
+msgctxt "@action:button"
+msgid ""
+"Please sync the material profiles with your printers before starting to "
+"print."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/MaterialManagementModel.py:56
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UltimakerCloud/CloudMaterialSync.py:67
+msgctxt "@action:button"
+msgid "New materials installed"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/MaterialManagementModel.py:63
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UltimakerCloud/CloudMaterialSync.py:74
+msgctxt "@action:button"
+msgid "Sync materials"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/MaterialManagementModel.py:71
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UltimakerCloud/CloudMaterialSync.py:82
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SolidView/SolidView.py:80
+msgctxt "@action:button"
+msgid "Learn more"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/MaterialManagementModel.py:288
+msgctxt "@label"
+msgid "Custom Material"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Machines/Models/MaterialManagementModel.py:289
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:335
+msgctxt "@label"
+msgid "Custom"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/API/Account.py:190
+msgctxt "@info:title"
+msgid "Login failed"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UltimakerCloud/CloudMaterialSync.py:135
+msgctxt "@message:text"
+msgid "Could not save material archive to {}:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UltimakerCloud/CloudMaterialSync.py:136
+msgctxt "@message:title"
+msgid "Failed to save material archive"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/UltimakerCloud/CloudMaterialSync.py:188
+msgctxt "@text"
+msgid "Unknown error."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:104
+msgctxt "@text:error"
+msgid "Failed to create archive of materials to sync with printers."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:111
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:165
+msgctxt "@text:error"
+msgid "Failed to load the archive of materials to sync it with printers."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:143
+msgctxt "@text:error"
+msgid "The response from Digital Factory appears to be corrupted."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:147
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:151
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:155
+msgctxt "@text:error"
+msgid "The response from Digital Factory is missing important information."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:218
+msgctxt "@text:error"
+msgid ""
+"Failed to connect to Digital Factory to sync materials with some of the "
+"printers."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/PrinterOutput/UploadMaterialsJob.py:232
+msgctxt "@text:error"
+msgid "Failed to connect to Digital Factory."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/BuildVolume.py:100
+msgctxt "@info:status"
+msgid ""
+"The build volume height has been reduced due to the value of the \"Print "
+"Sequence\" setting to prevent the gantry from colliding with printed models."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/BuildVolume.py:103
+msgctxt "@info:title"
+msgid "Build Volume"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Backups/Backup.py:115
+msgctxt "@info:backup_failed"
+msgid "Could not create archive from user data directory: {}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Backups/Backup.py:122
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Backups/Backup.py:159
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:118
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:126
+msgctxt "@info:title"
+msgid "Backup"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Backups/Backup.py:134
+msgctxt "@info:backup_failed"
+msgid "Tried to restore a Cura backup without having proper data or meta data."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Backups/Backup.py:145
+msgctxt "@info:backup_failed"
+msgid "Tried to restore a Cura backup that is higher than the current version."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/Backups/Backup.py:158
+msgctxt "@info:backup_failed"
+msgid "The following error occurred while trying to restore a Cura backup:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:107
 msgctxt "@title:window"
 msgid "Cura can't start"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:113
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:113
 msgctxt "@label crash message"
 msgid ""
 "<p><b>Oops, Ultimaker Cura has encountered something that doesn't seem right."
@@ -1715,32 +729,32 @@ msgid ""
 "                "
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:122
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:122
 msgctxt "@action:button"
 msgid "Send crash report to Ultimaker"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:125
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:125
 msgctxt "@action:button"
 msgid "Show detailed crash report"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:129
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:129
 msgctxt "@action:button"
 msgid "Show configuration folder"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:140
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:140
 msgctxt "@action:button"
 msgid "Backup and Reset Configuration"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:171
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:171
 msgctxt "@title:window"
 msgid "Crash Report"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:190
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:190
 msgctxt "@label crash message"
 msgid ""
 "<p><b>A fatal error has occurred in Cura. Please send us this Crash Report "
@@ -1750,394 +764,1545 @@ msgid ""
 "        "
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:198
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:198
 msgctxt "@title:groupbox"
 msgid "System information"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:207
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:207
 msgctxt "@label unknown version of Cura"
 msgid "Unknown"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:228
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:228
 msgctxt "@label Cura version number"
 msgid "Cura version"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:229
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:229
 msgctxt "@label"
 msgid "Cura language"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:230
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:230
 msgctxt "@label"
 msgid "OS language"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:231
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:231
 msgctxt "@label Type of platform"
 msgid "Platform"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:232
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:232
 msgctxt "@label"
 msgid "Qt version"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:233
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:233
 msgctxt "@label"
 msgid "PyQt version"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:234
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:234
 msgctxt "@label OpenGL version"
 msgid "OpenGL"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:264
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:264
 msgctxt "@label"
 msgid "Not yet initialized<br/>"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:267
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:267
 #, python-brace-format
 msgctxt "@label OpenGL version"
 msgid "<li>OpenGL Version: {version}</li>"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:268
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:268
 #, python-brace-format
 msgctxt "@label OpenGL vendor"
 msgid "<li>OpenGL Vendor: {vendor}</li>"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:269
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:269
 #, python-brace-format
 msgctxt "@label OpenGL renderer"
 msgid "<li>OpenGL Renderer: {renderer}</li>"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:303
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:303
 msgctxt "@title:groupbox"
 msgid "Error traceback"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:389
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:389
 msgctxt "@title:groupbox"
 msgid "Logs"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/cura/CrashHandler.py:417
+#: /Users/j.delarago/development/cura_installation/Cura/cura/CrashHandler.py:417
 msgctxt "@action:button"
 msgid "Send report"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MonitorStage/MonitorMain.qml:100
-msgctxt "@info"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsAction.py:32
+msgctxt "@action"
+msgid "Machine Settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/__init__.py:14
+msgctxt "@item:inlistbox"
+msgid "JPG Image"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/__init__.py:18
+msgctxt "@item:inlistbox"
+msgid "JPEG Image"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/__init__.py:22
+msgctxt "@item:inlistbox"
+msgid "PNG Image"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/__init__.py:26
+msgctxt "@item:inlistbox"
+msgid "BMP Image"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/__init__.py:30
+msgctxt "@item:inlistbox"
+msgid "GIF Image"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/XRayView/__init__.py:12
+msgctxt "@item:inlistbox"
+msgid "X-Ray view"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/X3DReader/__init__.py:13
+msgctxt "@item:inlistbox"
+msgid "X3D File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraProfileReader/__init__.py:14
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraProfileWriter/__init__.py:14
+msgctxt "@item:inlistbox"
+msgid "Cura Profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:35
+msgctxt "@item:inmenu"
+msgid "Post Processing"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:36
+msgctxt "@item:inmenu"
+msgid "Modify G-Code"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/MeshFormatHandler.py:118
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:66
+msgctxt "@info:status"
+msgid "There are no file formats available to write with!"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadQueueFullMessage.py:16
+msgctxt "@info:status"
+msgid "Print job queue is full. The printer can't accept a new job."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadQueueFullMessage.py:17
+msgctxt "@info:title"
+msgid "Queue Full"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py:15
+msgctxt "@info:text"
+msgid "Could not upload the data to the printer."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py:16
+msgctxt "@info:title"
+msgid "Network error"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadBlockedMessage.py:15
+msgctxt "@info:status"
+msgid "Please wait until the current job has been sent."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadBlockedMessage.py:16
+msgctxt "@info:title"
+msgid "Print error"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:25
+#, python-brace-format
+msgctxt "@info:status"
 msgid ""
-"Please make sure your printer has a connection:\n"
-"- Check if the printer is turned on.\n"
-"- Check if the printer is connected to the network.\n"
-"- Check if you are signed in to discover cloud-connected printers."
+"Your printer <b>{printer_name}</b> could be connected via cloud.\n"
+" Manage your print queue and monitor your prints from anywhere connecting "
+"your printer to Digital Factory"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MonitorStage/MonitorMain.qml:113
-msgctxt "@info"
-msgid "Please connect your printer to the network."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:26
+msgctxt "@info:title"
+msgid "Are you ready for cloud printing?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MonitorStage/MonitorMain.qml:146
-msgctxt "@label link to technical assistance"
-msgid "View user manuals online"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:30
+msgctxt "@action"
+msgid "Get started"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MonitorStage/MonitorMain.qml:163
-msgctxt "@info"
-msgid "In order to monitor your print from Cura, please connect the printer."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:31
+msgctxt "@action"
+msgid "Learn more"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:17
-msgctxt "@title:window"
-msgid "Select Settings to Customize for this model"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadProgressMessage.py:15
+msgctxt "@info:status"
+msgid "Sending Print Job"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:61
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:100
-msgctxt "@label:textbox"
-msgid "Filter..."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadProgressMessage.py:16
+msgctxt "@info:status"
+msgid "Uploading print job to printer."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:75
-msgctxt "@label:checkbox"
-msgid "Show all"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/MaterialSyncMessage.py:24
+#, python-brace-format
+msgctxt "@info:status"
+msgid ""
+"Cura has detected material profiles that were not yet installed on the host "
+"printer of group {0}."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:41
-msgctxt "@label"
-msgid "Mesh Type"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/MaterialSyncMessage.py:26
+msgctxt "@info:title"
+msgid "Sending materials to printer"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:81
-msgctxt "@label"
-msgid "Normal model"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:27
+#, python-brace-format
+msgctxt "@info:status"
+msgid ""
+"You are attempting to connect to {0} but it is not the host of a group. You "
+"can visit the web page to configure it as a group host."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:96
-msgctxt "@label"
-msgid "Print as support"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:30
+msgctxt "@info:title"
+msgid "Not a group host"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:111
-msgctxt "@label"
-msgid "Modify settings for overlaps"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:36
+msgctxt "@action"
+msgid "Configure group"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:126
-msgctxt "@label"
-msgid "Don't support overlaps"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/LegacyDeviceNoLongerSupportedMessage.py:18
+msgctxt "@info:status"
+msgid ""
+"You are attempting to connect to a printer that is not running Ultimaker "
+"Connect. Please update the printer to the latest firmware."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:159
-msgctxt "@item:inlistbox"
-msgid "Infill mesh only"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/LegacyDeviceNoLongerSupportedMessage.py:21
+msgctxt "@info:title"
+msgid "Update your printer"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:160
-msgctxt "@item:inlistbox"
-msgid "Cutting mesh"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadSuccessMessage.py:15
+msgctxt "@info:status"
+msgid "Print job was successfully sent to the printer."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:385
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadSuccessMessage.py:16
+msgctxt "@info:title"
+msgid "Data Sent"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:58
+msgctxt "@action:button Preceded by 'Ready to'."
+msgid "Print over network"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:59
+msgctxt "@properties:tooltip"
+msgid "Print over network"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:60
+msgctxt "@info:status"
+msgid "Connected over the network"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Utils.py:27
+msgctxt "@info:status"
+msgid "tomorrow"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Utils.py:30
+msgctxt "@info:status"
+msgid "today"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterAction.py:28
+msgctxt "@action"
+msgid "Connect via Network"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:229
+msgctxt "info:status"
+msgid "New printer detected from your Ultimaker account"
+msgid_plural "New printers detected from your Ultimaker account"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:242
+#, python-brace-format
+msgctxt "info:status Filled in with printer name and printer model."
+msgid "Adding printer {name} ({model}) from your account"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:261
+#, python-brace-format
+msgctxt "info:{0} gets replaced by a number of printers"
+msgid "... and {0} other"
+msgid_plural "... and {0} others"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:266
+msgctxt "info:status"
+msgid "Printers added from Digital Factory:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:334
+msgctxt "info:status"
+msgid "A cloud connection is not available for a printer"
+msgid_plural "A cloud connection is not available for some printers"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:343
+msgctxt "info:status"
+msgid "This printer is not linked to the Digital Factory:"
+msgid_plural "These printers are not linked to the Digital Factory:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:348
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:440
+msgctxt "info:name"
+msgid "Ultimaker Digital Factory"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:352
+#, python-brace-format
+msgctxt "info:status"
+msgid "To establish a connection, please visit the {website_link}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:356
 msgctxt "@action:button"
-msgid "Select settings"
+msgid "Keep printer configurations"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:31
-msgctxt "@title"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:361
+msgctxt "@action:button"
+msgid "Remove printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:442
+#, python-brace-format
+msgctxt "@message {printer_name} is replaced with the name of the printer"
+msgid "{printer_name} will be removed until the next account sync."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:443
+#, python-brace-format
+msgctxt "@message {printer_name} is replaced with the name of the printer"
+msgid "To remove {printer_name} permanently, visit {digital_factory_link}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:444
+#, python-brace-format
+msgctxt "@message {printer_name} is replaced with the name of the printer"
+msgid "Are you sure you want to remove {printer_name} temporarily?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:481
+msgctxt "@title:window"
+msgid "Remove printers?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:484
+#, python-brace-format
+msgctxt "@label"
+msgid ""
+"You are about to remove {0} printer from Cura. This action cannot be "
+"undone.\n"
+"Are you sure you want to continue?"
+msgid_plural ""
+"You are about to remove {0} printers from Cura. This action cannot be "
+"undone.\n"
+"Are you sure you want to continue?"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:489
+msgctxt "@label"
+msgid ""
+"You are about to remove all printers from Cura. This action cannot be "
+"undone.\n"
+"Are you sure you want to continue?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:154
+msgctxt "@action:button"
+msgid "Print via cloud"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:155
+msgctxt "@properties:tooltip"
+msgid "Print via cloud"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:156
+msgctxt "@info:status"
+msgid "Connected via cloud"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:261
+msgctxt "@action:button"
+msgid "Monitor print"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:263
+msgctxt "@action:tooltip"
+msgid "Track the print in Ultimaker Digital Factory"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:279
+#, python-brace-format
+msgctxt "@error:send"
+msgid "Unknown error code when uploading print job: {0}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFWriter/__init__.py:28
+msgctxt "@item:inlistbox"
+msgid "3MF file"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFWriter/__init__.py:36
+msgctxt "@item:inlistbox"
+msgid "Cura Project 3MF file"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFWriter/ThreeMFWriter.py:226
+msgctxt "@error:zip"
+msgid "Error writing 3mf file."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:31
+msgctxt "@error:zip"
+msgid "3MF Writer plug-in is corrupt."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:37
+msgctxt "@error"
+msgid "There is no workspace yet to write. Please add a printer first."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:64
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:97
+msgctxt "@error:zip"
+msgid "No permission to write the workspace here."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:101
+msgctxt "@error:zip"
+msgid ""
+"The operating system does not allow saving a project file to this location "
+"or with this file name."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/DriveApiService.py:86
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/RestoreBackupJob.py:26
+msgctxt "@info:backup_status"
+msgid "There was an error trying to restore your backup."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:69
+msgctxt "@item:inmenu"
+msgid "Manage backups"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/CreateBackupJob.py:25
+msgctxt "@info:title"
+msgid "Backups"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/CreateBackupJob.py:26
+msgctxt "@info:backup_status"
+msgid "There was an error while uploading your backup."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/CreateBackupJob.py:46
+msgctxt "@info:backup_status"
+msgid "Creating your backup..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/CreateBackupJob.py:55
+msgctxt "@info:backup_status"
+msgid "There was an error while creating your backup."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/CreateBackupJob.py:59
+msgctxt "@info:backup_status"
+msgid "Uploading your backup..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/CreateBackupJob.py:69
+msgctxt "@info:backup_status"
+msgid "Your backup has finished uploading."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/CreateBackupJob.py:103
+msgctxt "@error:file_size"
+msgid "The backup exceeds the maximum file size."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SliceInfoPlugin/SliceInfo.py:95
+msgctxt "@text"
+msgid "Unable to read example data file."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UFPWriter/UFPWriter.py:57
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UFPWriter/UFPWriter.py:72
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UFPWriter/UFPWriter.py:94
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UFPWriter/UFPWriter.py:149
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UFPWriter/UFPWriter.py:159
+msgctxt "@info:error"
+msgid "Can't write to UFP file:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UFPWriter/__init__.py:28
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UFPReader/__init__.py:22
+msgctxt "@item:inlistbox"
+msgid "Ultimaker Format Package"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeProfileReader/__init__.py:14
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeReader/__init__.py:14
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeWriter/__init__.py:16
+msgctxt "@item:inlistbox"
+msgid "G-code File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeReader/FlavorParser.py:350
+msgctxt "@info:status"
+msgid "Parsing G-code"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeReader/FlavorParser.py:352
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeReader/FlavorParser.py:506
+msgctxt "@info:title"
+msgid "G-code Details"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeReader/FlavorParser.py:504
+msgctxt "@info:generic"
+msgid ""
+"Make sure the g-code is suitable for your printer and printer configuration "
+"before sending the file to it. The g-code representation may not be accurate."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeReader/__init__.py:18
+msgctxt "@item:inlistbox"
+msgid "G File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/TrimeshReader/__init__.py:15
+msgctxt "@item:inlistbox 'Open' is part of the name of this file format."
+msgid "Open Compressed Triangle Mesh"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/TrimeshReader/__init__.py:19
+msgctxt "@item:inlistbox"
+msgid "COLLADA Digital Asset Exchange"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/TrimeshReader/__init__.py:23
+msgctxt "@item:inlistbox"
+msgid "glTF Binary"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/TrimeshReader/__init__.py:27
+msgctxt "@item:inlistbox"
+msgid "glTF Embedded JSON"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/TrimeshReader/__init__.py:36
+msgctxt "@item:inlistbox"
+msgid "Stanford Triangle Format"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/TrimeshReader/__init__.py:40
+msgctxt "@item:inlistbox"
+msgid "Compressed COLLADA Digital Asset Exchange"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.py:24
+msgctxt "@action"
+msgid "Level build plate"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelection.py:21
+msgctxt "@action"
+msgid "Select upgrades"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeGzReader/__init__.py:17
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeGzWriter/__init__.py:17
+msgctxt "@item:inlistbox"
+msgid "Compressed G-code File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/RemotePackageList.py:116
+msgctxt "@info:error"
+msgid "Could not interpret the server's response."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/RemotePackageList.py:147
+msgctxt "@info:error"
+msgid "Could not reach Marketplace."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:12
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:82
+msgctxt "@button"
+msgid "Decline"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:13
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:53
+msgctxt "@button"
+msgid "Agree"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:147
+msgctxt "@action:button"
+msgid "Sync"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/LocalPackageList.py:28
+msgctxt "@label"
+msgid "Installed Plugins"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/LocalPackageList.py:29
+msgctxt "@label"
+msgid "Installed Materials"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/LocalPackageList.py:33
+msgctxt "@label"
+msgid "Bundled Plugins"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/LocalPackageList.py:34
+msgctxt "@label"
+msgid "Bundled Materials"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/PackageModel.py:43
+msgctxt "@label:property"
+msgid "Unknown Package"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/PackageModel.py:66
+msgctxt "@label:property"
+msgid "Unknown Author"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/WindowsRemovableDrivePlugin.py:76
+msgctxt "@item:intext"
+msgid "Removable Drive"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:23
+msgctxt "@action:button Preceded by 'Ready to'."
+msgid "Save to Removable Drive"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:24
+#, python-brace-format
+msgctxt "@item:inlistbox"
+msgid "Save to Removable Drive {0}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:97
+#, python-brace-format
+msgctxt "@info:progress Don't translate the XML tags <filename>!"
+msgid "Saving to Removable Drive <filename>{0}</filename>"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:98
+msgctxt "@info:title"
+msgid "Saving"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:108
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:111
+#, python-brace-format
+msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
+msgid "Could not save to <filename>{0}</filename>: <message>{1}</message>"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:127
+#, python-brace-format
+msgctxt "@info:status Don't translate the tag {device}!"
+msgid "Could not find a file name when trying to write to {device}."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:140
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:159
+#, python-brace-format
+msgctxt "@info:status"
+msgid "Could not save to removable drive {0}: {1}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:150
+#, python-brace-format
+msgctxt "@info:status"
+msgid "Saved to Removable Drive {0} as {1}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:151
+msgctxt "@info:title"
+msgid "File Saved"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:153
+msgctxt "@action:button"
+msgid "Eject"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:153
+#, python-brace-format
+msgctxt "@action"
+msgid "Eject removable device {0}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:172
+#, python-brace-format
+msgctxt "@info:status"
+msgid "Ejected {0}. You can now safely remove the drive."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:173
+msgctxt "@info:title"
+msgid "Safely Remove Hardware"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:176
+#, python-brace-format
+msgctxt "@info:status"
+msgid "Failed to eject {0}. Another program may be using the drive."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MonitorStage/__init__.py:14
+msgctxt "@item:inmenu"
+msgid "Monitor"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:161
+msgctxt "@message"
+msgid ""
+"Slicing failed with an unexpected error. Please consider reporting a bug on "
+"our issue tracker."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:162
+msgctxt "@message:title"
+msgid "Slicing failed"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:167
+msgctxt "@message:button"
+msgid "Report a bug"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:168
+msgctxt "@message:description"
+msgid "Report a bug on Ultimaker Cura's issue tracker."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:395
+msgctxt "@info:status"
+msgid ""
+"Unable to slice with the current material as it is incompatible with the "
+"selected machine or configuration."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:396
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:429
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:456
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:468
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:480
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:493
+msgctxt "@info:title"
+msgid "Unable to slice"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:428
+#, python-brace-format
+msgctxt "@info:status"
+msgid ""
+"Unable to slice with the current settings. The following settings have "
+"errors: {0}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:455
+#, python-brace-format
+msgctxt "@info:status"
+msgid ""
+"Unable to slice due to some per-model settings. The following settings have "
+"errors on one or more models: {error_labels}"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:467
+msgctxt "@info:status"
+msgid ""
+"Unable to slice because the prime tower or prime position(s) are invalid."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:479
+#, python-format
+msgctxt "@info:status"
+msgid ""
+"Unable to slice because there are objects associated with disabled Extruder "
+"%s."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:489
+msgctxt "@info:status"
+msgid ""
+"Please review settings and check if your models:\n"
+"- Fit within the build volume\n"
+"- Are assigned to an enabled extruder\n"
+"- Are not all set as modifier meshes"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:52
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:260
+msgctxt "@info:status"
+msgid "Processing Layers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:261
+msgctxt "@info:title"
+msgid "Information"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/__init__.py:27
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/__init__.py:33
+msgctxt "@item:inlistbox"
+msgid "3MF File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.py:203
+msgctxt "@title:tab"
+msgid "Recommended"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.py:205
+msgctxt "@title:tab"
+msgid "Custom"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:544
+#, python-brace-format
+msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
+msgid ""
+"Project file <filename>{0}</filename> contains an unknown machine type "
+"<message>{1}</message>. Cannot import the machine. Models will be imported "
+"instead."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:547
+msgctxt "@info:title"
+msgid "Open Project File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:644
+#, python-brace-format
+msgctxt "@info:error Don't translate the XML tags <filename> or <message>!"
+msgid ""
+"Project file <filename>{0}</filename> is suddenly inaccessible: <message>{1}"
+"</message>."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:645
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:653
+msgctxt "@info:title"
+msgid "Can't Open Project File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:652
+#, python-brace-format
+msgctxt "@info:error Don't translate the XML tags <filename> or <message>!"
+msgid ""
+"Project file <filename>{0}</filename> is corrupt: <message>{1}</message>."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:705
+#, python-brace-format
+msgctxt "@info:error Don't translate the XML tag <filename>!"
+msgid ""
+"Project file <filename>{0}</filename> is made using profiles that are "
+"unknown to this version of Ultimaker Cura."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/__init__.py:14
+msgctxt "@label"
+msgid "Per Model Settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/__init__.py:15
+msgctxt "@info:tooltip"
+msgid "Configure Per Model Settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ModelChecker/ModelChecker.py:31
+msgctxt "@info:title"
+msgid "3D Model Assistant"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ModelChecker/ModelChecker.py:97
+#, python-brace-format
+msgctxt "@info:status"
+msgid ""
+"<p>One or more 3D models may not print optimally due to the model size and "
+"material configuration:</p>\n"
+"<p>{model_names}</p>\n"
+"<p>Find out how to ensure the best possible print quality and reliability.</"
+"p>\n"
+"<p><a href=\"https://ultimaker.com/3D-model-assistant\">View print quality "
+"guide</a></p>"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:42
+msgctxt "@item:inmenu"
+msgid "USB printing"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:43
+msgctxt "@action:button Preceded by 'Ready to'."
+msgid "Print via USB"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:44
+msgctxt "@info:tooltip"
+msgid "Print via USB"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:80
+msgctxt "@info:status"
+msgid "Connected via USB"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:110
+msgctxt "@label"
+msgid ""
+"A USB print is in progress, closing Cura will stop this print. Are you sure?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:135
+msgctxt "@message"
+msgid ""
+"A print is still in progress. Cura cannot start another print via USB until "
+"the previous print has completed."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:136
+msgctxt "@message"
+msgid "Print in Progress"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PreviewStage/__init__.py:13
+msgctxt "@item:inmenu"
+msgid "Preview"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeWriter/GCodeWriter.py:74
+msgctxt "@error:not supported"
+msgid "GCodeWriter does not support non-text mode."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeWriter/GCodeWriter.py:80
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeWriter/GCodeWriter.py:96
+msgctxt "@warning:status"
+msgid "Please prepare G-code before exporting."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.py:27
+msgctxt "@action"
 msgid "Update Firmware"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:37
-msgctxt "@label"
-msgid ""
-"Firmware is the piece of software running directly on your 3D printer. This "
-"firmware controls the step motors, regulates the temperature and ultimately "
-"makes your printer work."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/GCodeGzWriter/GCodeGzWriter.py:43
+msgctxt "@error:not supported"
+msgid "GCodeGzWriter does not support text mode."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:43
-msgctxt "@label"
-msgid ""
-"The firmware shipping with new printers works, but new versions tend to have "
-"more features and improvements."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/__init__.py:15
+msgctxt "@item:inlistbox"
+msgid "Layer view"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:55
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationView.py:129
+msgctxt "@info:status"
+msgid "Cura does not accurately display layers when Wire Printing is enabled."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationView.py:130
+msgctxt "@info:title"
+msgid "Simulation View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationView.py:133
+msgctxt "@info:status"
+msgid "Nothing is shown because you need to slice first."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationView.py:134
+msgctxt "@info:title"
+msgid "No layers to show"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationView.py:136
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SolidView/SolidView.py:74
+msgctxt "@info:option_text"
+msgid "Do not show this message again"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/LegacyProfileReader/__init__.py:14
+msgctxt "@item:inlistbox"
+msgid "Cura 15.04 profiles"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/AMFReader/__init__.py:15
+msgctxt "@item:inlistbox"
+msgid "AMF File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SolidView/SolidView.py:71
+msgctxt "@info:status"
+msgid ""
+"The highlighted areas indicate either missing or extraneous surfaces. Fix "
+"your model and open it again into Cura."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SolidView/SolidView.py:73
+msgctxt "@info:title"
+msgid "Model Errors"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SolidView/__init__.py:12
+msgctxt "@item:inmenu"
+msgid "Solid view"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:17
+#, python-brace-format
+msgctxt ""
+"@info Don't translate {machine_name}, since it gets replaced by a printer "
+"name!"
+msgid ""
+"New features or bug-fixes may be available for your {machine_name}! If you "
+"haven't done so already, it is recommended to update the firmware on your "
+"printer to version {latest_version}."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:22
+#, python-format
+msgctxt "@info:title The %s gets replaced with the printer name."
+msgid "New %s stable firmware available"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:28
 msgctxt "@action:button"
-msgid "Automatically upgrade Firmware"
+msgid "How to update"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:66
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerJob.py:127
+msgctxt "@info"
+msgid "Could not access update information."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SupportEraser/__init__.py:12
+msgctxt "@label"
+msgid "Support Blocker"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SupportEraser/__init__.py:13
+msgctxt "@info:tooltip"
+msgid "Create a volume in which supports are not printed."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PrepareStage/__init__.py:12
+msgctxt "@item:inmenu"
+msgid "Prepare"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:56
+msgctxt "@title:label"
+msgid "Printer Settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:70
+msgctxt "@label"
+msgid "X (Width)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:74
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:89
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:104
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:205
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:225
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:245
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:265
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:283
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:79
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:93
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:109
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:124
+msgctxt "@label"
+msgid "mm"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:85
+msgctxt "@label"
+msgid "Y (Depth)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:100
+msgctxt "@label"
+msgid "Z (Height)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:114
+msgctxt "@label"
+msgid "Build plate shape"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:127
+msgctxt "@label"
+msgid "Origin at center"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:139
+msgctxt "@label"
+msgid "Heated bed"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:151
+msgctxt "@label"
+msgid "Heated build volume"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:163
+msgctxt "@label"
+msgid "G-code flavor"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:187
+msgctxt "@title:label"
+msgid "Printhead Settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:201
+msgctxt "@label"
+msgid "X min"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:221
+msgctxt "@label"
+msgid "Y min"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:241
+msgctxt "@label"
+msgid "X max"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:261
+msgctxt "@label"
+msgid "Y max"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:279
+msgctxt "@label"
+msgid "Gantry Height"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:293
+msgctxt "@label"
+msgid "Number of Extruders"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:345
+msgctxt "@label"
+msgid "Apply Extruder offsets to GCode"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:393
+msgctxt "@title:label"
+msgid "Start G-code"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:404
+msgctxt "@title:label"
+msgid "End G-code"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsAction.qml:42
+msgctxt "@title:tab"
+msgid "Printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:63
+msgctxt "@title:label"
+msgid "Nozzle Settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:75
+msgctxt "@label"
+msgid "Nozzle size"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:89
+msgctxt "@label"
+msgid "Compatible material diameter"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:105
+msgctxt "@label"
+msgid "Nozzle offset X"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:120
+msgctxt "@label"
+msgid "Nozzle offset Y"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:135
+msgctxt "@label"
+msgid "Cooling Fan Number"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:163
+msgctxt "@title:label"
+msgid "Extruder Start G-code"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:177
+msgctxt "@title:label"
+msgid "Extruder End G-code"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:14
+msgctxt "@title:window"
+msgid "Convert Image"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:33
+msgctxt "@action:label"
+msgid "Height (mm)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:56
+msgctxt "@info:tooltip"
+msgid "The maximum distance of each pixel from \"Base.\""
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:66
+msgctxt "@action:label"
+msgid "Base (mm)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:90
+msgctxt "@info:tooltip"
+msgid "The base height from the build plate in millimeters."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:100
+msgctxt "@action:label"
+msgid "Width (mm)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:124
+msgctxt "@info:tooltip"
+msgid "The width in millimeters on the build plate"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:134
+msgctxt "@action:label"
+msgid "Depth (mm)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:158
+msgctxt "@info:tooltip"
+msgid "The depth in millimeters on the build plate"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:187
+msgctxt "@item:inlistbox"
+msgid "Darker is higher"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:188
+msgctxt "@item:inlistbox"
+msgid "Lighter is higher"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:195
+msgctxt "@info:tooltip"
+msgid ""
+"For lithophanes dark pixels should correspond to thicker locations in order "
+"to block more light coming through. For height maps lighter pixels signify "
+"higher terrain, so lighter pixels should correspond to thicker locations in "
+"the generated 3D model."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:205
+msgctxt "@action:label"
+msgid "Color Model"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:224
+msgctxt "@item:inlistbox"
+msgid "Linear"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:225
+msgctxt "@item:inlistbox"
+msgid "Translucency"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:232
+msgctxt "@info:tooltip"
+msgid ""
+"For lithophanes a simple logarithmic model for translucency is available. "
+"For height maps the pixel values correspond to heights linearly."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:242
+msgctxt "@action:label"
+msgid "1mm Transmittance (%)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:263
+msgctxt "@info:tooltip"
+msgid ""
+"The percentage of light penetrating a print with a thickness of 1 "
+"millimeter. Lowering this value increases the contrast in dark regions and "
+"decreases the contrast in light regions of the image."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:274
+msgctxt "@action:label"
+msgid "Smoothing"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:298
+msgctxt "@info:tooltip"
+msgid "The amount of smoothing to apply to the image."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/ImageReader/ConfigUI.qml:329
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:138
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/RenameDialog.qml:80
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ColorDialog.qml:143
 msgctxt "@action:button"
-msgid "Upload custom Firmware"
+msgid "OK"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:79
-msgctxt "@label"
-msgid ""
-"Firmware can not be updated because there is no connection with the printer."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:86
-msgctxt "@label"
-msgid ""
-"Firmware can not be updated because the connection with the printer does not "
-"support upgrading firmware."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:93
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:17
 msgctxt "@title:window"
-msgid "Select custom firmware"
+msgid "Post Processing Plugin"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:114
-msgctxt "@title:window"
-msgid "Firmware Update"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:138
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:57
 msgctxt "@label"
-msgid "Updating firmware."
+msgid "Post Processing Scripts"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:140
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:215
+msgctxt "@action"
+msgid "Add a script"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:251
 msgctxt "@label"
-msgid "Firmware update completed."
+msgid "Settings"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:142
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:460
+msgctxt "@info:tooltip"
+msgid "Change active post-processing scripts."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:464
+msgctxt "@info:tooltip"
+msgid "The following script is active:"
+msgid_plural "The following scripts are active:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:54
 msgctxt "@label"
-msgid "Firmware update failed due to an unknown error."
+msgid "Move to top"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:144
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:70
 msgctxt "@label"
-msgid "Firmware update failed due to an communication error."
+msgid "Delete"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:146
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:100
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:284
 msgctxt "@label"
-msgid "Firmware update failed due to an input/output error."
+msgid "Resume"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:148
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:102
 msgctxt "@label"
-msgid "Firmware update failed due to missing firmware."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:70
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:82
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:84
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:86
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:88
-msgctxt "@label:status"
-msgid "Aborted"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:72
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:74
-msgctxt "@label:status"
-msgid "Finished"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:76
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:78
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:351
-msgctxt "@label:status"
-msgid "Preparing..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:80
-msgctxt "@label:status"
-msgid "Aborting..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:90
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:92
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:94
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:96
-msgctxt "@label:status"
-msgid "Failed"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:98
-msgctxt "@label:status"
 msgid "Pausing..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:100
-msgctxt "@label:status"
-msgid "Paused"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:102
-msgctxt "@label:status"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:104
+msgctxt "@label"
 msgid "Resuming..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:104
-msgctxt "@label:status"
-msgid "Action required"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:106
-msgctxt "@label:status"
-msgid "Finishes %1 at %2"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:148
-msgctxt "@label link to Connect and Cloud interfaces"
-msgid "Manage printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:178
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:151
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:175
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:106
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:279
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:288
 msgctxt "@label"
-msgid "Glass"
+msgid "Pause"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:241
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:467
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:239
-msgctxt "@info"
-msgid "Please update your printer's firmware to manage the queue remotely."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:275
-msgctxt "@info"
-msgid ""
-"Webcam feeds for cloud printers cannot be viewed from Ultimaker Cura. Click "
-"\"Manage printer\" to visit Ultimaker Digital Factory and view this webcam."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:335
-msgctxt "@label:status"
-msgid "Loading..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:339
-msgctxt "@label:status"
-msgid "Unavailable"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:343
-msgctxt "@label:status"
-msgid "Unreachable"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:347
-msgctxt "@label:status"
-msgid "Idle"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:356
-msgctxt "@label:status"
-msgid "Printing"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:397
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:124
 msgctxt "@label"
-msgid "Untitled"
+msgid "Aborting..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:412
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:124
 msgctxt "@label"
-msgid "Anonymous"
+msgid "Abort"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:433
-msgctxt "@label:status"
-msgid "Requires configuration changes"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:142
+msgctxt "@label %1 is the name of a print job."
+msgid "Are you sure you want to move %1 to the top of the queue?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:447
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:143
+msgctxt "@window:title"
+msgid "Move print job to top"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:151
+msgctxt "@label %1 is the name of a print job."
+msgid "Are you sure you want to delete %1?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:152
+msgctxt "@window:title"
+msgid "Delete print job"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:160
+msgctxt "@label %1 is the name of a print job."
+msgid "Are you sure you want to abort %1?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:161
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:326
+msgctxt "@window:title"
+msgid "Abort print"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:12
+msgctxt "@title:window"
+msgid "Print over network"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:53
 msgctxt "@action:button"
-msgid "Details"
+msgid "Print"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:20
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:81
+msgctxt "@label"
+msgid "Printer selection"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:20
 msgctxt "@title:window"
 msgid "Configuration Changes"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:36
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:36
 msgctxt "@action:button"
 msgid "Override"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:83
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:83
 msgctxt "@label"
 msgid "The assigned printer, %1, requires the following configuration change:"
 msgid_plural ""
@@ -2145,66 +2310,139 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:87
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:87
 msgctxt "@label"
 msgid ""
 "The printer %1 is assigned, but the job contains an unknown material "
 "configuration."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:97
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:97
 msgctxt "@label"
 msgid "Change material %1 from %2 to %3."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:100
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:100
 msgctxt "@label"
 msgid "Load %3 as material %1 (This cannot be overridden)."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:103
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:103
 msgctxt "@label"
 msgid "Change print core %1 from %2 to %3."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:106
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:106
 msgctxt "@label"
 msgid "Change build plate to %1 (This cannot be overridden)."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:113
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:113
 msgctxt "@label"
 msgid ""
 "Override will use the specified settings with the existing printer "
 "configuration. This may result in a failed print."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:154
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:151
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:178
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:175
+msgctxt "@label"
+msgid "Glass"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:154
 msgctxt "@label"
 msgid "Aluminum"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:12
-msgctxt "@title:window"
-msgid "Print over network"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:148
+msgctxt "@label link to Connect and Cloud interfaces"
+msgid "Manage printer"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:53
-msgctxt "@action:button"
-msgid "Print"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:241
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:467
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:239
+msgctxt "@info"
+msgid "Please update your printer's firmware to manage the queue remotely."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:81
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:275
+msgctxt "@info"
+msgid ""
+"Webcam feeds for cloud printers cannot be viewed from Ultimaker Cura. Click "
+"\"Manage printer\" to visit Ultimaker Digital Factory and view this webcam."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:335
+msgctxt "@label:status"
+msgid "Loading..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:339
+msgctxt "@label:status"
+msgid "Unavailable"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:343
+msgctxt "@label:status"
+msgid "Unreachable"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:347
+msgctxt "@label:status"
+msgid "Idle"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:351
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:76
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:78
+msgctxt "@label:status"
+msgid "Preparing..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:356
+msgctxt "@label:status"
+msgid "Printing"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:397
 msgctxt "@label"
-msgid "Printer selection"
+msgid "Untitled"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:44
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:412
+msgctxt "@label"
+msgid "Anonymous"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:433
+msgctxt "@label:status"
+msgid "Requires configuration changes"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:447
+msgctxt "@action:button"
+msgid "Details"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:126
+msgctxt "@label"
+msgid "Unavailable printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:128
+msgctxt "@label"
+msgid "First available"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:44
 msgctxt "@title:window"
 msgid "Connect to Networked Printer"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:51
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:51
 msgctxt "@label"
 msgid ""
 "To print directly to your printer over the network, please make sure your "
@@ -2214,738 +2452,326 @@ msgid ""
 "printer."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:51
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:51
 msgctxt "@label"
 msgid "Select your printer from the list below:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:71
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:71
 msgctxt "@action:button"
 msgid "Edit"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:82
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/MachinesPage.qml:141
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:186
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:320
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:82
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:186
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/MachinesPage.qml:140
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:321
 msgctxt "@action:button"
 msgid "Remove"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:90
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:90
 msgctxt "@action:button"
 msgid "Refresh"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:161
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:161
 msgctxt "@label"
 msgid ""
 "If your printer is not listed, read the <a href='%1'>network printing "
 "troubleshooting guide</a>"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:186
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:263
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:186
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:263
 msgctxt "@label"
 msgid "Type"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:202
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:279
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:202
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:279
 msgctxt "@label"
 msgid "Firmware version"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:212
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:295
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:212
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:295
 msgctxt "@label"
 msgid "Address"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:232
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:232
 msgctxt "@label"
 msgid "This printer is not set up to host a group of printers."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:236
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:236
 msgctxt "@label"
 msgid "This printer is the host for a group of %1 printers."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:245
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:245
 msgctxt "@label"
 msgid "The printer at this address has not yet responded."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:250
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:250
 msgctxt "@action:button"
 msgid "Connect"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:261
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:261
 msgctxt "@title:window"
 msgid "Invalid IP address"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:262
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:146
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:262
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:146
 msgctxt "@text"
 msgid "Please enter a valid IP address."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:272
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:272
 msgctxt "@title:window"
 msgid "Printer Address"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:297
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:102
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:297
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:102
 msgctxt "@label"
 msgid "Enter the IP address of your printer on the network."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:126
-msgctxt "@label"
-msgid "Unavailable printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:128
-msgctxt "@label"
-msgid "First available"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:54
-msgctxt "@label"
-msgid "Move to top"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:70
-msgctxt "@label"
-msgid "Delete"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:100
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:284
-msgctxt "@label"
-msgid "Resume"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:102
-msgctxt "@label"
-msgid "Pausing..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:104
-msgctxt "@label"
-msgid "Resuming..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:106
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:279
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:288
-msgctxt "@label"
-msgid "Pause"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:124
-msgctxt "@label"
-msgid "Aborting..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:124
-msgctxt "@label"
-msgid "Abort"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:142
-msgctxt "@label %1 is the name of a print job."
-msgid "Are you sure you want to move %1 to the top of the queue?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:143
-msgctxt "@window:title"
-msgid "Move print job to top"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:151
-msgctxt "@label %1 is the name of a print job."
-msgid "Are you sure you want to delete %1?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:152
-msgctxt "@window:title"
-msgid "Delete print job"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:160
-msgctxt "@label %1 is the name of a print job."
-msgid "Are you sure you want to abort %1?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:161
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:326
-msgctxt "@window:title"
-msgid "Abort print"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:29
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:29
 msgctxt "@label"
 msgid "Queued"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:63
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:63
 msgctxt "@label link to connect manager"
 msgid "Manage in browser"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:90
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:90
 msgctxt "@label"
 msgid "There are no print jobs in the queue. Slice and send a job to add one."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:98
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:98
 msgctxt "@label"
 msgid "Print jobs"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:107
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:107
 msgctxt "@label"
 msgid "Total print time"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:116
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:116
 msgctxt "@label"
 msgid "Waiting for"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:19
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:48
-msgctxt "@label"
-msgid "Color scheme"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:70
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:82
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:84
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:86
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:88
+msgctxt "@label:status"
+msgid "Aborted"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:105
-msgctxt "@label:listbox"
-msgid "Material Color"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:72
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:74
+msgctxt "@label:status"
+msgid "Finished"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:109
-msgctxt "@label:listbox"
-msgid "Line Type"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:80
+msgctxt "@label:status"
+msgid "Aborting..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:113
-msgctxt "@label:listbox"
-msgid "Speed"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:90
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:92
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:94
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:96
+msgctxt "@label:status"
+msgid "Failed"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:117
-msgctxt "@label:listbox"
-msgid "Layer Thickness"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:98
+msgctxt "@label:status"
+msgid "Pausing..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:121
-msgctxt "@label:listbox"
-msgid "Line Width"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:100
+msgctxt "@label:status"
+msgid "Paused"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:125
-msgctxt "@label:listbox"
-msgid "Flow"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:102
+msgctxt "@label:status"
+msgid "Resuming..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:165
-msgctxt "@label"
-msgid "Compatibility Mode"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:104
+msgctxt "@label:status"
+msgid "Action required"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:232
-msgctxt "@label"
-msgid "Travels"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:106
+msgctxt "@label:status"
+msgid "Finishes %1 at %2"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:238
-msgctxt "@label"
-msgid "Helpers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:244
-msgctxt "@label"
-msgid "Shell"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:250
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:64
-msgctxt "@label"
-msgid "Infill"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:258
-msgctxt "@label"
-msgid "Starts"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:307
-msgctxt "@label"
-msgid "Only Show Top Layers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:316
-msgctxt "@label"
-msgid "Show 5 Detailed Layers On Top"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:329
-msgctxt "@label"
-msgid "Top / Bottom"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:333
-msgctxt "@label"
-msgid "Inner Wall"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:400
-msgctxt "@label"
-msgid "min"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:465
-msgctxt "@label"
-msgid "max"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:14
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/main.qml:25
 msgctxt "@title:window"
-msgid "Convert Image"
+msgid "Cura Backups"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:33
-msgctxt "@action:label"
-msgid "Height (mm)"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:56
-msgctxt "@info:tooltip"
-msgid "The maximum distance of each pixel from \"Base.\""
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:66
-msgctxt "@action:label"
-msgid "Base (mm)"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:90
-msgctxt "@info:tooltip"
-msgid "The base height from the build plate in millimeters."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:100
-msgctxt "@action:label"
-msgid "Width (mm)"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:124
-msgctxt "@info:tooltip"
-msgid "The width in millimeters on the build plate"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:134
-msgctxt "@action:label"
-msgid "Depth (mm)"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:158
-msgctxt "@info:tooltip"
-msgid "The depth in millimeters on the build plate"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:187
-msgctxt "@item:inlistbox"
-msgid "Darker is higher"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:188
-msgctxt "@item:inlistbox"
-msgid "Lighter is higher"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:195
-msgctxt "@info:tooltip"
-msgid ""
-"For lithophanes dark pixels should correspond to thicker locations in order "
-"to block more light coming through. For height maps lighter pixels signify "
-"higher terrain, so lighter pixels should correspond to thicker locations in "
-"the generated 3D model."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:205
-msgctxt "@action:label"
-msgid "Color Model"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:224
-msgctxt "@item:inlistbox"
-msgid "Linear"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:225
-msgctxt "@item:inlistbox"
-msgid "Translucency"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:232
-msgctxt "@info:tooltip"
-msgid ""
-"For lithophanes a simple logarithmic model for translucency is available. "
-"For height maps the pixel values correspond to heights linearly."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:242
-msgctxt "@action:label"
-msgid "1mm Transmittance (%)"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:263
-msgctxt "@info:tooltip"
-msgid ""
-"The percentage of light penetrating a print with a thickness of 1 "
-"millimeter. Lowering this value increases the contrast in dark regions and "
-"decreases the contrast in light regions of the image."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:274
-msgctxt "@action:label"
-msgid "Smoothing"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:298
-msgctxt "@info:tooltip"
-msgid "The amount of smoothing to apply to the image."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/ImageReader/ConfigUI.qml:329
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:139
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/RenameDialog.qml:80
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ColorDialog.qml:140
-msgctxt "@action:button"
-msgid "OK"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:15
-msgctxt "@title:window"
-msgid "Open Project"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:55
-msgctxt "@action:ComboBox Update/override existing profile"
-msgid "Update existing"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:56
-msgctxt "@action:ComboBox Save settings in a new profile"
-msgid "Create new"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:74
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:52
-msgctxt "@action:title"
-msgid "Summary - Cura Project"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:100
-msgctxt "@info:tooltip"
-msgid "How should the conflict in the machine be resolved?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:156
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:88
-msgctxt "@action:label"
-msgid "Printer settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:167
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:97
-msgctxt "@action:label"
-msgid "Type"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:184
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:112
-msgctxt "@action:label"
-msgid "Printer Group"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:209
-msgctxt "@info:tooltip"
-msgid "How should the conflict in the profile be resolved?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:231
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:213
-msgctxt "@action:label"
-msgid "Profile settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:242
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:367
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:112
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:237
-msgctxt "@action:label"
-msgid "Name"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:260
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:254
-msgctxt "@action:label"
-msgid "Intent"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:278
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:221
-msgctxt "@action:label"
-msgid "Not in profile"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:284
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:226
-msgctxt "@action:label"
-msgid "%1 override"
-msgid_plural "%1 overrides"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:297
-msgctxt "@action:label"
-msgid "Derivative from"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:303
-msgctxt "@action:label"
-msgid "%1, %2 override"
-msgid_plural "%1, %2 overrides"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:325
-msgctxt "@info:tooltip"
-msgid "How should the conflict in the material be resolved?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:352
-msgctxt "@action:label"
-msgid "Material settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:388
-msgctxt "@action:label"
-msgid "Setting visibility"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:397
-msgctxt "@action:label"
-msgid "Mode"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:413
-msgctxt "@action:label"
-msgid "Visible settings:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:418
-msgctxt "@action:label"
-msgid "%1 out of %2"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:439
-msgctxt "@action:warning"
-msgid "Loading a project will clear all models on the build plate."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/3MFReader/WorkspaceDialog.qml:456
-msgctxt "@action:button"
-msgid "Open"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:22
-msgctxt "@button"
-msgid "Want more?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:31
-msgctxt "@button"
-msgid "Backup Now"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:43
-msgctxt "@checkbox:description"
-msgid "Auto Backup"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:44
-msgctxt "@checkbox:description"
-msgid "Automatically create a backup each day that Cura is started."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:21
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:21
 msgctxt "@backuplist:label"
 msgid "Cura Version"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:29
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:29
 msgctxt "@backuplist:label"
 msgid "Machines"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:37
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:37
 msgctxt "@backuplist:label"
 msgid "Materials"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:45
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:45
 msgctxt "@backuplist:label"
 msgid "Profiles"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:53
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:53
 msgctxt "@backuplist:label"
 msgid "Plugins"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:64
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:22
+msgctxt "@button"
+msgid "Want more?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:31
+msgctxt "@button"
+msgid "Backup Now"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:43
+msgctxt "@checkbox:description"
+msgid "Auto Backup"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:44
+msgctxt "@checkbox:description"
+msgid "Automatically create a backup each day that Cura is started."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:64
 msgctxt "@button"
 msgid "Restore"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:93
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:93
 msgctxt "@dialog:title"
 msgid "Delete Backup"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:94
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:94
 msgctxt "@dialog:info"
 msgid "Are you sure you want to delete this backup? This cannot be undone."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:102
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:102
 msgctxt "@dialog:title"
 msgid "Restore Backup"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:103
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:103
 msgctxt "@dialog:info"
 msgid ""
 "You will need to restart Cura before your backup is restored. Do you want to "
 "close Cura now?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/pages/WelcomePage.qml:34
-msgctxt "@description"
-msgid "Backup and synchronize your Cura settings."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/pages/WelcomePage.qml:47
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/GeneralOperations.qml:49
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:163
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/CloudContent.qml:225
-msgctxt "@button"
-msgid "Sign in"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:28
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:28
 msgctxt "@title"
 msgid "My Backups"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:38
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:38
 msgctxt "@empty_state"
 msgid ""
 "You don't have any backups currently. Use the 'Backup Now' button to create "
 "one."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:60
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:60
 msgctxt "@backup_limit_info"
 msgid ""
 "During the preview phase, you'll be limited to 5 visible backups. Remove a "
 "backup to see older ones."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/CuraDrive/src/qml/main.qml:25
-msgctxt "@title:window"
-msgid "Cura Backups"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/pages/WelcomePage.qml:34
+msgctxt "@description"
+msgid "Backup and synchronize your Cura settings."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:17
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/CuraDrive/src/qml/pages/WelcomePage.qml:47
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:164
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/CloudContent.qml:225
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/GeneralOperations.qml:49
+msgctxt "@button"
+msgid "Sign in"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:16
 msgctxt "@title:window"
 msgid "More information on anonymous data collection"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:74
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:73
 msgctxt "@text:window"
 msgid ""
 "Ultimaker Cura collects anonymous data in order to improve the print quality "
 "and user experience. Below is an example of all the data that is shared:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:110
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:109
 msgctxt "@text:window"
 msgid "I don't want to send anonymous data"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:119
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:118
 msgctxt "@text:window"
 msgid "Allow sending anonymous data"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:17
-msgctxt "@title:window"
-msgid "Post Processing Plugin"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:57
-msgctxt "@label"
-msgid "Post Processing Scripts"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:221
-msgctxt "@action"
-msgid "Add a script"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:257
-msgctxt "@label"
-msgid "Settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:466
-msgctxt "@info:tooltip"
-msgid "Change active post-processing scripts."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:470
-msgctxt "@info:tooltip"
-msgid "The following script is active:"
-msgid_plural "The following scripts are active:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml:30
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml:30
 msgctxt "@label"
 msgid "Please select any upgrades made to this Ultimaker Original"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml:41
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml:41
 msgctxt "@label"
 msgid "Heated Build Plate (official kit or self-built)"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:30
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:30
 msgctxt "@title"
 msgid "Build Plate Leveling"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:44
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:44
 msgctxt "@label"
 msgid ""
 "To make sure your prints will come out great, you can now adjust your "
@@ -2953,7 +2779,7 @@ msgid ""
 "the different positions that can be adjusted."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:57
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:57
 msgctxt "@label"
 msgid ""
 "For every position; insert a piece of paper under the nozzle and adjust the "
@@ -2961,733 +2787,2612 @@ msgid ""
 "paper is slightly gripped by the tip of the nozzle."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:75
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:75
 msgctxt "@action:button"
 msgid "Start Build Plate Leveling"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:87
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:87
 msgctxt "@action:button"
 msgid "Move to Next Position"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:21
-msgctxt "@info"
-msgid "Ultimaker Verified Plug-in"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:22
-msgctxt "@info"
-msgid "Ultimaker Certified Material"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:23
-msgctxt "@info"
-msgid "Ultimaker Verified Package"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:84
-msgctxt "@title"
-msgid "Loading..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:143
-msgctxt "@button"
-msgid "Plugins"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:151
-msgctxt "@button"
-msgid "Materials"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:188
-msgctxt "@info"
-msgid "Search in the browser"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:266
-msgctxt "@button"
-msgid "In order to use the package you will need to restart Cura"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:274
-msgctxt "@info:button, %1 is the application name"
-msgid "Quit %1"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:165
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:163
 msgctxt "@label"
 msgid "By"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:199
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:197
 msgctxt "@button"
 msgid "Enable"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:199
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:197
 msgctxt "@button"
 msgid "Disable"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:217
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:215
 msgctxt "@button"
 msgid "Downgrading..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:218
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:216
 msgctxt "@button"
 msgid "Downgrade"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:222
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:220
 msgctxt "@button"
 msgid "Installing..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:223
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:221
 msgctxt "@button"
 msgid "Install"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:227
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:225
 msgctxt "@button"
 msgid "Uninstall"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:242
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:240
 msgctxt "@button"
 msgid "Updating..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:242
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:240
 msgctxt "@button"
 msgid "Update"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Plugins.qml:8
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Plugins.qml:8
 msgctxt "@header"
 msgid "Install Plugins"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Plugins.qml:12
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Plugins.qml:12
 msgctxt "@text"
 msgid ""
 "Streamline your workflow and customize your Ultimaker Cura experience with "
 "plugins contributed by our amazing community of users."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/ManagePackagesButton.qml:32
-msgctxt "@info:tooltip"
-msgid "Manage packages"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:85
-msgctxt "@header"
-msgid "Description"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:117
-msgctxt "@header"
-msgid "Compatible printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:143
-msgctxt "@info"
-msgid "No compatibility information"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:162
-msgctxt "@header"
-msgid "Compatible support materials"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:188
-msgctxt "@info No materials"
-msgid "None"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:206
-msgctxt "@header"
-msgid "Compatible with Material Station"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:216
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:244
-msgctxt "@info"
-msgid "Yes"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:216
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:244
-msgctxt "@info"
-msgid "No"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:234
-msgctxt "@header"
-msgid "Optimized for Air Manager"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:260
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
 msgctxt "@button"
-msgid "Visit plug-in website"
+msgid "Dismiss"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:260
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/FirstStartMachineActionsContent.qml:77
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/WhatsNewContent.qml:176
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:123
 msgctxt "@button"
-msgid "Website"
+msgid "Next"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:269
-msgctxt "@button"
-msgid "Buy spool"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:278
-msgctxt "@button"
-msgid "Safety datasheet"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:94
+msgctxt "@label"
+msgid ""
+"The following packages can not be installed because of an incompatible Cura "
+"version:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:287
-msgctxt "@button"
-msgid "Technical datasheet"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:101
+msgctxt "@button:label"
+msgid "Learn More"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageDetails.qml:15
-msgctxt "@header"
-msgid "Package details"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/PackageDetails.qml:40
-msgctxt "@button:tooltip"
-msgid "Back"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:16
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:15
 msgctxt "@button"
 msgid "Plugin license agreement"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:48
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:47
 msgctxt "@text"
 msgid "Please read and agree with the plugin licence."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:74
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:73
 msgctxt "@button"
 msgid "Accept"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:83
-msgctxt "@button"
-msgid "Decline"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Packages.qml:164
-msgctxt "@button"
-msgid "Failed to load packages:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Packages.qml:164
-msgctxt "@button"
-msgid "Retry?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Packages.qml:180
-msgctxt "@button"
-msgid "Loading"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Packages.qml:196
-msgctxt "@message"
-msgid "No more results to load"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Packages.qml:196
-msgctxt "@message"
-msgid "No results found with current filter"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Packages.qml:239
-msgctxt "@button"
-msgid "Load more"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/ManagedPackages.qml:11
-msgctxt "@header"
-msgid "Manage packages"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/ManagedPackages.qml:15
-msgctxt "@text"
-msgid ""
-"Manage your Ultimaker Cura plugins and material profiles here. Make sure to "
-"keep your plugins up to date and backup your setup regularly."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Materials.qml:8
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Materials.qml:8
 msgctxt "@header"
 msgid "Install Materials"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/Marketplace/resources/qml/Materials.qml:12
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Materials.qml:12
 msgctxt "@text"
 msgid ""
 "Select and install material profiles optimised for your Ultimaker 3D "
 "printers."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsAction.qml:42
-msgctxt "@title:tab"
-msgid "Printer"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/ManagePackagesButton.qml:32
+msgctxt "@info:tooltip"
+msgid "Manage packages"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:63
-msgctxt "@title:label"
-msgid "Nozzle Settings"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:85
+msgctxt "@header"
+msgid "Description"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:75
-msgctxt "@label"
-msgid "Nozzle size"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:117
+msgctxt "@header"
+msgid "Compatible printers"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:79
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:93
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:109
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:124
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:74
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:89
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:104
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:205
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:225
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:245
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:265
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:283
-msgctxt "@label"
-msgid "mm"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:143
+msgctxt "@info"
+msgid "No compatibility information"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:89
-msgctxt "@label"
-msgid "Compatible material diameter"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:162
+msgctxt "@header"
+msgid "Compatible support materials"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:105
-msgctxt "@label"
-msgid "Nozzle offset X"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:188
+msgctxt "@info No materials"
+msgid "None"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:120
-msgctxt "@label"
-msgid "Nozzle offset Y"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:206
+msgctxt "@header"
+msgid "Compatible with Material Station"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:135
-msgctxt "@label"
-msgid "Cooling Fan Number"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:216
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:244
+msgctxt "@info"
+msgid "Yes"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:163
-msgctxt "@title:label"
-msgid "Extruder Start G-code"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:216
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:244
+msgctxt "@info"
+msgid "No"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:177
-msgctxt "@title:label"
-msgid "Extruder End G-code"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:234
+msgctxt "@header"
+msgid "Optimized for Air Manager"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:56
-msgctxt "@title:label"
-msgid "Printer Settings"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:260
+msgctxt "@button"
+msgid "Visit plug-in website"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:70
-msgctxt "@label"
-msgid "X (Width)"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:260
+msgctxt "@button"
+msgid "Website"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:85
-msgctxt "@label"
-msgid "Y (Depth)"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:269
+msgctxt "@button"
+msgid "Buy spool"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:100
-msgctxt "@label"
-msgid "Z (Height)"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:278
+msgctxt "@button"
+msgid "Safety datasheet"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:114
-msgctxt "@label"
-msgid "Build plate shape"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:287
+msgctxt "@button"
+msgid "Technical datasheet"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:127
-msgctxt "@label"
-msgid "Origin at center"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageDetails.qml:15
+msgctxt "@header"
+msgid "Package details"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:139
-msgctxt "@label"
-msgid "Heated bed"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/PackageDetails.qml:40
+msgctxt "@button:tooltip"
+msgid "Back"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:151
-msgctxt "@label"
-msgid "Heated build volume"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Packages.qml:149
+msgctxt "@button"
+msgid "Failed to load packages:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:163
-msgctxt "@label"
-msgid "G-code flavor"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Packages.qml:149
+msgctxt "@button"
+msgid "Retry?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:187
-msgctxt "@title:label"
-msgid "Printhead Settings"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Packages.qml:165
+msgctxt "@button"
+msgid "Loading"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:201
-msgctxt "@label"
-msgid "X min"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Packages.qml:181
+msgctxt "@message"
+msgid "No more results to load"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:221
-msgctxt "@label"
-msgid "Y min"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Packages.qml:181
+msgctxt "@message"
+msgid "No results found with current filter"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:241
-msgctxt "@label"
-msgid "X max"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Packages.qml:224
+msgctxt "@button"
+msgid "Load more"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:261
-msgctxt "@label"
-msgid "Y max"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:21
+msgctxt "@info"
+msgid "Ultimaker Verified Plug-in"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:279
-msgctxt "@label"
-msgid "Gantry Height"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:22
+msgctxt "@info"
+msgid "Ultimaker Certified Material"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:293
-msgctxt "@label"
-msgid "Number of Extruders"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:23
+msgctxt "@info"
+msgid "Ultimaker Verified Package"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:345
-msgctxt "@label"
-msgid "Apply Extruder offsets to GCode"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/ManagedPackages.qml:11
+msgctxt "@header"
+msgid "Manage packages"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:393
-msgctxt "@title:label"
-msgid "Start G-code"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/ManagedPackages.qml:15
+msgctxt "@text"
+msgid ""
+"Manage your Ultimaker Cura plugins and material profiles here. Make sure to "
+"keep your plugins up to date and backup your setup regularly."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:404
-msgctxt "@title:label"
-msgid "End G-code"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:84
+msgctxt "@title"
+msgid "Loading..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:32
-msgctxt "@label:button"
-msgid "My printers"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:143
+msgctxt "@button"
+msgid "Plugins"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:34
-msgctxt "@tooltip:button"
-msgid "Monitor printers in Ultimaker Digital Factory."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:151
+msgctxt "@button"
+msgid "Materials"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:41
-msgctxt "@tooltip:button"
-msgid "Create print projects in Digital Library."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:188
+msgctxt "@info"
+msgid "Search in the browser"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:46
-msgctxt "@label:button"
-msgid "Print jobs"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:266
+msgctxt "@button"
+msgid "In order to use the package you will need to restart Cura"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:48
-msgctxt "@tooltip:button"
-msgid "Monitor print jobs and reprint from your print history."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:274
+msgctxt "@info:button, %1 is the application name"
+msgid "Quit %1"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:55
-msgctxt "@tooltip:button"
-msgid "Extend Ultimaker Cura with plugins and material profiles."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MonitorStage/MonitorMain.qml:100
+msgctxt "@info"
+msgid ""
+"Please make sure your printer has a connection:\n"
+"- Check if the printer is turned on.\n"
+"- Check if the printer is connected to the network.\n"
+"- Check if you are signed in to discover cloud-connected printers."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:62
-msgctxt "@tooltip:button"
-msgid "Become a 3D printing expert with Ultimaker e-learning."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MonitorStage/MonitorMain.qml:113
+msgctxt "@info"
+msgid "Please connect your printer to the network."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:67
-msgctxt "@label:button"
-msgid "Ultimaker support"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MonitorStage/MonitorMain.qml:146
+msgctxt "@label link to technical assistance"
+msgid "View user manuals online"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:69
-msgctxt "@tooltip:button"
-msgid "Learn how to get started with Ultimaker Cura."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/MonitorStage/MonitorMain.qml:163
+msgctxt "@info"
+msgid "In order to monitor your print from Cura, please connect the printer."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:74
-msgctxt "@label:button"
-msgid "Ask a question"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:15
+msgctxt "@title:window"
+msgid "Open Project"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:76
-msgctxt "@tooltip:button"
-msgid "Consult the Ultimaker Community."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:55
+msgctxt "@action:ComboBox Update/override existing profile"
+msgid "Update existing"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:81
-msgctxt "@label:button"
-msgid "Report a bug"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:56
+msgctxt "@action:ComboBox Save settings in a new profile"
+msgid "Create new"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:83
-msgctxt "@tooltip:button"
-msgid "Let developers know that something is going wrong."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:74
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:59
+msgctxt "@action:title"
+msgid "Summary - Cura Project"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:90
-msgctxt "@tooltip:button"
-msgid "Visit the Ultimaker website."
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:100
+msgctxt "@info:tooltip"
+msgid "How should the conflict in the machine be resolved?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ExtruderButton.qml:16
-msgctxt "@label %1 is filled in with the name of an extruder"
-msgid "Print Selected Model with %1"
-msgid_plural "Print Selected Models with %1"
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:156
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:95
+msgctxt "@action:label"
+msgid "Printer settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:167
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:104
+msgctxt "@action:label"
+msgid "Type"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:184
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:119
+msgctxt "@action:label"
+msgid "Printer Group"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:209
+msgctxt "@info:tooltip"
+msgid "How should the conflict in the profile be resolved?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:231
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:220
+msgctxt "@action:label"
+msgid "Profile settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:242
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:367
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:119
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:244
+msgctxt "@action:label"
+msgid "Name"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:260
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:261
+msgctxt "@action:label"
+msgid "Intent"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:278
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:228
+msgctxt "@action:label"
+msgid "Not in profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:284
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:233
+msgctxt "@action:label"
+msgid "%1 override"
+msgid_plural "%1 overrides"
 msgstr[0] ""
 msgstr[1] ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MainWindow/ApplicationMenu.qml:63
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingsMenu.qml:13
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:297
+msgctxt "@action:label"
+msgid "Derivative from"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:303
+msgctxt "@action:label"
+msgid "%1, %2 override"
+msgid_plural "%1, %2 overrides"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:325
+msgctxt "@info:tooltip"
+msgid "How should the conflict in the material be resolved?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:352
+msgctxt "@action:label"
+msgid "Material settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:388
+msgctxt "@action:label"
+msgid "Setting visibility"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:397
+msgctxt "@action:label"
+msgid "Mode"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:413
+msgctxt "@action:label"
+msgid "Visible settings:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:418
+msgctxt "@action:label"
+msgid "%1 out of %2"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:439
+msgctxt "@action:warning"
+msgid "Loading a project will clear all models on the build plate."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/3MFReader/WorkspaceDialog.qml:456
+msgctxt "@action:button"
+msgid "Open"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:41
+msgctxt "@label"
+msgid "Mesh Type"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:81
+msgctxt "@label"
+msgid "Normal model"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:96
+msgctxt "@label"
+msgid "Print as support"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:111
+msgctxt "@label"
+msgid "Modify settings for overlaps"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:126
+msgctxt "@label"
+msgid "Don't support overlaps"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:159
+msgctxt "@item:inlistbox"
+msgid "Infill mesh only"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:160
+msgctxt "@item:inlistbox"
+msgid "Cutting mesh"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:385
+msgctxt "@action:button"
+msgid "Select settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:17
+msgctxt "@title:window"
+msgid "Select Settings to Customize for this model"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:61
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:102
+msgctxt "@label:textbox"
+msgid "Filter..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:75
+msgctxt "@label:checkbox"
+msgid "Show all"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:31
+msgctxt "@title"
+msgid "Update Firmware"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:37
+msgctxt "@label"
+msgid ""
+"Firmware is the piece of software running directly on your 3D printer. This "
+"firmware controls the step motors, regulates the temperature and ultimately "
+"makes your printer work."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:43
+msgctxt "@label"
+msgid ""
+"The firmware shipping with new printers works, but new versions tend to have "
+"more features and improvements."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:55
+msgctxt "@action:button"
+msgid "Automatically upgrade Firmware"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:66
+msgctxt "@action:button"
+msgid "Upload custom Firmware"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:79
+msgctxt "@label"
+msgid ""
+"Firmware can not be updated because there is no connection with the printer."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:86
+msgctxt "@label"
+msgid ""
+"Firmware can not be updated because the connection with the printer does not "
+"support upgrading firmware."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:93
+msgctxt "@title:window"
+msgid "Select custom firmware"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:113
+msgctxt "@title:window"
+msgid "Firmware Update"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:137
+msgctxt "@label"
+msgid "Updating firmware."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:139
+msgctxt "@label"
+msgid "Firmware update completed."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:141
+msgctxt "@label"
+msgid "Firmware update failed due to an unknown error."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:143
+msgctxt "@label"
+msgid "Firmware update failed due to an communication error."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:145
+msgctxt "@label"
+msgid "Firmware update failed due to an input/output error."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:147
+msgctxt "@label"
+msgid "Firmware update failed due to missing firmware."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:18
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:47
+msgctxt "@label"
+msgid "Color scheme"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:104
+msgctxt "@label:listbox"
+msgid "Material Color"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:108
+msgctxt "@label:listbox"
+msgid "Line Type"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:112
+msgctxt "@label:listbox"
+msgid "Speed"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:116
+msgctxt "@label:listbox"
+msgid "Layer Thickness"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:120
+msgctxt "@label:listbox"
+msgid "Line Width"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:124
+msgctxt "@label:listbox"
+msgid "Flow"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:164
+msgctxt "@label"
+msgid "Compatibility Mode"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:231
+msgctxt "@label"
+msgid "Travels"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:237
+msgctxt "@label"
+msgid "Helpers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:243
+msgctxt "@label"
+msgid "Shell"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:249
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:64
+msgctxt "@label"
+msgid "Infill"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:257
+msgctxt "@label"
+msgid "Starts"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:306
+msgctxt "@label"
+msgid "Only Show Top Layers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:315
+msgctxt "@label"
+msgid "Show 5 Detailed Layers On Top"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:328
+msgctxt "@label"
+msgid "Top / Bottom"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:332
+msgctxt "@label"
+msgid "Inner Wall"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:399
+msgctxt "@label"
+msgid "min"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:464
+msgctxt "@label"
+msgid "max"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/SearchBar.qml:17
+msgctxt "@placeholder"
+msgid "Search"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingItem.qml:84
+msgctxt "@label"
+msgid ""
+"This setting is not used because all the settings that it influences are "
+"overridden."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingItem.qml:89
+msgctxt "@label Header for list of settings."
+msgid "Affects"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingItem.qml:94
+msgctxt "@label Header for list of settings."
+msgid "Affected By"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingItem.qml:191
+msgctxt "@label"
+msgid ""
+"This setting is always shared between all extruders. Changing it here will "
+"change the value for all extruders."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingItem.qml:195
+msgctxt "@label"
+msgid "This setting is resolved from conflicting extruder-specific values:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingItem.qml:235
+msgctxt "@label"
+msgid ""
+"This setting has a value that is different from the profile.\n"
+"\n"
+"Click to restore the value of the profile."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingItem.qml:335
+msgctxt "@label"
+msgid ""
+"This setting is normally calculated, but it currently has an absolute value "
+"set.\n"
+"\n"
+"Click to restore the calculated value."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingView.qml:48
+msgctxt "@label:textbox"
+msgid "Search settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingView.qml:395
+msgctxt "@action:menu"
+msgid "Copy value to all extruders"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingView.qml:404
+msgctxt "@action:menu"
+msgid "Copy all changed values to all extruders"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingView.qml:440
+msgctxt "@action:menu"
+msgid "Hide this setting"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingView.qml:453
+msgctxt "@action:menu"
+msgid "Don't show this setting"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingView.qml:457
+msgctxt "@action:menu"
+msgid "Keep this setting visible"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingView.qml:476
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:467
+msgctxt "@action:menu"
+msgid "Configure setting visibility..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Settings/SettingCategory.qml:115
+msgctxt "@label"
+msgid ""
+"Some hidden settings use values different from their normal calculated "
+"value.\n"
+"\n"
+"Click to make these settings visible."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MainWindow/MainWindowHeader.qml:135
+msgctxt "@action:button"
+msgid "Marketplace"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MainWindow/ApplicationMenu.qml:63
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SettingsMenu.qml:13
 msgctxt "@title:menu menubar:toplevel"
 msgid "&Settings"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MainWindow/ApplicationMenu.qml:87
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MainWindow/ApplicationMenu.qml:87
 msgctxt "@title:window"
 msgid "New project"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MainWindow/ApplicationMenu.qml:88
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MainWindow/ApplicationMenu.qml:88
 msgctxt "@info:question"
 msgid ""
 "Are you sure you want to start a new project? This will clear the build "
 "plate and any unsaved settings."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MainWindow/MainWindowHeader.qml:135
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:13
+msgctxt "@title:tab"
+msgid "Setting Visibility"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:24
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:131
 msgctxt "@action:button"
-msgid "Marketplace"
+msgid "Defaults"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:25
-msgctxt "@label"
-msgid "Build plate"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:55
+msgctxt "@label:textbox"
+msgid "Check all"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:55
-msgctxt "@tooltip"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:18
+msgctxt "@title:window"
+msgid "Sync materials with printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:49
+msgctxt "@title:header"
+msgid "Sync materials with printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:55
+msgctxt "@text"
 msgid ""
-"The target temperature of the heated bed. The bed will heat up or cool down "
-"towards this temperature. If this is 0, the bed heating is turned off."
+"Following a few simple steps, you will be able to synchronize all your "
+"material profiles with your printers."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:88
-msgctxt "@tooltip"
-msgid "The current temperature of the heated bed."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:162
-msgctxt "@tooltip of temperature input"
-msgid "The temperature to pre-heat the bed to."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:259
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:271
-msgctxt "@button Cancel pre-heating"
-msgid "Cancel"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:263
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:274
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:77
 msgctxt "@button"
-msgid "Pre-heat"
+msgid "Why do I need to sync material profiles?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:286
-msgctxt "@tooltip of pre-heat"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:86
+msgctxt "@button"
+msgid "Start"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:128
+msgctxt "@title:header"
+msgid "Sign in"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:134
+msgctxt "@text"
 msgid ""
-"Heat the bed in advance before printing. You can continue adjusting your "
-"print while it is heating, and you won't have to wait for the bed to heat up "
-"when you're ready to print."
+"To automatically sync the material profiles with all your printers connected "
+"to Digital Factory you need to be signed in in Cura."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/OutputDeviceHeader.qml:56
-msgctxt "@info:status"
-msgid "The printer is not connected."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:158
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:447
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:588
+msgctxt "@button"
+msgid "Sync materials with USB"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:51
-msgctxt "@label"
-msgid "Printer control"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:191
+msgctxt "@title:header"
+msgid "The following printers will receive the new material profiles:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:66
-msgctxt "@label"
-msgid "Jog Position"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:198
+msgctxt "@title:header"
+msgid "Something went wrong when sending the materials to the printers."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:82
-msgctxt "@label"
-msgid "X/Y"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:205
+msgctxt "@title:header"
+msgid "Material profiles successfully synced with the following printers:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:162
-msgctxt "@label"
-msgid "Z"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:243
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:430
+msgctxt "@button"
+msgid "Troubleshooting"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:217
-msgctxt "@label"
-msgid "Jog Distance"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:407
+msgctxt "@text Asking the user whether printers are missing in a list."
+msgid "Printers missing?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:257
-msgctxt "@label"
-msgid "Send G-code"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:319
-msgctxt "@tooltip of G-code command input"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:409
+msgctxt "@text"
 msgid ""
-"Send a custom G-code command to the connected printer. Press 'enter' to send "
-"the command."
+"Make sure all your printers are turned ON and connected to Digital Factory."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:40
-msgctxt "@label"
-msgid "Extruder"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:418
+msgctxt "@button"
+msgid "Refresh List"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:70
-msgctxt "@tooltip"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:458
+msgctxt "@button"
+msgid "Try again"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:462
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:699
+msgctxt "@button"
+msgid "Done"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:464
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:608
+msgctxt "@button"
+msgid "Sync"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:520
+msgctxt "@button"
+msgid "Syncing"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:538
+msgctxt "@title:header"
+msgid "No printers found"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:559
+msgctxt "@text"
 msgid ""
-"The target temperature of the hotend. The hotend will heat up or cool down "
-"towards this temperature. If this is 0, the hotend heating is turned off."
+"It seems like you don't have any compatible printers connected to Digital "
+"Factory. Make sure your printer is connected and it's running the latest "
+"firmware."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:105
-msgctxt "@tooltip"
-msgid "The current temperature of this hotend."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:571
+msgctxt "@button"
+msgid "Learn how to connect your printer to Digital Factory"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:182
-msgctxt "@tooltip of temperature input"
-msgid "The temperature to pre-heat the hotend to."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:599
+msgctxt "@button"
+msgid "Refresh"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:297
-msgctxt "@tooltip of pre-heat"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:628
+msgctxt "@title:header"
+msgid "Sync material profiles via USB"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:634
+msgctxt ""
+"@text In the UI this is followed by a list of steps the user needs to take."
 msgid ""
-"Heat the hotend in advance before printing. You can continue adjusting your "
-"print while it is heating, and you won't have to wait for the hotend to heat "
-"up when you're ready to print."
+"Follow the following steps to load the new material profiles to your printer."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:335
-msgctxt "@tooltip"
-msgid "The colour of the material in this extruder."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:666
+msgctxt "@text"
+msgid "Click the export material archive button."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:367
-msgctxt "@tooltip"
-msgid "The material in this extruder."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:667
+msgctxt "@text"
+msgid "Save the .umm file on a USB stick."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:400
-msgctxt "@tooltip"
-msgid "The nozzle inserted in this extruder."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:668
+msgctxt "@text"
+msgid ""
+"Insert the USB stick into your printer and launch the procedure to load new "
+"material profiles."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:17
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:676
+msgctxt "@button"
+msgid "How to load new material profiles to my printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:690
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:334
+msgctxt "@button"
+msgid "Back"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:699
+msgctxt "@button"
+msgid "Export material archive"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:734
 msgctxt "@title:window"
-msgid "Open project file"
+msgid "Export All Materials"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:83
-msgctxt "@text:window"
-msgid ""
-"This is a Cura project file. Would you like to open it as a project or "
-"import the models from it?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:91
-msgctxt "@text:window"
-msgid "Remember my choice"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:105
-msgctxt "@action:button"
-msgid "Open as project"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:110
-msgctxt "@action:button"
-msgid "Import models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:14
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:121
 msgctxt "@title:window"
-msgid "Save Project"
+msgid "Confirm Diameter Change"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:168
-msgctxt "@action:label"
-msgid "Extruder %1"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:122
+msgctxt "@label (%1 is a number)"
+msgid ""
+"The new filament diameter is set to %1 mm, which is not compatible with the "
+"current extruder. Do you wish to continue?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:184
-msgctxt "@action:label"
-msgid "%1 & material"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:152
+msgctxt "@label"
+msgid "Display Name"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:186
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:171
+msgctxt "@label"
+msgid "Brand"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:190
+msgctxt "@label"
+msgid "Material Type"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:210
+msgctxt "@label"
+msgid "Color"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:262
+msgctxt "@title"
+msgid "Material color picker"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:275
+msgctxt "@label"
+msgid "Properties"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:286
+msgctxt "@label"
+msgid "Density"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:319
+msgctxt "@label"
+msgid "Diameter"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:369
+msgctxt "@label"
+msgid "Filament Cost"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:401
+msgctxt "@label"
+msgid "Filament weight"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:433
+msgctxt "@label"
+msgid "Filament length"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:451
+msgctxt "@label"
+msgid "Cost per Meter"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:465
+msgctxt "@label"
+msgid "This material is linked to %1 and shares some of its properties."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:472
+msgctxt "@label"
+msgid "Unlink Material"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:485
+msgctxt "@label"
+msgid "Description"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:503
+msgctxt "@label"
+msgid "Adhesion Information"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:638
+msgctxt "@title"
+msgid "Information"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:643
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/PrintSetupSelector.qml:18
+msgctxt "@label"
+msgid "Print settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:70
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:467
+msgctxt "@title:tab"
+msgid "Materials"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:72
+msgctxt "@label"
+msgid "Materials compatible with active printer:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:78
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:94
+msgctxt "@action:button"
+msgid "Create new"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:90
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:88
+msgctxt "@action:button"
+msgid "Import"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:101
+msgctxt "@action:button"
+msgid "Sync with Printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:160
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/MachinesPage.qml:134
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:294
+msgctxt "@action:button"
+msgid "Activate"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:174
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:311
+msgctxt "@action:button"
+msgid "Duplicate"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:198
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:342
+msgctxt "@action:button"
+msgid "Export"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:212
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:392
+msgctxt "@title:window"
+msgid "Confirm Remove"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:215
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:393
+msgctxt "@label (%1 is object name)"
+msgid "Are you sure you wish to remove %1? This cannot be undone!"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:228
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:238
+msgctxt "@title:window"
+msgid "Import Material"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:242
+msgctxt "@info:status Don't translate the XML tag <filename>!"
+msgid "Successfully imported material <filename>%1</filename>"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:245
+msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
+msgid ""
+"Could not import material <filename>%1</filename>: <message>%2</message>"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:256
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:267
+msgctxt "@title:window"
+msgid "Export Material"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:272
+msgctxt "@info:status Don't translate the XML tags <filename> and <message>!"
+msgid ""
+"Failed to export material to <filename>%1</filename>: <message>%2</message>"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:275
+msgctxt "@info:status Don't translate the XML tag <filename>!"
+msgid "Successfully exported material to <filename>%1</filename>"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/SettingVisibilityItem.qml:56
+msgctxt "@item:tooltip"
+msgid ""
+"This setting has been hidden by the active machine and will not be visible."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/SettingVisibilityItem.qml:73
+msgctxt "@item:tooltip %1 is list of setting names"
+msgid ""
+"This setting has been hidden by the value of %1. Change the value of that "
+"setting to make this setting visible."
+msgid_plural ""
+"This setting has been hidden by the values of %1. Change the values of those "
+"settings to make this setting visible."
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:14
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:460
+msgctxt "@title:tab"
+msgid "General"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:169
+msgctxt "@label"
+msgid "Interface"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:213
+msgctxt "@heading"
+msgid "-- incomplete --"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:258
+msgctxt "@label"
+msgid "Currency:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:274
+msgctxt ""
+"@label: Please keep the asterix, it's to indicate that a restart is needed."
+msgid "Theme*:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:320
+msgctxt "@info:tooltip"
+msgid "Slice automatically when changing settings."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:328
+msgctxt "@option:check"
+msgid "Slice automatically"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:337
+msgctxt "@label"
+msgid ""
+"*You will need to restart the application for these changes to have effect."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:352
+msgctxt "@label"
+msgid "Viewport behavior"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:360
+msgctxt "@info:tooltip"
+msgid ""
+"Highlight unsupported areas of the model in red. Without support these areas "
+"will not print properly."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:369
+msgctxt "@option:check"
+msgid "Display overhang"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:379
+msgctxt "@info:tooltip"
+msgid ""
+"Highlight missing or extraneous surfaces of the model using warning signs. "
+"The toolpaths will often be missing parts of the intended geometry."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:388
+msgctxt "@option:check"
+msgid "Display model errors"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:396
+msgctxt "@info:tooltip"
+msgid ""
+"Moves the camera so the model is in the center of the view when a model is "
+"selected"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:401
+msgctxt "@action:button"
+msgid "Center camera when item is selected"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:411
+msgctxt "@info:tooltip"
+msgid "Should the default zoom behavior of cura be inverted?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:416
+msgctxt "@action:button"
+msgid "Invert the direction of camera zoom."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:432
+msgctxt "@info:tooltip"
+msgid "Should zooming move in the direction of the mouse?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:432
+msgctxt "@info:tooltip"
+msgid ""
+"Zooming towards the mouse is not supported in the orthographic perspective."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:437
+msgctxt "@action:button"
+msgid "Zoom toward mouse direction"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:463
+msgctxt "@info:tooltip"
+msgid ""
+"Should models on the platform be moved so that they no longer intersect?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:468
+msgctxt "@option:check"
+msgid "Ensure models are kept apart"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:477
+msgctxt "@info:tooltip"
+msgid "Should models on the platform be moved down to touch the build plate?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:482
+msgctxt "@option:check"
+msgid "Automatically drop models to the build plate"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:494
+msgctxt "@info:tooltip"
+msgid "Show caution message in g-code reader."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:503
+msgctxt "@option:check"
+msgid "Caution message in g-code reader"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:511
+msgctxt "@info:tooltip"
+msgid "Should layer be forced into compatibility mode?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:516
+msgctxt "@option:check"
+msgid "Force layer view compatibility mode (restart required)"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:526
+msgctxt "@info:tooltip"
+msgid "Should Cura open at the location it was closed?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:531
+msgctxt "@option:check"
+msgid "Restore window position on start"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:541
+msgctxt "@info:tooltip"
+msgid "What type of camera rendering should be used?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:548
+msgctxt "@window:text"
+msgid "Camera rendering:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:555
+msgid "Perspective"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:556
+msgid "Orthographic"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:596
+msgctxt "@label"
+msgid "Opening and saving files"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:603
+msgctxt "@info:tooltip"
+msgid ""
+"Should opening files from the desktop or external applications open in the "
+"same instance of Cura?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:608
+msgctxt "@option:check"
+msgid "Use a single instance of Cura"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:619
+msgctxt "@info:tooltip"
+msgid ""
+"Should the build plate be cleared before loading a new model in the single "
+"instance of Cura?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:625
+msgctxt "@option:check"
+msgid "Clear buildplate before loading model into the single instance"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:635
+msgctxt "@info:tooltip"
+msgid "Should models be scaled to the build volume if they are too large?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:640
+msgctxt "@option:check"
+msgid "Scale large models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:650
+msgctxt "@info:tooltip"
+msgid ""
+"An model may appear extremely small if its unit is for example in meters "
+"rather than millimeters. Should these models be scaled up?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:655
+msgctxt "@option:check"
+msgid "Scale extremely small models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:665
+msgctxt "@info:tooltip"
+msgid "Should models be selected after they are loaded?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:670
+msgctxt "@option:check"
+msgid "Select models when loaded"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:680
+msgctxt "@info:tooltip"
+msgid ""
+"Should a prefix based on the printer name be added to the print job name "
+"automatically?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:685
+msgctxt "@option:check"
+msgid "Add machine prefix to job name"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:695
+msgctxt "@info:tooltip"
+msgid "Should a summary be shown when saving a project file?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:699
+msgctxt "@option:check"
+msgid "Show summary dialog when saving project"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:709
+msgctxt "@info:tooltip"
+msgid "Default behavior when opening a project file"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:717
+msgctxt "@window:text"
+msgid "Default behavior when opening a project file: "
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:732
+msgctxt "@option:openProject"
+msgid "Always ask me this"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:733
+msgctxt "@option:openProject"
+msgid "Always open as a project"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:734
+msgctxt "@option:openProject"
+msgid "Always import models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:771
+msgctxt "@info:tooltip"
+msgid ""
+"When you have made changes to a profile and switched to a different one, a "
+"dialog will be shown asking whether you want to keep your modifications or "
+"not, or you can choose a default behaviour and never show that dialog again."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:780
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelector.qml:50
+msgctxt "@label"
+msgid "Profiles"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:785
+msgctxt "@window:text"
+msgid ""
+"Default behavior for changed setting values when switching to a different "
+"profile: "
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:799
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:104
+msgctxt "@option:discardOrKeep"
+msgid "Always ask me this"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:800
+msgctxt "@option:discardOrKeep"
+msgid "Always discard changed settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:801
+msgctxt "@option:discardOrKeep"
+msgid "Always transfer changed settings to new profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:835
+msgctxt "@label"
+msgid "Privacy"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:841
+msgctxt "@info:tooltip"
+msgid ""
+"Should anonymous data about your print be sent to Ultimaker? Note, no "
+"models, IP addresses or other personally identifiable information is sent or "
+"stored."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:846
+msgctxt "@option:check"
+msgid "Send (anonymous) print information"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:876
+msgctxt "@label"
+msgid "Updates"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:883
+msgctxt "@info:tooltip"
+msgid "Should Cura check for updates when the program is started?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:888
+msgctxt "@option:check"
+msgid "Check for updates on start"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:904
+msgctxt "@info:tooltip"
+msgid "When checking for updates, only check for stable releases."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:910
+msgctxt "@option:radio"
+msgid "Stable releases only"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:920
+msgctxt "@info:tooltip"
+msgid "When checking for updates, check for both stable and for beta releases."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:926
+msgctxt "@option:radio"
+msgid "Stable and Beta releases"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:936
+msgctxt "@info:tooltip"
+msgid ""
+"Should an automatic check for new plugins be done every time Cura is "
+"started? It is highly recommended that you do not disable this!"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/GeneralPage.qml:941
+msgctxt "@option:check"
+msgid "Get notifications for plugin updates"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/RenameDialog.qml:22
+msgctxt "@title:window"
+msgid "Rename"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/RenameDialog.qml:23
+msgctxt "@info"
+msgid "Please provide a new name."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/MachinesPage.qml:17
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:465
+msgctxt "@title:tab"
+msgid "Printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/MachinesPage.qml:50
+msgctxt "@action:button"
+msgid "Add New"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/MachinesPage.qml:146
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:331
+msgctxt "@action:button"
+msgid "Rename"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:57
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:469
+msgctxt "@title:tab"
+msgid "Profiles"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:59
+msgctxt "@label"
+msgid "Profiles compatible with active printer:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:98
+msgctxt "@action:tooltip"
+msgid "Create new profile from current settings/overrides"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:125
 msgctxt "@action:label"
+msgid "Some settings from current profile were overwritten."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:140
+msgctxt "@action:button"
+msgid "Update profile."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:143
+msgctxt "@action:tooltip"
+msgid "Update profile with current settings/overrides"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:148
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Custom/QualitiesWithIntentMenu.qml:256
+msgctxt "@action:button"
+msgid "Discard current changes"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:158
+msgctxt "@action:label"
+msgid ""
+"This profile uses the defaults specified by the printer, so it has no "
+"settings/overrides in the list below."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:165
+msgctxt "@action:label"
+msgid "Your current settings match the selected profile."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:175
+msgctxt "@title:tab"
+msgid "Global Settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:278
+msgctxt "@title:window"
+msgid "Create Profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:280
+msgctxt "@info"
+msgid "Please provide a name for this profile."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:352
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:368
+msgctxt "@title:window"
+msgid "Export Profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:382
+msgctxt "@title:window"
+msgid "Duplicate Profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:409
+msgctxt "@title:window"
+msgid "Rename Profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:422
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Preferences/ProfilesPage.qml:429
+msgctxt "@title:window"
+msgid "Import Profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ViewsSelector.qml:50
+msgctxt "@label"
+msgid "View type"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ViewOrientationControls.qml:25
+msgctxt "@info:tooltip"
+msgid "3D View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ViewOrientationControls.qml:38
+msgctxt "@info:tooltip"
+msgid "Front View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ViewOrientationControls.qml:51
+msgctxt "@info:tooltip"
+msgid "Top View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ViewOrientationControls.qml:64
+msgctxt "@info:tooltip"
+msgid "Left View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ViewOrientationControls.qml:77
+msgctxt "@info:tooltip"
+msgid "Right View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ObjectItemButton.qml:109
+msgctxt "@label"
+msgid "Is printed as support."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ObjectItemButton.qml:112
+msgctxt "@label"
+msgid "Other models overlapping with this model are modified."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ObjectItemButton.qml:115
+msgctxt "@label"
+msgid "Infill overlapping with this model is modified."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ObjectItemButton.qml:118
+msgctxt "@label"
+msgid "Overlaps with this model are not supported."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ObjectItemButton.qml:125
+msgctxt "@label %1 is the number of settings it overrides."
+msgid "Overrides %1 setting."
+msgid_plural "Overrides %1 settings."
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintMonitor.qml:156
+msgctxt "@label"
+msgid "Active print"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintMonitor.qml:164
+msgctxt "@label"
+msgid "Job Name"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintMonitor.qml:172
+msgctxt "@label"
+msgid "Printing Time"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintMonitor.qml:180
+msgctxt "@label"
+msgid "Estimated time left"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:24
+msgctxt "@label"
+msgid "Add a printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:39
+msgctxt "@label"
+msgid "Add a networked printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:88
+msgctxt "@label"
+msgid "Add a non-networked printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/WhatsNewContent.qml:28
+msgctxt "@label"
+msgid "What's New"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:204
+msgctxt "@label"
+msgid "Manufacturer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:215
+msgctxt "@label"
+msgid "Profile author"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:227
+msgctxt "@label"
+msgid "Printer name"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:233
+msgctxt "@text"
+msgid "Please name your printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/ChangelogContent.qml:24
+msgctxt "@label"
+msgid "Release Notes"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:43
+msgctxt "@label"
+msgid "There is no printer found over your network."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:162
+msgctxt "@label"
+msgid "Refresh"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:173
+msgctxt "@label"
+msgid "Add printer by IP"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:184
+msgctxt "@label"
+msgid "Add cloud printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:220
+msgctxt "@label"
+msgid "Troubleshooting"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/CloudContent.qml:64
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/GeneralOperations.qml:19
+msgctxt "@label"
+msgid "Sign in to the Ultimaker platform"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/CloudContent.qml:124
+msgctxt "@text"
+msgid "Add material settings and plugins from the Marketplace"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/CloudContent.qml:154
+msgctxt "@text"
+msgid "Backup and sync your material settings and plugins"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/CloudContent.qml:184
+msgctxt "@text"
+msgid "Share ideas and get help from 48,000+ users in the Ultimaker Community"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/CloudContent.qml:202
+msgctxt "@button"
+msgid "Skip"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/CloudContent.qml:214
+msgctxt "@text"
+msgid "Create a free Ultimaker Account"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:24
+msgctxt "@label"
+msgid "Help us to improve Ultimaker Cura"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:57
+msgctxt "@text"
+msgid ""
+"Ultimaker Cura collects anonymous data to improve print quality and user "
+"experience, including:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:71
+msgctxt "@text"
+msgid "Machine types"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:77
+msgctxt "@text"
+msgid "Material usage"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:83
+msgctxt "@text"
+msgid "Number of slices"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:89
+msgctxt "@text"
+msgid "Print settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:102
+msgctxt "@text"
+msgid ""
+"Data collected by Ultimaker Cura will not contain any personal information."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:103
+msgctxt "@text"
+msgid "More information"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/DropDownWidget.qml:93
+msgctxt "@label"
+msgid "Empty"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:47
+msgctxt "@label"
+msgid "Add a Cloud printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:74
+msgctxt "@label"
+msgid "Waiting for Cloud response"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:86
+msgctxt "@label"
+msgid "No printers found in your account?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:121
+msgctxt "@label"
+msgid "The following printers in your account have been added in Cura:"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:194
+msgctxt "@button"
+msgid "Add printer manually"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:23
+msgctxt "@label"
+msgid "User Agreement"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:67
+msgctxt "@button"
+msgid "Decline and close"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:70
+msgctxt "@label"
+msgid "Add printer by IP address"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:133
+msgctxt "@text"
+msgid "Enter your printer's IP address."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:158
+msgctxt "@button"
+msgid "Add"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:206
+msgctxt "@label"
+msgid "Could not connect to device."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:207
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:212
+msgctxt "@label"
+msgid "Can't connect to your Ultimaker printer?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:211
+msgctxt "@label"
+msgid "The printer at this address has not responded yet."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:245
+msgctxt "@label"
+msgid ""
+"This printer cannot be added because it's an unknown printer or it's not the "
+"host of a group."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:347
+msgctxt "@button"
+msgid "Connect"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/WelcomeContent.qml:56
+msgctxt "@label"
+msgid "Welcome to Ultimaker Cura"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/WelcomeContent.qml:68
+msgctxt "@text"
+msgid ""
+"Please follow these steps to set up Ultimaker Cura. This will only take a "
+"few moments."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/WelcomePages/WelcomeContent.qml:86
+msgctxt "@button"
+msgid "Get started"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ObjectSelector.qml:59
+msgctxt "@label"
+msgid "Object list"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:81
+msgctxt "@action:inmenu"
+msgid "Show Online Troubleshooting"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:88
+msgctxt "@action:inmenu"
+msgid "Toggle Full Screen"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:96
+msgctxt "@action:inmenu"
+msgid "Exit Full Screen"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:103
+msgctxt "@action:inmenu menubar:edit"
+msgid "&Undo"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:113
+msgctxt "@action:inmenu menubar:edit"
+msgid "&Redo"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:131
+msgctxt "@action:inmenu menubar:file"
+msgid "&Quit"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:139
+msgctxt "@action:inmenu menubar:view"
+msgid "3D View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:146
+msgctxt "@action:inmenu menubar:view"
+msgid "Front View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:153
+msgctxt "@action:inmenu menubar:view"
+msgid "Top View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:160
+msgctxt "@action:inmenu menubar:view"
+msgid "Bottom View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:167
+msgctxt "@action:inmenu menubar:view"
+msgid "Left Side View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:174
+msgctxt "@action:inmenu menubar:view"
+msgid "Right Side View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:188
+msgctxt "@action:inmenu"
+msgid "Configure Cura..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:195
+msgctxt "@action:inmenu menubar:printer"
+msgid "&Add Printer..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:201
+msgctxt "@action:inmenu menubar:printer"
+msgid "Manage Pr&inters..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:208
+msgctxt "@action:inmenu"
+msgid "Manage Materials..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:216
+msgctxt ""
+"@action:inmenu Marketplace is a brand name of Ultimaker's, so don't "
+"translate."
+msgid "Add more materials from Marketplace"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:223
+msgctxt "@action:inmenu menubar:profile"
+msgid "&Update profile with current settings/overrides"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:231
+msgctxt "@action:inmenu menubar:profile"
+msgid "&Discard current changes"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:243
+msgctxt "@action:inmenu menubar:profile"
+msgid "&Create profile from current settings/overrides..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:249
+msgctxt "@action:inmenu menubar:profile"
+msgid "Manage Profiles..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:257
+msgctxt "@action:inmenu menubar:help"
+msgid "Show Online &Documentation"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:265
+msgctxt "@action:inmenu menubar:help"
+msgid "Report a &Bug"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:273
+msgctxt "@action:inmenu menubar:help"
+msgid "What's New"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:287
+msgctxt "@action:inmenu menubar:help"
+msgid "About..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:294
+msgctxt "@action:inmenu menubar:edit"
+msgid "Delete Selected"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:304
+msgctxt "@action:inmenu menubar:edit"
+msgid "Center Selected"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:313
+msgctxt "@action:inmenu menubar:edit"
+msgid "Multiply Selected"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:322
+msgctxt "@action:inmenu"
+msgid "Delete Model"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:330
+msgctxt "@action:inmenu"
+msgid "Ce&nter Model on Platform"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:336
+msgctxt "@action:inmenu menubar:edit"
+msgid "&Group Models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:356
+msgctxt "@action:inmenu menubar:edit"
+msgid "Ungroup Models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:366
+msgctxt "@action:inmenu menubar:edit"
+msgid "&Merge Models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:376
+msgctxt "@action:inmenu"
+msgid "&Multiply Model..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:383
+msgctxt "@action:inmenu menubar:edit"
+msgid "Select All Models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:393
+msgctxt "@action:inmenu menubar:edit"
+msgid "Clear Build Plate"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:403
+msgctxt "@action:inmenu menubar:file"
+msgid "Reload All Models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:412
+msgctxt "@action:inmenu menubar:edit"
+msgid "Arrange All Models"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:420
+msgctxt "@action:inmenu menubar:edit"
+msgid "Arrange Selection"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:427
+msgctxt "@action:inmenu menubar:edit"
+msgid "Reset All Model Positions"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:434
+msgctxt "@action:inmenu menubar:edit"
+msgid "Reset All Model Transformations"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:443
+msgctxt "@action:inmenu menubar:file"
+msgid "&Open File(s)..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:453
+msgctxt "@action:inmenu menubar:file"
+msgid "&New Project..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Actions.qml:460
+msgctxt "@action:inmenu menubar:help"
+msgid "Show Configuration Folder"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ExtruderButton.qml:16
+msgctxt "@label %1 is filled in with the name of an extruder"
+msgid "Print Selected Model with %1"
+msgid_plural "Print Selected Models with %1"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:115
+msgctxt "@label:MonitorStatus"
+msgid "Not connected to a printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:119
+msgctxt "@label:MonitorStatus"
+msgid "Printer does not accept commands"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:129
+msgctxt "@label:MonitorStatus"
+msgid "In maintenance. Please check the printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:140
+msgctxt "@label:MonitorStatus"
+msgid "Lost connection with the printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:142
+msgctxt "@label:MonitorStatus"
+msgid "Printing..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:145
+msgctxt "@label:MonitorStatus"
+msgid "Paused"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:148
+msgctxt "@label:MonitorStatus"
+msgid "Preparing..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:150
+msgctxt "@label:MonitorStatus"
+msgid "Please remove the print"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:318
+msgctxt "@label"
+msgid "Abort Print"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/MonitorButton.qml:327
+msgctxt "@label"
+msgid "Are you sure you want to abort the print?"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ProfileOverview.qml:36
+msgctxt "@title:column"
+msgid "Setting"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ProfileOverview.qml:37
+msgctxt "@title:column"
+msgid "Profile"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ProfileOverview.qml:38
+msgctxt "@title:column"
+msgid "Current"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ProfileOverview.qml:39
+msgctxt "@title:column Unit of measurement"
+msgid "Unit"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SettingsMenu.qml:34
+msgctxt "@title:menu"
+msgid "&Material"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SettingsMenu.qml:49
+msgctxt "@action:inmenu"
+msgid "Set as Active Extruder"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SettingsMenu.qml:55
+msgctxt "@action:inmenu"
+msgid "Enable Extruder"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SettingsMenu.qml:63
+msgctxt "@action:inmenu"
+msgid "Disable Extruder"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/FileMenu.qml:13
+msgctxt "@title:menu menubar:toplevel"
+msgid "&File"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/FileMenu.qml:45
+msgctxt "@title:menu menubar:file"
+msgid "&Save Project..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/FileMenu.qml:78
+msgctxt "@title:menu menubar:file"
+msgid "&Export..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/FileMenu.qml:89
+msgctxt "@action:inmenu menubar:file"
+msgid "Export Selection..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/MaterialMenu.qml:13
+msgctxt "@label:category menu label"
 msgid "Material"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:275
-msgctxt "@action:label"
-msgid "Don't show project summary on save again"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/MaterialMenu.qml:53
+msgctxt "@label:category menu label"
+msgid "Favorites"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:289
-msgctxt "@action:button"
-msgid "Save"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/MaterialMenu.qml:78
+msgctxt "@label:category menu label"
+msgid "Generic"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:16
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:637
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/PrinterMenu.qml:13
+msgctxt "@title:menu menubar:settings"
+msgid "&Printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/PrinterMenu.qml:17
+msgctxt "@label:category menu label"
+msgid "Network enabled printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/PrinterMenu.qml:50
+msgctxt "@label:category menu label"
+msgid "Local printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ExtensionMenu.qml:13
+msgctxt "@title:menu menubar:toplevel"
+msgid "E&xtensions"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/OpenFilesMenu.qml:15
+msgctxt "@title:menu menubar:file"
+msgid "Open File(s)..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/PreferencesMenu.qml:21
+msgctxt "@title:menu menubar:toplevel"
+msgid "P&references"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/AutoConfiguration.qml:18
+msgctxt "@header"
+msgid "Configurations"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:27
+msgctxt "@header"
+msgid "Custom"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:62
+msgctxt "@label"
+msgid "Printer"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:214
+msgctxt "@label"
+msgid "Enabled"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:263
+msgctxt "@label"
+msgid "Material"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:389
+msgctxt "@label"
+msgid "Use glue for better adhesion with this material combination."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml:52
+msgctxt "@label"
+msgid "Loading available configurations from the printer..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml:53
+msgctxt "@label"
+msgid ""
+"The configurations are not available because the printer is disconnected."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml:137
+msgctxt "@label"
+msgid ""
+"This configuration is not available because %1 is not recognized. Please "
+"visit %2 to download the correct material profile."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml:138
+msgctxt "@label"
+msgid "Marketplace"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:101
+msgctxt "@tooltip"
+msgid ""
+"The configuration of this extruder is not allowed, and prohibits slicing."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:105
+msgctxt "@tooltip"
+msgid "There are no profiles matching the configuration of this extruder."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:245
+msgctxt "@label"
+msgid "Select configuration"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:353
+msgctxt "@label"
+msgid "Configurations"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/HelpMenu.qml:14
+msgctxt "@title:menu menubar:toplevel"
+msgid "&Help"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SaveProjectMenu.qml:15
+msgctxt "@title:menu menubar:file"
+msgid "Save Project..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/RecentFilesMenu.qml:15
+msgctxt "@title:menu menubar:file"
+msgid "Open &Recent"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ViewMenu.qml:13
+msgctxt "@title:menu menubar:toplevel"
+msgid "&View"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ViewMenu.qml:17
+msgctxt "@action:inmenu menubar:view"
+msgid "&Camera position"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ViewMenu.qml:30
+msgctxt "@action:inmenu menubar:view"
+msgid "Camera view"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ViewMenu.qml:48
+msgctxt "@action:inmenu menubar:view"
+msgid "Perspective"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ViewMenu.qml:59
+msgctxt "@action:inmenu menubar:view"
+msgid "Orthographic"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ContextMenu.qml:29
+msgctxt "@label"
+msgid "Print Selected Model With:"
+msgid_plural "Print Selected Models With:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ContextMenu.qml:92
+msgctxt "@title:window"
+msgid "Multiply Selected Model"
+msgid_plural "Multiply Selected Models"
+msgstr[0] ""
+msgstr[1] ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/ContextMenu.qml:123
+msgctxt "@label"
+msgid "Number of Copies"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/EditMenu.qml:12
+msgctxt "@title:menu menubar:toplevel"
+msgid "&Edit"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:16
+msgctxt "@action:inmenu"
+msgid "Visible Settings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:42
+msgctxt "@action:inmenu"
+msgid "Collapse All Categories"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:51
+msgctxt "@action:inmenu"
+msgid "Manage Setting Visibility..."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:16
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:634
 msgctxt "@title:window"
 msgid "Open file(s)"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:47
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:47
 msgctxt "@text:window"
 msgid ""
 "We have found one or more project file(s) within the files you have "
@@ -3695,185 +5400,44 @@ msgid ""
 "import models from those files. Would you like to proceed?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:64
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:64
 msgctxt "@action:button"
 msgid "Import all as models"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:15
-msgctxt "@title:window The argument is the application name."
-msgid "About %1"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:17
+msgctxt "@title:window"
+msgid "Open project file"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:57
-msgctxt "@label"
-msgid "version: %1"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:72
-msgctxt "@label"
-msgid "End-to-end solution for fused filament 3D printing."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:85
-msgctxt "@info:credit"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:83
+msgctxt "@text:window"
 msgid ""
-"Cura is developed by Ultimaker B.V. in cooperation with the community.\n"
-"Cura proudly uses the following open source projects:"
+"This is a Cura project file. Would you like to open it as a project or "
+"import the models from it?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:134
-msgctxt "@label"
-msgid "Graphical user interface"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:91
+msgctxt "@text:window"
+msgid "Remember my choice"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:135
-msgctxt "@label"
-msgid "Application framework"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:105
+msgctxt "@action:button"
+msgid "Open as project"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:136
-msgctxt "@label"
-msgid "G-code generator"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:110
+msgctxt "@action:button"
+msgid "Import models"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:137
-msgctxt "@label"
-msgid "Interprocess communication library"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:139
-msgctxt "@label"
-msgid "Programming language"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:140
-msgctxt "@label"
-msgid "GUI framework"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:141
-msgctxt "@label"
-msgid "GUI framework bindings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:142
-msgctxt "@label"
-msgid "C/C++ Binding library"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:143
-msgctxt "@label"
-msgid "Data interchange format"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:144
-msgctxt "@label"
-msgid "Support library for scientific computing"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:145
-msgctxt "@label"
-msgid "Support library for faster math"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:146
-msgctxt "@label"
-msgid "Support library for handling STL files"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:147
-msgctxt "@label"
-msgid "Support library for handling triangular meshes"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:148
-msgctxt "@label"
-msgid "Support library for handling 3MF files"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:149
-msgctxt "@label"
-msgid "Support library for file metadata and streaming"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:150
-msgctxt "@label"
-msgid "Serial communication library"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:151
-msgctxt "@label"
-msgid "ZeroConf discovery library"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:152
-msgctxt "@label"
-msgid "Polygon clipping library"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:153
-msgctxt "@label"
-msgid "Python bindings for Clipper"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:154
-msgctxt "@Label"
-msgid "Static type checker for Python"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:155
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:156
-msgctxt "@Label"
-msgid "Root Certificates for validating SSL trustworthiness"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:157
-msgctxt "@Label"
-msgid "Python Error tracking library"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:158
-msgctxt "@label"
-msgid "Polygon packing library, developed by Prusa Research"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:159
-msgctxt "@label"
-msgid "Python bindings for libnest2d"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:160
-msgctxt "@label"
-msgid "Support library for system keyring access"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:161
-msgctxt "@label"
-msgid "Python extensions for Microsoft Windows"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:162
-msgctxt "@label"
-msgid "Font"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:163
-msgctxt "@label"
-msgid "SVG icons"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/AboutDialog.qml:164
-msgctxt "@label"
-msgid "Linux cross-distribution application deployment"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:14
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:13
 msgctxt "@title:window"
 msgid "Discard or Keep changes"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:50
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:49
 msgctxt "@text:window, %1 is a profile name"
 msgid ""
 "You have customized some profile settings. Would you like to Keep these "
@@ -3881,529 +5445,352 @@ msgid ""
 "the changes to load the defaults from '%1'."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:76
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:75
 msgctxt "@title:column"
 msgid "Profile settings"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:78
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:77
 msgctxt "@title:column"
 msgid "Current changes"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:107
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:798
-msgctxt "@option:discardOrKeep"
-msgid "Always ask me this"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:108
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:105
 msgctxt "@option:discardOrKeep"
 msgid "Discard and never ask again"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:109
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:106
 msgctxt "@option:discardOrKeep"
 msgid "Keep and never ask again"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:139
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:136
 msgctxt "@action:button"
 msgid "Discard changes"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:145
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:142
 msgctxt "@action:button"
 msgid "Keep changes"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Widgets/ComboBox.qml:18
-msgctxt "@label"
-msgid "No items to select from"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/OpenFilesMenu.qml:15
-msgctxt "@title:menu menubar:file"
-msgid "Open File(s)..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/RecentFilesMenu.qml:15
-msgctxt "@title:menu menubar:file"
-msgid "Open &Recent"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:16
-msgctxt "@action:inmenu"
-msgid "Visible Settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:45
-msgctxt "@action:inmenu"
-msgid "Collapse All Categories"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:54
-msgctxt "@action:inmenu"
-msgid "Manage Setting Visibility..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingsMenu.qml:34
-msgctxt "@title:menu"
-msgid "&Material"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingsMenu.qml:49
-msgctxt "@action:inmenu"
-msgid "Set as Active Extruder"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingsMenu.qml:55
-msgctxt "@action:inmenu"
-msgid "Enable Extruder"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingsMenu.qml:63
-msgctxt "@action:inmenu"
-msgid "Disable Extruder"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/MaterialMenu.qml:13
-msgctxt "@label:category menu label"
-msgid "Material"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/MaterialMenu.qml:53
-msgctxt "@label:category menu label"
-msgid "Favorites"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/MaterialMenu.qml:78
-msgctxt "@label:category menu label"
-msgid "Generic"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/HelpMenu.qml:14
-msgctxt "@title:menu menubar:toplevel"
-msgid "&Help"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/FileMenu.qml:13
-msgctxt "@title:menu menubar:toplevel"
-msgid "&File"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/FileMenu.qml:44
-msgctxt "@title:menu menubar:file"
-msgid "&Save Project..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/FileMenu.qml:77
-msgctxt "@title:menu menubar:file"
-msgid "&Export..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/FileMenu.qml:88
-msgctxt "@action:inmenu menubar:file"
-msgid "Export Selection..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/PreferencesMenu.qml:21
-msgctxt "@title:menu menubar:toplevel"
-msgid "P&references"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/EditMenu.qml:12
-msgctxt "@title:menu menubar:toplevel"
-msgid "&Edit"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/PrinterMenu.qml:13
-msgctxt "@title:menu menubar:settings"
-msgid "&Printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/PrinterMenu.qml:17
-msgctxt "@label:category menu label"
-msgid "Network enabled printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/PrinterMenu.qml:50
-msgctxt "@label:category menu label"
-msgid "Local printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ExtensionMenu.qml:13
-msgctxt "@title:menu menubar:toplevel"
-msgid "E&xtensions"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/AutoConfiguration.qml:18
-msgctxt "@header"
-msgid "Configurations"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml:52
-msgctxt "@label"
-msgid "Loading available configurations from the printer..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml:53
-msgctxt "@label"
-msgid ""
-"The configurations are not available because the printer is disconnected."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml:137
-msgctxt "@label"
-msgid ""
-"This configuration is not available because %1 is not recognized. Please "
-"visit %2 to download the correct material profile."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml:138
-msgctxt "@label"
-msgid "Marketplace"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:101
-msgctxt "@tooltip"
-msgid ""
-"The configuration of this extruder is not allowed, and prohibits slicing."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:105
-msgctxt "@tooltip"
-msgid "There are no profiles matching the configuration of this extruder."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:245
-msgctxt "@label"
-msgid "Select configuration"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:354
-msgctxt "@label"
-msgid "Configurations"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:27
-msgctxt "@header"
-msgid "Custom"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:62
-msgctxt "@label"
-msgid "Printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:214
-msgctxt "@label"
-msgid "Enabled"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:263
-msgctxt "@label"
-msgid "Material"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:391
-msgctxt "@label"
-msgid "Use glue for better adhesion with this material combination."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ContextMenu.qml:29
-msgctxt "@label"
-msgid "Print Selected Model With:"
-msgid_plural "Print Selected Models With:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ContextMenu.qml:92
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:14
 msgctxt "@title:window"
-msgid "Multiply Selected Model"
-msgid_plural "Multiply Selected Models"
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ContextMenu.qml:123
-msgctxt "@label"
-msgid "Number of Copies"
+msgid "Save Project"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SaveProjectMenu.qml:15
-msgctxt "@title:menu menubar:file"
-msgid "Save Project..."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:175
+msgctxt "@action:label"
+msgid "Extruder %1"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ViewMenu.qml:13
-msgctxt "@title:menu menubar:toplevel"
-msgid "&View"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:191
+msgctxt "@action:label"
+msgid "%1 & material"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ViewMenu.qml:17
-msgctxt "@action:inmenu menubar:view"
-msgid "&Camera position"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:193
+msgctxt "@action:label"
+msgid "Material"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ViewMenu.qml:30
-msgctxt "@action:inmenu menubar:view"
-msgid "Camera view"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:282
+msgctxt "@action:label"
+msgid "Don't show project summary on save again"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ViewMenu.qml:48
-msgctxt "@action:inmenu menubar:view"
-msgid "Perspective"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/ViewMenu.qml:59
-msgctxt "@action:inmenu menubar:view"
-msgid "Orthographic"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ViewsSelector.qml:50
-msgctxt "@label"
-msgid "View type"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/GeneralOperations.qml:19
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/CloudContent.qml:64
-msgctxt "@label"
-msgid "Sign in to the Ultimaker platform"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/GeneralOperations.qml:39
-msgctxt "@text"
-msgid ""
-"- Add material profiles and plug-ins from the Marketplace\n"
-"- Back-up and sync your material profiles and plug-ins\n"
-"- Share ideas and get help from 48,000+ users in the Ultimaker community"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/GeneralOperations.qml:58
-msgctxt "@button"
-msgid "Create a free Ultimaker account"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/AccountWidget.qml:24
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:296
 msgctxt "@action:button"
-msgid "Sign in"
+msgid "Save"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/UserOperations.qml:77
-msgctxt "@label The argument is a timestamp"
-msgid "Last update: %1"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:15
+msgctxt "@title:window The argument is the application name."
+msgid "About %1"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/UserOperations.qml:104
-msgctxt "@button"
-msgid "Ultimaker Account"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/UserOperations.qml:120
-msgctxt "@button"
-msgid "Sign Out"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/SyncState.qml:28
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:57
 msgctxt "@label"
-msgid "Checking..."
+msgid "version: %1"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/SyncState.qml:35
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:72
 msgctxt "@label"
-msgid "Account synced"
+msgid "End-to-end solution for fused filament 3D printing."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/SyncState.qml:42
-msgctxt "@label"
-msgid "Something went wrong..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/SyncState.qml:95
-msgctxt "@button"
-msgid "Install pending updates"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Account/SyncState.qml:116
-msgctxt "@button"
-msgid "Check for account updates"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:54
-msgctxt "@label:PrintjobStatus"
-msgid "Slicing..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:81
-msgctxt "@label:PrintjobStatus"
-msgid "Unable to slice"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:120
-msgctxt "@button"
-msgid "Processing"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:120
-msgctxt "@button"
-msgid "Slice"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:121
-msgctxt "@label"
-msgid "Start the slicing process"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:137
-msgctxt "@button"
-msgid "Cancel"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:31
-msgctxt "@label"
-msgid "Time estimation"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:114
-msgctxt "@label"
-msgid "Material estimation"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:164
-msgctxt "@label m for meter"
-msgid "%1m"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:165
-msgctxt "@label g for grams"
-msgid "%1g"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:59
-msgctxt "@label"
-msgid "No time estimation available"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:77
-msgctxt "@label"
-msgid "No cost estimation available"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:127
-msgctxt "@button"
-msgid "Preview"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:253
-msgctxt "@label"
-msgid "This package will be installed after restarting."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:463
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:14
-msgctxt "@title:tab"
-msgid "General"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:466
-msgctxt "@title:tab"
-msgid "Settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:468
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/MachinesPage.qml:16
-msgctxt "@title:tab"
-msgid "Printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:470
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:70
-msgctxt "@title:tab"
-msgid "Materials"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:472
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:56
-msgctxt "@title:tab"
-msgid "Profiles"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:589
-msgctxt "@title:window %1 is the application name"
-msgid "Closing %1"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:590
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:599
-msgctxt "@label %1 is the application name"
-msgid "Are you sure you want to exit %1?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:747
-msgctxt "@window:title"
-msgid "Install Package"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:754
-msgctxt "@title:window"
-msgid "Open File(s)"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:756
-msgctxt "@text:window"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:85
+msgctxt "@info:credit"
 msgid ""
-"We have found one or more G-Code files within the files you have selected. "
-"You can only open one G-Code file at a time. If you want to open a G-Code "
-"file, please just select only one."
+"Cura is developed by Ultimaker B.V. in cooperation with the community.\n"
+"Cura proudly uses the following open source projects:"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:836
-msgctxt "@title:window"
-msgid "Add Printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Cura.qml:844
-msgctxt "@title:window"
-msgid "What's New"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:13
-msgctxt "@label:Should be short"
-msgid "On"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:14
-msgctxt "@label:Should be short"
-msgid "Off"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:34
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:134
 msgctxt "@label"
-msgid "Experimental"
+msgid "Graphical user interface"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/PrintSetupSelector.qml:19
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:642
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:135
 msgctxt "@label"
-msgid "Print settings"
+msgid "Application framework"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/PrintSetupSelector.qml:21
-msgctxt "@label shown when we load a Gcode file"
-msgid "Print setup disabled. G-code file can not be modified."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:136
+msgctxt "@label"
+msgid "G-code generator"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml:144
-msgctxt "@button"
-msgid "Recommended"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:137
+msgctxt "@label"
+msgid "Interprocess communication library"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml:158
-msgctxt "@button"
-msgid "Custom"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:139
+msgctxt "@label"
+msgid "Programming language"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/NoIntentIcon.qml:31
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:140
+msgctxt "@label"
+msgid "GUI framework"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:141
+msgctxt "@label"
+msgid "GUI framework bindings"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:142
+msgctxt "@label"
+msgid "C/C++ Binding library"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:143
+msgctxt "@label"
+msgid "Data interchange format"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:144
+msgctxt "@label"
+msgid "Support library for scientific computing"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:145
+msgctxt "@label"
+msgid "Support library for faster math"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:146
+msgctxt "@label"
+msgid "Support library for handling STL files"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:147
+msgctxt "@label"
+msgid "Support library for handling triangular meshes"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:148
+msgctxt "@label"
+msgid "Support library for handling 3MF files"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:149
+msgctxt "@label"
+msgid "Support library for file metadata and streaming"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:150
+msgctxt "@label"
+msgid "Serial communication library"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:151
+msgctxt "@label"
+msgid "ZeroConf discovery library"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:152
+msgctxt "@label"
+msgid "Polygon clipping library"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:153
+msgctxt "@label"
+msgid "Python bindings for Clipper"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:154
+msgctxt "@Label"
+msgid "Static type checker for Python"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:155
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:156
+msgctxt "@Label"
+msgid "Root Certificates for validating SSL trustworthiness"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:157
+msgctxt "@Label"
+msgid "Python Error tracking library"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:158
+msgctxt "@label"
+msgid "Polygon packing library, developed by Prusa Research"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:159
+msgctxt "@label"
+msgid "Python bindings for libnest2d"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:160
+msgctxt "@label"
+msgid "Support library for system keyring access"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:161
+msgctxt "@label"
+msgid "Python extensions for Microsoft Windows"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:162
+msgctxt "@label"
+msgid "Font"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:163
+msgctxt "@label"
+msgid "SVG icons"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Dialogs/AboutDialog.qml:164
+msgctxt "@label"
+msgid "Linux cross-distribution application deployment"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ColorDialog.qml:107
+msgctxt "@label"
+msgid "Hex"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:32
+msgctxt "@label:button"
+msgid "My printers"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:34
+msgctxt "@tooltip:button"
+msgid "Monitor printers in Ultimaker Digital Factory."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:41
+msgctxt "@tooltip:button"
+msgid "Create print projects in Digital Library."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:46
+msgctxt "@label:button"
+msgid "Print jobs"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:48
+msgctxt "@tooltip:button"
+msgid "Monitor print jobs and reprint from your print history."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:55
+msgctxt "@tooltip:button"
+msgid "Extend Ultimaker Cura with plugins and material profiles."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:62
+msgctxt "@tooltip:button"
+msgid "Become a 3D printing expert with Ultimaker e-learning."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:67
+msgctxt "@label:button"
+msgid "Ultimaker support"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:69
+msgctxt "@tooltip:button"
+msgid "Learn how to get started with Ultimaker Cura."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:74
+msgctxt "@label:button"
+msgid "Ask a question"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:76
+msgctxt "@tooltip:button"
+msgid "Consult the Ultimaker Community."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:81
+msgctxt "@label:button"
+msgid "Report a bug"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:83
+msgctxt "@tooltip:button"
+msgid "Let developers know that something is going wrong."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:90
+msgctxt "@tooltip:button"
+msgid "Visit the Ultimaker website."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:28
+msgctxt "@label"
+msgid "Support"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:69
+msgctxt "@label"
+msgid ""
+"Generate structures to support parts of the model which have overhangs. "
+"Without these structures, such parts would collapse during printing."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:199
+msgctxt "@label"
+msgid "Gradual infill"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:237
+msgctxt "@label"
+msgid ""
+"Gradual infill will gradually increase the amount of infill towards the top."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelector.qml:80
+msgctxt "@tooltip"
+msgid ""
+"You have modified some profile settings. If you want to change these go to "
+"custom mode."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml:27
+msgctxt "@label"
+msgid "Adhesion"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml:72
+msgctxt "@label"
+msgid ""
+"Enable printing a brim or raft. This will add a flat area around or under "
+"your object which is easy to cut off afterwards."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/NoIntentIcon.qml:31
 msgctxt ""
 "@label %1 is filled in with the type of a profile. %2 is filled with a list "
 "of numbers (eg '1' or '1, 2')"
@@ -4416,71 +5803,42 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:195
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/PrintSetupSelector.qml:20
+msgctxt "@label shown when we load a Gcode file"
+msgid "Print setup disabled. G-code file can not be modified."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:13
+msgctxt "@label:Should be short"
+msgid "On"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:14
+msgctxt "@label:Should be short"
+msgid "Off"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:34
 msgctxt "@label"
-msgid "Gradual infill"
+msgid "Experimental"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:233
-msgctxt "@label"
-msgid ""
-"Gradual infill will gradually increase the amount of infill towards the top."
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml:142
+msgctxt "@button"
+msgid "Recommended"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:28
-msgctxt "@label"
-msgid "Support"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml:156
+msgctxt "@button"
+msgid "Custom"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:69
-msgctxt "@label"
-msgid ""
-"Generate structures to support parts of the model which have overhangs. "
-"Without these structures, such parts would collapse during printing."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelector.qml:50
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:779
-msgctxt "@label"
-msgid "Profiles"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelector.qml:80
-msgctxt "@tooltip"
-msgid ""
-"You have modified some profile settings. If you want to change these go to "
-"custom mode."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml:27
-msgctxt "@label"
-msgid "Adhesion"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml:72
-msgctxt "@label"
-msgid ""
-"Enable printing a brim or raft. This will add a flat area around or under "
-"your object which is easy to cut off afterwards."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Custom/QualitiesWithIntentMenu.qml:158
-msgctxt "@label:header"
-msgid "Custom profiles"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Custom/QualitiesWithIntentMenu.qml:256
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:147
-msgctxt "@action:button"
-msgid "Discard current changes"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml:46
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml:46
 msgctxt "@label"
 msgid "Profile"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml:157
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml:158
 msgctxt "@tooltip"
 msgid ""
 "Some setting/override values are different from the values stored in the "
@@ -4489,2278 +5847,998 @@ msgid ""
 "Click to open the profile manager."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ProfileOverview.qml:37
-msgctxt "@title:column"
-msgid "Setting"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrintSetupSelector/Custom/QualitiesWithIntentMenu.qml:158
+msgctxt "@label:header"
+msgid "Custom profiles"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ProfileOverview.qml:38
-msgctxt "@title:column"
-msgid "Profile"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/OutputDeviceHeader.qml:56
+msgctxt "@info:status"
+msgid "The printer is not connected."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ProfileOverview.qml:39
-msgctxt "@title:column"
-msgid "Current"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:25
+msgctxt "@label"
+msgid "Build plate"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ProfileOverview.qml:40
-msgctxt "@title:column Unit of measurement"
-msgid "Unit"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/RenameDialog.qml:22
-msgctxt "@title:window"
-msgid "Rename"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/RenameDialog.qml:23
-msgctxt "@info"
-msgid "Please provide a new name."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/SettingVisibilityItem.qml:56
-msgctxt "@item:tooltip"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:55
+msgctxt "@tooltip"
 msgid ""
-"This setting has been hidden by the active machine and will not be visible."
+"The target temperature of the heated bed. The bed will heat up or cool down "
+"towards this temperature. If this is 0, the bed heating is turned off."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/SettingVisibilityItem.qml:73
-msgctxt "@item:tooltip %1 is list of setting names"
-msgid ""
-"This setting has been hidden by the value of %1. Change the value of that "
-"setting to make this setting visible."
-msgid_plural ""
-"This setting has been hidden by the values of %1. Change the values of those "
-"settings to make this setting visible."
-msgstr[0] ""
-msgstr[1] ""
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:88
+msgctxt "@tooltip"
+msgid "The current temperature of the heated bed."
+msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:13
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:162
+msgctxt "@tooltip of temperature input"
+msgid "The temperature to pre-heat the bed to."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:259
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:271
+msgctxt "@button Cancel pre-heating"
+msgid "Cancel"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:263
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:274
+msgctxt "@button"
+msgid "Pre-heat"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:286
+msgctxt "@tooltip of pre-heat"
+msgid ""
+"Heat the bed in advance before printing. You can continue adjusting your "
+"print while it is heating, and you won't have to wait for the bed to heat up "
+"when you're ready to print."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:40
+msgctxt "@label"
+msgid "Extruder"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:70
+msgctxt "@tooltip"
+msgid ""
+"The target temperature of the hotend. The hotend will heat up or cool down "
+"towards this temperature. If this is 0, the hotend heating is turned off."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:105
+msgctxt "@tooltip"
+msgid "The current temperature of this hotend."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:182
+msgctxt "@tooltip of temperature input"
+msgid "The temperature to pre-heat the hotend to."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:297
+msgctxt "@tooltip of pre-heat"
+msgid ""
+"Heat the hotend in advance before printing. You can continue adjusting your "
+"print while it is heating, and you won't have to wait for the hotend to heat "
+"up when you're ready to print."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:335
+msgctxt "@tooltip"
+msgid "The colour of the material in this extruder."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:367
+msgctxt "@tooltip"
+msgid "The material in this extruder."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:400
+msgctxt "@tooltip"
+msgid "The nozzle inserted in this extruder."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:51
+msgctxt "@label"
+msgid "Printer control"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:66
+msgctxt "@label"
+msgid "Jog Position"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:82
+msgctxt "@label"
+msgid "X/Y"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:162
+msgctxt "@label"
+msgid "Z"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:217
+msgctxt "@label"
+msgid "Jog Distance"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:257
+msgctxt "@label"
+msgid "Send G-code"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:319
+msgctxt "@tooltip of G-code command input"
+msgid ""
+"Send a custom G-code command to the connected printer. Press 'enter' to send "
+"the command."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:250
+msgctxt "@label"
+msgid "This package will be installed after restarting."
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:463
 msgctxt "@title:tab"
-msgid "Setting Visibility"
+msgid "Settings"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:22
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:131
-msgctxt "@action:button"
-msgid "Defaults"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:586
+msgctxt "@title:window %1 is the application name"
+msgid "Closing %1"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:53
-msgctxt "@label:textbox"
-msgid "Check all"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:587
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:596
+msgctxt "@label %1 is the application name"
+msgid "Are you sure you want to exit %1?"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/MachinesPage.qml:49
-msgctxt "@action:button"
-msgid "Add New"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:739
+msgctxt "@window:title"
+msgid "Install Package"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/MachinesPage.qml:135
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:160
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:293
-msgctxt "@action:button"
-msgid "Activate"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/MachinesPage.qml:147
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:330
-msgctxt "@action:button"
-msgid "Rename"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:121
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:746
 msgctxt "@title:window"
-msgid "Confirm Diameter Change"
+msgid "Open File(s)"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:122
-msgctxt "@label (%1 is a number)"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:748
+msgctxt "@text:window"
 msgid ""
-"The new filament diameter is set to %1 mm, which is not compatible with the "
-"current extruder. Do you wish to continue?"
+"We have found one or more G-Code files within the files you have selected. "
+"You can only open one G-Code file at a time. If you want to open a G-Code "
+"file, please just select only one."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:152
-msgctxt "@label"
-msgid "Display Name"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:171
-msgctxt "@label"
-msgid "Brand"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:190
-msgctxt "@label"
-msgid "Material Type"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:209
-msgctxt "@label"
-msgid "Color"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:261
-msgctxt "@title"
-msgid "Material color picker"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:274
-msgctxt "@label"
-msgid "Properties"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:285
-msgctxt "@label"
-msgid "Density"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:318
-msgctxt "@label"
-msgid "Diameter"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:368
-msgctxt "@label"
-msgid "Filament Cost"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:400
-msgctxt "@label"
-msgid "Filament weight"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:432
-msgctxt "@label"
-msgid "Filament length"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:450
-msgctxt "@label"
-msgid "Cost per Meter"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:464
-msgctxt "@label"
-msgid "This material is linked to %1 and shares some of its properties."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:471
-msgctxt "@label"
-msgid "Unlink Material"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:484
-msgctxt "@label"
-msgid "Description"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:502
-msgctxt "@label"
-msgid "Adhesion Information"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:637
-msgctxt "@title"
-msgid "Information"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:17
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:828
 msgctxt "@title:window"
-msgid "Sync materials with printers"
+msgid "Add Printer"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:48
-msgctxt "@title:header"
-msgid "Sync materials with printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:54
-msgctxt "@text"
-msgid ""
-"Following a few simple steps, you will be able to synchronize all your "
-"material profiles with your printers."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:76
-msgctxt "@button"
-msgid "Why do I need to sync material profiles?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:85
-msgctxt "@button"
-msgid "Start"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:127
-msgctxt "@title:header"
-msgid "Sign in"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:133
-msgctxt "@text"
-msgid ""
-"To automatically sync the material profiles with all your printers connected "
-"to Digital Factory you need to be signed in in Cura."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:157
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:446
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:587
-msgctxt "@button"
-msgid "Sync materials with USB"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:190
-msgctxt "@title:header"
-msgid "The following printers will receive the new material profiles:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:197
-msgctxt "@title:header"
-msgid "Something went wrong when sending the materials to the printers."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:204
-msgctxt "@title:header"
-msgid "Material profiles successfully synced with the following printers:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:242
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:429
-msgctxt "@button"
-msgid "Troubleshooting"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:406
-msgctxt "@text Asking the user whether printers are missing in a list."
-msgid "Printers missing?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:408
-msgctxt "@text"
-msgid ""
-"Make sure all your printers are turned ON and connected to Digital Factory."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:417
-msgctxt "@button"
-msgid "Refresh List"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:457
-msgctxt "@button"
-msgid "Try again"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:461
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:698
-msgctxt "@button"
-msgid "Done"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:463
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:607
-msgctxt "@button"
-msgid "Sync"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:519
-msgctxt "@button"
-msgid "Syncing"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:537
-msgctxt "@title:header"
-msgid "No printers found"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:558
-msgctxt "@text"
-msgid ""
-"It seems like you don't have any compatible printers connected to Digital "
-"Factory. Make sure your printer is connected and it's running the latest "
-"firmware."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:570
-msgctxt "@button"
-msgid "Learn how to connect your printer to Digital Factory"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:598
-msgctxt "@button"
-msgid "Refresh"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:627
-msgctxt "@title:header"
-msgid "Sync material profiles via USB"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:633
-msgctxt ""
-"@text In the UI this is followed by a list of steps the user needs to take."
-msgid ""
-"Follow the following steps to load the new material profiles to your printer."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:665
-msgctxt "@text"
-msgid "Click the export material archive button."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:666
-msgctxt "@text"
-msgid "Save the .umm file on a USB stick."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:667
-msgctxt "@text"
-msgid ""
-"Insert the USB stick into your printer and launch the procedure to load new "
-"material profiles."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:675
-msgctxt "@button"
-msgid "How to load new material profiles to my printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:689
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:334
-msgctxt "@button"
-msgid "Back"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:698
-msgctxt "@button"
-msgid "Export material archive"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:733
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Cura.qml:836
 msgctxt "@title:window"
-msgid "Export All Materials"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:72
-msgctxt "@label"
-msgid "Materials compatible with active printer:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:78
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:93
-msgctxt "@action:button"
-msgid "Create new"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:90
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:87
-msgctxt "@action:button"
-msgid "Import"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:101
-msgctxt "@action:button"
-msgid "Sync with Printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:174
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:310
-msgctxt "@action:button"
-msgid "Duplicate"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:198
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:341
-msgctxt "@action:button"
-msgid "Export"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:212
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:386
-msgctxt "@title:window"
-msgid "Confirm Remove"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:215
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:387
-msgctxt "@label (%1 is object name)"
-msgid "Are you sure you wish to remove %1? This cannot be undone!"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:228
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:238
-msgctxt "@title:window"
-msgid "Import Material"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:242
-msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "Successfully imported material <filename>%1</filename>"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:245
-msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
-msgid ""
-"Could not import material <filename>%1</filename>: <message>%2</message>"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:256
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:265
-msgctxt "@title:window"
-msgid "Export Material"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:270
-msgctxt "@info:status Don't translate the XML tags <filename> and <message>!"
-msgid ""
-"Failed to export material to <filename>%1</filename>: <message>%2</message>"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:273
-msgctxt "@info:status Don't translate the XML tag <filename>!"
-msgid "Successfully exported material to <filename>%1</filename>"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:58
-msgctxt "@label"
-msgid "Profiles compatible with active printer:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:97
-msgctxt "@action:tooltip"
-msgid "Create new profile from current settings/overrides"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:124
-msgctxt "@action:label"
-msgid "Some settings from current profile were overwritten."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:139
-msgctxt "@action:button"
-msgid "Update profile."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:142
-msgctxt "@action:tooltip"
-msgid "Update profile with current settings/overrides"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:157
-msgctxt "@action:label"
-msgid ""
-"This profile uses the defaults specified by the printer, so it has no "
-"settings/overrides in the list below."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:164
-msgctxt "@action:label"
-msgid "Your current settings match the selected profile."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:174
-msgctxt "@title:tab"
-msgid "Global Settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:277
-msgctxt "@title:window"
-msgid "Create Profile"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:279
-msgctxt "@info"
-msgid "Please provide a name for this profile."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:351
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:362
-msgctxt "@title:window"
-msgid "Export Profile"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:376
-msgctxt "@title:window"
-msgid "Duplicate Profile"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:403
-msgctxt "@title:window"
-msgid "Rename Profile"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:416
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/ProfilesPage.qml:423
-msgctxt "@title:window"
-msgid "Import Profile"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:169
-msgctxt "@label"
-msgid "Interface"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:213
-msgctxt "@heading"
-msgid "-- incomplete --"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:258
-msgctxt "@label"
-msgid "Currency:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:273
-msgctxt ""
-"@label: Please keep the asterix, it's to indicate that a restart is needed."
-msgid "Theme*:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:319
-msgctxt "@info:tooltip"
-msgid "Slice automatically when changing settings."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:327
-msgctxt "@option:check"
-msgid "Slice automatically"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:336
-msgctxt "@label"
-msgid ""
-"*You will need to restart the application for these changes to have effect."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:351
-msgctxt "@label"
-msgid "Viewport behavior"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:359
-msgctxt "@info:tooltip"
-msgid ""
-"Highlight unsupported areas of the model in red. Without support these areas "
-"will not print properly."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:368
-msgctxt "@option:check"
-msgid "Display overhang"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:378
-msgctxt "@info:tooltip"
-msgid ""
-"Highlight missing or extraneous surfaces of the model using warning signs. "
-"The toolpaths will often be missing parts of the intended geometry."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:387
-msgctxt "@option:check"
-msgid "Display model errors"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:395
-msgctxt "@info:tooltip"
-msgid ""
-"Moves the camera so the model is in the center of the view when a model is "
-"selected"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:400
-msgctxt "@action:button"
-msgid "Center camera when item is selected"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:410
-msgctxt "@info:tooltip"
-msgid "Should the default zoom behavior of cura be inverted?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:415
-msgctxt "@action:button"
-msgid "Invert the direction of camera zoom."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:431
-msgctxt "@info:tooltip"
-msgid "Should zooming move in the direction of the mouse?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:431
-msgctxt "@info:tooltip"
-msgid ""
-"Zooming towards the mouse is not supported in the orthographic perspective."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:436
-msgctxt "@action:button"
-msgid "Zoom toward mouse direction"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:462
-msgctxt "@info:tooltip"
-msgid ""
-"Should models on the platform be moved so that they no longer intersect?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:467
-msgctxt "@option:check"
-msgid "Ensure models are kept apart"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:476
-msgctxt "@info:tooltip"
-msgid "Should models on the platform be moved down to touch the build plate?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:481
-msgctxt "@option:check"
-msgid "Automatically drop models to the build plate"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:493
-msgctxt "@info:tooltip"
-msgid "Show caution message in g-code reader."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:502
-msgctxt "@option:check"
-msgid "Caution message in g-code reader"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:510
-msgctxt "@info:tooltip"
-msgid "Should layer be forced into compatibility mode?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:515
-msgctxt "@option:check"
-msgid "Force layer view compatibility mode (restart required)"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:525
-msgctxt "@info:tooltip"
-msgid "Should Cura open at the location it was closed?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:530
-msgctxt "@option:check"
-msgid "Restore window position on start"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:540
-msgctxt "@info:tooltip"
-msgid "What type of camera rendering should be used?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:547
-msgctxt "@window:text"
-msgid "Camera rendering:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:554
-msgid "Perspective"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:555
-msgid "Orthographic"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:595
-msgctxt "@label"
-msgid "Opening and saving files"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:602
-msgctxt "@info:tooltip"
-msgid ""
-"Should opening files from the desktop or external applications open in the "
-"same instance of Cura?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:607
-msgctxt "@option:check"
-msgid "Use a single instance of Cura"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:618
-msgctxt "@info:tooltip"
-msgid ""
-"Should the build plate be cleared before loading a new model in the single "
-"instance of Cura?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:624
-msgctxt "@option:check"
-msgid "Clear buildplate before loading model into the single instance"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:634
-msgctxt "@info:tooltip"
-msgid "Should models be scaled to the build volume if they are too large?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:639
-msgctxt "@option:check"
-msgid "Scale large models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:649
-msgctxt "@info:tooltip"
-msgid ""
-"An model may appear extremely small if its unit is for example in meters "
-"rather than millimeters. Should these models be scaled up?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:654
-msgctxt "@option:check"
-msgid "Scale extremely small models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:664
-msgctxt "@info:tooltip"
-msgid "Should models be selected after they are loaded?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:669
-msgctxt "@option:check"
-msgid "Select models when loaded"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:679
-msgctxt "@info:tooltip"
-msgid ""
-"Should a prefix based on the printer name be added to the print job name "
-"automatically?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:684
-msgctxt "@option:check"
-msgid "Add machine prefix to job name"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:694
-msgctxt "@info:tooltip"
-msgid "Should a summary be shown when saving a project file?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:698
-msgctxt "@option:check"
-msgid "Show summary dialog when saving project"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:708
-msgctxt "@info:tooltip"
-msgid "Default behavior when opening a project file"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:716
-msgctxt "@window:text"
-msgid "Default behavior when opening a project file: "
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:731
-msgctxt "@option:openProject"
-msgid "Always ask me this"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:732
-msgctxt "@option:openProject"
-msgid "Always open as a project"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:733
-msgctxt "@option:openProject"
-msgid "Always import models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:770
-msgctxt "@info:tooltip"
-msgid ""
-"When you have made changes to a profile and switched to a different one, a "
-"dialog will be shown asking whether you want to keep your modifications or "
-"not, or you can choose a default behaviour and never show that dialog again."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:784
-msgctxt "@window:text"
-msgid ""
-"Default behavior for changed setting values when switching to a different "
-"profile: "
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:799
-msgctxt "@option:discardOrKeep"
-msgid "Always discard changed settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:800
-msgctxt "@option:discardOrKeep"
-msgid "Always transfer changed settings to new profile"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:834
-msgctxt "@label"
-msgid "Privacy"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:840
-msgctxt "@info:tooltip"
-msgid ""
-"Should anonymous data about your print be sent to Ultimaker? Note, no "
-"models, IP addresses or other personally identifiable information is sent or "
-"stored."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:845
-msgctxt "@option:check"
-msgid "Send (anonymous) print information"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:875
-msgctxt "@label"
-msgid "Updates"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:882
-msgctxt "@info:tooltip"
-msgid "Should Cura check for updates when the program is started?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:887
-msgctxt "@option:check"
-msgid "Check for updates on start"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:903
-msgctxt "@info:tooltip"
-msgid "When checking for updates, only check for stable releases."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:909
-msgctxt "@option:radio"
-msgid "Stable releases only"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:919
-msgctxt "@info:tooltip"
-msgid "When checking for updates, check for both stable and for beta releases."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:925
-msgctxt "@option:radio"
-msgid "Stable and Beta releases"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:935
-msgctxt "@info:tooltip"
-msgid ""
-"Should an automatic check for new plugins be done every time Cura is "
-"started? It is highly recommended that you do not disable this!"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/GeneralPage.qml:940
-msgctxt "@option:check"
-msgid "Get notifications for plugin updates"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:70
-msgctxt "@label"
-msgid "Add printer by IP address"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:133
-msgctxt "@text"
-msgid "Enter your printer's IP address."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:158
-msgctxt "@button"
-msgid "Add"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:206
-msgctxt "@label"
-msgid "Could not connect to device."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:207
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:212
-msgctxt "@label"
-msgid "Can't connect to your Ultimaker printer?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:211
-msgctxt "@label"
-msgid "The printer at this address has not responded yet."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:245
-msgctxt "@label"
-msgid ""
-"This printer cannot be added because it's an unknown printer or it's not the "
-"host of a group."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:347
-msgctxt "@button"
-msgid "Connect"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/ChangelogContent.qml:24
-msgctxt "@label"
-msgid "Release Notes"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:23
-msgctxt "@label"
-msgid "User Agreement"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:53
-msgctxt "@button"
-msgid "Agree"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:67
-msgctxt "@button"
-msgid "Decline and close"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/WhatsNewContent.qml:29
-msgctxt "@label"
 msgid "What's New"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/WhatsNewContent.qml:184
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/FirstStartMachineActionsContent.qml:77
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:123
-msgctxt "@button"
-msgid "Next"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:47
-msgctxt "@label"
-msgid "Add a Cloud printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:74
-msgctxt "@label"
-msgid "Waiting for Cloud response"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:86
-msgctxt "@label"
-msgid "No printers found in your account?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:121
-msgctxt "@label"
-msgid "The following printers in your account have been added in Cura:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:194
-msgctxt "@button"
-msgid "Add printer manually"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/CloudContent.qml:124
-msgctxt "@text"
-msgid "Add material settings and plugins from the Marketplace"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/CloudContent.qml:154
-msgctxt "@text"
-msgid "Backup and sync your material settings and plugins"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/CloudContent.qml:184
-msgctxt "@text"
-msgid "Share ideas and get help from 48,000+ users in the Ultimaker Community"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/CloudContent.qml:202
-msgctxt "@button"
-msgid "Skip"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/CloudContent.qml:214
-msgctxt "@text"
-msgid "Create a free Ultimaker Account"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/WelcomeContent.qml:56
-msgctxt "@label"
-msgid "Welcome to Ultimaker Cura"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/WelcomeContent.qml:68
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/GeneralOperations.qml:39
 msgctxt "@text"
 msgid ""
-"Please follow these steps to set up Ultimaker Cura. This will only take a "
-"few moments."
+"- Add material profiles and plug-ins from the Marketplace\n"
+"- Back-up and sync your material profiles and plug-ins\n"
+"- Share ideas and get help from 48,000+ users in the Ultimaker community"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/WelcomeContent.qml:86
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/GeneralOperations.qml:58
 msgctxt "@button"
-msgid "Get started"
+msgid "Create a free Ultimaker account"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DropDownWidget.qml:93
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/AccountWidget.qml:24
+msgctxt "@action:button"
+msgid "Sign in"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/UserOperations.qml:78
+msgctxt "@label The argument is a timestamp"
+msgid "Last update: %1"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/UserOperations.qml:107
+msgctxt "@button"
+msgid "Ultimaker Account"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/UserOperations.qml:126
+msgctxt "@button"
+msgid "Sign Out"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/SyncState.qml:35
 msgctxt "@label"
-msgid "Empty"
+msgid "Checking..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:206
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/SyncState.qml:42
 msgctxt "@label"
-msgid "Manufacturer"
+msgid "Account synced"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:217
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/SyncState.qml:49
 msgctxt "@label"
-msgid "Profile author"
+msgid "Something went wrong..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:229
-msgctxt "@label"
-msgid "Printer name"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/SyncState.qml:102
+msgctxt "@button"
+msgid "Install pending updates"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:235
-msgctxt "@text"
-msgid "Please name your printer"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Account/SyncState.qml:123
+msgctxt "@button"
+msgid "Check for account updates"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:24
-msgctxt "@label"
-msgid "Add a printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:39
-msgctxt "@label"
-msgid "Add a networked printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:88
-msgctxt "@label"
-msgid "Add a non-networked printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:43
-msgctxt "@label"
-msgid "There is no printer found over your network."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:162
-msgctxt "@label"
-msgid "Refresh"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:173
-msgctxt "@label"
-msgid "Add printer by IP"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:184
-msgctxt "@label"
-msgid "Add cloud printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:221
-msgctxt "@label"
-msgid "Troubleshooting"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:24
-msgctxt "@label"
-msgid "Help us to improve Ultimaker Cura"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:57
-msgctxt "@text"
-msgid ""
-"Ultimaker Cura collects anonymous data to improve print quality and user "
-"experience, including:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:71
-msgctxt "@text"
-msgid "Machine types"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:77
-msgctxt "@text"
-msgid "Material usage"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:83
-msgctxt "@text"
-msgid "Number of slices"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:89
-msgctxt "@text"
-msgid "Print settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:102
-msgctxt "@text"
-msgid ""
-"Data collected by Ultimaker Cura will not contain any personal information."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:103
-msgctxt "@text"
-msgid "More information"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ObjectSelector.qml:59
-msgctxt "@label"
-msgid "Object list"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ObjectItemButton.qml:109
-msgctxt "@label"
-msgid "Is printed as support."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ObjectItemButton.qml:112
-msgctxt "@label"
-msgid "Other models overlapping with this model are modified."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ObjectItemButton.qml:115
-msgctxt "@label"
-msgid "Infill overlapping with this model is modified."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ObjectItemButton.qml:118
-msgctxt "@label"
-msgid "Overlaps with this model are not supported."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ObjectItemButton.qml:125
-msgctxt "@label %1 is the number of settings it overrides."
-msgid "Overrides %1 setting."
-msgid_plural "Overrides %1 settings."
-msgstr[0] ""
-msgstr[1] ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterSelector/MachineSelectorList.qml:24
-msgctxt "@label"
-msgid "Connected printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterSelector/MachineSelectorList.qml:24
-msgctxt "@label"
-msgid "Preset printers"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterSelector/MachineSelector.qml:47
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterSelector/MachineSelector.qml:47
 msgctxt "@status"
 msgid ""
 "The cloud printer is offline. Please check if the printer is turned on and "
 "connected to the internet."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterSelector/MachineSelector.qml:51
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterSelector/MachineSelector.qml:51
 msgctxt "@status"
 msgid ""
 "This printer is not linked to your account. Please visit the Ultimaker "
 "Digital Factory to establish a connection."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterSelector/MachineSelector.qml:56
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterSelector/MachineSelector.qml:56
 msgctxt "@status"
 msgid ""
 "The cloud connection is currently unavailable. Please sign in to connect to "
 "the cloud printer."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterSelector/MachineSelector.qml:60
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterSelector/MachineSelector.qml:60
 msgctxt "@status"
 msgid ""
 "The cloud connection is currently unavailable. Please check your internet "
 "connection."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterSelector/MachineSelector.qml:236
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterSelector/MachineSelector.qml:235
 msgctxt "@button"
 msgid "Add printer"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrinterSelector/MachineSelector.qml:253
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/PrinterSelector/MachineSelector.qml:252
 msgctxt "@button"
 msgid "Manage printers"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/SearchBar.qml:17
-msgctxt "@placeholder"
-msgid "Search"
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:54
+msgctxt "@label:PrintjobStatus"
+msgid "Slicing..."
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/JobSpecs.qml:93
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:81
+msgctxt "@label:PrintjobStatus"
+msgid "Unable to slice"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:120
+msgctxt "@button"
+msgid "Processing"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:120
+msgctxt "@button"
+msgid "Slice"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:121
+msgctxt "@label"
+msgid "Start the slicing process"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:138
+msgctxt "@button"
+msgid "Cancel"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:31
+msgctxt "@label"
+msgid "Time estimation"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:114
+msgctxt "@label"
+msgid "Material estimation"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:164
+msgctxt "@label m for meter"
+msgid "%1m"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:165
+msgctxt "@label g for grams"
+msgid "%1g"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:59
+msgctxt "@label"
+msgid "No time estimation available"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:77
+msgctxt "@label"
+msgid "No cost estimation available"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:127
+msgctxt "@button"
+msgid "Preview"
+msgstr ""
+
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/JobSpecs.qml:93
 msgctxt "@text Print job name"
 msgid "Untitled"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:115
-msgctxt "@label:MonitorStatus"
-msgid "Not connected to a printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:119
-msgctxt "@label:MonitorStatus"
-msgid "Printer does not accept commands"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:129
-msgctxt "@label:MonitorStatus"
-msgid "In maintenance. Please check the printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:140
-msgctxt "@label:MonitorStatus"
-msgid "Lost connection with the printer"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:142
-msgctxt "@label:MonitorStatus"
-msgid "Printing..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:145
-msgctxt "@label:MonitorStatus"
-msgid "Paused"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:148
-msgctxt "@label:MonitorStatus"
-msgid "Preparing..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:150
-msgctxt "@label:MonitorStatus"
-msgid "Please remove the print"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:318
+#: /Users/j.delarago/development/cura_installation/Cura/resources/qml/Widgets/ComboBox.qml:18
 msgctxt "@label"
-msgid "Abort Print"
+msgid "No items to select from"
 msgstr ""
 
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/MonitorButton.qml:327
-msgctxt "@label"
-msgid "Are you sure you want to abort the print?"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingCategory.qml:115
-msgctxt "@label"
-msgid ""
-"Some hidden settings use values different from their normal calculated "
-"value.\n"
-"\n"
-"Click to make these settings visible."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingView.qml:47
-msgctxt "@label:textbox"
-msgid "Search settings"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingView.qml:428
-msgctxt "@action:menu"
-msgid "Copy value to all extruders"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingView.qml:437
-msgctxt "@action:menu"
-msgid "Copy all changed values to all extruders"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingView.qml:473
-msgctxt "@action:menu"
-msgid "Hide this setting"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingView.qml:486
-msgctxt "@action:menu"
-msgid "Don't show this setting"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingView.qml:490
-msgctxt "@action:menu"
-msgid "Keep this setting visible"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingView.qml:509
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:467
-msgctxt "@action:menu"
-msgid "Configure setting visibility..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingItem.qml:78
-msgctxt "@label"
-msgid ""
-"This setting is not used because all the settings that it influences are "
-"overridden."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingItem.qml:83
-msgctxt "@label Header for list of settings."
-msgid "Affects"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingItem.qml:88
-msgctxt "@label Header for list of settings."
-msgid "Affected By"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingItem.qml:185
-msgctxt "@label"
-msgid ""
-"This setting is always shared between all extruders. Changing it here will "
-"change the value for all extruders."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingItem.qml:189
-msgctxt "@label"
-msgid "This setting is resolved from conflicting extruder-specific values:"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingItem.qml:229
-msgctxt "@label"
-msgid ""
-"This setting has a value that is different from the profile.\n"
-"\n"
-"Click to restore the value of the profile."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Settings/SettingItem.qml:329
-msgctxt "@label"
-msgid ""
-"This setting is normally calculated, but it currently has an absolute value "
-"set.\n"
-"\n"
-"Click to restore the calculated value."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ColorDialog.qml:104
-msgctxt "@label"
-msgid "Hex"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintMonitor.qml:156
-msgctxt "@label"
-msgid "Active print"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintMonitor.qml:164
-msgctxt "@label"
-msgid "Job Name"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintMonitor.qml:172
-msgctxt "@label"
-msgid "Printing Time"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/PrintMonitor.qml:180
-msgctxt "@label"
-msgid "Estimated time left"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:81
-msgctxt "@action:inmenu"
-msgid "Show Online Troubleshooting"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:88
-msgctxt "@action:inmenu"
-msgid "Toggle Full Screen"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:96
-msgctxt "@action:inmenu"
-msgid "Exit Full Screen"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:103
-msgctxt "@action:inmenu menubar:edit"
-msgid "&Undo"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:113
-msgctxt "@action:inmenu menubar:edit"
-msgid "&Redo"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:131
-msgctxt "@action:inmenu menubar:file"
-msgid "&Quit"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:139
-msgctxt "@action:inmenu menubar:view"
-msgid "3D View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:146
-msgctxt "@action:inmenu menubar:view"
-msgid "Front View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:153
-msgctxt "@action:inmenu menubar:view"
-msgid "Top View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:160
-msgctxt "@action:inmenu menubar:view"
-msgid "Bottom View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:167
-msgctxt "@action:inmenu menubar:view"
-msgid "Left Side View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:174
-msgctxt "@action:inmenu menubar:view"
-msgid "Right Side View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:188
-msgctxt "@action:inmenu"
-msgid "Configure Cura..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:195
-msgctxt "@action:inmenu menubar:printer"
-msgid "&Add Printer..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:201
-msgctxt "@action:inmenu menubar:printer"
-msgid "Manage Pr&inters..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:208
-msgctxt "@action:inmenu"
-msgid "Manage Materials..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:216
-msgctxt ""
-"@action:inmenu Marketplace is a brand name of Ultimaker's, so don't "
-"translate."
-msgid "Add more materials from Marketplace"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:223
-msgctxt "@action:inmenu menubar:profile"
-msgid "&Update profile with current settings/overrides"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:231
-msgctxt "@action:inmenu menubar:profile"
-msgid "&Discard current changes"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:243
-msgctxt "@action:inmenu menubar:profile"
-msgid "&Create profile from current settings/overrides..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:249
-msgctxt "@action:inmenu menubar:profile"
-msgid "Manage Profiles..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:257
-msgctxt "@action:inmenu menubar:help"
-msgid "Show Online &Documentation"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:265
-msgctxt "@action:inmenu menubar:help"
-msgid "Report a &Bug"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:273
-msgctxt "@action:inmenu menubar:help"
-msgid "What's New"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:287
-msgctxt "@action:inmenu menubar:help"
-msgid "About..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:294
-msgctxt "@action:inmenu menubar:edit"
-msgid "Delete Selected"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:304
-msgctxt "@action:inmenu menubar:edit"
-msgid "Center Selected"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:313
-msgctxt "@action:inmenu menubar:edit"
-msgid "Multiply Selected"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:322
-msgctxt "@action:inmenu"
-msgid "Delete Model"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:330
-msgctxt "@action:inmenu"
-msgid "Ce&nter Model on Platform"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:336
-msgctxt "@action:inmenu menubar:edit"
-msgid "&Group Models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:356
-msgctxt "@action:inmenu menubar:edit"
-msgid "Ungroup Models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:366
-msgctxt "@action:inmenu menubar:edit"
-msgid "&Merge Models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:376
-msgctxt "@action:inmenu"
-msgid "&Multiply Model..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:383
-msgctxt "@action:inmenu menubar:edit"
-msgid "Select All Models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:393
-msgctxt "@action:inmenu menubar:edit"
-msgid "Clear Build Plate"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:403
-msgctxt "@action:inmenu menubar:file"
-msgid "Reload All Models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:412
-msgctxt "@action:inmenu menubar:edit"
-msgid "Arrange All Models"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:420
-msgctxt "@action:inmenu menubar:edit"
-msgid "Arrange Selection"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:427
-msgctxt "@action:inmenu menubar:edit"
-msgid "Reset All Model Positions"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:434
-msgctxt "@action:inmenu menubar:edit"
-msgid "Reset All Model Transformations"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:443
-msgctxt "@action:inmenu menubar:file"
-msgid "&Open File(s)..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:453
-msgctxt "@action:inmenu menubar:file"
-msgid "&New Project..."
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:460
-msgctxt "@action:inmenu menubar:help"
-msgid "Show Configuration Folder"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ViewOrientationControls.qml:25
-msgctxt "@info:tooltip"
-msgid "3D View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ViewOrientationControls.qml:38
-msgctxt "@info:tooltip"
-msgid "Front View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ViewOrientationControls.qml:51
-msgctxt "@info:tooltip"
-msgid "Top View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ViewOrientationControls.qml:64
-msgctxt "@info:tooltip"
-msgid "Left View"
-msgstr ""
-
-#: /home/remco/dev/code/ulti/trans/Cura/resources/qml/ViewOrientationControls.qml:77
-msgctxt "@info:tooltip"
-msgid "Right View"
-msgstr ""
-
-#: PrepareStage/plugin.json
-msgctxt "description"
-msgid "Provides a prepare stage in Cura."
-msgstr ""
-
-#: PrepareStage/plugin.json
-msgctxt "name"
-msgid "Prepare Stage"
-msgstr ""
-
-#: CuraProfileWriter/plugin.json
-msgctxt "description"
-msgid "Provides support for exporting Cura profiles."
-msgstr ""
-
-#: CuraProfileWriter/plugin.json
-msgctxt "name"
-msgid "Cura Profile Writer"
-msgstr ""
-
-#: TrimeshReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading model files."
-msgstr ""
-
-#: TrimeshReader/plugin.json
-msgctxt "name"
-msgid "Trimesh Reader"
-msgstr ""
-
-#: FirmwareUpdateChecker/plugin.json
-msgctxt "description"
-msgid "Checks for firmware updates."
-msgstr ""
-
-#: FirmwareUpdateChecker/plugin.json
-msgctxt "name"
-msgid "Firmware Update Checker"
-msgstr ""
-
-#: SentryLogger/plugin.json
-msgctxt "description"
-msgid "Logs certain events so that they can be used by the crash reporter"
-msgstr ""
-
-#: SentryLogger/plugin.json
-msgctxt "name"
-msgid "Sentry Logger"
-msgstr ""
-
-#: MonitorStage/plugin.json
-msgctxt "description"
-msgid "Provides a monitor stage in Cura."
-msgstr ""
-
-#: MonitorStage/plugin.json
-msgctxt "name"
-msgid "Monitor Stage"
-msgstr ""
-
-#: RemovableDriveOutputDevice/plugin.json
-msgctxt "description"
-msgid "Provides removable drive hotplugging and writing support."
-msgstr ""
-
-#: RemovableDriveOutputDevice/plugin.json
-msgctxt "name"
-msgid "Removable Drive Output Device Plugin"
-msgstr ""
-
-#: AMFReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading AMF files."
-msgstr ""
-
-#: AMFReader/plugin.json
-msgctxt "name"
-msgid "AMF Reader"
-msgstr ""
-
-#: UFPReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading Ultimaker Format Packages."
-msgstr ""
-
-#: UFPReader/plugin.json
-msgctxt "name"
-msgid "UFP Reader"
-msgstr ""
-
-#: DigitalLibrary/plugin.json
-msgctxt "description"
-msgid ""
-"Connects to the Digital Library, allowing Cura to open files from and save "
-"files to the Digital Library."
-msgstr ""
-
-#: DigitalLibrary/plugin.json
-msgctxt "name"
-msgid "Ultimaker Digital Library"
-msgstr ""
-
-#: PerObjectSettingsTool/plugin.json
-msgctxt "description"
-msgid "Provides the Per Model Settings."
-msgstr ""
-
-#: PerObjectSettingsTool/plugin.json
-msgctxt "name"
-msgid "Per Model Settings Tool"
-msgstr ""
-
-#: FirmwareUpdater/plugin.json
-msgctxt "description"
-msgid "Provides a machine actions for updating firmware."
-msgstr ""
-
-#: FirmwareUpdater/plugin.json
-msgctxt "name"
-msgid "Firmware Updater"
-msgstr ""
-
-#: UM3NetworkPrinting/plugin.json
-msgctxt "description"
-msgid "Manages network connections to Ultimaker networked printers."
-msgstr ""
-
-#: UM3NetworkPrinting/plugin.json
-msgctxt "name"
-msgid "Ultimaker Network Connection"
-msgstr ""
-
-#: ModelChecker/plugin.json
-msgctxt "description"
-msgid ""
-"Checks models and print configuration for possible printing issues and give "
-"suggestions."
-msgstr ""
-
-#: ModelChecker/plugin.json
-msgctxt "name"
-msgid "Model Checker"
-msgstr ""
-
-#: SimulationView/plugin.json
-msgctxt "description"
-msgid "Provides the preview of sliced layerdata."
-msgstr ""
-
-#: SimulationView/plugin.json
-msgctxt "name"
-msgid "Simulation View"
-msgstr ""
-
-#: GCodeWriter/plugin.json
-msgctxt "description"
-msgid "Writes g-code to a file."
-msgstr ""
-
-#: GCodeWriter/plugin.json
-msgctxt "name"
-msgid "G-code Writer"
-msgstr ""
-
-#: 3MFWriter/plugin.json
-msgctxt "description"
-msgid "Provides support for writing 3MF files."
-msgstr ""
-
-#: 3MFWriter/plugin.json
-msgctxt "name"
-msgid "3MF Writer"
-msgstr ""
-
-#: GCodeGzReader/plugin.json
-msgctxt "description"
-msgid "Reads g-code from a compressed archive."
-msgstr ""
-
-#: GCodeGzReader/plugin.json
-msgctxt "name"
-msgid "Compressed G-code Reader"
-msgstr ""
-
-#: XmlMaterialProfile/plugin.json
-msgctxt "description"
-msgid "Provides capabilities to read and write XML-based material profiles."
-msgstr ""
-
-#: XmlMaterialProfile/plugin.json
-msgctxt "name"
-msgid "Material Profiles"
-msgstr ""
-
-#: CuraEngineBackend/plugin.json
-msgctxt "description"
-msgid "Provides the link to the CuraEngine slicing backend."
-msgstr ""
-
-#: CuraEngineBackend/plugin.json
-msgctxt "name"
-msgid "CuraEngine Backend"
-msgstr ""
-
-#: X3DReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading X3D files."
-msgstr ""
-
-#: X3DReader/plugin.json
-msgctxt "name"
-msgid "X3D Reader"
-msgstr ""
-
-#: ImageReader/plugin.json
-msgctxt "description"
-msgid "Enables ability to generate printable geometry from 2D image files."
-msgstr ""
-
-#: ImageReader/plugin.json
-msgctxt "name"
-msgid "Image Reader"
-msgstr ""
-
-#: 3MFReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading 3MF files."
-msgstr ""
-
-#: 3MFReader/plugin.json
-msgctxt "name"
-msgid "3MF Reader"
-msgstr ""
-
-#: UFPWriter/plugin.json
-msgctxt "description"
-msgid "Provides support for writing Ultimaker Format Packages."
-msgstr ""
-
-#: UFPWriter/plugin.json
-msgctxt "name"
-msgid "UFP Writer"
-msgstr ""
-
-#: LegacyProfileReader/plugin.json
-msgctxt "description"
-msgid "Provides support for importing profiles from legacy Cura versions."
-msgstr ""
-
-#: LegacyProfileReader/plugin.json
-msgctxt "name"
-msgid "Legacy Cura Profile Reader"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade43to44/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.3 to Cura 4.4."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade43to44/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.3 to 4.4"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade21to22/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.1 to Cura 2.2."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade21to22/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.1 to 2.2"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade41to42/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.1 to Cura 4.2."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade41to42/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.1 to 4.2"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade413to50/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.13 to Cura 5.0."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade413to50/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.13 to 5.0"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade45to46/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.5 to Cura 4.6."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade45to46/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.5 to 4.6"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade33to34/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.3 to Cura 3.4."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade33to34/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.3 to 3.4"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade48to49/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.8 to Cura 4.9."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade48to49/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.8 to 4.9"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade27to30/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.7 to Cura 3.0."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade27to30/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.7 to 3.0"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade44to45/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.4 to Cura 4.5."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade44to45/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.4 to 4.5"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade30to31/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.0 to Cura 3.1."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade30to31/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.0 to 3.1"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade460to462/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.6.0 to Cura 4.6.2."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade460to462/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.6.0 to 4.6.2"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade26to27/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.6 to Cura 2.7."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade26to27/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.6 to 2.7"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade42to43/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.2 to Cura 4.3."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade42to43/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.2 to 4.3"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade40to41/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.0 to Cura 4.1."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade40to41/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.0 to 4.1"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade462to47/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.6.2 to Cura 4.7."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade462to47/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.6.2 to 4.7"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade49to410/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.9 to Cura 4.10."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade49to410/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.9 to 4.10"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade22to24/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.2 to Cura 2.4."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade22to24/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.2 to 2.4"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade32to33/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.2 to Cura 3.3."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade32to33/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.2 to 3.3"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade25to26/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.5 to Cura 2.6."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade25to26/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.5 to 2.6"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade35to40/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.5 to Cura 4.0."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade35to40/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.5 to 4.0"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade34to35/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.4 to Cura 3.5."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade34to35/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.4 to 3.5"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade47to48/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.7 to Cura 4.8."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade47to48/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.7 to 4.8"
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade411to412/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.11 to Cura 4.12."
-msgstr ""
-
-#: VersionUpgrade/VersionUpgrade411to412/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.11 to 4.12"
-msgstr ""
-
-#: CuraDrive/plugin.json
-msgctxt "description"
-msgid "Backup and restore your configuration."
-msgstr ""
-
-#: CuraDrive/plugin.json
-msgctxt "name"
-msgid "Cura Backups"
-msgstr ""
-
-#: CuraProfileReader/plugin.json
-msgctxt "description"
-msgid "Provides support for importing Cura profiles."
-msgstr ""
-
-#: CuraProfileReader/plugin.json
-msgctxt "name"
-msgid "Cura Profile Reader"
-msgstr ""
-
-#: SliceInfoPlugin/plugin.json
-msgctxt "description"
-msgid "Submits anonymous slice info. Can be disabled through preferences."
-msgstr ""
-
-#: SliceInfoPlugin/plugin.json
-msgctxt "name"
-msgid "Slice info"
-msgstr ""
-
-#: GCodeProfileReader/plugin.json
-msgctxt "description"
-msgid "Provides support for importing profiles from g-code files."
-msgstr ""
-
-#: GCodeProfileReader/plugin.json
-msgctxt "name"
-msgid "G-code Profile Reader"
-msgstr ""
-
-#: GCodeGzWriter/plugin.json
-msgctxt "description"
-msgid "Writes g-code to a compressed archive."
-msgstr ""
-
-#: GCodeGzWriter/plugin.json
-msgctxt "name"
-msgid "Compressed G-code Writer"
-msgstr ""
-
-#: PostProcessingPlugin/plugin.json
-msgctxt "description"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr ""
-
-#: PostProcessingPlugin/plugin.json
-msgctxt "name"
-msgid "Post Processing"
-msgstr ""
-
-#: SupportEraser/plugin.json
-msgctxt "description"
-msgid ""
-"Creates an eraser mesh to block the printing of support in certain places"
-msgstr ""
-
-#: SupportEraser/plugin.json
-msgctxt "name"
-msgid "Support Eraser"
-msgstr ""
-
-#: PreviewStage/plugin.json
-msgctxt "description"
-msgid "Provides a preview stage in Cura."
-msgstr ""
-
-#: PreviewStage/plugin.json
-msgctxt "name"
-msgid "Preview Stage"
-msgstr ""
-
-#: XRayView/plugin.json
-msgctxt "description"
-msgid "Provides the X-Ray view."
-msgstr ""
-
-#: XRayView/plugin.json
-msgctxt "name"
-msgid "X-Ray View"
-msgstr ""
-
-#: UltimakerMachineActions/plugin.json
-msgctxt "description"
-msgid ""
-"Provides machine actions for Ultimaker machines (such as bed leveling "
-"wizard, selecting upgrades, etc.)."
-msgstr ""
-
-#: UltimakerMachineActions/plugin.json
-msgctxt "name"
-msgid "Ultimaker machine actions"
-msgstr ""
-
-#: Marketplace/plugin.json
-msgctxt "description"
-msgid ""
-"Manages extensions to the application and allows browsing extensions from "
-"the Ultimaker website."
-msgstr ""
-
-#: Marketplace/plugin.json
-msgctxt "name"
-msgid "Marketplace"
-msgstr ""
-
-#: SolidView/plugin.json
-msgctxt "description"
-msgid "Provides a normal solid mesh view."
-msgstr ""
-
-#: SolidView/plugin.json
-msgctxt "name"
-msgid "Solid View"
-msgstr ""
-
-#: GCodeReader/plugin.json
-msgctxt "description"
-msgid "Allows loading and displaying G-code files."
-msgstr ""
-
-#: GCodeReader/plugin.json
-msgctxt "name"
-msgid "G-code Reader"
-msgstr ""
-
-#: MachineSettingsAction/plugin.json
+#: /MachineSettingsAction/plugin.json
 msgctxt "description"
 msgid ""
 "Provides a way to change machine settings (such as build volume, nozzle "
 "size, etc.)."
 msgstr ""
 
-#: MachineSettingsAction/plugin.json
+#: /MachineSettingsAction/plugin.json
 msgctxt "name"
 msgid "Machine Settings Action"
 msgstr ""
 
-#: USBPrinting/plugin.json
+#: /ImageReader/plugin.json
+msgctxt "description"
+msgid "Enables ability to generate printable geometry from 2D image files."
+msgstr ""
+
+#: /ImageReader/plugin.json
+msgctxt "name"
+msgid "Image Reader"
+msgstr ""
+
+#: /XRayView/plugin.json
+msgctxt "description"
+msgid "Provides the X-Ray view."
+msgstr ""
+
+#: /XRayView/plugin.json
+msgctxt "name"
+msgid "X-Ray View"
+msgstr ""
+
+#: /X3DReader/plugin.json
+msgctxt "description"
+msgid "Provides support for reading X3D files."
+msgstr ""
+
+#: /X3DReader/plugin.json
+msgctxt "name"
+msgid "X3D Reader"
+msgstr ""
+
+#: /CuraProfileReader/plugin.json
+msgctxt "description"
+msgid "Provides support for importing Cura profiles."
+msgstr ""
+
+#: /CuraProfileReader/plugin.json
+msgctxt "name"
+msgid "Cura Profile Reader"
+msgstr ""
+
+#: /PostProcessingPlugin/plugin.json
+msgctxt "description"
+msgid "Extension that allows for user created scripts for post processing"
+msgstr ""
+
+#: /PostProcessingPlugin/plugin.json
+msgctxt "name"
+msgid "Post Processing"
+msgstr ""
+
+#: /UM3NetworkPrinting/plugin.json
+msgctxt "description"
+msgid "Manages network connections to Ultimaker networked printers."
+msgstr ""
+
+#: /UM3NetworkPrinting/plugin.json
+msgctxt "name"
+msgid "Ultimaker Network Connection"
+msgstr ""
+
+#: /3MFWriter/plugin.json
+msgctxt "description"
+msgid "Provides support for writing 3MF files."
+msgstr ""
+
+#: /3MFWriter/plugin.json
+msgctxt "name"
+msgid "3MF Writer"
+msgstr ""
+
+#: /CuraDrive/plugin.json
+msgctxt "description"
+msgid "Backup and restore your configuration."
+msgstr ""
+
+#: /CuraDrive/plugin.json
+msgctxt "name"
+msgid "Cura Backups"
+msgstr ""
+
+#: /SliceInfoPlugin/plugin.json
+msgctxt "description"
+msgid "Submits anonymous slice info. Can be disabled through preferences."
+msgstr ""
+
+#: /SliceInfoPlugin/plugin.json
+msgctxt "name"
+msgid "Slice info"
+msgstr ""
+
+#: /UFPWriter/plugin.json
+msgctxt "description"
+msgid "Provides support for writing Ultimaker Format Packages."
+msgstr ""
+
+#: /UFPWriter/plugin.json
+msgctxt "name"
+msgid "UFP Writer"
+msgstr ""
+
+#: /DigitalLibrary/plugin.json
+msgctxt "description"
+msgid ""
+"Connects to the Digital Library, allowing Cura to open files from and save "
+"files to the Digital Library."
+msgstr ""
+
+#: /DigitalLibrary/plugin.json
+msgctxt "name"
+msgid "Ultimaker Digital Library"
+msgstr ""
+
+#: /GCodeProfileReader/plugin.json
+msgctxt "description"
+msgid "Provides support for importing profiles from g-code files."
+msgstr ""
+
+#: /GCodeProfileReader/plugin.json
+msgctxt "name"
+msgid "G-code Profile Reader"
+msgstr ""
+
+#: /GCodeReader/plugin.json
+msgctxt "description"
+msgid "Allows loading and displaying G-code files."
+msgstr ""
+
+#: /GCodeReader/plugin.json
+msgctxt "name"
+msgid "G-code Reader"
+msgstr ""
+
+#: /TrimeshReader/plugin.json
+msgctxt "description"
+msgid "Provides support for reading model files."
+msgstr ""
+
+#: /TrimeshReader/plugin.json
+msgctxt "name"
+msgid "Trimesh Reader"
+msgstr ""
+
+#: /UltimakerMachineActions/plugin.json
+msgctxt "description"
+msgid ""
+"Provides machine actions for Ultimaker machines (such as bed leveling "
+"wizard, selecting upgrades, etc.)."
+msgstr ""
+
+#: /UltimakerMachineActions/plugin.json
+msgctxt "name"
+msgid "Ultimaker machine actions"
+msgstr ""
+
+#: /GCodeGzReader/plugin.json
+msgctxt "description"
+msgid "Reads g-code from a compressed archive."
+msgstr ""
+
+#: /GCodeGzReader/plugin.json
+msgctxt "name"
+msgid "Compressed G-code Reader"
+msgstr ""
+
+#: /Marketplace/plugin.json
+msgctxt "description"
+msgid ""
+"Manages extensions to the application and allows browsing extensions from "
+"the Ultimaker website."
+msgstr ""
+
+#: /Marketplace/plugin.json
+msgctxt "name"
+msgid "Marketplace"
+msgstr ""
+
+#: /RemovableDriveOutputDevice/plugin.json
+msgctxt "description"
+msgid "Provides removable drive hotplugging and writing support."
+msgstr ""
+
+#: /RemovableDriveOutputDevice/plugin.json
+msgctxt "name"
+msgid "Removable Drive Output Device Plugin"
+msgstr ""
+
+#: /MonitorStage/plugin.json
+msgctxt "description"
+msgid "Provides a monitor stage in Cura."
+msgstr ""
+
+#: /MonitorStage/plugin.json
+msgctxt "name"
+msgid "Monitor Stage"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade25to26/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.5 to Cura 2.6."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade25to26/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.5 to 2.6"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade26to27/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.6 to Cura 2.7."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade26to27/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.6 to 2.7"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade413to50/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.13 to Cura 5.0."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade413to50/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.13 to 5.0"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade48to49/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.8 to Cura 4.9."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade48to49/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.8 to 4.9"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade34to35/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.4 to Cura 3.5."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade34to35/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.4 to 3.5"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade44to45/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.4 to Cura 4.5."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade44to45/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.4 to 4.5"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade43to44/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.3 to Cura 4.4."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade43to44/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.3 to 4.4"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade32to33/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.2 to Cura 3.3."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade32to33/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.2 to 3.3"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade33to34/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.3 to Cura 3.4."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade33to34/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.3 to 3.4"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade41to42/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.1 to Cura 4.2."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade41to42/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.1 to 4.2"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade42to43/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.2 to Cura 4.3."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade42to43/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.2 to 4.3"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade462to47/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.6.2 to Cura 4.7."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade462to47/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.6.2 to 4.7"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade35to40/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.5 to Cura 4.0."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade35to40/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.5 to 4.0"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade22to24/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.2 to Cura 2.4."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade22to24/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.2 to 2.4"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade21to22/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.1 to Cura 2.2."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade21to22/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.1 to 2.2"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade460to462/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.6.0 to Cura 4.6.2."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade460to462/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.6.0 to 4.6.2"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade47to48/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.7 to Cura 4.8."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade47to48/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.7 to 4.8"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade49to410/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.9 to Cura 4.10."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade49to410/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.9 to 4.10"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade45to46/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.5 to Cura 4.6."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade45to46/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.5 to 4.6"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade27to30/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.7 to Cura 3.0."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade27to30/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.7 to 3.0"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade30to31/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.0 to Cura 3.1."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade30to31/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.0 to 3.1"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade411to412/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.11 to Cura 4.12."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade411to412/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.11 to 4.12"
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade40to41/plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.0 to Cura 4.1."
+msgstr ""
+
+#: /VersionUpgrade/VersionUpgrade40to41/plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.0 to 4.1"
+msgstr ""
+
+#: /CuraEngineBackend/plugin.json
+msgctxt "description"
+msgid "Provides the link to the CuraEngine slicing backend."
+msgstr ""
+
+#: /CuraEngineBackend/plugin.json
+msgctxt "name"
+msgid "CuraEngine Backend"
+msgstr ""
+
+#: /3MFReader/plugin.json
+msgctxt "description"
+msgid "Provides support for reading 3MF files."
+msgstr ""
+
+#: /3MFReader/plugin.json
+msgctxt "name"
+msgid "3MF Reader"
+msgstr ""
+
+#: /PerObjectSettingsTool/plugin.json
+msgctxt "description"
+msgid "Provides the Per Model Settings."
+msgstr ""
+
+#: /PerObjectSettingsTool/plugin.json
+msgctxt "name"
+msgid "Per Model Settings Tool"
+msgstr ""
+
+#: /XmlMaterialProfile/plugin.json
+msgctxt "description"
+msgid "Provides capabilities to read and write XML-based material profiles."
+msgstr ""
+
+#: /XmlMaterialProfile/plugin.json
+msgctxt "name"
+msgid "Material Profiles"
+msgstr ""
+
+#: /CuraProfileWriter/plugin.json
+msgctxt "description"
+msgid "Provides support for exporting Cura profiles."
+msgstr ""
+
+#: /CuraProfileWriter/plugin.json
+msgctxt "name"
+msgid "Cura Profile Writer"
+msgstr ""
+
+#: /ModelChecker/plugin.json
+msgctxt "description"
+msgid ""
+"Checks models and print configuration for possible printing issues and give "
+"suggestions."
+msgstr ""
+
+#: /ModelChecker/plugin.json
+msgctxt "name"
+msgid "Model Checker"
+msgstr ""
+
+#: /USBPrinting/plugin.json
 msgctxt "description"
 msgid ""
 "Accepts G-Code and sends them to a printer. Plugin can also update firmware."
 msgstr ""
 
-#: USBPrinting/plugin.json
+#: /USBPrinting/plugin.json
 msgctxt "name"
 msgid "USB printing"
+msgstr ""
+
+#: /PreviewStage/plugin.json
+msgctxt "description"
+msgid "Provides a preview stage in Cura."
+msgstr ""
+
+#: /PreviewStage/plugin.json
+msgctxt "name"
+msgid "Preview Stage"
+msgstr ""
+
+#: /GCodeWriter/plugin.json
+msgctxt "description"
+msgid "Writes g-code to a file."
+msgstr ""
+
+#: /GCodeWriter/plugin.json
+msgctxt "name"
+msgid "G-code Writer"
+msgstr ""
+
+#: /UFPReader/plugin.json
+msgctxt "description"
+msgid "Provides support for reading Ultimaker Format Packages."
+msgstr ""
+
+#: /UFPReader/plugin.json
+msgctxt "name"
+msgid "UFP Reader"
+msgstr ""
+
+#: /FirmwareUpdater/plugin.json
+msgctxt "description"
+msgid "Provides a machine actions for updating firmware."
+msgstr ""
+
+#: /FirmwareUpdater/plugin.json
+msgctxt "name"
+msgid "Firmware Updater"
+msgstr ""
+
+#: /GCodeGzWriter/plugin.json
+msgctxt "description"
+msgid "Writes g-code to a compressed archive."
+msgstr ""
+
+#: /GCodeGzWriter/plugin.json
+msgctxt "name"
+msgid "Compressed G-code Writer"
+msgstr ""
+
+#: /SimulationView/plugin.json
+msgctxt "description"
+msgid "Provides the preview of sliced layerdata."
+msgstr ""
+
+#: /SimulationView/plugin.json
+msgctxt "name"
+msgid "Simulation View"
+msgstr ""
+
+#: /LegacyProfileReader/plugin.json
+msgctxt "description"
+msgid "Provides support for importing profiles from legacy Cura versions."
+msgstr ""
+
+#: /LegacyProfileReader/plugin.json
+msgctxt "name"
+msgid "Legacy Cura Profile Reader"
+msgstr ""
+
+#: /AMFReader/plugin.json
+msgctxt "description"
+msgid "Provides support for reading AMF files."
+msgstr ""
+
+#: /AMFReader/plugin.json
+msgctxt "name"
+msgid "AMF Reader"
+msgstr ""
+
+#: /SolidView/plugin.json
+msgctxt "description"
+msgid "Provides a normal solid mesh view."
+msgstr ""
+
+#: /SolidView/plugin.json
+msgctxt "name"
+msgid "Solid View"
+msgstr ""
+
+#: /FirmwareUpdateChecker/plugin.json
+msgctxt "description"
+msgid "Checks for firmware updates."
+msgstr ""
+
+#: /FirmwareUpdateChecker/plugin.json
+msgctxt "name"
+msgid "Firmware Update Checker"
+msgstr ""
+
+#: /SentryLogger/plugin.json
+msgctxt "description"
+msgid "Logs certain events so that they can be used by the crash reporter"
+msgstr ""
+
+#: /SentryLogger/plugin.json
+msgctxt "name"
+msgid "Sentry Logger"
+msgstr ""
+
+#: /SupportEraser/plugin.json
+msgctxt "description"
+msgid ""
+"Creates an eraser mesh to block the printing of support in certain places"
+msgstr ""
+
+#: /SupportEraser/plugin.json
+msgctxt "name"
+msgid "Support Eraser"
+msgstr ""
+
+#: /PrepareStage/plugin.json
+msgctxt "description"
+msgid "Provides a prepare stage in Cura."
+msgstr ""
+
+#: /PrepareStage/plugin.json
+msgctxt "name"
+msgid "Prepare Stage"
 msgstr ""

--- a/resources/i18n/cura.pot
+++ b/resources/i18n/cura.pot
@@ -2894,6 +2894,11 @@ msgctxt "@button:label"
 msgid "Learn More"
 msgstr ""
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr ""
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/de_DE/cura.po
+++ b/resources/i18n/de_DE/cura.po
@@ -6801,6 +6801,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB-Drucken"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Mehr Erfahren"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/de_DE/cura.po
+++ b/resources/i18n/de_DE/cura.po
@@ -6801,41 +6801,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB-Drucken"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "Sie müssen die Lizenz akzeptieren, um das Paket zu installieren"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Von Ihrem Ultimaker-Konto erkannte Änderungen"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Änderungen in deinem Konto"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Verwerfen"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Ablehnen und vom Konto entfernen"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Möchten Sie Material- und Softwarepakete mit Ihrem Konto synchronisieren?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Synchronisierung läuft..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Die folgenden Pakete werden hinzugefügt:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "Sie müssen das Programm beenden und neu starten {}, bevor Änderungen wirksam werden."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr"Sie müssen das Programm beenden und neu starten {}, bevor Änderungen wirksam werden."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Plugin für Lizenzvereinbarung"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Materialien synchronisieren"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "Sie müssen das Programm beenden und neu starten {}, bevor Änderungen wirksam werden."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Synchronisierung läuft ..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Von Ihrem Ultimaker-Konto erkannte Änderungen"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Möchten Sie Material- und Softwarepakete mit Ihrem Konto synchronisieren?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Synchronisieren"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Ablehnen und vom Konto entfernen"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "{} Plugins konnten nicht heruntergeladen werden"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Plugin für Lizenzvereinbarung"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -7024,22 +7052,6 @@ msgstr "USB-Drucken"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Verbindung zur Cura Paket-Datenbank konnte nicht hergestellt werden. Bitte überprüfen Sie Ihre Verbindung."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "Sie müssen die Lizenz akzeptieren, um das Paket zu installieren"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Änderungen in deinem Konto"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Verwerfen"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Die folgenden Pakete werden hinzugefügt:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"
@@ -7466,22 +7478,6 @@ msgstr "USB-Drucken"
 #~ msgctxt "@button"
 #~ msgid "Create an account"
 #~ msgstr "Ein Konto erstellen"
-
-#~ msgctxt "@info:generic"
-#~ msgid ""
-#~ "\n"
-#~ "Do you want to sync material and software packages with your account?"
-#~ msgstr ""
-#~ "\n"
-#~ "Möchten Sie Material- und Softwarepakete mit Ihrem Konto synchronisieren?"
-
-#~ msgctxt "@info:generic"
-#~ msgid ""
-#~ "\n"
-#~ "Syncing..."
-#~ msgstr ""
-#~ "\n"
-#~ "Synchronisierung läuft ..."
 
 #~ msgctxt "@info:status"
 #~ msgid "Nothing to slice because none of the models fit the build volume or are assigned to a disabled extruder. Please scale or rotate models to fit, or enable an extruder."
@@ -9583,10 +9579,6 @@ msgstr "USB-Drucken"
 #~ msgctxt "@info"
 #~ msgid "Cura collects anonymised slicing statistics. You can disable this in the preferences."
 #~ msgstr "Cura erfasst anonymisierte Slice-Informationen. Sie können dies in den Einstellungen deaktivieren."
-
-#~ msgctxt "@action:button"
-#~ msgid "Dismiss"
-#~ msgstr "Verwerfen"
 
 #~ msgctxt "@menuitem"
 #~ msgid "Global"

--- a/resources/i18n/es_ES/cura.po
+++ b/resources/i18n/es_ES/cura.po
@@ -6803,41 +6803,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Impresión USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "Tiene que aceptar la licencia para instalar el paquete"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Se han detectado cambios desde su cuenta de Ultimaker"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Cambios desde su cuenta"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Descartar"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Rechazar y eliminar de la cuenta"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "¿Desea sincronizar el material y los paquetes de software con su cuenta?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Sincronizando..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Se añadirán los siguientes paquetes:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "Tiene que salir y reiniciar {} para que los cambios surtan efecto."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "Error al descargar los complementos {}"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Acuerdo de licencia de complemento"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Sincronizar materiales"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "Tiene que salir y reiniciar {} para que los cambios surtan efecto."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Sincronizando..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Se han detectado cambios desde su cuenta de Ultimaker"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "¿Desea sincronizar el material y los paquetes de software con su cuenta?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Sincronizar"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Rechazar y eliminar de la cuenta"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "Error al descargar los complementos {}"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Acuerdo de licencia de complemento"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -7026,22 +7054,6 @@ msgstr "Impresión USB"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "No se ha podido conectar con la base de datos del Paquete Cura. Compruebe la conexión."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "Tiene que aceptar la licencia para instalar el paquete"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Cambios desde su cuenta"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Descartar"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Se añadirán los siguientes paquetes:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"
@@ -7468,22 +7480,6 @@ msgstr "Impresión USB"
 #~ msgctxt "@button"
 #~ msgid "Create an account"
 #~ msgstr "Crear una cuenta"
-
-#~ msgctxt "@info:generic"
-#~ msgid ""
-#~ "\n"
-#~ "Do you want to sync material and software packages with your account?"
-#~ msgstr ""
-#~ "\n"
-#~ "¿Desea sincronizar el material y los paquetes de software con su cuenta?"
-
-#~ msgctxt "@info:generic"
-#~ msgid ""
-#~ "\n"
-#~ "Syncing..."
-#~ msgstr ""
-#~ "\n"
-#~ "Sincronizando..."
 
 #~ msgctxt "@info:status"
 #~ msgid "Nothing to slice because none of the models fit the build volume or are assigned to a disabled extruder. Please scale or rotate models to fit, or enable an extruder."

--- a/resources/i18n/es_ES/cura.po
+++ b/resources/i18n/es_ES/cura.po
@@ -6803,6 +6803,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Impresión USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Más Información"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/fr_FR/cura.po
+++ b/resources/i18n/fr_FR/cura.po
@@ -6804,41 +6804,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Impression par USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "Vous devez accepter la licence pour installer le package"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Changements détectés à partir de votre compte Ultimaker"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Changements à partir de votre compte"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Ignorer"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Décliner et supprimer du compte"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Vous souhaitez synchroniser du matériel et des logiciels avec votre compte ?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Synchronisation..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Les packages suivants seront ajoutés:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "Vous devez quitter et redémarrer {} avant que les changements apportés ne prennent effet."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "Échec de téléchargement des plugins {}"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Plug-in d'accord de licence"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Synchroniser les matériaux"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "Vous devez quitter et redémarrer {} avant que les changements apportés ne prennent effet."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Synchronisation..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Changements détectés à partir de votre compte Ultimaker"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Vous souhaitez synchroniser du matériel et des logiciels avec votre compte ?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Synchroniser"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Décliner et supprimer du compte"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "Échec de téléchargement des plugins {}"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Plug-in d'accord de licence"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -7027,22 +7055,6 @@ msgstr "Impression par USB"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Impossible de se connecter à la base de données Cura Package. Veuillez vérifier votre connexion."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "Vous devez accepter la licence pour installer le package"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Changements à partir de votre compte"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Ignorer"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Les packages suivants seront ajoutés :"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"
@@ -9586,10 +9598,6 @@ msgstr "Impression par USB"
 #~ msgctxt "@info"
 #~ msgid "Cura collects anonymised slicing statistics. You can disable this in the preferences."
 #~ msgstr "Cura collecte des statistiques anonymes sur le découpage. Vous pouvez désactiver cette fonctionnalité dans les préférences."
-
-#~ msgctxt "@action:button"
-#~ msgid "Dismiss"
-#~ msgstr "Ignorer"
 
 #~ msgctxt "@menuitem"
 #~ msgid "Global"

--- a/resources/i18n/fr_FR/cura.po
+++ b/resources/i18n/fr_FR/cura.po
@@ -6804,6 +6804,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Impression par USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "En Savoir Plus"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/it_IT/cura.po
+++ b/resources/i18n/it_IT/cura.po
@@ -6798,6 +6798,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Stampa USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Ulteriori Informazioni"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/it_IT/cura.po
+++ b/resources/i18n/it_IT/cura.po
@@ -6798,41 +6798,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Stampa USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "È necessario accettare la licenza per installare il pacchetto"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Modifiche rilevate dal tuo account Ultimaker"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Modifiche dall'account"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Rimuovi"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Rifiuta e rimuovi dall'account"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Desiderate sincronizzare pacchetti materiale e software con il vostro account?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Sincronizzazione in corso..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Verranno aggiunti i seguenti pacchetti:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "Affinché le modifiche diventino effettive, è necessario chiudere e riavviare {}."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "Impossibile scaricare i plugin {}"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Accordo di licenza plugin"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Sincronizza materiali"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "Affinché le modifiche diventino effettive, è necessario chiudere e riavviare {}."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Sincronizzazione in corso..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Modifiche rilevate dal tuo account Ultimaker"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Desiderate sincronizzare pacchetti materiale e software con il vostro account?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Sincronizza"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Rifiuta e rimuovi dall'account"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "Impossibile scaricare i plugin {}"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Accordo di licenza plugin"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -7021,22 +7049,6 @@ msgstr "Stampa USB"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Impossibile connettersi al database pacchetto Cura. Verificare la connessione."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "È necessario accettare la licenza per installare il pacchetto"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Modifiche dall'account"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Rimuovi"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Verranno aggiunti i seguenti pacchetti:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/resources/i18n/ja_JP/cura.po
+++ b/resources/i18n/ja_JP/cura.po
@@ -6750,6 +6750,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USBプリンティング"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "詳しく見る"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/ja_JP/cura.po
+++ b/resources/i18n/ja_JP/cura.po
@@ -6750,41 +6750,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USBプリンティング"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "パッケージをインストールするにはライセンスに同意する必要があります"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Ultimakerアカウントから変更が検出されました"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "アカウントにおける変更"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "無視"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "拒否してアカウントから削除"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "材料パッケージとソフトウェアパッケージをアカウントと同期しますか？"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "同期中..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "次のパッケージが追加されます:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "変更を有効にするために{}を終了して再始動する必要があります。"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "{}プラグインのダウンロードに失敗しました"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "プラグインライセンス同意書"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "材料をプリンターと同期"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "変更を有効にするために{}を終了して再始動する必要があります。"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "同期中..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Ultimakerアカウントから変更が検出されました"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "材料パッケージとソフトウェアパッケージをアカウントと同期しますか？"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "同期"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "拒否してアカウントから削除"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "{}プラグインのダウンロードに失敗しました"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "プラグインライセンス同意書"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -6973,22 +7001,6 @@ msgstr "USBプリンティング"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Curaパッケージデータベースに接続できません。接続を確認してください。"
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "パッケージをインストールするにはライセンスに同意する必要があります"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "アカウントにおける変更"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "無視"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "次のパッケージが追加されます:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"
@@ -9528,10 +9540,6 @@ msgstr "USBプリンティング"
 #~ msgctxt "@info"
 #~ msgid "Cura collects anonymised slicing statistics. You can disable this in the preferences."
 #~ msgstr "Curaが非特定なスライスされた数字を集めました。プレファレンス内で無効にできます。"
-
-#~ msgctxt "@action:button"
-#~ msgid "Dismiss"
-#~ msgstr "却下する"
 
 #~ msgctxt "@menuitem"
 #~ msgid "Global"

--- a/resources/i18n/ko_KR/cura.po
+++ b/resources/i18n/ko_KR/cura.po
@@ -6752,6 +6752,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB 프린팅"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "자세히 알아보기"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/ko_KR/cura.po
+++ b/resources/i18n/ko_KR/cura.po
@@ -6752,41 +6752,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB 프린팅"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "패키지를 설치하려면 라이선스를 수락해야 합니다"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Ultimaker 계정에서 변경 사항이 감지되었습니다"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "계정의 변경 사항"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "취소"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "계정에서 거절 및 제거"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "귀하의 계정으로 재료와 소프트웨어 패키지를 동기화하시겠습니까?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "동기화 중..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "다음 패키지가 추가됩니다:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "변경 사항이 적용되기 전에 {}을(를) 멈추고 다시 시작해야 합니다."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "{}개의 플러그인을 다운로드하지 못했습니다"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "플러그인 사용 계약"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "재료를 프린터와 동기화"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "변경 사항이 적용되기 전에 {}을(를) 멈추고 다시 시작해야 합니다."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "동기화 중..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Ultimaker 계정에서 변경 사항이 감지되었습니다"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "귀하의 계정으로 재료와 소프트웨어 패키지를 동기화하시겠습니까?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "동기화"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "계정에서 거절 및 제거"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "{}개의 플러그인을 다운로드하지 못했습니다"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "플러그인 사용 계약"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -6975,22 +7003,6 @@ msgstr "USB 프린팅"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Cura 패키지 데이터베이스에 연결할 수 없습니다. 연결을 확인하십시오."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "패키지를 설치하려면 라이선스를 수락해야 합니다"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "계정의 변경 사항"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "취소"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "다음 패키지가 추가됩니다:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/resources/i18n/nl_NL/cura.po
+++ b/resources/i18n/nl_NL/cura.po
@@ -6800,6 +6800,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB-printen"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Meer Informatie"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/nl_NL/cura.po
+++ b/resources/i18n/nl_NL/cura.po
@@ -6800,41 +6800,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB-printen"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "U moet de licentie accepteren om de package te installeren"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Wijzigingen gedetecteerd van uw Ultimaker-account"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Wijzigingen van uw account"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Verwijderen"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Weigeren en verwijderen uit account"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Wilt u materiaal- en softwarepackages synchroniseren met uw account?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Synchroniseren ..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "De volgende packages worden toegevoegd:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "U moet {} afsluiten en herstarten voordat de wijzigingen van kracht worden."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "{} plug-ins zijn niet gedownload"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Licentieovereenkomst plug-in"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Synchroniseer materialen"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "U moet {} afsluiten en herstarten voordat de wijzigingen van kracht worden."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Synchroniseren ..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Wijzigingen gedetecteerd van uw Ultimaker-account"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Wilt u materiaal- en softwarepackages synchroniseren met uw account?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Synchroniseren"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Weigeren en verwijderen uit account"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "{} plug-ins zijn niet gedownload"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Licentieovereenkomst plug-in"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -7023,22 +7051,6 @@ msgstr "USB-printen"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Kan geen verbinding maken met de Cura Package-database. Controleer uw verbinding."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "U moet de licentie accepteren om de package te installeren"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Wijzigingen van uw account"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Verwijderen"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "De volgende packages worden toegevoegd:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/resources/i18n/pt_BR/cura.po
+++ b/resources/i18n/pt_BR/cura.po
@@ -6389,41 +6389,70 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Impressão USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "Você precisa aceitar a licença para que o pacote possa ser instalado"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Alterações detectadas de sua conta Ultimaker"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Alterações da sua conta"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Dispensar"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Recusar e remover da conta"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Você quer sincronizar os pacotes de material e software com sua conta?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Sincronizando..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Os seguintes pacotes serão adicionados:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "Você precisa sair e reiniciar {} para que as alterações tenham efeito."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "{} complementos falharam em baixar"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Acordo de Licença do Complemento"
+
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Sincronizar materiais"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "Você precisa sair e reiniciar {} para que as alterações tenham efeito."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Sincronizando..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Alterações detectadas de sua conta Ultimaker"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Você quer sincronizar os pacotes de material e software com sua conta?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Sincronizar"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Recusar e remover da conta"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "{} complementos falharam em baixar"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Acordo de Licença do Complemento"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -6612,22 +6641,6 @@ msgstr "Impressão USB"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Não foi possível conectar-se à base de dados de Pacotes do Cura. Por favor verifique sua conexão."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "Você precisa aceitar a licença para que o pacote possa ser instalado"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Alterações da sua conta"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Dispensar"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Os seguintes pacotes serão adicionados:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/resources/i18n/pt_BR/cura.po
+++ b/resources/i18n/pt_BR/cura.po
@@ -6389,6 +6389,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Impressão USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Saiba mais"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/pt_PT/cura.po
+++ b/resources/i18n/pt_PT/cura.po
@@ -6803,41 +6803,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Impressão USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "É necessário aceitar a licença para instalar o pacote"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Foram detetadas alterações da sua conta Ultimaker"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Alterações feitas desde a sua conta"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Descartar"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Rejeitar e remover da conta"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Pretende sincronizar o material e os pacotes de software com a sua conta?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "A sincronizar..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Os seguintes pacotes vão ser instalados:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "É necessário reiniciar o {} para que as alterações tenham efeito."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "Falhou a transferência de {} plug-ins"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Contrato de licença do plug-in"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Sincronizar materiais"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "É necessário reiniciar o {} para que as alterações tenham efeito."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "A sincronizar..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Foram detetadas alterações da sua conta Ultimaker"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Pretende sincronizar o material e os pacotes de software com a sua conta?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Sincronizar"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Rejeitar e remover da conta"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "Falhou a transferência de {} plug-ins"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Contrato de licença do plug-in"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -7026,22 +7054,6 @@ msgstr "Impressão USB"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Não foi possível aceder á base de dados de Pacotes do Cura. Por favor verifique a sua ligação."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "É necessário aceitar a licença para instalar o pacote"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Alterações feitas desde a sua conta"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Descartar"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Os seguintes pacotes vão ser instalados:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/resources/i18n/pt_PT/cura.po
+++ b/resources/i18n/pt_PT/cura.po
@@ -6803,6 +6803,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Impressão USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Saber Mais"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/ru_RU/cura.po
+++ b/resources/i18n/ru_RU/cura.po
@@ -6806,6 +6806,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Печать через USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Узнать Больше"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/ru_RU/cura.po
+++ b/resources/i18n/ru_RU/cura.po
@@ -6806,41 +6806,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "Печать через USB"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "Для установки пакета необходимо принять лицензию"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "В вашей учетной записи Ultimaker обнаружены изменения"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Изменения в вашей учетной записи"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Отклонить"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Отклонить и удалить из учетной записи"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Хотите синхронизировать пакеты материалов и программного обеспечения со своей учетной записью?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Синхронизация..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Будут добавлены следующие пакеты:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "Для активации изменений вам потребуется завершить работу программного обеспечения {} и перезапустить его."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "Встраиваемые модули ({} шт.) не загружены"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Лицензионное соглашение плагина"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Синхронизация материалов"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "Для активации изменений вам потребуется завершить работу программного обеспечения {} и перезапустить его."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Синхронизация..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "В вашей учетной записи Ultimaker обнаружены изменения"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Хотите синхронизировать пакеты материалов и программного обеспечения со своей учетной записью?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Синхронизация"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Отклонить и удалить из учетной записи"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "Встраиваемые модули ({} шт.) не загружены"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Лицензионное соглашение плагина"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -7029,22 +7057,6 @@ msgstr "Печать через USB"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Не удалось подключиться к базе данных пакета Cura. Проверьте свое подключение."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "Для установки пакета необходимо принять лицензию"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Изменения в вашей учетной записи"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Отклонить"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Будут добавлены следующие пакеты:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/resources/i18n/tr_TR/cura.po
+++ b/resources/i18n/tr_TR/cura.po
@@ -6790,6 +6790,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB yazdırma"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "Daha Fazla Bilgi Edinin"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/tr_TR/cura.po
+++ b/resources/i18n/tr_TR/cura.po
@@ -6790,41 +6790,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB yazdırma"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "Paketi yüklemek için lisansı kabul etmeniz gerekir"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "Ultimaker hesabınızda değişiklik tespit edildi"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "Hesabınızda değişiklik var"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "Kapat"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "Reddet ve hesaptan kaldır"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "Malzeme ve yazılım paketlerini hesabınızla senkronize etmek istiyor musunuz?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "Senkronize ediliyor..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "Aşağıdaki paketler eklenecek:"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "Değişikliklerin etkili olması için {} uygulamasını kapatarak yeniden başlatmalısınız."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "{} eklenti indirilemedi"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "Eklenti Lisans Anlaşması"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "Malzemeleri yazıcılarla senkronize et"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "Değişikliklerin etkili olması için {} uygulamasını kapatarak yeniden başlatmalısınız."
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "Senkronize ediliyor..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "Ultimaker hesabınızda değişiklik tespit edildi"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "Malzeme ve yazılım paketlerini hesabınızla senkronize etmek istiyor musunuz?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "Senkronize et"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "Reddet ve hesaptan kaldır"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "{} eklenti indirilemedi"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "Eklenti Lisans Anlaşması"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -7013,22 +7041,6 @@ msgstr "USB yazdırma"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "Cura Paket veri tabanına bağlanılamadı. Lütfen bağlantınızı kontrol edin."
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "Paketi yüklemek için lisansı kabul etmeniz gerekir"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "Hesabınızda değişiklik var"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "Kapat"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "Aşağıdaki paketler eklenecek:"
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/resources/i18n/zh_CN/cura.po
+++ b/resources/i18n/zh_CN/cura.po
@@ -6749,41 +6749,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB 联机打印"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "需要接受许可证才能安装该程序包"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "检测到您的 Ultimaker 帐户有更改"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "您的帐户有更改"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "解除"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "拒绝并从帐户中删除"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "是否要与您的帐户同步材料和软件包?"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "正在同步..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "将添加以下程序包："
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "需要退出并重新启动 {}，然后更改才能生效。"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "{} 个插件下载失败"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "插件许可协议"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "同步材料与打印机"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "需要退出并重新启动 {}，然后更改才能生效。"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "正在同步..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "检测到您的 Ultimaker 帐户有更改"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "是否要与您的帐户同步材料和软件包?"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "同步"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "拒绝并从帐户中删除"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "{} 个插件下载失败"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "插件许可协议"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -6972,22 +7000,6 @@ msgstr "USB 联机打印"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "无法连接到Cura包数据库。请检查您的连接。"
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "需要接受许可证才能安装该程序包"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "您的帐户有更改"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "解除"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "将添加以下程序包："
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/resources/i18n/zh_CN/cura.po
+++ b/resources/i18n/zh_CN/cura.po
@@ -6749,6 +6749,11 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB 联机打印"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:35
+msgctxt "@button:label"
+msgid "Learn More"
+msgstr "详细了解"
+
 #: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"

--- a/resources/i18n/zh_CN/cura.po
+++ b/resources/i18n/zh_CN/cura.po
@@ -1676,7 +1676,7 @@ msgstr "所提供的状态不正确。"
 #: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationRequestHandler.py:80
 msgctxt "@message"
 msgid "Timeout when authenticating with the account server."
-msgstr "Timeout when authenticating with the account server."
+msgstr "使用帐户服务器进行身份验证超时。"
 
 #: /home/remco/dev/code/ulti/trans/Cura/cura/OAuth2/AuthorizationRequestHandler.py:97
 msgctxt "@message"
@@ -3939,7 +3939,7 @@ msgstr "管理设置可见性..."
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingsMenu.qml:34
 msgctxt "@title:menu"
 msgid "&Material"
-msgstr "材料（&M）"
+msgstr "材料(&M)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/SettingsMenu.qml:49
 msgctxt "@action:inmenu"
@@ -3984,7 +3984,7 @@ msgstr "文件(&F)"
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/FileMenu.qml:44
 msgctxt "@title:menu menubar:file"
 msgid "&Save Project..."
-msgstr "保存项目(＆S)..."
+msgstr "保存项目(&S)..."
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/FileMenu.qml:77
 msgctxt "@title:menu menubar:file"
@@ -3999,17 +3999,17 @@ msgstr "导出选择..."
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/PreferencesMenu.qml:21
 msgctxt "@title:menu menubar:toplevel"
 msgid "P&references"
-msgstr "偏好设置（&R）"
+msgstr "偏好设置(&R)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/EditMenu.qml:12
 msgctxt "@title:menu menubar:toplevel"
 msgid "&Edit"
-msgstr "编辑（&E）"
+msgstr "编辑(&E)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/PrinterMenu.qml:13
 msgctxt "@title:menu menubar:settings"
 msgid "&Printer"
-msgstr "打印机（&P）"
+msgstr "打印机(&P)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Menus/PrinterMenu.qml:17
 msgctxt "@label:category menu label"
@@ -4696,7 +4696,7 @@ msgstr "要自动将材料配置文件与连接到 Digital Factory 的所有打�
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:587
 msgctxt "@button"
 msgid "Sync materials with USB"
-msgstr "Sync materials with USB"
+msgstr "使用 USB 同步材料"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:190
 msgctxt "@title:header"
@@ -5868,12 +5868,12 @@ msgstr "显示联机故障排除"
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:88
 msgctxt "@action:inmenu"
 msgid "Toggle Full Screen"
-msgstr "切换完整界面"
+msgstr "切换全屏"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:96
 msgctxt "@action:inmenu"
 msgid "Exit Full Screen"
-msgstr "退出完整界面"
+msgstr "退出全屏"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:103
 msgctxt "@action:inmenu menubar:edit"
@@ -5950,17 +5950,17 @@ msgstr "从市场添加更多材料"
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:223
 msgctxt "@action:inmenu menubar:profile"
 msgid "&Update profile with current settings/overrides"
-msgstr "使用当前设置 / 重写值更新配置文件（&U）"
+msgstr "使用当前设置 / 重写值更新配置文件(&U)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:231
 msgctxt "@action:inmenu menubar:profile"
 msgid "&Discard current changes"
-msgstr "舍弃当前更改（&D）"
+msgstr "舍弃当前更改(&D)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:243
 msgctxt "@action:inmenu menubar:profile"
 msgid "&Create profile from current settings/overrides..."
-msgstr "从当前设置 / 重写值创建配置文件（&C）..."
+msgstr "从当前设置 / 重写值创建配置文件(&C)..."
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:249
 msgctxt "@action:inmenu menubar:profile"
@@ -6010,12 +6010,12 @@ msgstr "删除模型"
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:330
 msgctxt "@action:inmenu"
 msgid "Ce&nter Model on Platform"
-msgstr "使模型居于平台中央（&N）"
+msgstr "使模型居于平台中央(&N)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:336
 msgctxt "@action:inmenu menubar:edit"
 msgid "&Group Models"
-msgstr "绑定模型（&G）"
+msgstr "绑定模型(&G)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:356
 msgctxt "@action:inmenu menubar:edit"
@@ -6025,12 +6025,12 @@ msgstr "拆分模型"
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:366
 msgctxt "@action:inmenu menubar:edit"
 msgid "&Merge Models"
-msgstr "合并模型（&M）"
+msgstr "合并模型(&M)"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:376
 msgctxt "@action:inmenu"
 msgid "&Multiply Model..."
-msgstr "复制模型…（&M）"
+msgstr "复制模型(&M)…"
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:383
 msgctxt "@action:inmenu menubar:edit"
@@ -6070,12 +6070,12 @@ msgstr "复位所有模型的变动"
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:443
 msgctxt "@action:inmenu menubar:file"
 msgid "&Open File(s)..."
-msgstr "打开文件（&O）..."
+msgstr "打开文件(&O)..."
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:453
 msgctxt "@action:inmenu menubar:file"
 msgid "&New Project..."
-msgstr "新建项目（&N）..."
+msgstr "新建项目(&N)..."
 
 #: /home/remco/dev/code/ulti/trans/Cura/resources/qml/Actions.qml:460
 msgctxt "@action:inmenu menubar:help"

--- a/resources/i18n/zh_TW/cura.po
+++ b/resources/i18n/zh_TW/cura.po
@@ -6530,41 +6530,69 @@ msgctxt "name"
 msgid "USB printing"
 msgstr "USB 連線列印"
 
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+msgctxt "@label"
+msgid "You need to accept the license to install the package"
+msgstr "你必需同意授權協議才能安裝套件"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+msgctxt "@info:title"
+msgid "Changes detected from your Ultimaker account"
+msgstr "從你的 Ultimaker 帳號偵測到資料更動"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+msgctxt "@title"
+msgid "Changes from your account"
+msgstr "你帳戶的更動"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+msgctxt "@button"
+msgid "Dismiss"
+msgstr "捨棄"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+msgctxt "@button"
+msgid "Decline and remove from account"
+msgstr "拒絕並從帳號中刪除"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+msgctxt "@info:generic"
+msgid "Do you want to sync material and software packages with your account?"
+msgstr "你要使用你的帳號同步線材資料和軟體套件嗎？"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+msgctxt "@info:generic"
+msgid "Syncing..."
+msgstr "同步中..."
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+msgctxt "@label"
+msgid "The following packages will be added:"
+msgstr "將新增下列套件："
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+msgctxt "@info:generic"
+msgid "You need to quit and restart {} before changes have effect."
+msgstr "你需要結束並重新啟動 {} ，更動才能生效。"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+msgctxt "@info:generic"
+msgid "{} plugins failed to download"
+msgstr "下載外掛 {} 失敗"
+
+#: /Users/j.delarago/development/cura_installation/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+msgctxt "@title:window"
+msgid "Plugin License Agreement"
+msgstr "外掛授權協議"
+
 #~ msgctxt "@action:button"
 #~ msgid "Sync materials with printers"
 #~ msgstr "列印機同步線材資料"
 
-#~ msgctxt "@info:generic"
-#~ msgid "You need to quit and restart {} before changes have effect."
-#~ msgstr "你需要結束並重新啟動 {} ，更動才能生效。"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Syncing..."
-#~ msgstr "同步中..."
-
-#~ msgctxt "@info:title"
-#~ msgid "Changes detected from your Ultimaker account"
-#~ msgstr "從你的 Ultimaker 帳號偵測到資料更動"
-
-#~ msgctxt "@info:generic"
-#~ msgid "Do you want to sync material and software packages with your account?"
-#~ msgstr "你要使用你的帳號同步線材資料和軟體套件嗎？"
-
 #~ msgctxt "@action:button"
 #~ msgid "Sync"
 #~ msgstr "同步"
-
-#~ msgctxt "@button"
-#~ msgid "Decline and remove from account"
-#~ msgstr "拒絕並從帳號中刪除"
-
-#~ msgctxt "@info:generic"
-#~ msgid "{} plugins failed to download"
-#~ msgstr "下載外掛 {} 失敗"
-
-#~ msgctxt "@title:window"
-#~ msgid "Plugin License Agreement"
-#~ msgstr "外掛授權協議"
 
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
@@ -6753,22 +6781,6 @@ msgstr "USB 連線列印"
 #~ msgctxt "@info"
 #~ msgid "Could not connect to the Cura Package database. Please check your connection."
 #~ msgstr "無法連上 Cura 套件資料庫。請檢查你的網路連線。"
-
-#~ msgctxt "@label"
-#~ msgid "You need to accept the license to install the package"
-#~ msgstr "你必需同意授權協議才能安裝套件"
-
-#~ msgctxt "@title"
-#~ msgid "Changes from your account"
-#~ msgstr "你帳戶的更動"
-
-#~ msgctxt "@button"
-#~ msgid "Dismiss"
-#~ msgstr "捨棄"
-
-#~ msgctxt "@label"
-#~ msgid "The following packages will be added:"
-#~ msgstr "將新增下列套件："
 
 #~ msgctxt "@label"
 #~ msgid "The following packages can not be installed because of an incompatible Cura version:"

--- a/scripts/update_po_with_changes.py
+++ b/scripts/update_po_with_changes.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     parser.add_argument("updated_file", type=str, help="Input .po file with updated translations added")
     args = parser.parse_args()
 
-    messages_updated = parse_po_file(args.updated_file)
-    messages_original = parse_po_file(args.original_file)
-    different_messages = get_different_messages(messages_original, messages_updated)
-    update_po_file(args.original_file, "updated.po", different_messages)
+    messages_updated = parsePOFile(args.updated_file)
+    messages_original = parsePOFile(args.original_file)
+    different_messages = getDifferentMessages(messages_original, messages_updated)
+    updatePOFile(args.original_file, "updated.po", different_messages)

--- a/scripts/update_po_with_changes.py
+++ b/scripts/update_po_with_changes.py
@@ -71,7 +71,7 @@ def getDifferentMessages(messages_original: List[Msg], messages_new: List[Msg]) 
     return different_messages
 
 
-def update_po_file(input_filename: str, output_filename: str, messages: List[Msg]):
+def updatePOFile(input_filename: str, output_filename: str, messages: List[Msg]) -> None:
     # Takes a list of changed messages and writes a copy of input file with updated message strings
     with open(input_filename, "r") as input_file, open(output_filename, "w") as output_file:
         iterator = iter(input_file.readlines())

--- a/scripts/update_po_with_changes.py
+++ b/scripts/update_po_with_changes.py
@@ -24,7 +24,7 @@ class Msg:
         return self.msgctxt + self.msgid + self.msgstr
 
 
-def parse_po_file(filename: str) -> List[Msg]:
+def parsePOFile(filename: str) -> List[Msg]:
     messages = []
     with open(filename) as f:
         iterator = iter(f.readlines())

--- a/scripts/update_po_with_changes.py
+++ b/scripts/update_po_with_changes.py
@@ -1,0 +1,121 @@
+import argparse
+
+from typing import List
+
+"""
+    Takes in one of the po files in resources/i18n/[LANG_CODE]/cura.po and updates it with translations from a 
+    new po file without changing the translation ordering. 
+    This script should be used when we get a po file that has updated translations but is no longer correctly ordered 
+    so the merge becomes messy.
+    
+    If you are importing files from lionbridge/smartling use lionbridge_import.py.
+    
+    Note: This does NOT include new strings, it only UPDATES existing strings   
+"""
+
+
+class Msg:
+    def __init__(self, msgctxt: str = "", msgid: str = "", msgstr: str = ""):
+        self.msgctxt = msgctxt
+        self.msgid = msgid
+        self.msgstr = msgstr
+
+    def __str__(self):
+        return self.msgctxt + self.msgid + self.msgstr
+
+
+def parse_po_file(filename: str) -> List[Msg]:
+    messages = []
+    with open(filename) as f:
+        iterator = iter(f.readlines())
+        while True:
+            try:
+                line = next(iterator)
+                if line[0:7] == "msgctxt":
+                    #  Start of a translation item block
+                    msg = Msg()
+                    msg.msgctxt = line
+
+                    while True:
+                        line = next(iterator)
+                        if line[0:5] == "msgid":
+                            msg.msgid = line
+                            break
+
+                    while True:
+                        #  msgstr can be split over multiple lines
+                        line = next(iterator)
+                        if line == "\n":
+                            break
+                        if line[0:6] == "msgstr":
+                            msg.msgstr = line
+                        else:
+                            msg.msgstr += line
+
+                    messages.append(msg)
+            except StopIteration:
+                return messages
+
+
+def get_different_messages(messages_original: List[Msg], messages_new: List[Msg]) -> List[Msg]:
+    #  Return messages that have changed in messages_new
+    different_messages = []
+
+    for m_new in messages_new:
+        for m_original in messages_original:
+            if m_new.msgstr != m_original.msgstr \
+                    and m_new.msgid == m_original.msgid and m_new.msgctxt == m_original.msgctxt \
+                    and m_new.msgid != 'msgid ""\n':
+                different_messages.append(m_new)
+
+    return different_messages
+
+
+def update_po_file(input_filename: str, output_filename: str, messages: List[Msg]):
+    # Takes a list of changed messages and writes a copy of input file with updated message strings
+    with open(input_filename, "r") as input_file, open(output_filename, "w") as output_file:
+        iterator = iter(input_file.readlines())
+        while True:
+            try:
+                line = next(iterator)
+                output_file.write(line)
+                if line[0: 7] == "msgctxt":
+                    #  Start of translation block
+                    msgctxt = line
+
+                    msgid = next(iterator)
+                    output_file.write(msgid)
+
+                    #  Check for updated version of msgstr
+                    message = list(filter(lambda m: m.msgctxt == msgctxt and m.msgid == msgid, messages))
+                    if message and message[0]:
+                        #  Write update translation
+                        output_file.write(message[0].msgstr)
+
+                        # Skip lines until next translation. This should skip multiline msgstr
+                        while True:
+                            line = next(iterator)
+                            if line == "\n":
+                                output_file.write(line)
+                                break
+
+            except StopIteration:
+                return
+
+
+if __name__ == "__main__":
+    print("********************************************************************************************************************")
+    print("This creates a new file 'updated.po' that is a copy of original_file with any changed translations from updated_file")
+    print("This does not change the order of translations")
+    print("This does not include new translations, only existing changed translations")
+    print("Do not use this to import lionbridge/smarting translations")
+    print("********************************************************************************************************************")
+    parser = argparse.ArgumentParser(description="Update po file with translations from new po file. This ")
+    parser.add_argument("original_file", type=str, help="Input .po file inside resources/i18n/[LANG]/")
+    parser.add_argument("updated_file", type=str, help="Input .po file with updated translations added")
+    args = parser.parse_args()
+
+    messages_updated = parse_po_file(args.updated_file)
+    messages_original = parse_po_file(args.original_file)
+    different_messages = get_different_messages(messages_original, messages_updated)
+    update_po_file(args.original_file, "updated.po", different_messages)

--- a/scripts/update_po_with_changes.py
+++ b/scripts/update_po_with_changes.py
@@ -15,7 +15,7 @@ from typing import List
 
 
 class Msg:
-    def __init__(self, msgctxt: str = "", msgid: str = "", msgstr: str = ""):
+    def __init__(self, msgctxt: str = "", msgid: str = "", msgstr: str = "") -> None:
         self.msgctxt = msgctxt
         self.msgid = msgid
         self.msgstr = msgstr

--- a/scripts/update_po_with_changes.py
+++ b/scripts/update_po_with_changes.py
@@ -28,33 +28,31 @@ def parsePOFile(filename: str) -> List[Msg]:
     messages = []
     with open(filename) as f:
         iterator = iter(f.readlines())
-        while True:
-            try:
-                line = next(iterator)
-                if line[0:7] == "msgctxt":
-                    #  Start of a translation item block
-                    msg = Msg()
-                    msg.msgctxt = line
+        for line in iterator:
+            if line.startswith("msgctxt"):
+                #  Start of a translation item block
+                msg = Msg()
+                msg.msgctxt = line
 
-                    while True:
-                        line = next(iterator)
-                        if line[0:5] == "msgid":
-                            msg.msgid = line
-                            break
+                while True:
+                    line = next(iterator)
+                    if line.startswith("msgid"):
+                        msg.msgid = line
+                        break
 
-                    while True:
-                        #  msgstr can be split over multiple lines
-                        line = next(iterator)
-                        if line == "\n":
-                            break
-                        if line[0:6] == "msgstr":
-                            msg.msgstr = line
-                        else:
-                            msg.msgstr += line
+                while True:
+                    #  msgstr can be split over multiple lines
+                    line = next(iterator)
+                    if line == "\n":
+                        break
+                    if line.startswith("msgstr"):
+                        msg.msgstr = line
+                    else:
+                        msg.msgstr += line
 
-                    messages.append(msg)
-            except StopIteration:
-                return messages
+                messages.append(msg)
+
+        return messages
 
 
 def getDifferentMessages(messages_original: List[Msg], messages_new: List[Msg]) -> List[Msg]:
@@ -75,32 +73,27 @@ def updatePOFile(input_filename: str, output_filename: str, messages: List[Msg])
     # Takes a list of changed messages and writes a copy of input file with updated message strings
     with open(input_filename, "r") as input_file, open(output_filename, "w") as output_file:
         iterator = iter(input_file.readlines())
-        while True:
-            try:
-                line = next(iterator)
-                output_file.write(line)
-                if line[0: 7] == "msgctxt":
-                    #  Start of translation block
-                    msgctxt = line
+        for line in iterator:
+            output_file.write(line)
+            if line.startswith("msgctxt"):
+                #  Start of translation block
+                msgctxt = line
 
-                    msgid = next(iterator)
-                    output_file.write(msgid)
+                msgid = next(iterator)
+                output_file.write(msgid)
 
-                    #  Check for updated version of msgstr
-                    message = list(filter(lambda m: m.msgctxt == msgctxt and m.msgid == msgid, messages))
-                    if message and message[0]:
-                        #  Write update translation
-                        output_file.write(message[0].msgstr)
+                #  Check for updated version of msgstr
+                message = list(filter(lambda m: m.msgctxt == msgctxt and m.msgid == msgid, messages))
+                if message and message[0]:
+                    #  Write update translation
+                    output_file.write(message[0].msgstr)
 
-                        # Skip lines until next translation. This should skip multiline msgstr
-                        while True:
-                            line = next(iterator)
-                            if line == "\n":
-                                output_file.write(line)
-                                break
-
-            except StopIteration:
-                return
+                    # Skip lines until next translation. This should skip multiline msgstr
+                    while True:
+                        line = next(iterator)
+                        if line == "\n":
+                            output_file.write(line)
+                            break
 
 
 if __name__ == "__main__":

--- a/scripts/update_po_with_changes.py
+++ b/scripts/update_po_with_changes.py
@@ -57,7 +57,7 @@ def parse_po_file(filename: str) -> List[Msg]:
                 return messages
 
 
-def get_different_messages(messages_original: List[Msg], messages_new: List[Msg]) -> List[Msg]:
+def getDifferentMessages(messages_original: List[Msg], messages_new: List[Msg]) -> List[Msg]:
     #  Return messages that have changed in messages_new
     different_messages = []
 


### PR DESCRIPTION
A few translations were missed when generating the cura.pot template file, this caused them to be commented out in the po files for each language. I've uncommented these and moved them out of the comment section of the po files. 

I had to regenerate the cura.pot template file to find these, it's been shuffled around a bit but you can see by the length only a few have been added.

CURA-9141