### PR TITLE
CURA-9520_Fix_support_infill_tree_support

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -224,7 +224,7 @@
             "value": true
         },
         "support_infill_rate": {
-            "value": "80 if gradual_support_infill_steps != 0 else 15"
+            "value": "0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15"
         },
         "gradual_support_infill_steps": {
             "value": "2 if support_interface_enable else 0"


### PR DESCRIPTION
Fixed issue with tree support having an infill density set to 15%. Now it is set to 0%.

Relates to CURA-9520