### PR TITLE
repositories.md: reformat to aid reading

### DIFF
--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -7,7 +7,7 @@ Cura uses a number of repositories where parts of our source code are separated,
     -  specific tools for handling 3D printed models
     -  pretty much all of the GUI
     -  Ultimaker services such as the Marketplace and accounts.
-* [Uranium](https://github.com/Ultimaker/Uranium) is the underlying framework the Cura repository is built on. [Uranium](https://github.com/Ultimaker/Uranium) is a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with:
+* [Uranium](https://github.com/Ultimaker/Uranium) is the underlying framework the Cura repository is built on. [Uranium](https://github.com/Ultimaker/Uranium) is a framework for desktop applications that handle 3D models. It has a separate back-end. This provides Cura with:
     - a basic GUI framework ([Qt](https://www.qt.io/))
     - a 3D scene, a rendering system
     - a plug-in system

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -1,7 +1,7 @@
 Repositories
 ====
 Cura uses a number of repositories where parts of our source code are separated, in order to get a cleaner architecture. Those repositories are:
-* [Cura](https://github.com/Ultimaker/Cura), the main repository for the front-end of Cura. This contains:
+* [Cura](https://github.com/Ultimaker/Cura) is the main repository for the front-end of Cura. This contains:
     - all of the business logic for the front-end, including the specific types of profiles that are available
     -  the concept of 3D printers and materials
     -  specific tools for handling 3D printed models

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -1,8 +1,17 @@
 Repositories
 ====
 Cura uses a number of repositories where parts of our source code are separated, in order to get a cleaner architecture. Those repositories are:
-* [Cura](https://github.com/Ultimaker/Cura), the main repository for the front-end of Cura. This contains all of the business logic for the front-end, including the specific types of profiles that are available, the concept of 3D printers and materials, specific tools for handling 3D printed models, pretty much all of the GUI, as well as Ultimaker services such as the Marketplace and accounts.
-* The Cura repository is built on [Uranium](https://github.com/Ultimaker/Uranium), a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with a basic GUI framework ([Qt](https://www.qt.io/)), a 3D scene, a rendering system, a plug-in system and a system for stacked profiles that change settings.
+* [Cura](https://github.com/Ultimaker/Cura), the main repository for the front-end of Cura. This contains:
+    - all of the business logic for the front-end, including the specific types of profiles that are available
+    -  the concept of 3D printers and materials
+    -  specific tools for handling 3D printed models
+    -  pretty much all of the GUI
+    -  Ultimaker services such as the Marketplace and accounts.
+* The Cura repository is built on [Uranium](https://github.com/Ultimaker/Uranium), a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with:
+    - a basic GUI framework ([Qt](https://www.qt.io/))
+    - a 3D scene, a rendering system
+    - a plug-in system
+    - a system for stacked profiles that change settings.
 * In order to slice, Cura starts [CuraEngine](https://github.com/Ultimaker/CuraEngine) in the background. This does the actual process that converts 3D models into a toolpath for the printer.
 * Communication to CuraEngine goes via [libArcus](https://github.com/Ultimaker/libArcus), a small library that wraps around [Protobuf](https://developers.google.com/protocol-buffers/) in order to make it run over a local socket.
 * Cura's build scripts are in [cura-build](https://github.com/Ultimaker/cura-build) and build scripts for building dependencies are in [cura-build-environment](https://github.com/Ultimaker/cura-build-environment).
@@ -10,7 +19,9 @@ Cura uses a number of repositories where parts of our source code are separated,
 There are also a number of repositories under our control that are not integral parts of Cura's architecture, but more like separated side-gigs:
 * Loading and writing 3MF files is done through [libSavitar](https://github.com/Ultimaker/libSavitar).
 * Loading and writing UFP files is done through [libCharon](https://github.com/Ultimaker/libCharon).
-* To make the build system a bit simpler, some parts are pre-compiled in [cura-binary-data](https://github.com/Ultimaker/cura-binary-data). This holds things like the machine-readable translation files and the Marlin builds for firmware updates, which would require considerable tooling to build automatically.
+* To make the build system a bit simpler, some parts are pre-compiled in [cura-binary-data](https://github.com/Ultimaker/cura-binary-data). This holds things  which would require considerable tooling to build automatically like:
+    - the machine-readable translation files
+    - the Marlin builds for firmware updates
 * There are automated GUI tests in [Cura-squish-tests](https://github.com/Ultimaker/Cura-squish-tests).
 * Material profiles are stored in [fdm_materials](https://github.com/Ultimaker/fdm_materials). This is separated out and combined in our build process, so that the firmware for Ultimaker's printers can use the same set of profiles too.
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -7,23 +7,24 @@ Cura uses a number of repositories where parts of our source code are separated,
     -  specific tools for handling 3D printed models
     -  pretty much all of the GUI
     -  Ultimaker services such as the Marketplace and accounts.
-* The Cura repository is built on [Uranium](https://github.com/Ultimaker/Uranium), a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with:
+* [Uranium](https://github.com/Ultimaker/Uranium) the underlying framework the Cura repository is built on . [Uranium](https://github.com/Ultimaker/Uranium) is a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with:
     - a basic GUI framework ([Qt](https://www.qt.io/))
     - a 3D scene, a rendering system
     - a plug-in system
     - a system for stacked profiles that change settings.
-* In order to slice, Cura starts [CuraEngine](https://github.com/Ultimaker/CuraEngine) in the background. This does the actual process that converts 3D models into a toolpath for the printer.
-* Communication to CuraEngine goes via [libArcus](https://github.com/Ultimaker/libArcus), a small library that wraps around [Protobuf](https://developers.google.com/protocol-buffers/) in order to make it run over a local socket.
-* Cura's build scripts are in [cura-build](https://github.com/Ultimaker/cura-build) and build scripts for building dependencies are in [cura-build-environment](https://github.com/Ultimaker/cura-build-environment).
+*  [CuraEngine](https://github.com/Ultimaker/CuraEngine) the slicer used by Cura in the background. This does the actual process that converts 3D models into a toolpath for the printer.
+* [libArcus](https://github.com/Ultimaker/libArcus) handles the communication to CuraEngine. [libArcus](https://github.com/Ultimaker/libArcus) is a small library that wraps around [Protobuf](https://developers.google.com/protocol-buffers/) in order to make it run over a local socket.
+* [cura-build](https://github.com/Ultimaker/cura-build): Cura's build scripts.  
+* [cura-build-environment](https://github.com/Ultimaker/cura-build-environment) build scripts for building dependencies.
 
 There are also a number of repositories under our control that are not integral parts of Cura's architecture, but more like separated side-gigs:
-* Loading and writing 3MF files is done through [libSavitar](https://github.com/Ultimaker/libSavitar).
-* Loading and writing UFP files is done through [libCharon](https://github.com/Ultimaker/libCharon).
-* To make the build system a bit simpler, some parts are pre-compiled in [cura-binary-data](https://github.com/Ultimaker/cura-binary-data). This holds things  which would require considerable tooling to build automatically like:
+* [libSavitar](https://github.com/Ultimaker/libSavitar) is used for loading and writing 3MF files.
+* [libCharon](https://github.com/Ultimaker/libCharon) is used for loading and writing UFP files.
+*  [cura-binary-data](https://github.com/Ultimaker/cura-binary-data) pre-compiled parts to make the build system a bit simpler. This holds things which would require considerable tooling to build automatically like:
     - the machine-readable translation files
     - the Marlin builds for firmware updates
-* There are automated GUI tests in [Cura-squish-tests](https://github.com/Ultimaker/Cura-squish-tests).
-* Material profiles are stored in [fdm_materials](https://github.com/Ultimaker/fdm_materials). This is separated out and combined in our build process, so that the firmware for Ultimaker's printers can use the same set of profiles too.
+* [Cura-squish-tests](https://github.com/Ultimaker/Cura-squish-tests): automated GUI tests.
+* [fdm_materials](https://github.com/Ultimaker/fdm_materials) stores Material profiles. This is separated out and combined in our build process, so that the firmware for Ultimaker's printers can use the same set of profiles too.
 
 Interplay
 ----

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -12,7 +12,7 @@ Cura uses a number of repositories where parts of our source code are separated,
     - a 3D scene, a rendering system
     - a plug-in system
     - a system for stacked profiles that change settings.
-*  [CuraEngine](https://github.com/Ultimaker/CuraEngine) is the slicer used by Cura in the background. This does the actual process that converts 3D models into a toolpath for the printer.
+* [CuraEngine](https://github.com/Ultimaker/CuraEngine) is the slicer used by Cura in the background. This does the actual process that converts 3D models into a toolpath for the printer.
 * [libArcus](https://github.com/Ultimaker/libArcus) handles the communication to CuraEngine. [libArcus](https://github.com/Ultimaker/libArcus) is a small library that wraps around [Protobuf](https://developers.google.com/protocol-buffers/) in order to make it run over a local socket.
 * [cura-build](https://github.com/Ultimaker/cura-build): Cura's build scripts.  
 * [cura-build-environment](https://github.com/Ultimaker/cura-build-environment) build scripts for building dependencies.
@@ -20,7 +20,7 @@ Cura uses a number of repositories where parts of our source code are separated,
 There are also a number of repositories under our control that are not integral parts of Cura's architecture, but more like separated side-gigs:
 * [libSavitar](https://github.com/Ultimaker/libSavitar) is used for loading and writing 3MF files.
 * [libCharon](https://github.com/Ultimaker/libCharon) is used for loading and writing UFP files.
-*  [cura-binary-data](https://github.com/Ultimaker/cura-binary-data) pre-compiled parts to make the build system a bit simpler. This holds things which would require considerable tooling to build automatically like:
+* [cura-binary-data](https://github.com/Ultimaker/cura-binary-data) pre-compiled parts to make the build system a bit simpler. This holds things which would require considerable tooling to build automatically like:
     - the machine-readable translation files
     - the Marlin builds for firmware updates
 * [Cura-squish-tests](https://github.com/Ultimaker/Cura-squish-tests): automated GUI tests.

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -7,12 +7,12 @@ Cura uses a number of repositories where parts of our source code are separated,
     -  specific tools for handling 3D printed models
     -  pretty much all of the GUI
     -  Ultimaker services such as the Marketplace and accounts.
-* [Uranium](https://github.com/Ultimaker/Uranium) the underlying framework the Cura repository is built on. [Uranium](https://github.com/Ultimaker/Uranium) is a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with:
+* [Uranium](https://github.com/Ultimaker/Uranium) is the underlying framework the Cura repository is built on. [Uranium](https://github.com/Ultimaker/Uranium) is a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with:
     - a basic GUI framework ([Qt](https://www.qt.io/))
     - a 3D scene, a rendering system
     - a plug-in system
     - a system for stacked profiles that change settings.
-*  [CuraEngine](https://github.com/Ultimaker/CuraEngine) the slicer used by Cura in the background. This does the actual process that converts 3D models into a toolpath for the printer.
+*  [CuraEngine](https://github.com/Ultimaker/CuraEngine) is the slicer used by Cura in the background. This does the actual process that converts 3D models into a toolpath for the printer.
 * [libArcus](https://github.com/Ultimaker/libArcus) handles the communication to CuraEngine. [libArcus](https://github.com/Ultimaker/libArcus) is a small library that wraps around [Protobuf](https://developers.google.com/protocol-buffers/) in order to make it run over a local socket.
 * [cura-build](https://github.com/Ultimaker/cura-build): Cura's build scripts.  
 * [cura-build-environment](https://github.com/Ultimaker/cura-build-environment) build scripts for building dependencies.

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -7,7 +7,7 @@ Cura uses a number of repositories where parts of our source code are separated,
     -  specific tools for handling 3D printed models
     -  pretty much all of the GUI
     -  Ultimaker services such as the Marketplace and accounts.
-* [Uranium](https://github.com/Ultimaker/Uranium) the underlying framework the Cura repository is built on . [Uranium](https://github.com/Ultimaker/Uranium) is a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with:
+* [Uranium](https://github.com/Ultimaker/Uranium) the underlying framework the Cura repository is built on. [Uranium](https://github.com/Ultimaker/Uranium) is a framework for desktop applications that handle 3D models and have a separate back-end. This provides Cura with:
     - a basic GUI framework ([Qt](https://www.qt.io/))
     - a 3D scene, a rendering system
     - a plug-in system


### PR DESCRIPTION
Reformatting of documentation file: repositories.md
- the name of each repo is now at the beginning of the section that describes what it does.
- the text that describes what each repo does is broken up into lists. This is easier to read and understand.
- a few grammatical improvements.
