### PR TITLE
[CURA-9535] Some trimesh operations require networkx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -228,6 +228,9 @@ SecretStorage==3.3.1 \
 keyring==23.0.1 \
     --hash=sha256:045703609dd3fccfcdb27da201684278823b72af515aedec1a8515719a038cb8 \
     --hash=sha256:8f607d7d1cc502c43a932a275a56fe47db50271904513a379d39df1af277ac48
+networkx==2.6.2 \
+    --hash=sha256:2306f1950ce772c5a59a57f5486d59bb9cab98497c45fc49cbc45ac0dec119bb \
+    --hash=sha256:5fcb7004be69e8fbdf07dcb502efa5c77cadcaad6982164134eeb9721f826c2e
 pywin32==303; \
     sys_platform=="win32" \
     --hash=sha256:51cb52c5ec6709f96c3f26e7795b0bf169ee0d8395b2c1d7eb2c029a5008ed51


### PR DESCRIPTION
Seems networkx itself is low on dependencies itself. It does require some optional ones for e.g. it's linalg sub-package, but those are numpy and scipy, which we already have.