### PR TITLE
[CURA-8849] more intent fixes

### DIFF
--- a/resources/qml/IconWithText.qml
+++ b/resources/qml/IconWithText.qml
@@ -24,6 +24,8 @@ Item
     property alias wrapMode: label.wrapMode
     property real spacing: UM.Theme.getSize("narrow_margin").width
 
+    property string tooltipText
+
     // These properties can be used in combination with layouts.
     readonly property real contentWidth: icon.width + margin + label.contentWidth
     readonly property real minContentWidth: Math.round(icon.width + margin + 0.5 * label.contentWidth)
@@ -65,5 +67,14 @@ Item
             leftMargin: spacing
             margins: margin
         }
+    }
+
+    MouseArea
+    {
+        enabled: tooltipText != null
+        anchors.fill: parent
+        hoverEnabled: true
+        onEntered: base.showTooltip(parent, Qt.point(-UM.Theme.getSize("thick_margin").width, 0), tooltipText)
+        onExited: base.hideTooltip()
     }
 }

--- a/resources/qml/IconWithText.qml
+++ b/resources/qml/IconWithText.qml
@@ -24,7 +24,7 @@ Item
     property alias wrapMode: label.wrapMode
     property real spacing: UM.Theme.getSize("narrow_margin").width
 
-    property string tooltipText
+    property string tooltipText: ""
 
     // These properties can be used in combination with layouts.
     readonly property real contentWidth: icon.width + margin + label.contentWidth
@@ -71,7 +71,7 @@ Item
 
     MouseArea
     {
-        enabled: tooltipText != null
+        enabled: tooltipText != ""
         anchors.fill: parent
         hoverEnabled: true
         onEntered: base.showTooltip(parent, Qt.point(-UM.Theme.getSize("thick_margin").width, 0), tooltipText)

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml
@@ -28,7 +28,6 @@ Item
         font: UM.Theme.getFont("medium")
         width: labelColumnWidth
         iconSize: UM.Theme.getSize("medium_button_icon").width
-        tooltipText: catalog.i18nc("@label", "Enable printing a brim or raft. This will add a flat area around or under your object which is easy to cut off afterwards.")
     }
 
     Item
@@ -48,8 +47,6 @@ Item
             id: enableAdhesionCheckBox
             anchors.verticalCenter: parent.verticalCenter
 
-            property alias _hovered: adhesionMouseArea.containsMouse
-
             //: Setting enable printing build-plate adhesion helper checkbox
             enabled: recommendedPrintSetup.settingsEnabled
 
@@ -61,20 +58,23 @@ Item
                 id: adhesionMouseArea
                 anchors.fill: parent
                 hoverEnabled: true
-
-                onClicked:
-                {
-                    curaRecommendedMode.setAdhesion(!parent.checked)
-                }
-
-                onEntered:
-                {
-                    base.showTooltip(enableAdhesionCheckBox, Qt.point(-enableAdhesionContainer.x - UM.Theme.getSize("thick_margin").width, 0),
-                        catalog.i18nc("@label", "Enable printing a brim or raft. This will add a flat area around or under your object which is easy to cut off afterwards."));
-                }
-                onExited: base.hideTooltip()
+                // propagateComposedEvents used on adhesionTooltipMouseArea does not work with Controls Components.
+                // It only works with other MouseAreas, so this is required
+                onClicked: curaRecommendedMode.setAdhesion(!parent.checked)
             }
         }
+    }
+
+    MouseArea
+    {
+        id: adhesionTooltipMouseArea
+        anchors.fill: parent
+        propagateComposedEvents: true
+        hoverEnabled: true
+
+        onEntered:base.showTooltip(enableAdhesionCheckBox, Qt.point(-enableAdhesionContainer.x - UM.Theme.getSize("thick_margin").width, 0),
+                catalog.i18nc("@label", "Enable printing a brim or raft. This will add a flat area around or under your object which is easy to cut off afterwards."));
+        onExited: base.hideTooltip()
     }
 
     UM.SettingPropertyProvider

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml
@@ -13,7 +13,7 @@ import Cura 1.0 as Cura
 Item
 {
     id: enableAdhesionRow
-    height: childrenRect.height
+    height: enableAdhesionContainer.height
 
     property real labelColumnWidth: Math.round(width / 3)
     property var curaRecommendedMode: Cura.RecommendedMode {}

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml
@@ -28,6 +28,7 @@ Item
         font: UM.Theme.getFont("medium")
         width: labelColumnWidth
         iconSize: UM.Theme.getSize("medium_button_icon").width
+        tooltipText: catalog.i18nc("@label", "Enable printing a brim or raft. This will add a flat area around or under your object which is easy to cut off afterwards.")
     }
 
     Item

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml
@@ -103,7 +103,6 @@ Item
                 id: backgroundLine
                 height: UM.Theme.getSize("print_setup_slider_groove").height
                 width: parent.width - UM.Theme.getSize("print_setup_slider_handle").width
-                implicitWidth: width
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
                 color: infillSlider.enabled ? UM.Theme.getColor("quality_slider_available") : UM.Theme.getColor("quality_slider_unavailable")

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml
@@ -65,6 +65,7 @@ Item
         font: UM.Theme.getFont("medium")
         width: labelColumnWidth
         iconSize: UM.Theme.getSize("medium_button_icon").width
+        tooltipText: catalog.i18nc("@label", "Gradual infill will gradually increase the amount of infill towards the top.")
     }
 
     Item

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml
@@ -62,7 +62,7 @@ Item
         {
             width: parent.width
             Layout.fillWidth: true
-            Layout.topMargin: UM.Theme.getSize("thin_margin").height
+            Layout.topMargin: UM.Theme.getSize("default_margin").height
             Layout.bottomMargin: UM.Theme.getSize("thin_margin").height
         }
 

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedResolutionSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedResolutionSelector.qml
@@ -22,6 +22,7 @@ Item
         id: resolutionTitle
         anchors.top: parent.top
         anchors.left: parent.left
+        anchors.leftMargin: - UM.Theme.getSize("thick_lining").width
         source: UM.Theme.getIcon("PrintQuality")
         text: catalog.i18nc("@label", "Resolution")
         width: labelColumnWidth

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
@@ -18,36 +18,39 @@ Item
 
     property real labelColumnWidth: Math.round(width / 3)
 
-    Cura.IconWithText
-    {
-        id: enableSupportRowTitle
-        anchors.top: parent.top
-        anchors.left: parent.left
-        visible: enableSupportCheckBox.visible
-        source: UM.Theme.getIcon("Support")
-        text: catalog.i18nc("@label", "Support")
-        font: UM.Theme.getFont("medium")
-        width: labelColumnWidth
-        iconSize: UM.Theme.getSize("medium_button_icon").width
-        tooltipText: catalog.i18nc("@label", "Generate structures to support parts of the model which have overhangs. Without these structures, such parts would collapse during printing.")
-    }
-
     Item
     {
         id: enableSupportContainer
-        height: enableSupportCheckBox.height
+        height: enableSupportCheckBox
+        width: childrenRect.width
 
         anchors
         {
-            left: enableSupportRowTitle.right
-            right: parent.right
-            verticalCenter: enableSupportRowTitle.verticalCenter
+            left: parent.left
+            top: parent.top
+            bottom: parent.bottom
+            rightMargin: UM.Theme.getSize("thick_margin").width
+            verticalCenter: parent.verticalCenter
+        }
+
+        Cura.IconWithText
+        {
+            id: enableSupportRowTitle
+            anchors.left: parent.left
+            visible: enableSupportCheckBox.visible
+            source: UM.Theme.getIcon("Support")
+            text: catalog.i18nc("@label", "Support")
+            font: UM.Theme.getFont("medium")
+            width: labelColumnWidth
+            iconSize: UM.Theme.getSize("medium_button_icon").width
+            tooltipText: catalog.i18nc("@label", "Generate structures to support parts of the model which have overhangs. Without these structures, such parts would collapse during printing.")
         }
 
         UM.CheckBox
         {
             id: enableSupportCheckBox
             anchors.verticalCenter: parent.verticalCenter
+            anchors.left: enableSupportRowTitle.right
 
             property alias _hovered: enableSupportMouseArea.containsMouse
 
@@ -61,157 +64,219 @@ Item
                 id: enableSupportMouseArea
                 anchors.fill: parent
                 hoverEnabled: true
-
+                // propagateComposedEvents used on supportToolTipMouseArea does not work with Controls Components.
+                // It only works with other MouseAreas, so this is required
                 onClicked: supportEnabled.setPropertyValue("value", supportEnabled.properties.value != "True")
-
-                onEntered:
-                {
-                    base.showTooltip(enableSupportCheckBox, Qt.point(-enableSupportContainer.x - UM.Theme.getSize("thick_margin").width, 0),
-                        catalog.i18nc("@label", "Generate structures to support parts of the model which have overhangs. Without these structures, such parts would collapse during printing."))
-                }
-                onExited: base.hideTooltip()
             }
         }
 
-        ComboBox
+        MouseArea
         {
-            id: supportExtruderCombobox
+            id: supportToolTipMouseArea
+            anchors.fill: parent
+            propagateComposedEvents: true
+            hoverEnabled: true
+            onEntered: base.showTooltip(enableSupportContainer, Qt.point(-enableSupportContainer.x - UM.Theme.getSize("thick_margin").width, 0),
+                    catalog.i18nc("@label", "Generate structures to support parts of the model which have overhangs. Without these structures, such parts would collapse during printing."))
+            onExited: base.hideTooltip()
+        }
+    }
 
-            height: UM.Theme.getSize("print_setup_big_item").height
-            anchors
+    ComboBox
+    {
+        id: supportExtruderCombobox
+
+        height: UM.Theme.getSize("print_setup_big_item").height
+        anchors
+        {
+            left: enableSupportContainer.right
+            right: parent.right
+            leftMargin: UM.Theme.getSize("default_margin").width
+            rightMargin: UM.Theme.getSize("thick_margin").width
+            verticalCenter: parent.verticalCenter
+        }
+
+        enabled: recommendedPrintSetup.settingsEnabled
+        visible: enableSupportCheckBox.visible && (supportEnabled.properties.value == "True") && (extrudersEnabledCount.properties.value > 1)
+        textRole: "name"  // this solves that the combobox isn't populated in the first time Cura is started
+
+        model: extruderModel
+
+        // knowing the extruder position, try to find the item index in the model
+        function getIndexByPosition(position)
+        {
+            var itemIndex = -1  // if position is not found, return -1
+            for (var item_index in model.items)
             {
-                left: enableSupportCheckBox.right
-                right: parent.right
-                leftMargin: UM.Theme.getSize("thick_margin").width
-                rightMargin: UM.Theme.getSize("thick_margin").width
-                verticalCenter: parent.verticalCenter
-            }
-
-            enabled: recommendedPrintSetup.settingsEnabled
-            visible: enableSupportCheckBox.visible && (supportEnabled.properties.value == "True") && (extrudersEnabledCount.properties.value > 1)
-            textRole: "name"  // this solves that the combobox isn't populated in the first time Cura is started
-
-            model: extruderModel
-
-            // knowing the extruder position, try to find the item index in the model
-            function getIndexByPosition(position)
-            {
-                var itemIndex = -1  // if position is not found, return -1
-                for (var item_index in model.items)
+                var item = model.getItem(item_index)
+                if (item.index == position)
                 {
-                    var item = model.getItem(item_index)
-                    if (item.index == position)
-                    {
-                        itemIndex = item_index
-                        break
-                    }
-                }
-                return itemIndex
-            }
-
-            onActivated:
-            {
-                if (model.getItem(index).enabled)
-                {
-                    forceActiveFocus();
-                    supportExtruderNr.setPropertyValue("value", model.getItem(index).index);
-                } else
-                {
-                    currentIndex = supportExtruderNr.properties.value;  // keep the old value
+                    itemIndex = item_index
+                    break
                 }
             }
+            return itemIndex
+        }
 
-            currentIndex: (supportExtruderNr.properties.value !== undefined) ? supportExtruderNr.properties.value : 0
-
-            property string color: "#fff"
-            Connections
+        onActivated:
+        {
+            if (model.getItem(index).enabled)
             {
-                target: extruderModel
-                function onModelChanged()
-                {
-                    var maybeColor = supportExtruderCombobox.model.getItem(supportExtruderCombobox.currentIndex).color
-                    if (maybeColor)
-                    {
-                        supportExtruderCombobox.color = maybeColor
-                    }
-                }
+                forceActiveFocus();
+                supportExtruderNr.setPropertyValue("value", model.getItem(index).index);
+            } else
+            {
+                currentIndex = supportExtruderNr.properties.value;  // keep the old value
             }
-            onCurrentIndexChanged:
+        }
+
+        currentIndex: (supportExtruderNr.properties.value !== undefined) ? supportExtruderNr.properties.value : 0
+
+        property string color: "#fff"
+        Connections
+        {
+            target: extruderModel
+            function onModelChanged()
             {
                 var maybeColor = supportExtruderCombobox.model.getItem(supportExtruderCombobox.currentIndex).color
-                if(maybeColor)
+                if (maybeColor)
                 {
                     supportExtruderCombobox.color = maybeColor
                 }
             }
-
-            Binding
+        }
+        onCurrentIndexChanged:
+        {
+            var maybeColor = supportExtruderCombobox.model.getItem(supportExtruderCombobox.currentIndex).color
+            if(maybeColor)
             {
-                target: supportExtruderCombobox
-                property: "currentIndex"
-                value: supportExtruderCombobox.getIndexByPosition(supportExtruderNr.properties.value)
-                // Sometimes when the value is already changed, the model is still being built.
-                // The when clause ensures that the current index is not updated when this happens.
-                when: supportExtruderCombobox.model.count > 0
+                supportExtruderCombobox.color = maybeColor
             }
+        }
 
-            indicator: UM.ColorImage
+        Binding
+        {
+            target: supportExtruderCombobox
+            property: "currentIndex"
+            value: supportExtruderCombobox.getIndexByPosition(supportExtruderNr.properties.value)
+            // Sometimes when the value is already changed, the model is still being built.
+            // The when clause ensures that the current index is not updated when this happens.
+            when: supportExtruderCombobox.model.count > 0
+        }
+
+        indicator: UM.ColorImage
+        {
+            id: downArrow
+            x: supportExtruderCombobox.width - width - supportExtruderCombobox.rightPadding
+            y: supportExtruderCombobox.topPadding + Math.round((supportExtruderCombobox.availableHeight - height) / 2)
+
+            source: UM.Theme.getIcon("ChevronSingleDown")
+            width: UM.Theme.getSize("standard_arrow").width
+            height: UM.Theme.getSize("standard_arrow").height
+
+            color: UM.Theme.getColor("setting_control_button")
+        }
+
+        background: Rectangle
+        {
+            color:
             {
-                id: downArrow
-                x: supportExtruderCombobox.width - width - supportExtruderCombobox.rightPadding
-                y: supportExtruderCombobox.topPadding + Math.round((supportExtruderCombobox.availableHeight - height) / 2)
+                if (!enabled)
+                {
+                    return UM.Theme.getColor("setting_control_disabled")
+                }
+                if (supportExtruderCombobox.hovered || base.activeFocus)
+                {
+                    return UM.Theme.getColor("setting_control_highlight")
+                }
+                return UM.Theme.getColor("setting_control")
+            }
+            radius: UM.Theme.getSize("setting_control_radius").width
+            border.width: UM.Theme.getSize("default_lining").width
+            border.color:
+            {
+                if (!enabled)
+                {
+                    return UM.Theme.getColor("setting_control_disabled_border")
+                }
+                if (supportExtruderCombobox.hovered || supportExtruderCombobox.activeFocus)
+                {
+                    return UM.Theme.getColor("setting_control_border_highlight")
+                }
+                return UM.Theme.getColor("setting_control_border")
+            }
+        }
 
-                source: UM.Theme.getIcon("ChevronSingleDown")
-                width: UM.Theme.getSize("standard_arrow").width
-                height: UM.Theme.getSize("standard_arrow").height
+        contentItem: UM.Label
+        {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.left: parent.left
+            anchors.leftMargin: UM.Theme.getSize("setting_unit_margin").width
+            anchors.right: downArrow.left
+            rightPadding: swatch.width + UM.Theme.getSize("setting_unit_margin").width
 
-                color: UM.Theme.getColor("setting_control_button")
+            text: supportExtruderCombobox.currentText
+            textFormat: Text.PlainText
+            color: enabled ? UM.Theme.getColor("setting_control_text") : UM.Theme.getColor("setting_control_disabled_text")
+
+            elide: Text.ElideLeft
+
+
+            background: Rectangle
+            {
+                id: swatch
+                height: Math.round(parent.height / 2)
+                width: height
+                radius: Math.round(width / 2)
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.rightMargin: UM.Theme.getSize("thin_margin").width
+
+                color: supportExtruderCombobox.color
+            }
+        }
+
+        popup: Popup
+        {
+            y: supportExtruderCombobox.height - UM.Theme.getSize("default_lining").height
+            width: supportExtruderCombobox.width
+            implicitHeight: contentItem.implicitHeight + 2 * UM.Theme.getSize("default_lining").width
+            padding: UM.Theme.getSize("default_lining").width
+
+            contentItem: ListView
+            {
+                implicitHeight: contentHeight
+
+                ScrollBar.vertical: UM.ScrollBar {}
+                clip: true
+                model: supportExtruderCombobox.popup.visible ? supportExtruderCombobox.delegateModel : null
+                currentIndex: supportExtruderCombobox.highlightedIndex
             }
 
             background: Rectangle
             {
-                color:
-                {
-                    if (!enabled)
-                    {
-                        return UM.Theme.getColor("setting_control_disabled")
-                    }
-                    if (supportExtruderCombobox.hovered || base.activeFocus)
-                    {
-                        return UM.Theme.getColor("setting_control_highlight")
-                    }
-                    return UM.Theme.getColor("setting_control")
-                }
-                radius: UM.Theme.getSize("setting_control_radius").width
-                border.width: UM.Theme.getSize("default_lining").width
-                border.color:
-                {
-                    if (!enabled)
-                    {
-                        return UM.Theme.getColor("setting_control_disabled_border")
-                    }
-                    if (supportExtruderCombobox.hovered || supportExtruderCombobox.activeFocus)
-                    {
-                        return UM.Theme.getColor("setting_control_border_highlight")
-                    }
-                    return UM.Theme.getColor("setting_control_border")
-                }
+                color: UM.Theme.getColor("setting_control")
+                border.color: UM.Theme.getColor("setting_control_border")
             }
+        }
+
+        delegate: ItemDelegate
+        {
+            width: supportExtruderCombobox.width - 2 * UM.Theme.getSize("default_lining").width
+            height: supportExtruderCombobox.height
+            highlighted: supportExtruderCombobox.highlightedIndex == index
 
             contentItem: UM.Label
             {
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.left: parent.left
+                anchors.fill: parent
                 anchors.leftMargin: UM.Theme.getSize("setting_unit_margin").width
-                anchors.right: downArrow.left
+                anchors.rightMargin: UM.Theme.getSize("setting_unit_margin").width
+
+                text: model.name
+                color: model.enabled ? UM.Theme.getColor("setting_control_text"): UM.Theme.getColor("action_button_disabled_text")
+
+                elide: Text.ElideRight
                 rightPadding: swatch.width + UM.Theme.getSize("setting_unit_margin").width
-
-                text: supportExtruderCombobox.currentText
-                textFormat: Text.PlainText
-                color: enabled ? UM.Theme.getColor("setting_control_text") : UM.Theme.getColor("setting_control_disabled_text")
-
-                elide: Text.ElideLeft
-
 
                 background: Rectangle
                 {
@@ -223,71 +288,14 @@ Item
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.rightMargin: UM.Theme.getSize("thin_margin").width
 
-                    color: supportExtruderCombobox.color
+                    color: supportExtruderCombobox.model.getItem(index).color
                 }
             }
 
-            popup: Popup
+            background: Rectangle
             {
-                y: supportExtruderCombobox.height - UM.Theme.getSize("default_lining").height
-                width: supportExtruderCombobox.width
-                implicitHeight: contentItem.implicitHeight + 2 * UM.Theme.getSize("default_lining").width
-                padding: UM.Theme.getSize("default_lining").width
-
-                contentItem: ListView
-                {
-                    implicitHeight: contentHeight
-
-                    ScrollBar.vertical: UM.ScrollBar {}
-                    clip: true
-                    model: supportExtruderCombobox.popup.visible ? supportExtruderCombobox.delegateModel : null
-                    currentIndex: supportExtruderCombobox.highlightedIndex
-                }
-
-                background: Rectangle
-                {
-                    color: UM.Theme.getColor("setting_control")
-                    border.color: UM.Theme.getColor("setting_control_border")
-                }
-            }
-
-            delegate: ItemDelegate
-            {
-                width: supportExtruderCombobox.width - 2 * UM.Theme.getSize("default_lining").width
-                height: supportExtruderCombobox.height
-                highlighted: supportExtruderCombobox.highlightedIndex == index
-
-                contentItem: UM.Label
-                {
-                    anchors.fill: parent
-                    anchors.leftMargin: UM.Theme.getSize("setting_unit_margin").width
-                    anchors.rightMargin: UM.Theme.getSize("setting_unit_margin").width
-
-                    text: model.name
-                    color: model.enabled ? UM.Theme.getColor("setting_control_text"): UM.Theme.getColor("action_button_disabled_text")
-
-                    elide: Text.ElideRight
-                    rightPadding: swatch.width + UM.Theme.getSize("setting_unit_margin").width
-
-                    background: Rectangle
-                    {
-                        id: swatch
-                        height: Math.round(parent.height / 2)
-                        width: height
-                        radius: Math.round(width / 2)
-                        anchors.right: parent.right
-                        anchors.verticalCenter: parent.verticalCenter
-                        anchors.rightMargin: UM.Theme.getSize("thin_margin").width
-
-                        color: supportExtruderCombobox.model.getItem(index).color
-                    }
-                }
-
-                background: Rectangle
-                {
-                    color: parent.highlighted ? UM.Theme.getColor("setting_control_highlight") : "transparent"
-                    border.color: parent.highlighted ? UM.Theme.getColor("setting_control_border_highlight") : "transparent"
-                }
+                color: parent.highlighted ? UM.Theme.getColor("setting_control_highlight") : "transparent"
+                border.color: parent.highlighted ? UM.Theme.getColor("setting_control_border_highlight") : "transparent"
             }
         }
     }

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
@@ -29,6 +29,7 @@ Item
         font: UM.Theme.getFont("medium")
         width: labelColumnWidth
         iconSize: UM.Theme.getSize("medium_button_icon").width
+        tooltipText: catalog.i18nc("@label", "Generate structures to support parts of the model which have overhangs. Without these structures, such parts would collapse during printing.")
     }
 
     Item

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
@@ -14,15 +14,14 @@ import Cura 1.0 as Cura
 Item
 {
     id: enableSupportRow
-    height: childrenRect.height
+    height: UM.Theme.getSize("print_setup_big_item").height
 
     property real labelColumnWidth: Math.round(width / 3)
 
     Item
     {
         id: enableSupportContainer
-        height: enableSupportCheckBox
-        width: childrenRect.width
+        width: labelColumnWidth + enableSupportCheckBox.width
 
         anchors
         {
@@ -30,7 +29,6 @@ Item
             top: parent.top
             bottom: parent.bottom
             rightMargin: UM.Theme.getSize("thick_margin").width
-            verticalCenter: parent.verticalCenter
         }
 
         Cura.IconWithText

--- a/resources/qml/Settings/SettingItem.qml
+++ b/resources/qml/Settings/SettingItem.qml
@@ -209,7 +209,7 @@ Item
                 height: UM.Theme.getSize("small_button_icon").height
                 width: height
 
-                color: UM.Theme.getColor("setting_control_button")
+                color: UM.Theme.getColor("accent_1")
                 hoverColor: UM.Theme.getColor("setting_control_button_hover")
 
                 iconSource: UM.Theme.getIcon("ArrowReset")

--- a/resources/qml/Widgets/ComboBox.qml
+++ b/resources/qml/Widgets/ComboBox.qml
@@ -56,28 +56,30 @@ ComboBox
 
     background: UM.UnderlineBackground
     {
-        //Rectangle for highlighting when this combobox needs to pulse.
+        // Rectangle for highlighting when this combobox needs to pulse.
         Rectangle
         {
             anchors.fill: parent
             opacity: 0
-            color: UM.Theme.getColor("warning")
+            color: "transparent"
+
+            border.color: UM.Theme.getColor("text_field_border_active")
+            border.width: UM.Theme.getSize("default_lining").width
 
             SequentialAnimation on opacity
             {
                 id: pulseAnimation
                 running: false
-                loops: 1
-                alwaysRunToEnd: true
+                loops: 2
                 PropertyAnimation
                 {
                     to: 1
-                    duration: 300
+                    duration: 150
                 }
                 PropertyAnimation
                 {
                     to: 0
-                    duration : 2000
+                    duration : 150
                 }
             }
         }


### PR DESCRIPTION
The changes to the recommended settings menu are as follows

- Replaced resolution combobox yellow warning with two blue flashes of the combobox lining 
- Hovering over the text/icon or the checkbox will now show the tooltip
- Made the print settings reset button blue to match the recommended settings reset button
- Fixed the left alignment of the Resolution icon in recommended settings