### PR TITLE
[CURA-9271] Build plate shrinks when using horizontal scaling shrinkage compensation

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -565,8 +565,8 @@ class BuildVolume(SceneNode):
         self._updateScaleFactor()
 
         self._volume_aabb = AxisAlignedBox(
-            minimum = Vector(min_w, min_h - 1.0, min_d).scale(self._scale_vector),
-            maximum = Vector(max_w, max_h - self._raft_thickness - self._extra_z_clearance, max_d).scale(self._scale_vector)
+            minimum = Vector(min_w, min_h - 1.0, min_d),
+            maximum = Vector(max_w, max_h - self._raft_thickness - self._extra_z_clearance, max_d)
         )
 
         bed_adhesion_size = self.getEdgeDisallowedSize()
@@ -575,8 +575,8 @@ class BuildVolume(SceneNode):
         # This is probably wrong in all other cases. TODO!
         # The +1 and -1 is added as there is always a bit of extra room required to work properly.
         scale_to_max_bounds = AxisAlignedBox(
-            minimum = Vector(min_w + bed_adhesion_size + 1, min_h, min_d + self._disallowed_area_size - bed_adhesion_size + 1).scale(self._scale_vector),
-            maximum = Vector(max_w - bed_adhesion_size - 1, max_h - self._raft_thickness - self._extra_z_clearance, max_d - self._disallowed_area_size + bed_adhesion_size - 1).scale(self._scale_vector)
+            minimum = Vector(min_w + bed_adhesion_size + 1, min_h, min_d + self._disallowed_area_size - bed_adhesion_size + 1),
+            maximum = Vector(max_w - bed_adhesion_size - 1, max_h - self._raft_thickness - self._extra_z_clearance, max_d - self._disallowed_area_size + bed_adhesion_size - 1)
         )
 
         self._application.getController().getScene()._maximum_bounds = scale_to_max_bounds  # type: ignore
@@ -645,7 +645,7 @@ class BuildVolume(SceneNode):
             for extruder in extruders:
                 extruder.propertyChanged.connect(self._onSettingPropertyChanged)
 
-            self._width = self._global_container_stack.getProperty("machine_width", "value") * self._scale_vector.x
+            self._width = self._global_container_stack.getProperty("machine_width", "value")
             machine_height = self._global_container_stack.getProperty("machine_height", "value")
             if self._global_container_stack.getProperty("print_sequence", "value") == "one_at_a_time" and len(self._scene_objects) > 1:
                 self._height = min(self._global_container_stack.getProperty("gantry_height", "value") * self._scale_vector.z, machine_height)
@@ -656,7 +656,7 @@ class BuildVolume(SceneNode):
             else:
                 self._height = self._global_container_stack.getProperty("machine_height", "value")
                 self._build_volume_message.hide()
-            self._depth = self._global_container_stack.getProperty("machine_depth", "value") * self._scale_vector.y
+            self._depth = self._global_container_stack.getProperty("machine_depth", "value")
             self._shape = self._global_container_stack.getProperty("machine_shape", "value")
 
             self._updateDisallowedAreas()
@@ -752,8 +752,8 @@ class BuildVolume(SceneNode):
             return
         self._updateScaleFactor()
         self._height = self._global_container_stack.getProperty("machine_height", "value") * self._scale_vector.z
-        self._width = self._global_container_stack.getProperty("machine_width", "value") * self._scale_vector.x
-        self._depth = self._global_container_stack.getProperty("machine_depth", "value") * self._scale_vector.y
+        self._width = self._global_container_stack.getProperty("machine_width", "value")
+        self._depth = self._global_container_stack.getProperty("machine_depth", "value")
         self._shape = self._global_container_stack.getProperty("machine_shape", "value")
 
     def _updateDisallowedAreasAndRebuild(self):
@@ -769,14 +769,6 @@ class BuildVolume(SceneNode):
         self._updateRaftThickness()
         self._extra_z_clearance = self._calculateExtraZClearance(ExtruderManager.getInstance().getUsedExtruderStacks())
         self.rebuild()
-
-    def _scaleAreas(self, result_areas: List[Polygon]) -> None:
-        if self._global_container_stack is None:
-            return
-        for i, polygon in enumerate(result_areas):
-            result_areas[i] = polygon.scale(
-                100.0 / max(100.0, self._global_container_stack.getProperty("material_shrinkage_percentage_xy", "value"))
-            )
 
     def _updateDisallowedAreas(self) -> None:
         if not self._global_container_stack:
@@ -833,11 +825,9 @@ class BuildVolume(SceneNode):
 
         self._disallowed_areas = []
         for extruder_id in result_areas:
-            self._scaleAreas(result_areas[extruder_id])
             self._disallowed_areas.extend(result_areas[extruder_id])
         self._disallowed_areas_no_brim = []
         for extruder_id in result_areas_no_brim:
-            self._scaleAreas(result_areas_no_brim[extruder_id])
             self._disallowed_areas_no_brim.extend(result_areas_no_brim[extruder_id])
 
     def _computeDisallowedAreasPrinted(self, used_extruders):

--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -983,6 +983,9 @@ class BuildVolume(SceneNode):
             half_machine_width = self._global_container_stack.getProperty("machine_width", "value") / 2
             half_machine_depth = self._global_container_stack.getProperty("machine_depth", "value") / 2
 
+            # We need at a minimum a very small border around the edge so that models can't go off the build plate
+            border_size = max(border_size, 0.1)
+
             if self._shape != "elliptic":
                 if border_size - left_unreachable_border > 0:
                     result[extruder_id].append(Polygon(numpy.array([


### PR DESCRIPTION
We were previously both scaling down the buildplate and scaling up the disallowed areas of the models with shrinkage compensation. Doing both reduces the max usable area when scaling.

<img width="707" alt="Screenshot 2022-06-08 at 15 37 33" src="https://user-images.githubusercontent.com/23387864/172630597-2a8a3eac-4ddc-4b93-9895-a9176adae4a5.png">

<img width="707" alt="Screenshot 2022-06-08 at 15 37 42" src="https://user-images.githubusercontent.com/23387864/172630611-1110fe8d-4821-4786-ac89-3b548030392d.png">

The solution is to do only one of these options.

Removing the disallowed area works fine when scaling models from their centre. However we scale 2 or more models from the buildplate centre rather than the model centre. This means that the models can go outside the buildplate without it being obvious from the visualisation.

The better solution is to remove the buildplate x/y scaling and keep the disallowed areas. This mean our preview can go above the max z shown in prepare, but this is the good solution without implementing 3d disallowed areas.

<img width="761" alt="Screenshot 2022-06-08 at 14 08 39" src="https://user-images.githubusercontent.com/23387864/172629811-6a06d71c-54b0-4630-aff8-efdae7108eea.png">

<img width="761" alt="Screenshot 2022-06-08 at 14 08 43" src="https://user-images.githubusercontent.com/23387864/172629819-9460353c-3cd2-4fea-8a5a-b4ee5637a519.png">

Removed shrinkage factor build volume scaling on x and y. This information is shown already by scaling the allowed areas around the objects.

Kept the bounding box scaling for z. This shows the max height a model can be. The objects disallowed area does not show this information.

Also removed scaling on non model disallowed areas on the build plate since this does not need to scale with the build plate anymore.

CURA-9271