### PR TITLE
Machine Actions improvement

### DIFF
--- a/cura/MachineAction.py
+++ b/cura/MachineAction.py
@@ -34,8 +34,10 @@ class MachineAction(QObject, PluginObject):
         self._view = None
         self._finished = False
         self._open_as_dialog = True
+        self._visible = True
 
     labelChanged = pyqtSignal()
+    visibilityChanged = pyqtSignal()
     onFinished = pyqtSignal()
 
     def getKey(self) -> str:
@@ -125,8 +127,8 @@ class MachineAction(QObject, PluginObject):
     def getDisplayItem(self) -> Optional["QObject"]:
         return self._createViewFromQML()
 
-    @pyqtSlot(result = bool)
-    def openAsDialog(self) -> bool:
+    @pyqtProperty(bool, constant=True)
+    def shouldOpenAsDialog(self) -> bool:
         """Whether this action will show a dialog.
 
          If not, the action will directly run the function inside execute().
@@ -135,9 +137,15 @@ class MachineAction(QObject, PluginObject):
         """
 
         return self._open_as_dialog
-
-    @pyqtSlot(result = bool)
-    def isVisible(self) -> bool:
+    
+    @pyqtSlot()
+    def setVisible(self, visible: bool) -> None:
+        if self._visible != visible:
+            self._visible = visible
+            self.visibilityChanged.emit()
+    
+    @pyqtProperty(bool, notify = visibilityChanged)
+    def visible(self) -> bool:
         """Whether this action button will be visible.
 
          Example: Show only when isLoggedIn
@@ -145,5 +153,4 @@ class MachineAction(QObject, PluginObject):
         :return: Defaults to true to be in line with the old behaviour.
         """
 
-        return True
-    
+        self._visible  

--- a/cura/MachineAction.py
+++ b/cura/MachineAction.py
@@ -33,6 +33,7 @@ class MachineAction(QObject, PluginObject):
         self._qml_url = ""
         self._view = None
         self._finished = False
+        self._open_as_dialog = True
 
     labelChanged = pyqtSignal()
     onFinished = pyqtSignal()
@@ -80,6 +81,15 @@ class MachineAction(QObject, PluginObject):
         pass
 
     @pyqtSlot()
+    def execute(self) -> None:
+        self._execute()
+    
+    def _execute(self) -> None:
+        """Protected implementation of execute."""
+        
+        pass
+
+    @pyqtSlot()
     def setFinished(self) -> None:
         self._finished = True
         self._reset()
@@ -114,6 +124,17 @@ class MachineAction(QObject, PluginObject):
     @pyqtSlot(result = QObject)
     def getDisplayItem(self) -> Optional["QObject"]:
         return self._createViewFromQML()
+
+    @pyqtSlot(result = bool)
+    def openAsDialog(self) -> bool:
+        """Whether this action will show a dialog.
+
+         If not, the action will directly run the function inside execute().
+
+        :return: Defaults to true to be in line with the old behaviour.
+        """
+
+        return self._open_as_dialog
 
     @pyqtSlot(result = bool)
     def isVisible(self) -> bool:

--- a/cura/MachineAction.py
+++ b/cura/MachineAction.py
@@ -114,3 +114,15 @@ class MachineAction(QObject, PluginObject):
     @pyqtSlot(result = QObject)
     def getDisplayItem(self) -> Optional["QObject"]:
         return self._createViewFromQML()
+
+    @pyqtSlot(result = bool)
+    def isVisible(self) -> bool:
+        """Whether this action button will be visible.
+
+         Example: Show only when isLoggedIn
+
+        :return: Defaults to true to be in line with the old behaviour.
+        """
+
+        return True
+    

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -74,10 +74,14 @@ UM.ManagementPage
                     onClicked:
                     {
                         var currentItem = machineActionRepeater.model[index]
-                        actionDialog.loader.manager = currentItem
-                        actionDialog.loader.source = currentItem.qmlPath
-                        actionDialog.title = currentItem.label
-                        actionDialog.show()
+                        if (currentItem.openAsDialog()) {
+                            actionDialog.loader.manager = currentItem
+                            actionDialog.loader.source = currentItem.qmlPath
+                            actionDialog.title = currentItem.label
+                            actionDialog.show()
+                        } else {
+                            currentItem.execute()
+                        }
                     }
                 }
             }

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -67,14 +67,14 @@ UM.ManagementPage
             {
                 width: Math.round(childrenRect.width + 2 * screenScaleFactor)
                 height: childrenRect.height
-                visible: machineActionRepeater.model[index].isVisible()
+                visible: machineActionRepeater.model[index].visible
                 Cura.SecondaryButton
                 {
                     text: machineActionRepeater.model[index].label
                     onClicked:
                     {
                         var currentItem = machineActionRepeater.model[index]
-                        if (currentItem.openAsDialog()) {
+                        if (currentItem.shouldOpenAsDialog) {
                             actionDialog.loader.manager = currentItem
                             actionDialog.loader.source = currentItem.qmlPath
                             actionDialog.title = currentItem.label

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -67,6 +67,7 @@ UM.ManagementPage
             {
                 width: Math.round(childrenRect.width + 2 * screenScaleFactor)
                 height: childrenRect.height
+                visible: machineActionRepeater.model[index].isVisible()
                 Cura.SecondaryButton
                 {
                     text: machineActionRepeater.model[index].label


### PR DESCRIPTION

<img width="626" alt="Screen Shot 2022-09-07 at 4 41 45 PM" src="https://user-images.githubusercontent.com/559677/188907361-bc0cd878-8c9f-4a57-8e02-336992a4640c.png">


[Added machine action buttons dynamic visibility](https://github.com/Ultimaker/Cura/commit/ed14e3bd44890ff15406f7f53c7199f3fa6018e6)
Based on this change, users now will be able to manage the visibility of their machine action plugin implementations. For example, a machine action only visible when loggedIn.

[Added machine action dialog optional](https://github.com/Ultimaker/Cura/commit/75840426d735ddc421b594e6fa2378ed03ad2364)
Based on this change, users will be able to run their machine action plugins code just by clicking the action button, so without having to open a modal.