### PR TITLE
Prevents the head from moving outside the print area

### DIFF
--- a/resources/definitions/kingroon_base.def.json
+++ b/resources/definitions/kingroon_base.def.json
@@ -129,7 +129,7 @@
     "overrides": {
         "machine_name": { "default_value": "Kingroon Base Printer" },
         "machine_start_gcode": { "default_value": "G28 ; home all axes\n M117 Purge extruder\n G92 E0 ; reset extruder\n G1 Z1.0 F3000 ; move z up little to prevent scratching of surface\n G1 X2 Y20 Z0.3 F5000.0 ; move to start-line position\n G1 X2 Y175.0 Z0.3 F1500.0 E15 ; draw 1st line\n G1 X2 Y175.0 Z0.4 F5000.0 ; move to side a little\n G1 X2 Y20 Z0.4 F1500.0 E30 ; draw 2nd line\n G92 E0 ; reset extruder\n G1 Z1.0 F3000 ; move z up little to prevent scratching of surface"},
-        "machine_end_gcode": { "default_value": "G91; relative positioning\n G1 Z1.0 F3000 ; move z up little to prevent scratching of print\n G90; absolute positioning\n G1 X0 Y200 F1000 ; prepare for part removal\n M104 S0; turn off extruder\n M140 S0 ; turn off bed\n G1 X0 Y300 F1000 ; prepare for part removal\n M84 ; disable motors\n M106 S0 ; turn off fan" },
+        "machine_end_gcode": { "default_value": "G91; relative positioning\n G1 Z1.0 F3000 ; move z up little to prevent scratching of print\n G90; absolute positioning\n M104 S0; turn off extruder\n M140 S0 ; turn off bed\n G1 X0 Y175 F1000 ; prepare for part removal\n M84 ; disable motors\n M106 S0 ; turn off fan" },
 
         "machine_width": { "default_value": 180 },
         "machine_depth": { "default_value": 180 },


### PR DESCRIPTION
Kingroon's KP3/KP3S print range is 180x180x180, but the current End G-Code contains a code that moves to Y 200 or Y 300.
As a result, after printing, an error occurs due to a move outside the range.
I have created a small fix code.
Please merge if it is OK.

Thank you.

_Before Fix_
<img width="50%" alt="after_fix" src="https://user-images.githubusercontent.com/11240403/184573538-fced5684-0be5-40d0-8397-3954fef1832d.jpeg">

_After Fix_
<img width="371" alt="after_fix" src="https://user-images.githubusercontent.com/11240403/184573564-3860d040-773a-445f-8ed4-6b3b854f2596.png">
<img width="892" alt="after_fix_all" src="https://user-images.githubusercontent.com/11240403/184573599-1f416441-0813-4fc7-963d-717b5b57807a.png">
.