### PR TITLE
[CURA-9746] Re-add tooltips for intent profile selection in recommended.

### DIFF
--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelector.qml
@@ -32,7 +32,7 @@ Item
             {
                 profileName: model.name
                 icon: model.icon
-
+                tooltipText: (model.description != undefined) ? model.description : ""
 
                 selected: Cura.MachineManager.activeIntentCategory == model.intent_category
 

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelectorButton.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedQualityProfileSelectorButton.qml
@@ -19,6 +19,7 @@ Rectangle
     property bool selected: false
     property string profileName: ""
     property string icon: ""
+    property alias tooltipText: tooltip.text
 
     signal clicked()
 
@@ -28,6 +29,13 @@ Rectangle
         anchors.fill: parent
         hoverEnabled: true
         onClicked: base.clicked()
+    }
+
+    UM.ToolTip
+    {
+        id: tooltip
+        visible: mouseArea.containsMouse
+        targetPoint: Qt.point(base.x + (base.width / 2), base.y + (base.height / 2))
     }
 
     Item


### PR DESCRIPTION
They where skipped over when transferring the radio bar to the current large button based setup.

