### PR TITLE
[CURA-9696] Fix windows uninstall.

### DIFF
--- a/packaging/NSIS/Ultimaker-Cura.nsi.jinja
+++ b/packaging/NSIS/Ultimaker-Cura.nsi.jinja
@@ -12,7 +12,7 @@
 !define INSTALLER_NAME "{{ destination }}"
 !define MAIN_APP_EXE "{{ main_app }}"
 !define INSTALL_TYPE "SetShellVarContext all"
-!define REG_ROOT "HKCR"
+!define REG_ROOT "HKLM"
 !define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_NAME}"
 !define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
 


### PR DESCRIPTION
So that uninstall is properly linked in the 'programs and features' again.

If you have a deja-vu: The line went from HKCU -> HKCR -> HKLM. The previous assumption that HKCR would take care of both HKCU _and_ HKLM behaviour is not correct. And anyway, we want installs to work for the whole local machine; the user (can) log(s) in afterwards in Cura itself.

Uninstaller works, we'll just have to deal with the users who'd expect the registry keys to the same place one more time, and then we're (hopefully) done.