### PR TITLE
[CURA-9488] Fix infill density being set incorrectly when changing intent

### DIFF
--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml
@@ -51,7 +51,17 @@ Item
     {
         target: infillSlider
         property: "value"
-        value: parseInt(infillDensity.properties.value)
+        value: {
+            // The infill slider has a max value of 100. When it is given a value > 100 onValueChanged updates the setting to be 100.
+            // When changing to an intent with infillDensity > 100, it would always be clamped to 100.
+            // This will force the slider to ignore the first onValueChanged for values > 100 so higher values can be set.
+            var density = parseInt(infillDensity.properties.value)
+            if (density > 100) {
+                infillSlider.ignoreValueChange = true
+            }
+
+            return density
+        }
     }
 
     // Here are the elements that are shown in the left column
@@ -83,6 +93,8 @@ Item
         Slider
         {
             id: infillSlider
+
+            property var ignoreValueChange: false
 
             width: parent.width
             height: UM.Theme.getSize("print_setup_slider_handle").height // The handle is the widest element of the slider
@@ -157,7 +169,13 @@ Item
                 target: infillSlider
                 function onValueChanged()
                 {
-                    // Don't round the value if it's already the same
+                    if (infillSlider.ignoreValueChange)
+                    {
+                        infillSlider.ignoreValueChange = false
+                        return
+                    }
+
+                    // Don't update if the setting value, if the slider has the same value
                     if (parseInt(infillDensity.properties.value) == infillSlider.value)
                     {
                         return


### PR DESCRIPTION
When changing to an intent with infillDensity > 100 in recommended settings the RecommendedInfillDensitySelector would set infillDensity=100.

This is because the onValueChanged function checks if the slider has a different value from the settings and updates the settings if it does. The slider has a max value of 100, so when setting the sliders value to 1000 the slider would update to have a value of 100. This would then update the setting to value to 100.

The fix is as follows. When updating the slider value > 100 just ignore the first onValueChanged. Following onValueChanged, which are triggered by the user sliding the slider, will still trigger.

CURA-9488