### PR TITLE
Update anycubic_mega_zero.def.json

### DIFF
--- a/resources/definitions/anycubic_mega_zero.def.json
+++ b/resources/definitions/anycubic_mega_zero.def.json
@@ -76,8 +76,8 @@
         "acceleration_enabled": { "value": false },
 
         "machine_max_jerk_xy": { "value": 10 },
-        "machine_max_jerk_z": { "value": 0.4 },
-        "machine_max_jerk_e": { "value": 5 },
+        "machine_max_jerk_z": { "value": 0.3 },
+        "machine_max_jerk_e": { "value": 15 },
         "jerk_print": { "value": 10 },
         "jerk_travel": { "value": "jerk_print" },
         "jerk_travel_layer_0": { "value": "jerk_travel" },


### PR DESCRIPTION
Equalizes settings to firmware, including the setting required for Linear Advance. See: MarlinFirmware/Marlin@5dc5d42
Note: Requires the same setting in the firmware. Recommended update to Marlin 2.1.1 with proper Configuration.h file.