### PR TITLE
Add setting to no longer use different jerk/acc for travels

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -3322,6 +3322,17 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },
+                "acceleration_travel_enabled":
+                {
+                    "label": "Enable Travel Acceleration",
+                    "description": "Use a separate acceleration rate for travel moves. If disabled, travel moves will use the acceleration value of the printed line at their destination.",
+                    "type": "bool",
+                    "default_value": true,
+                    "resolve": "any(extruderValues('acceleration_travel_enabled'))",
+                    "enabled": "acceleration_enabled",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
+                },
                 "acceleration_print":
                 {
                     "label": "Print Acceleration",
@@ -3541,7 +3552,7 @@
                     "minimum_value_warning": "100",
                     "maximum_value_warning": "10000",
                     "value": "acceleration_print if magic_spiralize else 5000",
-                    "enabled": "resolveOrValue('acceleration_enabled')",
+                    "enabled": "resolveOrValue('acceleration_enabled') and resolveOrValue('acceleration_travel_enabled')",
                     "settable_per_mesh": false
                 },
                 "acceleration_layer_0":
@@ -3584,7 +3595,7 @@
                             "minimum_value": "0.1",
                             "minimum_value_warning": "100",
                             "maximum_value_warning": "10000",
-                            "enabled": "resolveOrValue('acceleration_enabled')",
+                            "enabled": "resolveOrValue('acceleration_enabled') and resolveOrValue('acceleration_travel_enabled')",
                             "settable_per_extruder": true,
                             "settable_per_mesh": false
                         }
@@ -3612,6 +3623,17 @@
                     "type": "bool",
                     "default_value": false,
                     "resolve": "any(extruderValues('jerk_enabled'))",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
+                },
+                "jerk_travel_enabled":
+                {
+                    "label": "Enable Travel Jerk",
+                    "description": "Use a separate acceleration rate for travel moves. If disabled, travel moves will use the acceleration value of the printed line at their destination.",
+                    "type": "bool",
+                    "default_value": true,
+                    "resolve": "any(extruderValues('jerk_travel_enabled'))",
+                    "enabled": "jerk_enabled",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },
@@ -3820,7 +3842,7 @@
                     "minimum_value": "0",
                     "maximum_value_warning": "50",
                     "value": "jerk_print if magic_spiralize else 30",
-                    "enabled": "resolveOrValue('jerk_enabled')",
+                    "enabled": "resolveOrValue('jerk_enabled') and resolveOrValue('jerk_travel_enabled')",
                     "settable_per_mesh": false
                 },
                 "jerk_layer_0":
@@ -3860,7 +3882,7 @@
                             "value": "jerk_layer_0 * jerk_travel / jerk_print",
                             "minimum_value": "0",
                             "maximum_value_warning": "50",
-                            "enabled": "resolveOrValue('jerk_enabled')",
+                            "enabled": "resolveOrValue('jerk_enabled') and resolveOrValue('jerk_travel_enabled')",
                             "settable_per_extruder": true,
                             "settable_per_mesh": false
                         }


### PR DESCRIPTION
Enabling this adds more control, possibly improving the productivity of the printer by allowing higher acceleration and jerk rates during travel moves where they have less of an impact.
Disabling this reduces the size of the g-code and the CPU requirements of the printer.

If these settings are disabled, travel moves will be printed using the acceleration and/or jerk of the first extruded move _after_ the string of travel moves. This is considered better than using the acceleration/jerk _before_ the travel, because if a travel move ends at a sensitive structure like the outer wall, it's good if the printer doesn't shake any more as it arrives there so that it doesn't shake when extruding. If it starts at a sensitive part the shaking of the fast travel move doesn't happen until after that sensitive structure completed printing. So it's more important to be careful if the _next_ printed line is sensitive, than to be careful if the _previous_ printed line was sensitive.

If the travel move is at the end of a layer it will take on the acceleration/jerk of the first extruded move of the next layer. If there are no extruded moves there either, it doesn't emit any acceleration/jerk command, making it use the acceleration/jerk of the most recent extruded line. So this happens in two cases:
* If there are empty layers halfway through the print. This is very rare in a real print. If it happens it might arrive at the start of the next layer too fast.
* At the very end of every print. Then it doesn't matter any more since there are no extruded lines any more that could be sensitive to wobbling.

Also requires CuraEngine pull request: https://github.com/Ultimaker/CuraEngine/pull/1661

Contributes to issue CURA-8708.