### PR TITLE
[CURA-9678] Duplicate print jobs sent to cloud

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -411,3 +411,7 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
 
         root_url_prefix = "-staging" if self._account.is_staging else ""
         return f"https://digitalfactory{root_url_prefix}.ultimaker.com/app/jobs/{self.clusterData.cluster_id}"
+
+    def __del__(self):
+        CuraApplication.getInstance().getBackend().backendDone.disconnect(self._resetPrintJob)
+        CuraApplication.getInstance().getController().getScene().sceneChanged.disconnect(self._onSceneChanged)


### PR DESCRIPTION
Duplicate print jobs were being sent when printing via cloud from abstract printers.

This was due to the connect function not being called on the CloudOutputDevice used to print on the cloud. This function is only called when it becomes an active printer (AbstractCloudOutputDevice is the active printer instead now).

The fix is to always listen for signals to reset the print job even when not the active printer.

I've chosen different signals now so there is not too much spam on the reset function.

The BackendStateDone signal catches new slices. The SceneChanged signal catches ufp files being loaded (These do not trigger BackendState changes)

CURA-9678