### PR TITLE
PP-86 reduce support interface flow

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -68,6 +68,9 @@
         "skin_material_flow": {
             "value": "0.97 * material_flow"
         },
+        "support_interface_material_flow": {
+            "value": "skin_material_flow"
+        },
         "skin_monotonic" : {
             "value": true
         },


### PR DESCRIPTION
The reasoning of PP-86 also holds for the support interface layers, however we forgot about support when we implemented PP-86. When doing PP-108 we found this improvement.