### PR TITLE
[CURA-9289] Add abstract machines on startup

### DIFF
--- a/cura/Machines/ContainerTree.py
+++ b/cura/Machines/ContainerTree.py
@@ -82,6 +82,9 @@ class ContainerTree:
         currently_added = ContainerRegistry.getInstance().findContainerStacks()  # Find all currently added global stacks.
         JobQueue.getInstance().add(self._MachineNodeLoadJob(self, currently_added))
 
+        from cura.Settings.CuraStackBuilder import CuraStackBuilder  # Avoid circular import
+        CuraStackBuilder.createAbstractMachines(currently_added)
+
     class _MachineNodeMap:
         """Dictionary-like object that contains the machines.
 

--- a/cura/Settings/CuraStackBuilder.py
+++ b/cura/Settings/CuraStackBuilder.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
-from typing import Optional, cast
+from typing import Optional, cast, List
 
 from UM.ConfigurationErrorMessage import ConfigurationErrorMessage
 from UM.Logger import Logger
@@ -11,6 +11,7 @@ from UM.Settings.InstanceContainer import InstanceContainer
 from cura.Machines.ContainerTree import ContainerTree
 from .GlobalStack import GlobalStack
 from .ExtruderStack import ExtruderStack
+from ..PrinterOutput.PrinterOutputDevice import ConnectionType
 
 
 class CuraStackBuilder:
@@ -267,12 +268,26 @@ class CuraStackBuilder:
         return definition_changes_container
 
     @classmethod
+    def createAbstractMachines(cls, stacks: List[GlobalStack]) -> None:
+        connection_types = ConnectionType.NetworkConnection, ConnectionType.CloudConnection
+
+        for stack in stacks:
+            try:
+                if not any(connection_type in stack.configuredConnectionTypes for connection_type in connection_types):
+                    continue  # This printer is not cloud or network connected. It doesn't need an abstract machine.
+
+                cls.createAbstractMachine(stack.getDefinition().getId())
+            except Exception as e:
+                Logger.error(f"Failed to add abstract printer for container stack: {stack.getName()} with error: {e}")
+
+
+    @classmethod
     def createAbstractMachine(cls, definition_id: str) -> Optional[GlobalStack]:
         """Create a new instance of an abstract machine.
 
         :param definition_id: The ID of the machine definition to use.
 
-        :return: The new Abstract Machine or None if an error occurred.
+        :return: The existing or new Abstract Machine or None if an error occurred.
         """
         abstract_machine_id = f"{definition_id}_abstract_machine"
         from cura.CuraApplication import CuraApplication


### PR DESCRIPTION
Check on startup for new abstract machines. This will make sure that if we get into a state where an abstract machine is missing it will always be added back after a restart. 

This will also add abstract machines after an update.

CURA-9289