### PR TITLE
ShapeArray.py: Use is not operator rather than not ... is

### DIFF
--- a/cura/Arranging/ShapeArray.py
+++ b/cura/Arranging/ShapeArray.py
@@ -74,7 +74,7 @@ class ShapeArray:
         # If the child-nodes are included, adjust convex hulls as well:
         if include_children:
             children = node.getAllChildren()
-            if not children is None:
+            if children is not None:
                 for child in children:
                     # 'Inefficient' combination of convex hulls through known code rather than mess it up:
                     child_hull = child.callDecoration("getConvexHull")

--- a/cura/Arranging/ShapeArray.py
+++ b/cura/Arranging/ShapeArray.py
@@ -81,7 +81,7 @@ class ShapeArray:
                     if child_hull is not None:
                         hull_verts = hull_verts.unionConvexHulls(child_hull)
                     child_hull_head = child.callDecoration("getConvexHullHead") or child_hull
-                    if not child_hull_head is None:
+                    if child_hull_head is not None:
                         hull_head_verts = hull_head_verts.unionConvexHulls(child_hull_head)
 
         offset_verts = hull_head_verts.getMinkowskiHull(Polygon.approximatedCircle(min_offset))

--- a/cura/Arranging/ShapeArray.py
+++ b/cura/Arranging/ShapeArray.py
@@ -78,7 +78,7 @@ class ShapeArray:
                 for child in children:
                     # 'Inefficient' combination of convex hulls through known code rather than mess it up:
                     child_hull = child.callDecoration("getConvexHull")
-                    if not child_hull is None:
+                    if child_hull is not None:
                         hull_verts = hull_verts.unionConvexHulls(child_hull)
                     child_hull_head = child.callDecoration("getConvexHullHead") or child_hull
                     if not child_hull_head is None:


### PR DESCRIPTION
Change to use is not operator rather than not ... is 
in **cura/Arranging/ShapeArray.py** 
as advocated by PEP8 and Google Python Style Guide.

See comment by @fieldOfView in #12970

Atomic commits for easy merging.