### PR TITLE
Pp 230 enable conical support

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -7528,7 +7528,7 @@
                     "unit": "mm",
                     "type": "float",
                     "minimum_value": "0",
-                    "default_value": 5,
+                    "value": "line_width + support_xy_distance + 1.0",
                     "enabled": "bridge_settings_enabled",
                     "settable_per_mesh": true,
                     "settable_per_extruder": false

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4571,6 +4571,44 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
+                "support_conical_enabled": {
+                    "label": "Enable Conical Support",
+                    "description": "Make support areas smaller at the bottom than at the overhang.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": "support_enable and support_structure != 'tree'",
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "settable_per_mesh": true,
+                    "children": {
+                        "support_conical_angle": {
+                            "label": "Conical Support Angle",
+                            "description": "The angle of the tilt of conical support. With 0 degrees being vertical, and 90 degrees being horizontal. Smaller angles cause the support to be more sturdy, but consist of more material. Negative angles cause the base of the support to be wider than the top.",
+                            "unit": "°",
+                            "type": "float",
+                            "minimum_value": "-90",
+                            "minimum_value_warning": "-45",
+                            "maximum_value_warning": "45",
+                            "maximum_value": "90",
+                            "default_value": 30,
+                            "enabled": "support_conical_enabled and support_enable and support_structure != 'tree'",
+                            "limit_to_extruder": "support_infill_extruder_nr",
+                            "settable_per_mesh": true
+                        },
+                        "support_conical_min_width": {
+                            "label": "Conical Support Minimum Width",
+                            "description": "Minimum width to which the base of the conical support area is reduced. Small widths can lead to unstable support structures.",
+                            "unit": "mm",
+                            "default_value": 5.0,
+                            "minimum_value": "0",
+                            "minimum_value_warning": "machine_nozzle_size * 3",
+                            "maximum_value_warning": "100.0",
+                            "type": "float",
+                            "enabled": "support_conical_enabled and support_enable and support_structure != 'tree' and support_conical_angle > 0",
+                            "limit_to_extruder": "support_infill_extruder_nr",
+                            "settable_per_mesh": true
+                        }
+                    }
+                },
                 "support_type":
                 {
                     "label": "Support Placement",
@@ -5367,45 +5405,6 @@
                     "default_value": true,
                     "limit_to_extruder": "support_infill_extruder_nr",
                     "enabled": "support_enable and support_structure == 'normal'",
-                    "settable_per_mesh": true
-                },
-                "support_conical_enabled":
-                {
-                    "label": "Enable Conical Support",
-                    "description": "Make support areas smaller at the bottom than at the overhang.",
-                    "type": "bool",
-                    "default_value": false,
-                    "enabled": "support_enable and support_structure != 'tree'",
-                    "limit_to_extruder": "support_infill_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "support_conical_angle":
-                {
-                    "label": "Conical Support Angle",
-                    "description": "The angle of the tilt of conical support. With 0 degrees being vertical, and 90 degrees being horizontal. Smaller angles cause the support to be more sturdy, but consist of more material. Negative angles cause the base of the support to be wider than the top.",
-                    "unit": "°",
-                    "type": "float",
-                    "minimum_value": "-90",
-                    "minimum_value_warning": "-45",
-                    "maximum_value_warning": "45",
-                    "maximum_value": "90",
-                    "default_value": 30,
-                    "enabled": "support_conical_enabled and support_enable and support_structure != 'tree'",
-                    "limit_to_extruder": "support_infill_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "support_conical_min_width":
-                {
-                    "label": "Conical Support Minimum Width",
-                    "description": "Minimum width to which the base of the conical support area is reduced. Small widths can lead to unstable support structures.",
-                    "unit": "mm",
-                    "default_value": 5.0,
-                    "minimum_value": "0",
-                    "minimum_value_warning": "machine_nozzle_size * 3",
-                    "maximum_value_warning": "100.0",
-                    "type": "float",
-                    "enabled": "support_conical_enabled and support_enable and support_structure != 'tree' and support_conical_angle > 0",
-                    "limit_to_extruder": "support_infill_extruder_nr",
                     "settable_per_mesh": true
                 },
                 "support_tower_diameter":

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4578,36 +4578,34 @@
                     "default_value": false,
                     "enabled": "support_enable and support_structure != 'tree'",
                     "limit_to_extruder": "support_infill_extruder_nr",
-                    "settable_per_mesh": true,
-                    "children": {
-                        "support_conical_angle": {
-                            "label": "Conical Support Angle",
-                            "description": "The angle of the tilt of conical support. With 0 degrees being vertical, and 90 degrees being horizontal. Smaller angles cause the support to be more sturdy, but consist of more material. Negative angles cause the base of the support to be wider than the top.",
-                            "unit": "°",
-                            "type": "float",
-                            "minimum_value": "-90",
-                            "minimum_value_warning": "-45",
-                            "maximum_value_warning": "45",
-                            "maximum_value": "90",
-                            "default_value": 30,
-                            "enabled": "support_conical_enabled and support_enable and support_structure != 'tree'",
-                            "limit_to_extruder": "support_infill_extruder_nr",
-                            "settable_per_mesh": true
-                        },
-                        "support_conical_min_width": {
-                            "label": "Conical Support Minimum Width",
-                            "description": "Minimum width to which the base of the conical support area is reduced. Small widths can lead to unstable support structures.",
-                            "unit": "mm",
-                            "default_value": 5.0,
-                            "minimum_value": "0",
-                            "minimum_value_warning": "machine_nozzle_size * 3",
-                            "maximum_value_warning": "100.0",
-                            "type": "float",
-                            "enabled": "support_conical_enabled and support_enable and support_structure != 'tree' and support_conical_angle > 0",
-                            "limit_to_extruder": "support_infill_extruder_nr",
-                            "settable_per_mesh": true
-                        }
-                    }
+                    "settable_per_mesh": true
+                },
+                "support_conical_angle": {
+                    "label": "Conical Support Angle",
+                    "description": "The angle of the tilt of conical support. With 0 degrees being vertical, and 90 degrees being horizontal. Smaller angles cause the support to be more sturdy, but consist of more material. Negative angles cause the base of the support to be wider than the top.",
+                    "unit": "°",
+                    "type": "float",
+                    "minimum_value": "-90",
+                    "minimum_value_warning": "-45",
+                    "maximum_value_warning": "45",
+                    "maximum_value": "90",
+                    "default_value": 30,
+                    "enabled": "support_conical_enabled and support_enable and support_structure != 'tree'",
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "settable_per_mesh": true
+                },
+                "support_conical_min_width": {
+                    "label": "Conical Support Minimum Width",
+                    "description": "Minimum width to which the base of the conical support area is reduced. Small widths can lead to unstable support structures.",
+                    "unit": "mm",
+                    "default_value": 5.0,
+                    "minimum_value": "0",
+                    "minimum_value_warning": "machine_nozzle_size * 3",
+                    "maximum_value_warning": "100.0",
+                    "type": "float",
+                    "enabled": "support_conical_enabled and support_enable and support_structure != 'tree' and support_conical_angle > 0",
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "settable_per_mesh": true
                 },
                 "support_type":
                 {

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5369,6 +5369,45 @@
                     "enabled": "support_enable and support_structure == 'normal'",
                     "settable_per_mesh": true
                 },
+                "support_conical_enabled":
+                {
+                    "label": "Enable Conical Support",
+                    "description": "Make support areas smaller at the bottom than at the overhang.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": "support_enable and support_structure != 'tree'",
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "settable_per_mesh": true
+                },
+                "support_conical_angle":
+                {
+                    "label": "Conical Support Angle",
+                    "description": "The angle of the tilt of conical support. With 0 degrees being vertical, and 90 degrees being horizontal. Smaller angles cause the support to be more sturdy, but consist of more material. Negative angles cause the base of the support to be wider than the top.",
+                    "unit": "°",
+                    "type": "float",
+                    "minimum_value": "-90",
+                    "minimum_value_warning": "-45",
+                    "maximum_value_warning": "45",
+                    "maximum_value": "90",
+                    "default_value": 30,
+                    "enabled": "support_conical_enabled and support_enable and support_structure != 'tree'",
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "settable_per_mesh": true
+                },
+                "support_conical_min_width":
+                {
+                    "label": "Conical Support Minimum Width",
+                    "description": "Minimum width to which the base of the conical support area is reduced. Small widths can lead to unstable support structures.",
+                    "unit": "mm",
+                    "default_value": 5.0,
+                    "minimum_value": "0",
+                    "minimum_value_warning": "machine_nozzle_size * 3",
+                    "maximum_value_warning": "100.0",
+                    "type": "float",
+                    "enabled": "support_conical_enabled and support_enable and support_structure != 'tree' and support_conical_angle > 0",
+                    "limit_to_extruder": "support_infill_extruder_nr",
+                    "settable_per_mesh": true
+                },
                 "support_tower_diameter":
                 {
                     "label": "Tower Diameter",
@@ -6954,45 +6993,6 @@
                     "limit_to_extruder": "support_infill_extruder_nr",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
-                },
-                "support_conical_enabled":
-                {
-                    "label": "Enable Conical Support",
-                    "description": "Make support areas smaller at the bottom than at the overhang.",
-                    "type": "bool",
-                    "default_value": false,
-                    "enabled": "support_enable and support_structure != 'tree'",
-                    "limit_to_extruder": "support_infill_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "support_conical_angle":
-                {
-                    "label": "Conical Support Angle",
-                    "description": "The angle of the tilt of conical support. With 0 degrees being vertical, and 90 degrees being horizontal. Smaller angles cause the support to be more sturdy, but consist of more material. Negative angles cause the base of the support to be wider than the top.",
-                    "unit": "°",
-                    "type": "float",
-                    "minimum_value": "-90",
-                    "minimum_value_warning": "-45",
-                    "maximum_value_warning": "45",
-                    "maximum_value": "90",
-                    "default_value": 30,
-                    "enabled": "support_conical_enabled and support_enable and support_structure != 'tree'",
-                    "limit_to_extruder": "support_infill_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "support_conical_min_width":
-                {
-                    "label": "Conical Support Minimum Width",
-                    "description": "Minimum width to which the base of the conical support area is reduced. Small widths can lead to unstable support structures.",
-                    "unit": "mm",
-                    "default_value": 5.0,
-                    "minimum_value": "0",
-                    "minimum_value_warning": "machine_nozzle_size * 3",
-                    "maximum_value_warning": "100.0",
-                    "type": "float",
-                    "enabled": "support_conical_enabled and support_enable and support_structure != 'tree' and support_conical_angle > 0",
-                    "limit_to_extruder": "support_infill_extruder_nr",
-                    "settable_per_mesh": true
                 },
                 "magic_fuzzy_skin_enabled":
                 {

--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -112,10 +112,7 @@
             "value": "4 * layer_height if infill_sparse_density < 30 else 0"
         },
         "bridge_settings_enabled": {
-            "value": false
-        },
-        "bridge_wall_min_length": {
-            "value": 0
+            "value": true
         },
         "bridge_skin_support_threshold": {
             "value": 50
@@ -127,7 +124,7 @@
             "value": 0
         },
         "bridge_wall_speed": {
-            "value": "speed_wall"
+            "value": "bridge_skin_speed"
         },
         "bridge_wall_material_flow": {
             "value": "wall_material_flow"

--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -266,6 +266,12 @@
         "support_z_distance": {
             "value": "0"
         },
+        "support_conical_enabled": {
+            "value": true
+        },
+        "support_conical_min_width": {
+            "value": 10
+        },
         "top_bottom_pattern": {
             "value": "'zigzag'"
         }


### PR DESCRIPTION
Move conical support out of experimental and under the support category.
Enabled conical support by default for ultimaker profiles and increased min. width to 10mm.

Relates to PP-230 and CURA-6710