### PR TITLE
Cura 9031 add slice id to griffin gcode header

### DIFF
--- a/cura/UI/PrintInformation.py
+++ b/cura/UI/PrintInformation.py
@@ -38,6 +38,8 @@ class PrintInformation(QObject):
 
         self.initializeCuraMessagePrintTimeProperties()
 
+        self._slice_uuid: Optional[str] = None
+
         # Indexed by build plate number
         self._material_lengths = {}  # type: Dict[int, List[float]]
         self._material_weights = {}  # type: Dict[int, List[float]]
@@ -131,6 +133,14 @@ class PrintInformation(QObject):
             self._pre_sliced = pre_sliced
             self._updateJobName()
             self.preSlicedChanged.emit()
+
+    @property
+    def slice_uuid(self) -> Optional[str]:
+        return self._slice_uuid
+
+    @slice_uuid.setter
+    def slice_uuid(self, value: Optional[str]) -> None:
+        self._slice_uuid = value
 
     @pyqtProperty(QObject, notify = currentPrintTimeChanged)
     def currentPrintTime(self) -> Duration:

--- a/cura/UI/PrintInformation.py
+++ b/cura/UI/PrintInformation.py
@@ -38,7 +38,7 @@ class PrintInformation(QObject):
 
         self.initializeCuraMessagePrintTimeProperties()
 
-        self._slice_uuid: Optional[str] = None
+        self.slice_uuid: Optional[str] = None
 
         # Indexed by build plate number
         self._material_lengths = {}  # type: Dict[int, List[float]]
@@ -133,14 +133,6 @@ class PrintInformation(QObject):
             self._pre_sliced = pre_sliced
             self._updateJobName()
             self.preSlicedChanged.emit()
-
-    @property
-    def slice_uuid(self) -> Optional[str]:
-        return self._slice_uuid
-
-    @slice_uuid.setter
-    def slice_uuid(self, value: Optional[str]) -> None:
-        self._slice_uuid = value
 
     @pyqtProperty(QObject, notify = currentPrintTimeChanged)
     def currentPrintTime(self) -> Duration:

--- a/plugins/CuraEngineBackend/Cura.proto
+++ b/plugins/CuraEngineBackend/Cura.proto
@@ -139,5 +139,9 @@ message GCodePrefix {
     bytes data = 2; //Header string to be prepended before the rest of the g-code sent from the engine.
 }
 
+message SliceUUID {
+    string slice_uuid = 1; //The UUID of the slice.
+}
+
 message SlicingFinished {
 }

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -124,6 +124,7 @@ class CuraEngineBackend(QObject, Backend):
         self._message_handlers["cura.proto.Progress"] = self._onProgressMessage
         self._message_handlers["cura.proto.GCodeLayer"] = self._onGCodeLayerMessage
         self._message_handlers["cura.proto.GCodePrefix"] = self._onGCodePrefixMessage
+        self._message_handlers["cura.proto.SliceUUID"] = self._onSliceUUIDMessage
         self._message_handlers["cura.proto.PrintTimeMaterialEstimates"] = self._onPrintTimeMaterialEstimates
         self._message_handlers["cura.proto.SlicingFinished"] = self._onSlicingFinishedMessage
 
@@ -811,6 +812,10 @@ class CuraEngineBackend(QObject, Backend):
             self._scene.gcode_dict[self._start_slice_job_build_plate].insert(0, message.data.decode("utf-8", "replace")) #type: ignore #Because we generate this attribute dynamically.
         except KeyError:  # Can occur if the g-code has been cleared while a slice message is still arriving from the other end.
             pass  # Throw the message away.
+
+    def _onSliceUUIDMessage(self, message: Arcus.PythonMessage) -> None:
+        application = CuraApplication.getInstance()
+        application.getPrintInformation().slice_uuid = message.slice_uuid
 
     def _createSocket(self, protocol_file: str = None) -> None:
         """Creates a new socket connection."""

--- a/plugins/SliceInfoPlugin/SliceInfo.py
+++ b/plugins/SliceInfoPlugin/SliceInfo.py
@@ -133,6 +133,7 @@ class SliceInfo(QObject, Extension):
             data["is_logged_in"] = self._application.getCuraAPI().account.isLoggedIn
             data["organization_id"] = org_id if org_id else None
             data["subscriptions"] = user_profile.get("subscriptions", []) if user_profile else []
+            data["slice_uuid"] = print_information.slice_uuid
 
             active_mode = self._application.getPreferences().getValue("cura/active_mode")
             if active_mode == 0:

--- a/plugins/SliceInfoPlugin/example_data.html
+++ b/plugins/SliceInfoPlugin/example_data.html
@@ -9,6 +9,7 @@
     <b>Using Custom Settings:</b> No<br/>
     <b>Is Logged In:</b> Yes<br/>
     <b>Organization ID (if any):</b> ABCDefGHIjKlMNOpQrSTUvYxWZ0-1234567890abcDE=<br/>
+    <b>Slice ID:</b> aBcDeF01-2345-6789-aBcD-eF0123456789<br/>
     <b>Subscriptions (if any):</b>
     <ul>
         <li><b>Level:</b> 10, <b>Type:</b> Enterprise, <b>Plan:</b> Basic</li>


### PR DESCRIPTION
Add an UUID to the slice info data. This UUID is generated by CuraEngine and send via Arcus to the front-end

See also the PR on the CuraEngine side 