### PR TITLE
Allow text to be wider if favourite button is not shown

### DIFF
--- a/resources/qml/Preferences/Materials/MaterialsSlot.qml
+++ b/resources/qml/Preferences/Materials/MaterialsSlot.qml
@@ -47,7 +47,7 @@ Rectangle
         radius: width / 2
         anchors.verticalCenter: materialSlot.verticalCenter
         anchors.left: materialSlot.left
-        anchors.leftMargin: 2 * UM.Theme.getSize("default_margin").width
+        anchors.leftMargin: UM.Theme.getSize("default_margin").width
     }
     UM.Label
     {
@@ -58,7 +58,7 @@ Rectangle
         wrapMode: Text.NoWrap
         verticalAlignment: Text.AlignVCenter
         anchors.left: swatch.right
-        anchors.right: favoriteButton.left
+        anchors.right: favoriteButton.visible ? favoriteButton.left : parent.right
         anchors.leftMargin: UM.Theme.getSize("default_margin").width
         anchors.rightMargin: UM.Theme.getSize("narrow_margin").width
         anchors.verticalCenter: materialSlot.verticalCenter
@@ -102,7 +102,7 @@ Rectangle
         ]
 
         implicitHeight: parent.height
-        implicitWidth: height
+        implicitWidth: favoriteIndicator.width
         anchors.right: materialSlot.right
         visible: false
 


### PR DESCRIPTION
It can take the space of the favourite button then. Also made the margin on the left a little smaller.

Currently the list of materials is quite hard to read:
![image](https://user-images.githubusercontent.com/2448634/169242350-33ae78f0-1f09-49c1-84c4-340e6786cb4b.png)

With this change, it's a little better:
![image](https://user-images.githubusercontent.com/2448634/169242506-15038ca0-66f1-4c7d-b24c-130864a28009.png)

If a material is favourited (or hovered to show the favourite button) then it does become shorter again to make space for that button:
![image](https://user-images.githubusercontent.com/2448634/169242913-a9a1c64f-d419-48a0-a488-d1b770ee4fff.png)
