### PR TITLE
[CURA-9412] Project file saving fails on printers without materials

### DIFF
--- a/plugins/3MFWriter/ThreeMFWriter.py
+++ b/plugins/3MFWriter/ThreeMFWriter.py
@@ -12,6 +12,7 @@ from UM.Application import Application
 from UM.Message import Message
 from UM.Resources import Resources
 from UM.Scene.SceneNode import SceneNode
+from UM.Settings.ContainerRegistry import ContainerRegistry
 from UM.Settings.EmptyInstanceContainer import EmptyInstanceContainer
 
 from cura.CuraApplication import CuraApplication
@@ -269,7 +270,7 @@ class ThreeMFWriter(MeshWriter):
                 # Don't export materials not in use
                 continue
 
-            if type(extruder.material) is EmptyInstanceContainer:
+            if isinstance(extruder.material, type(ContainerRegistry.getInstance().getEmptyInstanceContainer())):
                 # This is an empty material container, no material to export
                 continue
 

--- a/plugins/3MFWriter/ThreeMFWriter.py
+++ b/plugins/3MFWriter/ThreeMFWriter.py
@@ -12,6 +12,7 @@ from UM.Application import Application
 from UM.Message import Message
 from UM.Resources import Resources
 from UM.Scene.SceneNode import SceneNode
+from UM.Settings.EmptyInstanceContainer import EmptyInstanceContainer
 
 from cura.CuraApplication import CuraApplication
 from cura.CuraPackageManager import CuraPackageManager
@@ -266,6 +267,10 @@ class ThreeMFWriter(MeshWriter):
         for extruder in CuraApplication.getInstance().getExtruderManager().getActiveExtruderStacks():
             if not extruder.isEnabled:
                 # Don't export materials not in use
+                continue
+
+            if type(extruder.material) is EmptyInstanceContainer:
+                # This is an empty material container, no material to export
                 continue
 
             if package_manager.isMaterialBundled(extruder.material.getFileName(), extruder.material.getMetaDataEntry("GUID")):


### PR DESCRIPTION
Add check for empty material instance containers before trying to fetch material metadata. This fixes failing to save a project on a printer with no materials (UM2 for example).

CURA-9412