### PR TITLE
Update tests with new required metadata fields

### DIFF
--- a/tests/Settings/TestCuraContainerRegistry.py
+++ b/tests/Settings/TestCuraContainerRegistry.py
@@ -314,8 +314,8 @@ class TestImportProfile:
 
 @pytest.mark.parametrize("metadata,result", [(None, False),
                                              ({}, False),
-                                             ({"setting_version": cura.CuraApplication.CuraApplication.SettingVersion}, True),
-                                             ({"setting_version": 0}, False)])
+                                             ({"setting_version": cura.CuraApplication.CuraApplication.SettingVersion, "type": "some_type", "name": "some_name"}, True),
+                                             ({"setting_version": 0, "type": "some_type", "name": "some_name"}, False)])
 def test_isMetaDataValid(container_registry, metadata, result):
     assert container_registry._isMetadataValid(metadata) == result
 


### PR DESCRIPTION
We're changing the validation function of metadata for containers to require the type and name parameters. That needs to be reflected in the tests.

Contributes to issue CURA-3Z4.

While this PR could be merged on its own without damage, it's only necessary when https://github.com/Ultimaker/Uranium/pull/830 is merged.