### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/conan-package.yml
+++ b/.github/workflows/conan-package.yml
@@ -47,13 +47,20 @@ on:
             - '[1-9].[0-9].[0-9]+'
             - '[1-9].[0-9][0-9].[0-9]+'
 
+permissions: {}
 jobs:
     conan-recipe-version:
+        permissions:
+          contents: read
+
         uses: ultimaker/cura/.github/workflows/conan-recipe-version.yml@main
         with:
             project_name: cura
 
     conan-package-export:
+        permissions:
+          contents: read
+
         needs: [ conan-recipe-version ]
         uses: ultimaker/cura/.github/workflows/conan-recipe-export.yml@main
         with:
@@ -65,6 +72,9 @@ jobs:
         secrets: inherit
 
     conan-package-create-linux:
+        permissions:
+          contents: read
+
         if: ${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master' || needs.conan-recipe-version.outputs.is_release_branch == 'true')) || (github.event_name == 'workflow_dispatch' && inputs.create_binaries_linux) }}
         needs: [ conan-recipe-version, conan-package-export ]
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -60,6 +60,9 @@ env:
     CONAN_LOGGING_LEVEL: info
     CONAN_NON_INTERACTIVE: 1
 
+permissions:
+  contents: read
+
 jobs:
     conan-recipe-version:
         uses: ultimaker/cura/.github/workflows/conan-recipe-version.yml@main
@@ -144,6 +147,11 @@ jobs:
                     path: "tests/**/*.xml"
 
     publish-test-results:
+        permissions:
+          contents: read # to fetch code (actions/checkout)
+          checks: write
+          pull-requests: write # to comment on pull request
+
         runs-on: ubuntu-20.04
         needs: [ testing ]
         if: success() || failure()


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.