### PR TITLE
Use is not operator rather than not ... is

### DIFF
--- a/cura/Arranging/ShapeArray.py
+++ b/cura/Arranging/ShapeArray.py
@@ -74,14 +74,14 @@ class ShapeArray:
         # If the child-nodes are included, adjust convex hulls as well:
         if include_children:
             children = node.getAllChildren()
-            if not children is None:
+            if children is not None:
                 for child in children:
                     # 'Inefficient' combination of convex hulls through known code rather than mess it up:
                     child_hull = child.callDecoration("getConvexHull")
-                    if not child_hull is None:
+                    if child_hull is not None:
                         hull_verts = hull_verts.unionConvexHulls(child_hull)
                     child_hull_head = child.callDecoration("getConvexHullHead") or child_hull
-                    if not child_hull_head is None:
+                    if child_hull_head is not None:
                         hull_head_verts = hull_head_verts.unionConvexHulls(child_hull_head)
 
         offset_verts = hull_head_verts.getMinkowskiHull(Polygon.approximatedCircle(min_offset))

--- a/plugins/X3DReader/X3DReader.py
+++ b/plugins/X3DReader/X3DReader.py
@@ -498,7 +498,7 @@ class X3DReader(MeshReader):
 
             if scale:
                 mscale = scale[i] if len(scale) > 1 else scale[0]
-                if not mscale is None:
+                if mscale is not None:
                     m = m.dot(mscale)
 
             # First the cross-section 2-vector is scaled,

--- a/plugins/X3DReader/X3DReader.py
+++ b/plugins/X3DReader/X3DReader.py
@@ -703,7 +703,7 @@ class X3DReader(MeshReader):
         for c in node:
             if c.tag == "Coordinate":
                 c = self.resolveDefUse(c)
-                if not c is None:
+                if c is not None:
                     pt = c.attrib.get("point")
                     if pt:
                         # allow the list of float values in 'point' attribute to

--- a/plugins/X3DReader/X3DReader.py
+++ b/plugins/X3DReader/X3DReader.py
@@ -493,7 +493,7 @@ class X3DReader(MeshReader):
             # Columns are the unit vectors for the xz plane for the cross-section
             if orient:
                 mrot = orient[i] if len(orient) > 1 else orient[0]
-                if not mrot is None:
+                if mrot is not None:
                     m = m.dot(mrot)  # Tested against X3DOM, the result matches, still not sure :(
 
             if scale:

--- a/plugins/X3DReader/X3DReader.py
+++ b/plugins/X3DReader/X3DReader.py
@@ -134,7 +134,7 @@ class X3DReader(MeshReader):
                 geometry = self.resolveDefUse(sub_node)
 
         # TODO: appearance is completely ignored. At least apply the material color...
-        if not geometry is None:
+        if geometry is not None:
             try:
                 self.verts = self.faces = [] # Safeguard
                 self.geometry_importers[geometry.tag](self, geometry)


### PR DESCRIPTION
This is advocated by both PEP8 and the Google Python Style Guide