### PR TITLE
[CURA-9714] Crash double 3mf that contains printer with no extruders

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -904,6 +904,7 @@ class MachineManager(QObject):
 
         if self._global_container_stack is None \
                 or self._global_container_stack.getProperty(setting_key, "value") == new_value \
+                or self._global_container_stack.definitionChanges.getProperty("extruders_enabled_count", "value") is None \
                 or self._global_container_stack.definitionChanges.getProperty("extruders_enabled_count", "value") < 2:
             return
 


### PR DESCRIPTION
…uders while the current global stack also has no extruders.

This was caused by trying to compare "extruders_enabled_count" which was None with an integer.

CURA-9714