### PR TITLE
LayerPolygon.py: Shorten excessively long lines

### DIFF
--- a/cura/LayerPolygon.py
+++ b/cura/LayerPolygon.py
@@ -120,7 +120,7 @@ class LayerPolygon:
 
         # Index to the points we need to represent the line mesh. This is constructed by generating simple
         # start and end points for each line. For line segment n these are points n and n+1. Row n reads [n n+1]
-        # Then then the indices for the points we don't need are thrown away based on the pre-calculated list.
+        # Then the indices for the points we don't need are thrown away based on the pre-calculated list.
         index_list = (numpy.arange(len(self._types)).reshape((-1, 1)) + numpy.array([[0, 1]])).reshape((-1, 1))[needed_points_list.reshape((-1, 1))]
 
         # The relative values of begin and end indices have already been set in buildCache, so we only need to offset them to the parents offset.

--- a/cura/LayerPolygon.py
+++ b/cura/LayerPolygon.py
@@ -118,8 +118,9 @@ class LayerPolygon:
         line_mesh_mask = self._build_cache_line_mesh_mask
         needed_points_list = self._build_cache_needed_points
 
-        # Index to the points we need to represent the line mesh. This is constructed by generating simple
-        # start and end points for each line. For line segment n these are points n and n+1. Row n reads [n n+1]
+        # Index to the points we need to represent the line mesh.
+        # This is constructed by generating simple start and end points for each line.
+        # For line segment n, these are points n and n+1. Row n reads [n n+1]
         # Then the indices for the points we don't need are thrown away based on the pre-calculated list.
         index_list = (numpy.arange(len(self._types)).reshape((-1, 1)) + numpy.array([[0, 1]])).reshape((-1, 1))[needed_points_list.reshape((-1, 1))]
 

--- a/cura/LayerPolygon.py
+++ b/cura/LayerPolygon.py
@@ -226,10 +226,9 @@ class LayerPolygon:
         normals[:, 1] = 0.0  # We are only interested in 2D normals
 
         # Calculate the edges between points.
-        # The call to numpy.roll shifts the entire array by one so that
-        # we end up subtracting each next point from the current, wrapping
-        # around. This gives us the edges from the next point to the current
-        # point.
+        # The call to numpy.roll shifts the entire array by one
+        # so that we end up subtracting each next point from the current, wrapping around.
+        # This gives us the edges from the next point to the current point.
         normals = numpy.diff(normals, 1, 0)
 
         # Calculate the length of each edge using standard Pythagoras


### PR DESCRIPTION
- Shortened excessively long lines: some lines in the file were excessively long, even in the context of the Cura project which seems to prefer a long line length.
These lines could not be read easily even on github .... 
- Removed some unnecessary whitespaces
- Added some extra spaces so that inline comments are separated by at least two spaces from the statement