### PR TITLE
Removed shrinkage compensation from the quality profiles. They have b…

### DIFF
--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_PETG_Normal_Quality.inst.cfg
@@ -19,5 +19,3 @@ top_bottom_thickness = 0.8
 initial_layer_line_width_factor = 100
 
 material_print_temperature = =default_material_print_temperature - 5
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -22,8 +22,6 @@ machine_nozzle_heat_up_speed = 1.4
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = 190
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 retraction_hop = 0.2
 skin_overlap = 5
 speed_layer_0 = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_TPLA_Normal_Quality.inst.cfg
@@ -22,8 +22,6 @@ machine_nozzle_heat_up_speed = 1.4
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature - 15
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 skin_overlap = 5
 speed_layer_0 = =math.ceil(speed_print * 30 / 30)
 speed_print = 30

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Draft_Print.inst.cfg
@@ -15,8 +15,6 @@ variant = AA 0.4
 material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature - 5
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 skin_overlap = 20
 speed_print = 60

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Fast_Print.inst.cfg
@@ -16,8 +16,6 @@ cool_min_speed = 7
 material_print_temperature = =default_material_print_temperature
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_High_Quality.inst.cfg
@@ -18,8 +18,6 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 10
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 50
 speed_layer_0 = =math.ceil(speed_print * 20 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PETG_Normal_Quality.inst.cfg
@@ -17,8 +17,6 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 55
 speed_layer_0 = =math.ceil(speed_print * 20 / 55)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Draft_Print.inst.cfg
@@ -18,8 +18,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Fast_Print.inst.cfg
@@ -17,8 +17,6 @@ cool_fan_speed_max = =cool_fan_speed
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_print = 70

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_High_Quality.inst.cfg
@@ -19,8 +19,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -18,8 +18,6 @@ cool_min_speed = 7
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_VeryDraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_PLA_VeryDraft_Print.inst.cfg
@@ -28,9 +28,6 @@ material_print_temperature = =default_material_print_temperature + 10
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
-
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -21,8 +21,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -19,8 +19,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_layer_0 = =math.ceil(speed_print * 20 / 45)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_High_Quality.inst.cfg
@@ -19,8 +19,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -20,8 +20,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_VeryDraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_TPLA_VeryDraft_Print.inst.cfg
@@ -28,9 +28,6 @@ material_print_temperature = =default_material_print_temperature - 5
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
-
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Draft_Print.inst.cfg
@@ -16,8 +16,6 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 40

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Superdraft_Print.inst.cfg
@@ -16,8 +16,6 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PETG_Verydraft_Print.inst.cfg
@@ -16,8 +16,6 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 40

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Draft_Print.inst.cfg
@@ -21,8 +21,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 support_angle = 70
 top_bottom_thickness = =layer_height * 4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -21,8 +21,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 15
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 raft_margin = 10
 support_angle = 70

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -21,8 +21,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 support_angle = 70
 top_bottom_thickness = =layer_height * 4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Draft_Print.inst.cfg
@@ -23,8 +23,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 0
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Superdraft_Print.inst.cfg
@@ -23,8 +23,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 5
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 raft_margin = 10
 retract_at_layer_change = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_TPLA_Verydraft_Print.inst.cfg
@@ -25,8 +25,6 @@ material_initial_print_temperature = =max(-273.15, material_print_temperature - 
 material_print_temperature = =default_material_print_temperature + 5
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retract_at_layer_change = False
 speed_infill = =math.ceil(speed_print * 30 / 35)

--- a/resources/quality/ultimaker_s3/um_s3_cc0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.4_PLA_Draft_Print.inst.cfg
@@ -24,8 +24,6 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_cc0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.4_PLA_Fast_Print.inst.cfg
@@ -24,8 +24,6 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Draft_Print.inst.cfg
@@ -24,8 +24,6 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.6_PLA_Fast_Print.inst.cfg
@@ -24,8 +24,6 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PETG_Normal_Quality.inst.cfg
@@ -17,7 +17,4 @@ speed_infill = =math.ceil(speed_print * 40 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 top_bottom_thickness = 0.8
 initial_layer_line_width_factor = 100
-
 material_print_temperature = =default_material_print_temperature - 5
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_PLA_Normal_Quality.inst.cfg
@@ -22,8 +22,6 @@ machine_nozzle_heat_up_speed = 1.4
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = 190
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 retraction_hop = 0.2
 skin_overlap = 5
 speed_layer_0 = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_TPLA_Normal_Quality.inst.cfg
@@ -22,8 +22,6 @@ machine_nozzle_heat_up_speed = 1.4
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature - 15
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 skin_overlap = 5
 speed_layer_0 = =math.ceil(speed_print * 30 / 30)
 speed_print = 30

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Draft_Print.inst.cfg
@@ -15,8 +15,6 @@ variant = AA 0.4
 material_print_temperature = =default_material_print_temperature + 5
 material_initial_print_temperature = =material_print_temperature
 material_final_print_temperature = =material_print_temperature - 5
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 skin_overlap = 20
 speed_print = 60

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Fast_Print.inst.cfg
@@ -16,8 +16,6 @@ cool_min_speed = 7
 material_print_temperature = =default_material_print_temperature
 material_initial_print_temperature = =material_print_temperature - 5
 material_final_print_temperature = =material_print_temperature - 10
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 60
 speed_layer_0 = =math.ceil(speed_print * 20 / 60)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_High_Quality.inst.cfg
@@ -18,8 +18,6 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 10
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 50
 speed_layer_0 = =math.ceil(speed_print * 20 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PETG_Normal_Quality.inst.cfg
@@ -17,8 +17,6 @@ machine_nozzle_heat_up_speed = 1.5
 material_print_temperature = =default_material_print_temperature - 5
 material_initial_print_temperature = =material_print_temperature - 10
 material_final_print_temperature = =material_print_temperature - 15
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 retraction_combing_max_distance = 8
 speed_print = 55
 speed_layer_0 = =math.ceil(speed_print * 20 / 55)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Draft_Print.inst.cfg
@@ -18,8 +18,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Fast_Print.inst.cfg
@@ -17,8 +17,6 @@ cool_fan_speed_max = =cool_fan_speed
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_print = 70

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_High_Quality.inst.cfg
@@ -19,8 +19,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_Normal_Quality.inst.cfg
@@ -18,8 +18,6 @@ cool_min_speed = 7
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_VeryDraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_PLA_VeryDraft_Print.inst.cfg
@@ -28,8 +28,6 @@ material_print_temperature = =default_material_print_temperature + 10
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Draft_Print.inst.cfg
@@ -21,8 +21,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Fast_Print.inst.cfg
@@ -19,8 +19,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature -10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_layer_0 = =math.ceil(speed_print * 20 / 45)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_High_Quality.inst.cfg
@@ -19,8 +19,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_Normal_Quality.inst.cfg
@@ -20,8 +20,6 @@ machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_print_temperature = =default_material_print_temperature - 15
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_VeryDraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_TPLA_VeryDraft_Print.inst.cfg
@@ -28,9 +28,6 @@ material_print_temperature = =default_material_print_temperature - 5
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
-
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 skin_overlap = 20

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Draft_Print.inst.cfg
@@ -16,8 +16,6 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 40

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Superdraft_Print.inst.cfg
@@ -16,8 +16,6 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PETG_Verydraft_Print.inst.cfg
@@ -16,8 +16,6 @@ brim_width = 7
 
 material_print_temperature = =default_material_print_temperature - 5
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.5
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retraction_combing_max_distance = 8
 speed_print = 40

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Draft_Print.inst.cfg
@@ -21,8 +21,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 support_angle = 70
 top_bottom_thickness = =layer_height * 4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Superdraft_Print.inst.cfg
@@ -21,8 +21,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 15
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 raft_margin = 10
 support_angle = 70

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_PLA_Verydraft_Print.inst.cfg
@@ -21,8 +21,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 support_angle = 70
 top_bottom_thickness = =layer_height * 4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Draft_Print.inst.cfg
@@ -23,8 +23,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 0
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Superdraft_Print.inst.cfg
@@ -23,8 +23,6 @@ machine_nozzle_heat_up_speed = 1.6
 material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 5
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 raft_margin = 10
 retract_at_layer_change = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_TPLA_Verydraft_Print.inst.cfg
@@ -25,8 +25,6 @@ material_initial_print_temperature = =max(-273.15, material_print_temperature - 
 material_print_temperature = =default_material_print_temperature + 5
 material_print_temperature_layer_0 = =material_print_temperature
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.3
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = False
 retract_at_layer_change = False
 speed_infill = =math.ceil(speed_print * 30 / 35)

--- a/resources/quality/ultimaker_s5/um_s5_cc0.4_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.4_PLA_Draft_Print.inst.cfg
@@ -24,8 +24,6 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_cc0.4_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.4_PLA_Fast_Print.inst.cfg
@@ -24,8 +24,6 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Draft_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Draft_Print.inst.cfg
@@ -24,8 +24,6 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.6_PLA_Fast_Print.inst.cfg
@@ -24,8 +24,6 @@ material_final_print_temperature = =max(-273.15, material_print_temperature - 15
 material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
 material_print_temperature = =default_material_print_temperature + 10
 material_standby_temperature = 100
-material_shrinkage_percentage_xy = 100.2
-material_shrinkage_percentage_z = 100.1
 prime_tower_enable = True
 retract_at_layer_change = False
 speed_print = 45


### PR DESCRIPTION
Move shrinkage compensation from quality profiles to the material profiles in the fdm_material repo.
This pull request removes the shrinkage factors from the quality files. This pull request should be merged together with PP-187 in the fdm_materials repo, which includes the shrinkage factors in the material files.

Relates to PP-187