### PR TITLE
Use intent category if no translation is available

### DIFF
--- a/cura/Machines/Models/IntentCategoryModel.py
+++ b/cura/Machines/Models/IntentCategoryModel.py
@@ -111,7 +111,7 @@ class IntentCategoryModel(ListModel):
             except ValueError:
                 weight = 99
             result.append({
-                "name": IntentCategoryModel.translation(category, "name", category),
+                "name": IntentCategoryModel.translation(category, "name", category.title()),
                 "description": IntentCategoryModel.translation(category, "description", None),
                 "intent_category": category,
                 "weight": weight,

--- a/cura/Machines/Models/QualityManagementModel.py
+++ b/cura/Machines/Models/QualityManagementModel.py
@@ -358,8 +358,9 @@ class QualityManagementModel(ListModel):
                 "quality_type": quality_type,
                 "quality_changes_group": None,
                 "intent_category": intent_category,
-                "section_name": catalog.i18nc("@label", intent_translations.get(intent_category, {}).get("name", catalog.i18nc("@label", "Unknown"))),
+                "section_name": catalog.i18nc("@label", intent_translations.get(intent_category, {}).get("name", catalog.i18nc("@label", intent_category.title()))),
             })
+
         # Sort by quality_type for each intent category
         intent_translations_list = list(intent_translations)
 

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -1611,7 +1611,7 @@ class MachineManager(QObject):
         if intent_category != "default":
             intent_display_name = IntentCategoryModel.translation(intent_category,
                                                                   "name",
-                                                                  catalog.i18nc("@label", "Unknown"))
+                                                                  intent_category.title())
             display_name = "{intent_name} - {the_rest}".format(intent_name = intent_display_name,
                                                                the_rest = display_name)
 


### PR DESCRIPTION
Previously we would only accept intents that had a translation. If we could not find one, we would use "unknown" as the intent category. However, we didn't really do this consistently. In some places it would show unknown and in others we'd show the intent type.

This should make the behavior the same across the board. It will try to get a translation for the intent category and show that. If it's unable to find that it will use the category instead. Note that it will use the python title function to ensure it has nice capitalization

CURA-9297