### PR TITLE
Hide cloud interaction buttons if the user has no permissions to them

### DIFF
--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -7,6 +7,7 @@ from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot, pyqtProperty, QTimer, py
 from PyQt6.QtNetwork import QNetworkRequest
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
+from UM.Decorators import deprecated
 from UM.Logger import Logger
 from UM.Message import Message
 from UM.i18n import i18nCatalog
@@ -319,12 +320,14 @@ class Account(QObject):
 
         self._authorization_service.deleteAuthData()
 
+    @deprecated("Get permissions from the 'permissions' property", since = "5.2.0")
     def updateAdditionalRight(self, **kwargs) -> None:
         """Update the additional rights of the account.
         The argument(s) are the rights that need to be set"""
         self._additional_rights.update(kwargs)
         self.additionalRightsChanged.emit(self._additional_rights)
 
+    @deprecated("Get permissions from the 'permissions' property", since = "5.2.0")
     @pyqtProperty("QVariantMap", notify = additionalRightsChanged)
     def additionalRights(self) -> Dict[str, Any]:
         """A dictionary which can be queried for additional account rights."""

--- a/cura/PrinterOutput/Models/PrintJobOutputModel.py
+++ b/cura/PrinterOutput/Models/PrintJobOutputModel.py
@@ -92,6 +92,11 @@ class PrintJobOutputModel(QObject):
     def isMine(self) -> bool:
         """
         Returns whether this print job was sent by the currently logged in user.
+
+        This checks the owner of the print job with the owner of the currently
+        logged in account. Both of these are human-readable account names which
+        may be duplicate. In practice the harm here is limited, but it's the
+        best we can do with the information available to the API.
         """
         return self._owner == CuraApplication.getInstance().getCuraAPI().account.userName
 

--- a/cura/PrinterOutput/Models/PrintJobOutputModel.py
+++ b/cura/PrinterOutput/Models/PrintJobOutputModel.py
@@ -1,10 +1,12 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2022 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
 from typing import Optional, TYPE_CHECKING, List
 
 from PyQt6.QtCore import pyqtSignal, pyqtProperty, QObject, pyqtSlot, QUrl
 from PyQt6.QtGui import QImage
+
+from cura.CuraApplication import CuraApplication
 
 if TYPE_CHECKING:
     from cura.PrinterOutput.PrinterOutputController import PrinterOutputController
@@ -85,6 +87,13 @@ class PrintJobOutputModel(QObject):
         if self._owner != owner:
             self._owner = owner
             self.ownerChanged.emit()
+
+    @pyqtProperty(bool, notify = ownerChanged)
+    def isMine(self) -> bool:
+        """
+        Returns whether this print job was sent by the currently logged in user.
+        """
+        return self._owner == CuraApplication.getInstance().getCuraAPI().account.userName
 
     @pyqtProperty(QObject, notify=assignedPrinterChanged)
     def assignedPrinter(self):

--- a/plugins/DigitalLibrary/src/DigitalFactoryApiClient.py
+++ b/plugins/DigitalLibrary/src/DigitalFactoryApiClient.py
@@ -71,8 +71,6 @@ class DigitalFactoryApiClient:
                 has_access = response.library_max_private_projects == -1 or response.library_max_private_projects > 0
                 callback(has_access)
                 self._library_max_private_projects = response.library_max_private_projects
-                # update the account with the additional user rights
-                self._account.updateAdditionalRight(df_access = has_access)
             else:
                 Logger.warning(f"Digital Factory: Response is not a feature budget, likely an error: {str(response)}")
                 callback(False)

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
@@ -54,7 +54,7 @@ Item
                     text: catalog.i18nc("@label", "Move to top");
                     visible: {
                         if (printJob && (printJob.state == "queued" || printJob.state == "error") && !isAssigned(printJob)) {
-                            if (OutputDevice && OutputDevice.queuedPrintJobs[0]) {
+                            if (OutputDevice && OutputDevice.queuedPrintJobs[0] && OutputDevice.canWriteOthersPrintJobs) {
                                 return OutputDevice.queuedPrintJobs[0].key != printJob.key;
                             }
                         }

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
@@ -62,40 +62,65 @@ Item
                     }
                 }
 
-                PrintJobContextMenuItem {
-                    onClicked: {
+                PrintJobContextMenuItem
+                {
+                    onClicked:
+                    {
                         deleteConfirmationDialog.visible = true;
                         popUp.close();
                     }
                     text: catalog.i18nc("@label", "Delete");
-                    visible: {
-                        if (!printJob) {
+                    visible:
+                    {
+                        if(!printJob)
+                        {
                             return false;
+                        }
+                        if(printJob.isMine)
+                        {
+                            if(!OutputDevice.canWriteOwnPrintJobs)
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            if(!OutputDevice.canWriteOthersPrintJobs)
+                            {
+                                return false;
+                            }
                         }
                         var states = ["queued", "error", "sent_to_printer"];
                         return states.indexOf(printJob.state) !== -1;
                     }
                 }
 
-                PrintJobContextMenuItem {
+                PrintJobContextMenuItem
+                {
                     enabled: visible && !(printJob.state == "pausing" || printJob.state == "resuming");
-                    onClicked: {
-                        if (printJob.state == "paused") {
+                    onClicked:
+                    {
+                        if (printJob.state == "paused")
+                        {
                             printJob.setState("resume");
                             popUp.close();
                             return;
                         }
-                        if (printJob.state == "printing") {
+                        if (printJob.state == "printing")
+                        {
                             printJob.setState("pause");
                             popUp.close();
                             return;
                         }
                     }
-                    text: {
-                        if (!printJob) {
+                    text:
+                    {
+                        if(!printJob)
+                        {
                             return "";
                         }
-                        switch(printJob.state) {
+                        switch(printJob.state)
+                        {
                             case "paused":
                                 return catalog.i18nc("@label", "Resume");
                             case "pausing":
@@ -106,25 +131,59 @@ Item
                                 catalog.i18nc("@label", "Pause");
                         }
                     }
-                    visible: {
-                        if (!printJob) {
+                    visible:
+                    {
+                        if(!printJob)
+                        {
                             return false;
+                        }
+                        if(printJob.isMine)
+                        {
+                            if(!OutputDevice.canWriteOwnPrintJobs)
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            if(!OutputDevice.canWriteOthersPrintJobs)
+                            {
+                                return false;
+                            }
                         }
                         var states = ["printing", "pausing", "paused", "resuming"];
                         return states.indexOf(printJob.state) !== -1;
                     }
                 }
 
-                PrintJobContextMenuItem {
+                PrintJobContextMenuItem
+                {
                     enabled: visible && printJob.state !== "aborting";
-                    onClicked: {
+                    onClicked:
+                    {
                         abortConfirmationDialog.visible = true;
                         popUp.close();
                     }
                     text: printJob && printJob.state == "aborting" ? catalog.i18nc("@label", "Aborting...") : catalog.i18nc("@label", "Abort");
-                    visible: {
-                        if (!printJob) {
+                    visible:
+                    {
+                        if (!printJob)
+                        {
                             return false;
+                        }
+                        if(printJob.isMine)
+                        {
+                            if(!OutputDevice.canWriteOwnPrintJobs)
+                            {
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            if(!OutputDevice.canWriteOthersPrintJobs)
+                            {
+                                return false;
+                            }
                         }
                         var states = ["pre_print", "printing", "pausing", "paused", "resuming"];
                         return states.indexOf(printJob.state) !== -1;

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
@@ -78,6 +78,7 @@ Item
         var states = ["printing", "pausing", "paused", "resuming"];
         return states.indexOf(printJob.state) !== -1;
     }
+
     property bool abortVisible:
     {
         if(!printJob)

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml
@@ -23,13 +23,14 @@ Item
     //So compute here the visibility of the menu items, so that we can use it for the visibility of the button.
     property bool sendToTopVisible:
     {
-        if (printJob && (printJob.state == "queued" || printJob.state == "error") && !isAssigned(printJob)) {
+        if (printJob && printJob.state in ("queued",  "error") && !isAssigned(printJob)) {
             if (OutputDevice && OutputDevice.queuedPrintJobs[0] && OutputDevice.canWriteOthersPrintJobs) {
                 return OutputDevice.queuedPrintJobs[0].key != printJob.key;
             }
         }
         return false;
     }
+    
     property bool deleteVisible:
     {
         if(!printJob)
@@ -53,6 +54,7 @@ Item
         var states = ["queued", "error", "sent_to_printer"];
         return states.indexOf(printJob.state) !== -1;
     }
+    
     property bool pauseVisible:
     {
         if(!printJob)
@@ -99,6 +101,7 @@ Item
         var states = ["pre_print", "printing", "pausing", "paused", "resuming"];
         return states.indexOf(printJob.state) !== -1;
     }
+
     property bool hasItems: sendToTopVisible || deleteVisible || pauseVisible || abortVisible
 
     GenericPopUp

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml
@@ -206,7 +206,11 @@ Item
         onClicked: enabled ? contextMenu.switchPopupState() : {}
         visible:
         {
-            if (!printJob)
+            if(!printJob)
+            {
+                return false;
+            }
+            if(!contextMenu.hasItems)
             {
                 return false;
             }

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
@@ -209,8 +209,13 @@ Item
             onClicked: enabled ? contextMenu.switchPopupState() : {}
             visible:
             {
-                if (!printer || !printer.activePrintJob) {
-                    return false
+                if(!printer || !printer.activePrintJob)
+                {
+                    return false;
+                }
+                if(!contextMenu.hasItems)
+                {
+                    return false;
                 }
                 var states = ["queued", "error", "sent_to_printer", "pre_print", "printing", "pausing", "paused", "resuming"]
                 return states.indexOf(printer.activePrintJob.state) !== -1

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml
@@ -39,6 +39,7 @@ Item
         }
         height: 18 * screenScaleFactor // TODO: Theme!
         width: childrenRect.width
+        visible: OutputDevice.canReadPrinterDetails
 
         UM.ColorImage
         {

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorStage.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorStage.qml
@@ -69,7 +69,7 @@ Component
                 top: printers.bottom
                 topMargin: 48 * screenScaleFactor // TODO: Theme!
             }
-            visible: OutputDevice.supportsPrintJobQueue
+            visible: OutputDevice.supportsPrintJobQueue && OutputDevice.canReadPrintJobs
         }
 
         PrinterVideoStream

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -366,6 +366,13 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         """
         return "digital-factory.print-job.write.own" in self._account.permissions
 
+    @pyqtProperty(bool, constant = True)
+    def canReadPrinterDetails(self) -> bool:
+        """
+        Whether this user can read the status of the printer.
+        """
+        return "digital-factory.printer.read" in self._account.permissions
+
     @property
     def clusterData(self) -> CloudClusterResponse:
         """Gets the cluster response from which this device was created."""

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
@@ -96,6 +96,13 @@ class LocalClusterOutputDevice(UltimakerNetworkedPrinterOutputDevice):
     def forceSendJob(self, print_job_uuid: str) -> None:
         self._getApiClient().forcePrintJob(print_job_uuid)
 
+    @pyqtProperty(bool, constant = True)
+    def supportsPrintJobQueue(self) -> bool:
+        """
+        Whether this printer knows about queueing print jobs.
+        """
+        return True  # This API always supports print job queueing.
+
     def setJobState(self, print_job_uuid: str, action: str) -> None:
         """Set the remote print job state.
 

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
@@ -96,35 +96,6 @@ class LocalClusterOutputDevice(UltimakerNetworkedPrinterOutputDevice):
     def forceSendJob(self, print_job_uuid: str) -> None:
         self._getApiClient().forcePrintJob(print_job_uuid)
 
-    @pyqtProperty(bool, constant = True)
-    def supportsPrintJobQueue(self) -> bool:
-        """
-        Whether this printer knows about queueing print jobs.
-        """
-        return True  # This API always supports print job queueing.
-
-    @pyqtProperty(bool, constant = True)
-    def canReadPrintJobs(self) -> bool:
-        """
-        Whether this user can read the list of print jobs and their properties.
-        """
-        return False  # On LAN, the user can always read it.
-
-    @pyqtProperty(bool, constant = True)
-    def canWriteOthersPrintJobs(self) -> bool:
-        """
-        Whether this user can change things about print jobs made by other
-        people.
-        """
-        return True  # On LAN, the user can always change this.
-
-    @pyqtProperty(bool, constant = True)
-    def canWriteOwnPrintJobs(self) -> bool:
-        """
-        Whether this user can change things about print jobs made by themself.
-        """
-        return True  # On LAN, the user can always change this.
-
     def setJobState(self, print_job_uuid: str, action: str) -> None:
         """Set the remote print job state.
 

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Ultimaker B.V.
+# Copyright (c) 2020 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 import os
 from typing import Optional, Dict, List, Callable, Any

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Ultimaker B.V.
+# Copyright (c) 2022 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 import os
 from typing import Optional, Dict, List, Callable, Any
@@ -102,6 +102,28 @@ class LocalClusterOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         Whether this printer knows about queueing print jobs.
         """
         return True  # This API always supports print job queueing.
+
+    @pyqtProperty(bool, constant = True)
+    def canReadPrintJobs(self) -> bool:
+        """
+        Whether this user can read the list of print jobs and their properties.
+        """
+        return False  # On LAN, the user can always read it.
+
+    @pyqtProperty(bool, constant = True)
+    def canWriteOthersPrintJobs(self) -> bool:
+        """
+        Whether this user can change things about print jobs made by other
+        people.
+        """
+        return True  # On LAN, the user can always change this.
+
+    @pyqtProperty(bool, constant = True)
+    def canWriteOwnPrintJobs(self) -> bool:
+        """
+        Whether this user can change things about print jobs made by themself.
+        """
+        return True  # On LAN, the user can always change this.
 
     def setJobState(self, print_job_uuid: str, action: str) -> None:
         """Set the remote print job state.

--- a/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
@@ -196,7 +196,7 @@ class UltimakerNetworkedPrinterOutputDevice(NetworkedPrinterOutputDevice):
         """
         Whether this user can read the list of print jobs and their properties.
         """
-        return True  # On LAN, the user can always read it.
+        return True
 
     @pyqtProperty(bool, constant = True)
     def canWriteOthersPrintJobs(self) -> bool:
@@ -204,14 +204,14 @@ class UltimakerNetworkedPrinterOutputDevice(NetworkedPrinterOutputDevice):
         Whether this user can change things about print jobs made by other
         people.
         """
-        return True  # On LAN, the user can always change this.
+        return False
 
     @pyqtProperty(bool, constant = True)
     def canWriteOwnPrintJobs(self) -> bool:
         """
         Whether this user can change things about print jobs made by themself.
         """
-        return True  # On LAN, the user can always change this.
+        return False
 
     @pyqtSlot(name="openPrintJobControlPanel")
     def openPrintJobControlPanel(self) -> None:

--- a/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
@@ -213,6 +213,13 @@ class UltimakerNetworkedPrinterOutputDevice(NetworkedPrinterOutputDevice):
         """
         return True
 
+    @pyqtProperty(bool, constant = True)
+    def canReadPrinterDetails(self) -> bool:
+        """
+        Whether this user can read the status of the printer.
+        """
+        return True
+
     @pyqtSlot(name="openPrintJobControlPanel")
     def openPrintJobControlPanel(self) -> None:
         raise NotImplementedError("openPrintJobControlPanel must be implemented")

--- a/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Ultimaker B.V.
+# Copyright (c) 2022 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 import os
 from time import time
@@ -183,6 +183,35 @@ class UltimakerNetworkedPrinterOutputDevice(NetworkedPrinterOutputDevice):
     @pyqtSlot(str, name="forceSendJob")
     def forceSendJob(self, print_job_uuid: str) -> None:
         raise NotImplementedError("forceSendJob must be implemented")
+
+    @pyqtProperty(bool, constant = True)
+    def supportsPrintJobQueue(self) -> bool:
+        """
+        Whether this printer knows about queueing print jobs.
+        """
+        return True  # This API always supports print job queueing.
+
+    @pyqtProperty(bool, constant = True)
+    def canReadPrintJobs(self) -> bool:
+        """
+        Whether this user can read the list of print jobs and their properties.
+        """
+        return True  # On LAN, the user can always read it.
+
+    @pyqtProperty(bool, constant = True)
+    def canWriteOthersPrintJobs(self) -> bool:
+        """
+        Whether this user can change things about print jobs made by other
+        people.
+        """
+        return True  # On LAN, the user can always change this.
+
+    @pyqtProperty(bool, constant = True)
+    def canWriteOwnPrintJobs(self) -> bool:
+        """
+        Whether this user can change things about print jobs made by themself.
+        """
+        return True  # On LAN, the user can always change this.
 
     @pyqtSlot(name="openPrintJobControlPanel")
     def openPrintJobControlPanel(self) -> None:

--- a/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterOutputDevice.py
@@ -204,14 +204,14 @@ class UltimakerNetworkedPrinterOutputDevice(NetworkedPrinterOutputDevice):
         Whether this user can change things about print jobs made by other
         people.
         """
-        return False
+        return True
 
     @pyqtProperty(bool, constant = True)
     def canWriteOwnPrintJobs(self) -> bool:
         """
         Whether this user can change things about print jobs made by themself.
         """
-        return False
+        return True
 
     @pyqtSlot(name="openPrintJobControlPanel")
     def openPrintJobControlPanel(self) -> None:

--- a/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml
+++ b/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml
@@ -33,7 +33,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("PrinterTriple", "high"),
                     description: catalog.i18nc("@tooltip:button", "Monitor printers in Ultimaker Digital Factory."),
                     link: "https://digitalfactory.ultimaker.com/app/printers?utm_source=cura&utm_medium=software&utm_campaign=switcher-digital-factory-printers",
-                    DFAccessRequired: true,
                     permissionsRequired: ["digital-factory.printer.read"]
                 },
                 {
@@ -41,7 +40,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("Library", "high"),
                     description: catalog.i18nc("@tooltip:button", "Create print projects in Digital Library."),
                     link: "https://digitalfactory.ultimaker.com/app/library?utm_source=cura&utm_medium=software&utm_campaign=switcher-library",
-                    DFAccessRequired: true,
                     permissionsRequired: ["digital-factory.project.read.shared"]
                 },
                 {
@@ -49,7 +47,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("FoodBeverages"),
                     description: catalog.i18nc("@tooltip:button", "Monitor print jobs and reprint from your print history."),
                     link: "https://digitalfactory.ultimaker.com/app/print-jobs?utm_source=cura&utm_medium=software&utm_campaign=switcher-digital-factory-printjobs",
-                    DFAccessRequired: true,
                     permissionsRequired: ["digital-factory.print-job.read"]
                 },
                 {
@@ -57,7 +54,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("Shop", "high"),
                     description: catalog.i18nc("@tooltip:button", "Extend Ultimaker Cura with plugins and material profiles."),
                     link: "https://marketplace.ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-marketplace-materials",
-                    DFAccessRequired: false,
                     permissionsRequired: []
                 },
                 {
@@ -65,7 +61,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("Knowledge"),
                     description: catalog.i18nc("@tooltip:button", "Become a 3D printing expert with Ultimaker e-learning."),
                     link: "https://academy.ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-academy",
-                    DFAccessRequired: false,
                     permissionsRequired: []
                 },
                 {
@@ -73,7 +68,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("Help", "high"),
                     description: catalog.i18nc("@tooltip:button", "Learn how to get started with Ultimaker Cura."),
                     link: "https://support.ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-support",
-                    DFAccessRequired: false,
                     permissionsRequired: []
                 },
                 {
@@ -81,7 +75,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("Speak", "high"),
                     description: catalog.i18nc("@tooltip:button", "Consult the Ultimaker Community."),
                     link: "https://community.ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-community",
-                    DFAccessRequired: false,
                     permissionsRequired: []
                 },
                 {
@@ -89,7 +82,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("Bug", "high"),
                     description: catalog.i18nc("@tooltip:button", "Let developers know that something is going wrong."),
                     link: "https://github.com/Ultimaker/Cura/issues/new/choose",
-                    DFAccessRequired: false,
                     permissionsRequired: []
                 },
                 {
@@ -97,7 +89,6 @@ Popup
                     thumbnail: UM.Theme.getIcon("Browser"),
                     description: catalog.i18nc("@tooltip:button", "Visit the Ultimaker website."),
                     link: "https://ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-umwebsite",
-                    DFAccessRequired: false,
                     permissionsRequired: []
                 }
             ]
@@ -110,10 +101,6 @@ Popup
                 isExternalLink: true
                 visible:
                 {
-                    if(modelData.DFAccessRequired && (!Cura.API.account.isLoggedIn || !Cura.API.account.additionalRights["df_access"]))
-                    {
-                        return false;
-                    }
                     try
                     {
                         modelData.permissionsRequired.forEach(function(permission)

--- a/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml
+++ b/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml
@@ -33,63 +33,72 @@ Popup
                     thumbnail: UM.Theme.getIcon("PrinterTriple", "high"),
                     description: catalog.i18nc("@tooltip:button", "Monitor printers in Ultimaker Digital Factory."),
                     link: "https://digitalfactory.ultimaker.com/app/printers?utm_source=cura&utm_medium=software&utm_campaign=switcher-digital-factory-printers",
-                    DFAccessRequired: true
+                    DFAccessRequired: true,
+                    permissionsRequired: ["digital-factory.printer.read"]
                 },
                 {
                     displayName: "Digital Library", //Not translated, since it's a brand name.
                     thumbnail: UM.Theme.getIcon("Library", "high"),
                     description: catalog.i18nc("@tooltip:button", "Create print projects in Digital Library."),
                     link: "https://digitalfactory.ultimaker.com/app/library?utm_source=cura&utm_medium=software&utm_campaign=switcher-library",
-                    DFAccessRequired: true
+                    DFAccessRequired: true,
+                    permissionsRequired: ["digital-factory.project.read.shared"]
                 },
                 {
                     displayName: catalog.i18nc("@label:button", "Print jobs"),
                     thumbnail: UM.Theme.getIcon("FoodBeverages"),
                     description: catalog.i18nc("@tooltip:button", "Monitor print jobs and reprint from your print history."),
                     link: "https://digitalfactory.ultimaker.com/app/print-jobs?utm_source=cura&utm_medium=software&utm_campaign=switcher-digital-factory-printjobs",
-                    DFAccessRequired: true
+                    DFAccessRequired: true,
+                    permissionsRequired: ["digital-factory.print-job.read"]
                 },
                 {
                     displayName: "Ultimaker Marketplace", //Not translated, since it's a brand name.
                     thumbnail: UM.Theme.getIcon("Shop", "high"),
                     description: catalog.i18nc("@tooltip:button", "Extend Ultimaker Cura with plugins and material profiles."),
                     link: "https://marketplace.ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-marketplace-materials",
-                    DFAccessRequired: false
+                    DFAccessRequired: false,
+                    permissionsRequired: []
                 },
                 {
                     displayName: "Ultimaker Academy", //Not translated, since it's a brand name.
                     thumbnail: UM.Theme.getIcon("Knowledge"),
                     description: catalog.i18nc("@tooltip:button", "Become a 3D printing expert with Ultimaker e-learning."),
                     link: "https://academy.ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-academy",
-                    DFAccessRequired: false
+                    DFAccessRequired: false,
+                    permissionsRequired: []
                 },
                 {
                     displayName: catalog.i18nc("@label:button", "Ultimaker support"),
                     thumbnail: UM.Theme.getIcon("Help", "high"),
                     description: catalog.i18nc("@tooltip:button", "Learn how to get started with Ultimaker Cura."),
                     link: "https://support.ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-support",
-                    DFAccessRequired: false
+                    DFAccessRequired: false,
+                    permissionsRequired: []
                 },
                 {
                     displayName: catalog.i18nc("@label:button", "Ask a question"),
                     thumbnail: UM.Theme.getIcon("Speak", "high"),
                     description: catalog.i18nc("@tooltip:button", "Consult the Ultimaker Community."),
                     link: "https://community.ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-community",
-                    DFAccessRequired: false
+                    DFAccessRequired: false,
+                    permissionsRequired: []
                 },
                 {
                     displayName: catalog.i18nc("@label:button", "Report a bug"),
                     thumbnail: UM.Theme.getIcon("Bug", "high"),
                     description: catalog.i18nc("@tooltip:button", "Let developers know that something is going wrong."),
                     link: "https://github.com/Ultimaker/Cura/issues/new/choose",
-                    DFAccessRequired: false
+                    DFAccessRequired: false,
+                    permissionsRequired: []
                 },
                 {
                     displayName: "Ultimaker.com", //Not translated, since it's a URL.
                     thumbnail: UM.Theme.getIcon("Browser"),
                     description: catalog.i18nc("@tooltip:button", "Visit the Ultimaker website."),
                     link: "https://ultimaker.com/?utm_source=cura&utm_medium=software&utm_campaign=switcher-umwebsite",
-                    DFAccessRequired: false
+                    DFAccessRequired: false,
+                    permissionsRequired: []
                 }
             ]
 
@@ -99,7 +108,28 @@ Popup
                 iconSource: modelData.thumbnail
                 tooltipText: modelData.description
                 isExternalLink: true
-                visible: modelData.DFAccessRequired ? Cura.API.account.isLoggedIn & Cura.API.account.additionalRights["df_access"] : true
+                visible:
+                {
+                    if(modelData.DFAccessRequired && (!Cura.API.account.isLoggedIn || !Cura.API.account.additionalRights["df_access"]))
+                    {
+                        return false;
+                    }
+                    try
+                    {
+                        modelData.permissionsRequired.forEach(function(permission)
+                        {
+                            if(!Cura.API.account.isLoggedIn || !Cura.API.account.permissions.includes(permission)) //This required permission is not in the account.
+                            {
+                                throw "No permission to use this application."; //Can't return from within this lambda. Throw instead.
+                            }
+                        });
+                    }
+                    catch(e)
+                    {
+                        return false;
+                    }
+                    return true;
+                }
 
                 onClicked: Qt.openUrlExternally(modelData.link)
             }

--- a/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml
+++ b/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml
@@ -88,7 +88,15 @@ UM.Window
                         {
                             if(Cura.API.account.isLoggedIn)
                             {
-                                swipeView.currentIndex += 2; //Skip sign in page.
+                                if(Cura.API.account.permissions.includes("digital-factory.printer.write"))
+                                {
+                                    swipeView.currentIndex += 2; //Skip sign in page. Continue to sync via cloud.
+                                }
+                                else
+                                {
+                                    //Logged in, but no permissions to start syncing. Direct them to USB.
+                                    swipeView.currentIndex = removableDriveSyncPage.SwipeView.index;
+                                }
                             }
                             else
                             {
@@ -112,7 +120,15 @@ UM.Window
                 {
                     if(is_logged_in && signinPage.SwipeView.isCurrentItem)
                     {
-                        swipeView.currentIndex += 1;
+                        if(Cura.API.account.permissions.includes("digital-factory.printer.write"))
+                        {
+                            swipeView.currentIndex += 1;
+                        }
+                        else
+                        {
+                            //Logged in, but no permissions to start syncing. Direct them to USB.
+                            swipeView.currentIndex = removableDriveSyncPage.SwipeView.index;
+                        }
                     }
                 }
             }

--- a/tests/API/TestAccount.py
+++ b/tests/API/TestAccount.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,7 +29,8 @@ def test_login():
     mocked_auth_service.startAuthorizationFlow.assert_called_once_with(False)
 
     # Fake a successful login
-    account._onLoginStateChanged(True)
+    with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.getInstance"):  # Don't want triggers for account information to actually make HTTP requests.
+        account._onLoginStateChanged(True)
 
     # Attempting to log in again shouldn't change anything.
     account.login()
@@ -59,7 +63,8 @@ def test_logout():
     assert not account.isLoggedIn
 
     # Pretend the stage changed
-    account._onLoginStateChanged(True)
+    with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.getInstance"):  # Don't want triggers for account information to actually make HTTP requests.
+        account._onLoginStateChanged(True)
     assert account.isLoggedIn
 
     account.logout()
@@ -72,12 +77,14 @@ def test_errorLoginState(application):
     account._authorization_service = mocked_auth_service
     account.loginStateChanged = MagicMock()
 
-    account._onLoginStateChanged(True, "BLARG!")
+    with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.getInstance"):  # Don't want triggers for account information to actually make HTTP requests.
+        account._onLoginStateChanged(True, "BLARG!")
     # Even though we said that the login worked, it had an error message, so the login failed.
     account.loginStateChanged.emit.called_with(False)
 
-    account._onLoginStateChanged(True)
-    account._onLoginStateChanged(False, "OMGZOMG!")
+    with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.getInstance"):
+        account._onLoginStateChanged(True)
+        account._onLoginStateChanged(False, "OMGZOMG!")
     account.loginStateChanged.emit.called_with(False)
 
 def test_sync_success():

--- a/tests/API/TestAccount.py
+++ b/tests/API/TestAccount.py
@@ -93,18 +93,19 @@ def test_sync_success():
     service1 = "test_service1"
     service2 = "test_service2"
 
-    account.setSyncState(service1, SyncState.SYNCING)
-    assert account.syncState == SyncState.SYNCING
+    with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.getInstance"):  # Don't want triggers for account information to actually make HTTP requests.
+        account.setSyncState(service1, SyncState.SYNCING)
+        assert account.syncState == SyncState.SYNCING
 
-    account.setSyncState(service2, SyncState.SYNCING)
-    assert account.syncState == SyncState.SYNCING
+        account.setSyncState(service2, SyncState.SYNCING)
+        assert account.syncState == SyncState.SYNCING
 
-    account.setSyncState(service1, SyncState.SUCCESS)
-    # service2 still syncing
-    assert account.syncState == SyncState.SYNCING
+        account.setSyncState(service1, SyncState.SUCCESS)
+        # service2 still syncing
+        assert account.syncState == SyncState.SYNCING
 
-    account.setSyncState(service2, SyncState.SUCCESS)
-    assert account.syncState == SyncState.SUCCESS
+        account.setSyncState(service2, SyncState.SUCCESS)
+        assert account.syncState == SyncState.SUCCESS
 
 
 def test_sync_update_action():
@@ -114,23 +115,24 @@ def test_sync_update_action():
 
     mockUpdateCallback = MagicMock()
 
-    account.setSyncState(service1, SyncState.SYNCING)
-    assert account.syncState == SyncState.SYNCING
+    with patch("UM.TaskManagement.HttpRequestManager.HttpRequestManager.getInstance"):  # Don't want triggers for account information to actually make HTTP requests.
+        account.setSyncState(service1, SyncState.SYNCING)
+        assert account.syncState == SyncState.SYNCING
 
-    account.setUpdatePackagesAction(mockUpdateCallback)
-    account.onUpdatePackagesClicked()
-    mockUpdateCallback.assert_called_once_with()
-    account.setSyncState(service1, SyncState.SUCCESS)
+        account.setUpdatePackagesAction(mockUpdateCallback)
+        account.onUpdatePackagesClicked()
+        mockUpdateCallback.assert_called_once_with()
+        account.setSyncState(service1, SyncState.SUCCESS)
 
-    account.sync()  # starting a new sync resets the update action to None
+        account.sync()  # starting a new sync resets the update action to None
 
-    account.setSyncState(service1, SyncState.SYNCING)
-    assert account.syncState == SyncState.SYNCING
+        account.setSyncState(service1, SyncState.SYNCING)
+        assert account.syncState == SyncState.SYNCING
 
-    account.onUpdatePackagesClicked()  # Should not be connected to an action anymore
-    mockUpdateCallback.assert_called_once_with()  # No additional calls
-    assert account.updatePackagesEnabled is False
-    account.setSyncState(service1, SyncState.SUCCESS)
+        account.onUpdatePackagesClicked()  # Should not be connected to an action anymore
+        mockUpdateCallback.assert_called_once_with()  # No additional calls
+        assert account.updatePackagesEnabled is False
+        account.setSyncState(service1, SyncState.SUCCESS)
 
 
 


### PR DESCRIPTION
Like Animal Farm taught us, some accounts have more access than others. For instance, they may be able to change print jobs only for their own jobs, not for others. Or they may be unable to read the print queue at all. This pull request is intended to hide buttons that would do things that the user doesn't have permission to do anyway.

It adds a request to the sync that requests the user's permissions. This list of permissions gets stored in the account and can be accessed via the Cura API, even from within QML.

Using this new property, the following changes are made:
* The print queue is hidden in the monitor page if the user can't read the print jobs.
* The "move to top" function is hidden if the user can't change other people's print jobs.
* The "pause" function is hidden if the user can't change other people's print jobs.
* The "abort" function is hidden if the user can't change that print job (their own or others, whichever applies).
* The "remove from queue" function is hidden if the user can't change that print job (their own or others).
* The context menu showing the above four options is hidden if all of them are hidden.
* The "manage in browser" link is hidden if the user can't see that management page in their browser.
* The option to sync materials with cloud printers redirects to the USB material syncing workflow if the user doesn't have permissions to sync via cloud.
* The application switcher no longer shows the links to the digital libraries, the print jobs or the printers if the user doesn't have permissions to see those respective pages.

Implements CURA-9220.