### PR TITLE
Remove unexpected spaces

### DIFF
--- a/cura/CameraAnimation.py
+++ b/cura/CameraAnimation.py
@@ -9,7 +9,7 @@ from UM.Math.Vector import Vector
 
 
 class CameraAnimation(QVariantAnimation):
-    def __init__(self, parent = None):
+    def __init__(self, parent=None):
         super().__init__(parent)
         self._camera_tool = None
         self.setDuration(300)


### PR DESCRIPTION
Avoid extraneous whitespace
This conforms to the PEP 8 Style Guide for Python Code:
"Don’t use spaces around the = sign when used to indicate a keyword argument,"