### PR TITLE
[CURA-8610] Fix warning when saving bundled packages

### DIFF
--- a/cura/CuraPackageManager.py
+++ b/cura/CuraPackageManager.py
@@ -60,6 +60,8 @@ class CuraPackageManager(PackageManager):
     def isMaterialBundled(self, file_name: str, guid: str):
         """ Check if there is a bundled material name with file_name and guid """
         for path in Resources.getSecureSearchPaths():
+            # Secure search paths are install directory paths, if a material is in here it must be bundled.
+
             paths = [Path(p) for p in glob.glob(path + '/**/*.xml.fdm_material')]
             for material in paths:
                 if material.name == file_name:

--- a/plugins/3MFWriter/ThreeMFWriter.py
+++ b/plugins/3MFWriter/ThreeMFWriter.py
@@ -267,18 +267,20 @@ class ThreeMFWriter(MeshWriter):
                 # Don't export materials not in use
                 continue
 
+            if package_manager.isMaterialBundled(extruder.material.getFileName(), extruder.material.getMetaDataEntry("GUID")):
+                # Don't export bundled materials
+                continue
+
             package_id = package_manager.getMaterialFilePackageId(extruder.material.getFileName(), extruder.material.getMetaDataEntry("GUID"))
             package_data = package_manager.getInstalledPackageInfo(package_id)
 
             if not package_data:
+                # We failed to find the package for this material
                 message = Message(catalog.i18nc("@error:material",
                                                 "It was not possible to store material package information in project file: {material}. This project may not open correctly on other systems.".format(material=extruder.getName())),
                                   title=catalog.i18nc("@info:title", "Failed to save material package information"),
                                   message_type=Message.MessageType.WARNING)
                 message.show()
-                continue
-
-            if package_data.get("is_bundled"):
                 continue
 
             material_metadata = {"id": package_id,


### PR DESCRIPTION
Before this change packages were only being checked if they were bundled after loading the package_id. However only installed packages were being loaded so this would always be false.

The solution here is to check first if a material file is inside "secure_paths" (these are install directory resource paths). If it is, it must be a bundled material.

CURA-8610