### PR TITLE
CURA 9365 add conan info to log

### DIFF
--- a/cura/ApplicationMetadata.py
+++ b/cura/ApplicationMetadata.py
@@ -64,7 +64,7 @@ except ImportError:
 DEPENDENCY_INFO = {}
 try:
     from pathlib import Path
-    conan_install_info = Path(__file__).parent.joinpath("conan_install_info.json")
+    conan_install_info = Path(__file__).parent.parent.joinpath("conan_install_info.json")
     if conan_install_info.exists():
         import json
         with open(conan_install_info, "r") as f:

--- a/cura/ApplicationMetadata.py
+++ b/cura/ApplicationMetadata.py
@@ -60,3 +60,14 @@ try:
 
 except ImportError:
     CuraAppDisplayName = DEFAULT_CURA_DISPLAY_NAME
+
+DEPENDENCY_INFO = {}
+try:
+    from pathlib import Path
+    conan_install_info = Path(__file__).parent.joinpath("conan_install_info.json")
+    if conan_install_info.exists():
+        import json
+        with open(conan_install_info, "r") as f:
+            DEPENDENCY_INFO = json.loads(f.read())
+except:
+    pass

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -823,6 +823,8 @@ class CuraApplication(QtApplication):
         if len(ApplicationMetadata.DEPENDENCY_INFO) > 0:
             Logger.debug("Using Conan managed dependencies: " + ", ".join(
                 [dep["recipe"]["id"] for dep in ApplicationMetadata.DEPENDENCY_INFO["installed"] if dep["recipe"]["version"] != "latest"]))
+        else:
+            Logger.warning("Could not find conan_install_info.json")
 
         Logger.log("i", "Initializing machine error checker")
         self._machine_error_checker = MachineErrorChecker(self)

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -820,6 +820,10 @@ class CuraApplication(QtApplication):
     def run(self):
         super().run()
 
+        if len(ApplicationMetadata.DEPENDENCY_INFO) > 0:
+            Logger.debug("Using Conan managed dependencies: " + ", ".join(
+                [dep["recipe"]["id"] for dep in ApplicationMetadata.DEPENDENCY_INFO["installed"] if dep["recipe"]["version"] != "latest"]))
+
         Logger.log("i", "Initializing machine error checker")
         self._machine_error_checker = MachineErrorChecker(self)
         self._machine_error_checker.initialize()


### PR DESCRIPTION
Add the information about the Conan managed dependencies to the log output

```
2022-07-15 17:40:41,437 - DEBUG - [MainThread] cura.CuraApplication.run [824]: Using Conan managed dependencies: arcus/5.1.0-beta+13@ultimaker/stable#e51ba5f9a7ad05441c0bfb4b12cd381bc85e2eff, protobuf/3.17.1#d4970b86fb1d8cbce961e2624834a0bc, zlib/1.2.12#3b9e037ae1c615d045a06c67d88491ae, cpython/3.10.4#4adc4633d487e404c356abf3933fd19d, openssl/1.1.1l#de73a8aad9d5a14da8ed43b40592195a, expat/2.4.1#a36c94ae11100f2e3259a9edd4f77055, libffi/3.2.1#33b3eff20f1be5d569235ae100266729, mpdecimal/2.5.0#d8aaabf46cfa93efaadfe66733885102, libuuid/1.0.3#42d244923e46f0a22bdafd1978cc4109, libxcrypt/4.4.25#a6ab0080853010bf96ed0b9539412e7b, bzip2/1.0.8#b056f852bd2d5af96fc7171aadfd6c0b, gdbm/1.19#c420bc00f3cc629aef665fdc3100f926, sqlite3/3.36.0#d42a67cd9049135c9d299f26809c4be1, tk/8.6.10#52dd820e70534d4342fe6caec84beaff, tcl/8.6.10#aec77174134a121aaa59321674d1e893, fontconfig/2.13.93#4c27ed60dd99ca89876ca1e99361b04a, freetype/2.12.1#0bbb81805455cee1339cfd08a4682f1b, libpng/1.6.37#abacd98afb859828aa70354fa7d55285, brotli/1.0.9#6fc2cda04f57470ce73d72d7f694507a, xorg/system#021f1f263d5550405071531aec5ccdc9, ncurses/6.2#3c01887ed633bac7876b56419c791d6e, xz_utils/5.2.5#dd8565c00d13a3a6fb2f01214f73a076, curaengine/5.1.0-beta+41@ultimaker/stable#498e6dbe4a13697ef537ecd93b4f4b65, clipper/6.4.2#4a99df8ff37476a0108cabee338a3cf2, boost/1.78.0#912b8b9ea38e6b85d815a9efecb5f689, rapidjson/1.1.0#947d56f97c67f87bd1db1ea5453fbcb2, stb/20200203#cba8fa43f7a0ea5389896744664823c9, savitar/5.1.0-beta+12@ultimaker/stable#611a712aa9af71fdaf68c50b8ff5305dcae80433, pugixml/1.12.1#5a39f82651eba3e7d6197903a3202e21, pynest2d/5.1.0-beta+16@ultimaker/stable#db913eb26dd90bea2c2ed096202633082923241b, libnest2d/5.1.0-beta+19@ultimaker/stable#c10ef8606957b9317ca07702b488495b, nlopt/2.7.0#d928ab39fe3f6d91120c738b0de4751c, fdm_materials/5.1.0-beta+6@ultimaker/stable#8ef195ae9ca3b0b3ee2d1e1ed2fb0aaf, cura_binary_data/5.1.0-beta+7@ultimaker/stable#466bb9ce433cf56b37610dc693551717
```
This should help with debugging.