### PR TITLE
[CURA-9422] 'Monitor page' for abstract printer types

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -531,6 +531,10 @@ class MachineManager(QObject):
         return bool(self._printer_output_devices)
 
     @pyqtProperty(bool, notify = printerConnectedStatusChanged)
+    def activeMachineIsAbstract(self) -> bool:
+        return (self.activeMachine is not None) and parseBool(self.activeMachine.getMetaDataEntry("is_abstract_machine", False))
+
+    @pyqtProperty(bool, notify = printerConnectedStatusChanged)
     def activeMachineIsGroup(self) -> bool:
         if self.activeMachine is None:
             return False
@@ -554,6 +558,8 @@ class MachineManager(QObject):
 
     @pyqtProperty(bool, notify = printerConnectedStatusChanged)
     def activeMachineHasCloudRegistration(self) -> bool:
+        if self.activeMachineIsAbstract:
+            return any(m.getMetaDataEntry("is_online", False) for m in self.getMachinesWithDefinition(self.activeMachine.definition.getId(), True))
         return self.activeMachine is not None and ConnectionType.CloudConnection in self.activeMachine.configuredConnectionTypes
 
     @pyqtProperty(bool, notify = printerConnectedStatusChanged)

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -126,7 +126,7 @@ Rectangle
             {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
-                spacing: UM.Theme.getSize("default_margin").height
+                spacing: UM.Theme.getSize("wide_margin").height
                 padding: UM.Theme.getSize("default_margin").width
                 topPadding: 0
 

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -120,16 +120,19 @@ Rectangle
         {
             id: sendToFactoryCard
             color: UM.Theme.getColor("detail_background")
-            height: childrenRect.height
-            width: childrenRect.width
+            height: childrenRect.height + UM.Theme.getSize("default_margin").height * 2
+            width: childrenRect.width + UM.Theme.getSize("wide_margin").width * 2
             Column
             {
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.verticalCenter: parent.verticalCenter
                 spacing: UM.Theme.getSize("default_margin").height
                 padding: UM.Theme.getSize("default_margin").width
                 topPadding: 0
 
                 Image
                 {
+                    id: sendToFactoryImage
                     anchors.horizontalCenter: parent.horizontalCenter
                     source: UM.Theme.getImage("first_run_ultimaker_cloud")
                 }
@@ -140,7 +143,10 @@ Rectangle
                     visible: isAbstractCloudPrinter
                     text: catalog.i18nc("@info", "Monitor your printers from everywhere using Ultimaker Digital Factory")
                     font: UM.Theme.getFont("medium")
-                    width: contentWidth
+                    width: sendToFactoryImage.width
+                    wrapMode: Text.WordWrap
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
                 }
 
                 Cura.PrimaryButton

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -12,6 +12,7 @@ Rectangle
     id: viewportOverlay
 
     property bool isConnected: Cura.MachineManager.activeMachineHasNetworkConnection || Cura.MachineManager.activeMachineHasCloudConnection
+    property bool isAbstractCloudPrinter: Cura.MachineManager.activeMachineIsAbstract // && Cura.MachineManager.activeMachineHasCloudRegistration
     property bool isNetworkConfigurable:
     {
         if(Cura.MachineManager.activeMachine === null)
@@ -96,7 +97,7 @@ Rectangle
             {
                 horizontalCenter: parent.horizontalCenter
             }
-            visible: isNetworkConfigured && !isConnected
+            visible: isNetworkConfigured && !isConnected && !isAbstractCloudPrinter
             text: catalog.i18nc("@info", "Please make sure your printer has a connection:\n- Check if the printer is turned on.\n- Check if the printer is connected to the network.\n- Check if you are signed in to discover cloud-connected printers.")
             font: UM.Theme.getFont("medium")
             width: contentWidth
@@ -109,11 +110,25 @@ Rectangle
             {
                 horizontalCenter: parent.horizontalCenter
             }
-            visible: !isNetworkConfigured && isNetworkConfigurable
+            visible: !isNetworkConfigured && isNetworkConfigurable && !isAbstractCloudPrinter
             text: catalog.i18nc("@info", "Please connect your printer to the network.")
             font: UM.Theme.getFont("medium")
             width: contentWidth
         }
+
+        UM.Label
+        {
+            id: sendToFactoryLabel
+            anchors
+            {
+                horizontalCenter: parent.horizontalCenter
+            }
+            visible: isAbstractCloudPrinter
+            text: catalog.i18nc("@info", "Please go to the Digital Factory. [PLACEHOLDER]")
+            font: UM.Theme.getFont("medium")
+            width: contentWidth
+        }
+
         Item
         {
             anchors

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -12,7 +12,7 @@ Rectangle
     id: viewportOverlay
 
     property bool isConnected: Cura.MachineManager.activeMachineHasNetworkConnection || Cura.MachineManager.activeMachineHasCloudConnection
-    property bool isAbstractCloudPrinter: Cura.MachineManager.activeMachineIsAbstract // && Cura.MachineManager.activeMachineHasCloudRegistration
+    property bool isAbstractCloudPrinter: Cura.MachineManager.activeMachineIsAbstract
     property bool isNetworkConfigurable:
     {
         if(Cura.MachineManager.activeMachine === null)

--- a/plugins/MonitorStage/MonitorMain.qml
+++ b/plugins/MonitorStage/MonitorMain.qml
@@ -116,17 +116,41 @@ Rectangle
             width: contentWidth
         }
 
-        UM.Label
+        Rectangle
         {
-            id: sendToFactoryLabel
-            anchors
+            id: sendToFactoryCard
+            color: UM.Theme.getColor("detail_background")
+            height: childrenRect.height
+            width: childrenRect.width
+            Column
             {
-                horizontalCenter: parent.horizontalCenter
+                spacing: UM.Theme.getSize("default_margin").height
+                padding: UM.Theme.getSize("default_margin").width
+                topPadding: 0
+
+                Image
+                {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    source: UM.Theme.getImage("first_run_ultimaker_cloud")
+                }
+
+                UM.Label
+                {
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    visible: isAbstractCloudPrinter
+                    text: catalog.i18nc("@info", "Monitor your printers from everywhere using Ultimaker Digital Factory")
+                    font: UM.Theme.getFont("medium")
+                    width: contentWidth
+                }
+
+                Cura.PrimaryButton
+                {
+                    id: sendToFactoryButton
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: catalog.i18nc("@button", "View printers in Digital Factory")
+                    onClicked: Qt.openUrlExternally("https://digitalfactory.ultimaker.com/app/print-jobs?utm_source=cura&utm_medium=software&utm_campaign=monitor-view-cloud-printer-type")
+                }
             }
-            visible: isAbstractCloudPrinter
-            text: catalog.i18nc("@info", "Please go to the Digital Factory. [PLACEHOLDER]")
-            font: UM.Theme.getFont("medium")
-            width: contentWidth
         }
 
         Item
@@ -135,7 +159,7 @@ Rectangle
             {
                 left: noNetworkLabel.left
             }
-            visible: !isNetworkConfigured && isNetworkConfigurable
+            visible: !isNetworkConfigured && isNetworkConfigurable && !isAbstractCloudPrinter
             width: childrenRect.width
             height: childrenRect.height
 


### PR DESCRIPTION
If an abstract, but cloud connected printer is chosen to monitor, send the user to digital factory instead. (Since we don't know which printer they want, since all we have is a type.)