### PR TITLE
UFPWriter: fix serialization of SettingFunctions

### DIFF
--- a/plugins/UFPWriter/UFPWriter.py
+++ b/plugins/UFPWriter/UFPWriter.py
@@ -230,11 +230,11 @@ class UFPWriter(MeshWriter):
         # Add global user or quality changes
         global_flattened_changes = InstanceContainer.createMergedInstanceContainer(global_stack.userChanges, global_stack.qualityChanges)
         for setting in global_flattened_changes.getAllKeys():
-            settings["global"]["changes"][setting] = global_flattened_changes.getProperty(setting, "value")
+            settings["global"]["changes"][setting] = str(global_flattened_changes.getProperty(setting, "value"))
 
         # Get global all settings values without user or quality changes
         for setting in global_stack.getAllKeys():
-            settings["global"]["all_settings"][setting] = global_stack.getProperty(setting, "value")
+            settings["global"]["all_settings"][setting] = str(global_stack.getProperty(setting, "value"))
 
         for i, extruder in enumerate(global_stack.extruderList):
             # Add extruder fields to settings dictionary
@@ -246,10 +246,10 @@ class UFPWriter(MeshWriter):
             # Add extruder user or quality changes
             extruder_flattened_changes = InstanceContainer.createMergedInstanceContainer(extruder.userChanges, extruder.qualityChanges)
             for setting in extruder_flattened_changes.getAllKeys():
-                settings[f"extruder_{i}"]["changes"][setting] = extruder_flattened_changes.getProperty(setting, "value")
+                settings[f"extruder_{i}"]["changes"][setting] = str(extruder_flattened_changes.getProperty(setting, "value"))
 
             # Get extruder all settings values without user or quality changes
             for setting in extruder.getAllKeys():
-                settings[f"extruder_{i}"]["all_settings"][setting] = extruder.getProperty(setting, "value")
+                settings[f"extruder_{i}"]["all_settings"][setting] = str(extruder.getProperty(setting, "value"))
 
         return settings


### PR DESCRIPTION
PR #13209 adds the modified settings to the UFP exports. The settings are serialized as JSON but doesn't handles the SettingFunctions. This was also reported by users in emtrax-ltd/Cura2MoonrakerPlugin#55.

**Reproduction steps:**: Modify a setting with a computed default, then click the ![image](https://user-images.githubusercontent.com/3748582/193446731-ef31b235-14be-4d9a-a46b-27fb8fa76196.png) icon. Slice and save the result as a .ufp file. Cura will crash with:
```
Traceback (most recent call last):
  File "Cura/cura/CuraApplication.py", line 1127, in event
    return super().event(event)
  File "Uranium/UM/Qt/QtApplication.py", line 502, in event
    event._function_event.call()
  File "Uranium/UM/Event.py", line 218, in call
    self._function(*self._args, **self._kwargs)
  File "Cura/cura/Utils/Threading.py", line 34, in _handle_call
    ico.result = func(*args, **kwargs)
  File "Cura/plugins/UFPWriter/UFPWriter.py", line 87, in write
    json.dump(self._getSliceMetadata(), setting_textio, separators=(", ", ": "), indent=4)
  File "$HOME/.conan/data/cpython/3.10.4/_/_/package/9054a82b60899c3ed90865d5b990fd99ef2dc167/lib/python3.10/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "$HOME/.conan/data/cpython/3.10.4/_/_/package/9054a82b60899c3ed90865d5b990fd99ef2dc167/lib/python3.10/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "$HOME/.conan/data/cpython/3.10.4/_/_/package/9054a82b60899c3ed90865d5b990fd99ef2dc167/lib/python3.10/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "$HOME/.conan/data/cpython/3.10.4/_/_/package/9054a82b60899c3ed90865d5b990fd99ef2dc167/lib/python3.10/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "$HOME/.conan/data/cpython/3.10.4/_/_/package/9054a82b60899c3ed90865d5b990fd99ef2dc167/lib/python3.10/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "$HOME/.conan/data/cpython/3.10.4/_/_/package/9054a82b60899c3ed90865d5b990fd99ef2dc167/lib/python3.10/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "$HOME/.conan/data/cpython/3.10.4/_/_/package/9054a82b60899c3ed90865d5b990fd99ef2dc167/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type SettingFunction is not JSON serializable
```

This patch mimics what `GcodeWriter` does, calling `str()` on the setting values.