### PR TITLE
Fix correct version number in uninstaller for patch releases

### DIFF
--- a/packaging/NSIS/Ultimaker-Cura.nsi.jinja
+++ b/packaging/NSIS/Ultimaker-Cura.nsi.jinja
@@ -13,8 +13,8 @@
 !define MAIN_APP_EXE "{{ main_app }}"
 !define INSTALL_TYPE "SetShellVarContext all"
 !define REG_ROOT "HKLM"
-!define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_NAME}"
-!define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
+!define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_NAME}-${VERSION}"
+!define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}-${VERSION}"
 
 !define REG_START_MENU "Start Menu Folder"
 


### PR DESCRIPTION
This should ensure that updating a patch doesn't override the uninstaller in the settings->Installed apps

Fixes: #13337

CURA-9670 Correct the version number in the uninstaller