### PR TITLE
Ensure the complete install folder is removed

### DIFF
--- a/packaging/NSIS/Ultimaker-Cura.nsi.jinja
+++ b/packaging/NSIS/Ultimaker-Cura.nsi.jinja
@@ -163,7 +163,7 @@ Delete "$INSTDIR\uninstall.exe"
 Delete "$INSTDIR\${APP_NAME} website.url"
 !endif
 
-RmDir "$INSTDIR"
+RmDir /r /REBOOTOK "$INSTDIR"
 
 !ifdef REG_START_MENU
 !insertmacro MUI_STARTMENU_GETFOLDER "Application" $SM_Folder


### PR DESCRIPTION
Add the `/r /REBOOTOK` flags when removing the `$INSTDIR` Should remove the folder in its entirety, even if files are being used.

https://nsis.sourceforge.io/Reference/RMDir

Fixes: CURA-9526 Uninstalling main build doesn't remove all files