### PR TITLE
Moved top layer (roofing) settings out of experimental: “Top surface …

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1443,7 +1443,63 @@
                     "value": "0",
                     "limit_to_extruder": "roofing_extruder_nr",
                     "settable_per_mesh": true,
-                    "enabled": "top_layers > 0"
+                    "enabled": "top_layers > 0",
+                    "children": {
+                            "roofing_line_width":
+                            {
+                                "label": "Top Surface Skin Line Width",
+                                "description": "Width of a single line of the areas at the top of the print.",
+                                "unit": "mm",
+                                "minimum_value": "0.001",
+                                "minimum_value_warning": "0.1 + 0.4 * machine_nozzle_size",
+                                "maximum_value_warning": "2 * machine_nozzle_size",
+                                "default_value": 0.4,
+                                "type": "float",
+                                "value": "skin_line_width",
+                                "limit_to_extruder": "roofing_extruder_nr",
+                                "settable_per_mesh": true,
+                                "enabled": "roofing_layer_count > 0 and top_layers > 0"
+                            },
+                            "roofing_pattern":
+                            {
+                                "label": "Top Surface Skin Pattern",
+                                "description": "The pattern of the top most layers.",
+                                "type": "enum",
+                                "options":
+                                {
+                                    "lines": "Lines",
+                                    "concentric": "Concentric",
+                                    "zigzag": "Zig Zag"
+                                },
+                                "default_value": "lines",
+                                "value": "top_bottom_pattern",
+                                "limit_to_extruder": "roofing_extruder_nr",
+                                "settable_per_mesh": true,
+                                "enabled": "roofing_layer_count > 0 and top_layers > 0"
+                            },
+                            "roofing_monotonic":
+                            {
+                                "label": "Monotonic Top Surface Order",
+                                "description": "Print top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
+                                "type": "bool",
+                                "default_value": false,
+                                "value": "skin_monotonic",
+                                "enabled": "roofing_layer_count > 0 and top_layers > 0 and roofing_pattern != 'concentric'",
+                                "limit_to_extruder": "roofing_extruder_nr",
+                                "settable_per_mesh": true
+                            },
+                            "roofing_angles":
+                            {
+                                "label": "Top Surface Skin Line Directions",
+                                "description": "A list of integer line directions to use when the top surface skin layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees).",
+                                "type": "[int]",
+                                "default_value": "[ ]",
+                                "value": "skin_angles",
+                                "enabled": "roofing_pattern != 'concentric' and roofing_layer_count > 0 and top_layers > 0",
+                                "limit_to_extruder": "roofing_extruder_nr",
+                                "settable_per_mesh": true
+                            }
+                    }
                 },
                 "top_bottom_extruder_nr":
                 {
@@ -6643,60 +6699,6 @@
                         "inclusive": "Inclusive"
                     },
                     "default_value": "middle",
-                    "settable_per_mesh": true
-                },
-                "roofing_line_width":
-                {
-                    "label": "Top Surface Skin Line Width",
-                    "description": "Width of a single line of the areas at the top of the print.",
-                    "unit": "mm",
-                    "minimum_value": "0.001",
-                    "minimum_value_warning": "0.1 + 0.4 * machine_nozzle_size",
-                    "maximum_value_warning": "2 * machine_nozzle_size",
-                    "default_value": 0.4,
-                    "type": "float",
-                    "value": "skin_line_width",
-                    "limit_to_extruder": "roofing_extruder_nr",
-                    "settable_per_mesh": true,
-                    "enabled": "roofing_layer_count > 0 and top_layers > 0"
-                },
-                "roofing_pattern":
-                {
-                    "label": "Top Surface Skin Pattern",
-                    "description": "The pattern of the top most layers.",
-                    "type": "enum",
-                    "options":
-                    {
-                        "lines": "Lines",
-                        "concentric": "Concentric",
-                        "zigzag": "Zig Zag"
-                    },
-                    "default_value": "lines",
-                    "value": "top_bottom_pattern",
-                    "limit_to_extruder": "roofing_extruder_nr",
-                    "settable_per_mesh": true,
-                    "enabled": "roofing_layer_count > 0 and top_layers > 0"
-                },
-                "roofing_monotonic":
-                {
-                    "label": "Monotonic Top Surface Order",
-                    "description": "Print top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
-                    "type": "bool",
-                    "default_value": false,
-                    "value": "skin_monotonic",
-                    "enabled": "roofing_layer_count > 0 and top_layers > 0 and roofing_pattern != 'concentric'",
-                    "limit_to_extruder": "roofing_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "roofing_angles":
-                {
-                    "label": "Top Surface Skin Line Directions",
-                    "description": "A list of integer line directions to use when the top surface skin layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees).",
-                    "type": "[int]",
-                    "default_value": "[ ]",
-                    "value": "skin_angles",
-                    "enabled": "roofing_pattern != 'concentric' and roofing_layer_count > 0 and top_layers > 0",
-                    "limit_to_extruder": "roofing_extruder_nr",
                     "settable_per_mesh": true
                 },
                 "infill_enable_travel_optimization":

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1445,60 +1445,60 @@
                     "settable_per_mesh": true,
                     "enabled": "top_layers > 0",
                     "children": {
-                            "roofing_line_width":
+                        "roofing_line_width":
+                        {
+                            "label": "Top Surface Skin Line Width",
+                            "description": "Width of a single line of the areas at the top of the print.",
+                            "unit": "mm",
+                            "minimum_value": "0.001",
+                            "minimum_value_warning": "0.1 + 0.4 * machine_nozzle_size",
+                            "maximum_value_warning": "2 * machine_nozzle_size",
+                            "default_value": 0.4,
+                            "type": "float",
+                            "value": "skin_line_width",
+                            "limit_to_extruder": "roofing_extruder_nr",
+                            "settable_per_mesh": true,
+                            "enabled": "roofing_layer_count > 0 and top_layers > 0"
+                        },
+                        "roofing_pattern":
+                        {
+                            "label": "Top Surface Skin Pattern",
+                            "description": "The pattern of the top most layers.",
+                            "type": "enum",
+                            "options":
                             {
-                                "label": "Top Surface Skin Line Width",
-                                "description": "Width of a single line of the areas at the top of the print.",
-                                "unit": "mm",
-                                "minimum_value": "0.001",
-                                "minimum_value_warning": "0.1 + 0.4 * machine_nozzle_size",
-                                "maximum_value_warning": "2 * machine_nozzle_size",
-                                "default_value": 0.4,
-                                "type": "float",
-                                "value": "skin_line_width",
-                                "limit_to_extruder": "roofing_extruder_nr",
-                                "settable_per_mesh": true,
-                                "enabled": "roofing_layer_count > 0 and top_layers > 0"
+                                "lines": "Lines",
+                                "concentric": "Concentric",
+                                "zigzag": "Zig Zag"
                             },
-                            "roofing_pattern":
-                            {
-                                "label": "Top Surface Skin Pattern",
-                                "description": "The pattern of the top most layers.",
-                                "type": "enum",
-                                "options":
-                                {
-                                    "lines": "Lines",
-                                    "concentric": "Concentric",
-                                    "zigzag": "Zig Zag"
-                                },
-                                "default_value": "lines",
-                                "value": "top_bottom_pattern",
-                                "limit_to_extruder": "roofing_extruder_nr",
-                                "settable_per_mesh": true,
-                                "enabled": "roofing_layer_count > 0 and top_layers > 0"
-                            },
-                            "roofing_monotonic":
-                            {
-                                "label": "Monotonic Top Surface Order",
-                                "description": "Print top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
-                                "type": "bool",
-                                "default_value": false,
-                                "value": "skin_monotonic",
-                                "enabled": "roofing_layer_count > 0 and top_layers > 0 and roofing_pattern != 'concentric'",
-                                "limit_to_extruder": "roofing_extruder_nr",
-                                "settable_per_mesh": true
-                            },
-                            "roofing_angles":
-                            {
-                                "label": "Top Surface Skin Line Directions",
-                                "description": "A list of integer line directions to use when the top surface skin layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees).",
-                                "type": "[int]",
-                                "default_value": "[ ]",
-                                "value": "skin_angles",
-                                "enabled": "roofing_pattern != 'concentric' and roofing_layer_count > 0 and top_layers > 0",
-                                "limit_to_extruder": "roofing_extruder_nr",
-                                "settable_per_mesh": true
-                            }
+                            "default_value": "lines",
+                            "value": "top_bottom_pattern",
+                            "limit_to_extruder": "roofing_extruder_nr",
+                            "settable_per_mesh": true,
+                            "enabled": "roofing_layer_count > 0 and top_layers > 0"
+                        },
+                        "roofing_monotonic":
+                        {
+                            "label": "Monotonic Top Surface Order",
+                            "description": "Print top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
+                            "type": "bool",
+                            "default_value": false,
+                            "value": "skin_monotonic",
+                            "enabled": "roofing_layer_count > 0 and top_layers > 0 and roofing_pattern != 'concentric'",
+                            "limit_to_extruder": "roofing_extruder_nr",
+                            "settable_per_mesh": true
+                        },
+                        "roofing_angles":
+                        {
+                            "label": "Top Surface Skin Line Directions",
+                            "description": "A list of integer line directions to use when the top surface skin layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees).",
+                            "type": "[int]",
+                            "default_value": "[ ]",
+                            "value": "skin_angles",
+                            "enabled": "roofing_pattern != 'concentric' and roofing_layer_count > 0 and top_layers > 0",
+                            "limit_to_extruder": "roofing_extruder_nr",
+                            "settable_per_mesh": true
+                        }
                     }
                 },
                 "top_bottom_extruder_nr":


### PR DESCRIPTION
…Skin Line Width”, “Top Surface Skin Pattern”, “Monotonic Top Surface Order” and “Top Surface Skin Line Directions” as children under “Top Surface Skin Layer“ in the Top/Bottom menu.

Relates to PP-216