### PR TITLE
Don't show warning color for children of support_infill_rate when using tree support

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -226,6 +226,12 @@
         "support_infill_rate": {
             "value": "0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15"
         },
+        "support_line_distance": {
+            "minimum_value_warning": "0 if support_structure == 'tree' else support_line_width"
+        },
+        "support_initial_layer_line_distance": {
+            "minimum_value_warning": "0 if support_structure == 'tree' else support_line_width"
+        },
         "gradual_support_infill_steps": {
             "value": "2 if support_interface_enable else 0"
         },


### PR DESCRIPTION
Lower the value of the warning color for the children of support_infill_rate when selecting tree support

See comment made by @Vandrasc in ticket CURA-9520 PPM: Tree support has infill density 15%, but should have 0%