### PR TITLE
CuraSceneController.py : Fix problem with log message and use f-string

### DIFF
--- a/cura/Scene/CuraSceneController.py
+++ b/cura/Scene/CuraSceneController.py
@@ -139,7 +139,7 @@ class CuraSceneController(QObject):
     def setActiveBuildPlate(self, nr):
         if nr == self._active_build_plate:
             return
-        Logger.log("d", "Select build plate: %s" % nr)
+        Logger.debug(f"Selected build plate: {nr}")
         self._active_build_plate = nr
         Selection.clear()
 


### PR DESCRIPTION
- Correct log message (we want to log the "select**ed**" build plate)
- Use f-string and debug method for Logger instead of "Old Style" string formatting.