### PR TITLE
Rename Ender-3 profile to include v2

### DIFF
--- a/resources/definitions/creality_ender3.def.json
+++ b/resources/definitions/creality_ender3.def.json
@@ -1,5 +1,5 @@
 {
-    "name": "Creality Ender-3",
+    "name": "Creality Ender-3 / Ender-3 v2",
     "version": 2,
     "inherits": "creality_base",
     "metadata": {


### PR DESCRIPTION
Since the Ender 3 v2 is the same hardware profile as the Ender 3, make it clear in the profile name.