### PR TITLE
Add the "clear" hack to the tableModel for discardOrkeepchanges

### DIFF
--- a/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml
+++ b/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml
@@ -24,6 +24,16 @@ UM.Dialog
 
     property var changesModel: Cura.UserChangesModel { id: userChangesModel }
 
+    // Hack to make sure that when the data of our model changes the tablemodel is also updated
+    // If we directly set the rows (So without the clear being called) it doesn't seem to
+    // get updated correctly.
+    property var modelRows: userChangesModel.items
+    onModelRowsChanged:
+    {
+        tableModel.clear()
+        tableModel.rows = modelRows
+    }
+
     onVisibilityChanged:
     {
         if(visible)
@@ -78,8 +88,9 @@ UM.Dialog
             ]
             model: UM.TableModel
             {
+                id: tableModel
                 headers: ["label", "original_value", "user_value"]
-                rows: userChangesModel.items
+                rows: modelRows
             }
             sectionRole: "category"
         }


### PR DESCRIPTION
It's the same hack that we already use for the other instances where we use the tableModel.
For some reason it wasn't done here, so we also had the not updating bug

CURA-9270