### PR TITLE
PP-195_Improve_bridging

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -7528,7 +7528,7 @@
                     "unit": "mm",
                     "type": "float",
                     "minimum_value": "0",
-                    "default_value": 5,
+                    "value": "line_width + support_xy_distance + 1.0",
                     "enabled": "bridge_settings_enabled",
                     "settable_per_mesh": true,
                     "settable_per_extruder": false

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -7528,6 +7528,7 @@
                     "unit": "mm",
                     "type": "float",
                     "minimum_value": "0",
+                    "default_value": 5,
                     "value": "line_width + support_xy_distance + 1.0",
                     "enabled": "bridge_settings_enabled",
                     "settable_per_mesh": true,

--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -112,10 +112,7 @@
             "value": "4 * layer_height if infill_sparse_density < 30 else 0"
         },
         "bridge_settings_enabled": {
-            "value": false
-        },
-        "bridge_wall_min_length": {
-            "value": 0
+            "value": true
         },
         "bridge_skin_support_threshold": {
             "value": 50
@@ -127,7 +124,7 @@
             "value": 0
         },
         "bridge_wall_speed": {
-            "value": "speed_wall"
+            "value": "bridge_skin_speed"
         },
         "bridge_wall_material_flow": {
             "value": "wall_material_flow"


### PR DESCRIPTION
Enable bridging settings for all Ultimaker machines.

Set bridge wall speed to equal to the skin speed such that all speeds around a bridge are approx. the same.
The minimum bridge wall length was changed to a length long enough to prevent switching of settings over small unsupported areas (e.g. X/Y distance). This was changed in fdmprinters.def.json

Relates to PP-195