### PR TITLE
MachineErrorChecker.py: Use one line conditional assignment

### DIFF
--- a/cura/Machines/MachineErrorChecker.py
+++ b/cura/Machines/MachineErrorChecker.py
@@ -204,10 +204,7 @@ class MachineErrorChecker(QObject):
             self._has_errors = result
             self.hasErrorUpdated.emit()
             self._machine_manager.stacksValidationChanged.emit()
-        if keys_to_recheck is None:
-            self._keys_to_check = set()
-        else:
-            self._keys_to_check = keys_to_recheck
+        self._keys_to_check = keys_to_recheck if keys_to_recheck else set()
         self._need_to_check = False
         self._check_in_progress = False
         self.needToWaitForResultChanged.emit()


### PR DESCRIPTION
Use one line conditional assignement instead of if else block.
The intent is now clearer and the code is easier to read.