### PR TITLE
[CURA-9401] Toolbar visible on monitor page

### DIFF
--- a/cura/Stages/CuraStage.py
+++ b/cura/Stages/CuraStage.py
@@ -15,6 +15,8 @@ from UM.Stage import Stage
 class CuraStage(Stage):
     def __init__(self, parent = None) -> None:
         super().__init__(parent)
+        # True if the toolbar should be visible when this stage is active
+        self._toolbarEnabled = False
 
     @pyqtProperty(str, constant = True)
     def stageId(self) -> str:
@@ -27,6 +29,10 @@ class CuraStage(Stage):
     @pyqtProperty(QUrl, constant = True)
     def stageMenuComponent(self) -> QUrl:
         return self.getDisplayComponent("menu")
+
+    @pyqtProperty(bool, constant = True)
+    def toolbarEnabled(self) -> bool:
+        return self._toolbarEnabled
 
 
 __all__ = ["CuraStage"]

--- a/plugins/PrepareStage/PrepareStage.py
+++ b/plugins/PrepareStage/PrepareStage.py
@@ -13,6 +13,7 @@ class PrepareStage(CuraStage):
     def __init__(self, parent = None):
         super().__init__(parent)
         Application.getInstance().engineCreatedSignal.connect(self._engineCreated)
+        self._toolbarEnabled = True
 
     def _engineCreated(self):
         menu_component_path = os.path.join(PluginRegistry.getInstance().getPluginPath("PrepareStage"), "PrepareMenu.qml")

--- a/plugins/PreviewStage/PreviewStage.py
+++ b/plugins/PreviewStage/PreviewStage.py
@@ -25,6 +25,7 @@ class PreviewStage(CuraStage):
         self._application = application
         self._application.engineCreatedSignal.connect(self._engineCreated)
         self._previously_active_view = None  # type: Optional[View]
+        self._toolbarEnabled = True
 
     def onStageSelected(self) -> None:
         """When selecting the stage, remember which was the previous view so that

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -318,7 +318,7 @@ UM.MainWindow
                     verticalCenter: tallerThanParent ? undefined : parent.verticalCenter
                     left: parent.left
                 }
-                visible: CuraApplication.platformActivity && !PrintInformation.preSliced
+                visible: CuraApplication.platformActivity && !PrintInformation.preSliced && UM.Controller.activeStage.toolbarEnabled
             }
 
             // A hint for the loaded content view. Overlay items / controls can safely be placed in this area


### PR DESCRIPTION
Fix a bug where the toolbar was showing on the monitor screen. The fix is to have a boolean in CuraStage objects which says whether they should show the toolbar. I think this will be useful for plugin developers.

The default is not to show the toolbar now. I expect this will not change the functionality of plugins, however if a reviewer thinks a default of true is more sensible please suggest the change.