### PR TITLE
Removed the 'support_infill_sparse_thickness' setting from the global…

### DIFF
--- a/resources/quality/ultimaker3/um3_aa0.4_BAM_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_BAM_Fast_Print.inst.cfg
@@ -12,6 +12,7 @@ material = generic_bam
 variant = AA 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 cool_fan_full_at_height = =layer_height_0 + 2 * layer_height
 cool_fan_speed_max = =cool_fan_speed

--- a/resources/quality/ultimaker3/um3_aa0.4_BAM_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_aa0.4_BAM_Normal_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_bam
 variant = AA 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 cool_fan_full_at_height = =layer_height_0 + 2 * layer_height
 cool_fan_speed_max = =cool_fan_speed

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Fast_Print.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_High_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =3*layer_height
 brim_replaces_support = False
 material_standby_temperature = 100
 prime_tower_enable = False

--- a/resources/quality/ultimaker3/um3_bb0.4_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.4_PVA_Normal_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 material_standby_temperature = 100
 prime_tower_enable = False

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Superdraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Superdraft_Print.inst.cfg
@@ -13,7 +13,6 @@ variant = BB 0.8
 
 [values]
 brim_replaces_support = False
-layer_height = 0.4
 material_standby_temperature = 100
 retraction_count_max = 5
 support_brim_enable = True

--- a/resources/quality/ultimaker3/um3_bb0.8_PVA_Verydraft_Print.inst.cfg
+++ b/resources/quality/ultimaker3/um3_bb0.8_PVA_Verydraft_Print.inst.cfg
@@ -13,11 +13,9 @@ variant = BB 0.8
 
 [values]
 brim_replaces_support = False
-layer_height = 0.3
 material_standby_temperature = 100
 retraction_count_max = 5
 support_brim_enable = True
-support_infill_sparse_thickness = 0.3
 support_interface_enable = True
 skirt_brim_minimal_length = =min(2000, 175/(layer_height*line_width))
 cool_fan_enabled = =not (support_enable and (extruder_nr == support_infill_extruder_nr))

--- a/resources/quality/ultimaker3/um3_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Fast_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.15
-support_infill_sparse_thickness = =2*layer_height

--- a/resources/quality/ultimaker3/um3_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_High_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.06
-support_infill_sparse_thickness = =3*layer_height

--- a/resources/quality/ultimaker3/um3_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker3/um3_global_Normal_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.1
-support_infill_sparse_thickness = =2*layer_height

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Fast_Print.inst.cfg
@@ -12,6 +12,7 @@ material = generic_bam
 variant = AA 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 cool_fan_full_at_height = =layer_height_0 + 2 * layer_height
 cool_fan_speed_max = =cool_fan_speed

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_BAM_Normal_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_bam
 variant = AA 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 cool_fan_full_at_height = =layer_height_0 + 2 * layer_height
 cool_fan_speed_max = =cool_fan_speed

--- a/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Fast_Print.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100

--- a/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_High_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =3*layer_height
 brim_replaces_support = False
 material_standby_temperature = 100
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_bb0.4_PVA_Normal_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 material_standby_temperature = 100
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_Fast_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.15
-support_infill_sparse_thickness = =2*layer_height

--- a/resources/quality/ultimaker_s3/um_s3_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_High_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.06
-support_infill_sparse_thickness = =3*layer_height

--- a/resources/quality/ultimaker_s3/um_s3_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_global_Normal_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.1
-support_infill_sparse_thickness = =2*layer_height

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Fast_Print.inst.cfg
@@ -12,6 +12,7 @@ material = generic_bam
 variant = AA 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 cool_fan_full_at_height = =layer_height_0 + 2 * layer_height
 cool_fan_speed_max = =cool_fan_speed

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_BAM_Normal_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_bam
 variant = AA 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 cool_fan_full_at_height = =layer_height_0 + 2 * layer_height
 cool_fan_speed_max = =cool_fan_speed

--- a/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Fast_Print.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Fast_Print.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 material_print_temperature = =default_material_print_temperature + 5
 material_standby_temperature = 100

--- a/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_High_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =3*layer_height
 brim_replaces_support = False
 material_standby_temperature = 100
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_bb0.4_PVA_Normal_Quality.inst.cfg
@@ -12,6 +12,7 @@ material = generic_pva
 variant = BB 0.4
 
 [values]
+support_infill_sparse_thickness = =2*layer_height
 brim_replaces_support = False
 material_standby_temperature = 100
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_Fast_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.15
-support_infill_sparse_thickness = =2*layer_height

--- a/resources/quality/ultimaker_s5/um_s5_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_High_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.06
-support_infill_sparse_thickness = =3*layer_height

--- a/resources/quality/ultimaker_s5/um_s5_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_global_Normal_Quality.inst.cfg
@@ -12,4 +12,3 @@ global_quality = True
 
 [values]
 layer_height = 0.1
-support_infill_sparse_thickness = =2*layer_height


### PR DESCRIPTION
Fixed after system testing.
Removed the 'support_infill_sparse_thickness' setting from the global quality files and only added them to the PVA and BAM quality files. This prevents infill layer skipping during self support.

Relates to PP-193