### PR TITLE
Fix for tooltip

### DIFF
--- a/resources/qml/TableView.qml
+++ b/resources/qml/TableView.qml
@@ -171,6 +171,12 @@ Item
 
                 acceptedButtons: Qt.LeftButton
                 text: (cellTextMetrics.elidedText == cellContent.text) ? "" : cellContent.text //Show full text in tooltip if it was elided.
+            }
+
+            MouseArea
+            {
+                anchors.fill: parent
+                propagateComposedEvents: true
                 onClicked:
                 {
                     if(tableBase.allowSelection)


### PR DESCRIPTION
Problem was that the mouse events were not properly propagated to the underlying mouse area. Fixed by placing the MouseArea on top of the content (instead of under) and allowing the mouse events to propagate through the mouse area. This way we don't have to propagate the mouse event for each individual component that could be located within the ToolTipArea.

Also removed some logic where the properties of the Mouse area were exposed. However this was only used in one instance (as far as I could find) and in my opinion this was abusing the intended use of the ToolTipArea component. This last issue is simply fixed by adding an additional mouse area.

CURA-9219