### PR TITLE
Only enable monotonic ordering for the roof layer

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1482,8 +1482,7 @@
                             "label": "Monotonic Top Surface Order",
                             "description": "Print top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent.",
                             "type": "bool",
-                            "default_value": false,
-                            "value": "skin_monotonic",
+                            "value": true,
                             "enabled": "roofing_layer_count > 0 and top_layers > 0 and roofing_pattern != 'concentric'",
                             "limit_to_extruder": "roofing_extruder_nr",
                             "settable_per_mesh": true

--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -79,7 +79,7 @@
             "value": "skin_material_flow"
         },
         "skin_monotonic" : {
-            "value": true
+            "value": "roofing_layer_count == 0"
         },
         "speed_equalize_flow_width_factor": {
             "value": "110.0"


### PR DESCRIPTION
 Enable monotonic roofing only when roofing_layer_count is > 0 otherwise enable monotonic ordering for all skin layers (skin_monotonic).

Relates to PP-232