### PR TITLE
LayerPolygon.py: Refactor check for unknown line types

### DIFF
--- a/cura/LayerPolygon.py
+++ b/cura/LayerPolygon.py
@@ -43,7 +43,7 @@ class LayerPolygon:
         if unknown_types:
             # Got faulty line data from the engine.
             for idx in unknown_types:
-                Logger.log("w", "Found an unknown line type at: %s", idx)
+                Logger.warn(f"Found an unknown line type at: {idx}")
                 self._types[idx] = self.NoneType
         self._data = data
         self._line_widths = line_widths

--- a/cura/LayerPolygon.py
+++ b/cura/LayerPolygon.py
@@ -39,10 +39,10 @@ class LayerPolygon:
 
         self._extruder = extruder
         self._types = line_types
-        for i in range(len(self._types)):
-            if self._types[i] >= self.__number_of_types: # Got faulty line data from the engine.
-                Logger.log("w", "Found an unknown line type: %s", i)
-                self._types[i] = self.NoneType
+        for idx, line_type in enumerate(self._types):
+            if line_type >= self.__number_of_types: # Got faulty line data from the engine.
+                Logger.log("w", "Found an unknown line type: %s", line_type)
+                self._types[idx] = self.NoneType
         self._data = data
         self._line_widths = line_widths
         self._line_thicknesses = line_thicknesses

--- a/cura/LayerPolygon.py
+++ b/cura/LayerPolygon.py
@@ -39,9 +39,11 @@ class LayerPolygon:
 
         self._extruder = extruder
         self._types = line_types
-        for idx, line_type in enumerate(self._types):
-            if line_type >= self.__number_of_types: # Got faulty line data from the engine.
-                Logger.log("w", "Found an unknown line type: %s", line_type)
+        unknown_types = np.where(self_types >= self_number_of_types)
+        if unknown_types:
+            # Got faulty line data from the engine.
+            for idx in unknown_types:
+                Logger.log("w", "Found an unknown line type at: %s", idx)
                 self._types[idx] = self.NoneType
         self._data = data
         self._line_widths = line_widths


### PR DESCRIPTION
First commit improved the iteration using enumerate.
Second commit uses np.where() instead to improve clarity of intent.