### PR TITLE
[CURA-9714] Crash loading abstract machine 3mf

### DIFF
--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -53,6 +53,7 @@ _ignored_machine_network_metadata = {
     "connection_type",
     "capabilities",
     "octoprint_api_key",
+    "is_abstract_machine"
 }  # type: Set[str]
 
 


### PR DESCRIPTION
3mf project files saved with an abstract printer would crash on loading when selecting a non abstract printer to load the project with.

This was because the metadata "is_abstract_machine" was being loaded into the non abstract machine. This caused a crash in MachineListModel.py by trying to delete this non abstract machine from a list where it didn't exist.

The solution is to ignore the "is_abstract_machine" metadata when loading settings from saved machines in 3mf files.

CURA-9714