### PR TITLE
Fix rendering issues when moving dialogs between screen with different scale settings

### DIFF
--- a/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml
+++ b/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml
@@ -8,9 +8,9 @@ import QtQuick.Layouts 1.15
 import QtQuick.Window 2.1
 
 import Cura 1.1 as Cura
-import UM 1.5 as UM
+import UM 1.6 as UM
 
-Window
+UM.Window
 {
     id: materialsSyncDialog
     property variant catalog: UM.I18nCatalog { name: "cura" }


### PR DESCRIPTION
We had some issues when dragging dialogs between screens with different scale issues.

This issue was fixed by introducing `UM.Window` a python class that inherits from `QQuickWindow`, thereby exposing all available python methods. By intercepting the window's `moveEvent` and triggering an `update` the rendering issues seemed to be resolved on my machine.

Currently the fix is only applied to the preference dialogs and sync dialog windows. If the fix works for other devices as well we might want to update [the `Window` element in the default dialog object](https://github.com/Ultimaker/Uranium/blob/6bd71a153ffe8dbf397ace17874f62f96ad3e901/UM/Qt/qml/UM/Dialog.qml#L11) to an `UM.Window` as well. I decided not to do that in this PR as
1. it was a bit invasive; it didn't feel right to put through such a big change just before the release,
2. my first attempts were unsuccessful due to "incompatible versioning". 

Merge this PR along with its Uranium counterpart at https://github.com/Ultimaker/Uranium/pull/841

CURA-9428