### PR TITLE
Add config for Creality Ender 3 Neo and Ender 3 v2 Neo

### DIFF
--- a/resources/definitions/creality_ender3_neo.def.json
+++ b/resources/definitions/creality_ender3_neo.def.json
@@ -1,0 +1,19 @@
+{
+    "name": "Creality Ender-3 Neo / Ender-3 v2 Neo",
+    "version": 2,
+    "inherits": "creality_ender3",
+    "metadata": {
+        "quality_definition": "creality_base",
+        "visible": true,
+        "platform": "creality_ender3.3mf"
+    },
+    "overrides": {
+        "machine_name": { "default_value": "Creality Ender-3 Neo" },
+        "machine_disallowed_areas": {
+            "default_value": []
+        },
+        "machine_start_gcode": {
+            "default_value": "; Ender 3 Custom Start G-code\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nG29 ; Automatic Bed Leveling\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0.1 Y20 Z0.3 F5000.0 ; Move to start position\nG1 X0.1 Y200.0 Z0.3 F1500.0 E15 ; Draw the first line\nG1 X0.4 Y200.0 Z0.3 F5000.0 ; Move to side a little\nG1 X0.4 Y20 Z0.3 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.3 F5000.0 ; Move over to prevent blob squish"
+        }
+    }
+}

--- a/resources/variants/creality_ender3_neo_0.2.inst.cfg
+++ b/resources/variants/creality_ender3_neo_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = creality_ender3_neo
+
+[metadata]
+setting_version = 20
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/creality_ender3_neo_0.3.inst.cfg
+++ b/resources/variants/creality_ender3_neo_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = creality_ender3_neo
+
+[metadata]
+setting_version = 20
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/creality_ender3_neo_0.4.inst.cfg
+++ b/resources/variants/creality_ender3_neo_0.4.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.4mm Nozzle
+version = 4
+definition = creality_ender3_neo
+
+[metadata]
+setting_version = 20
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.4

--- a/resources/variants/creality_ender3_neo_0.5.inst.cfg
+++ b/resources/variants/creality_ender3_neo_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = creality_ender3_neo
+
+[metadata]
+setting_version = 20
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/creality_ender3_neo_0.6.inst.cfg
+++ b/resources/variants/creality_ender3_neo_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = creality_ender3_neo
+
+[metadata]
+setting_version = 20
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/creality_ender3_neo_0.8.inst.cfg
+++ b/resources/variants/creality_ender3_neo_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = creality_ender3_neo
+
+[metadata]
+setting_version = 20
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/creality_ender3_neo_1.0.inst.cfg
+++ b/resources/variants/creality_ender3_neo_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = creality_ender3_neo
+
+[metadata]
+setting_version = 20
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0


### PR DESCRIPTION
Creality now sells pre upgraded Ender 3 and Ender 3 v2 with the apendix "Neo".

The config relevant changes are:
- A magnetic print bed, so it has no more clips holding the bed that requires the machine_disallowed_areas
- An automatic bed levling sensor, so i added the automatic bed levling G29 code to the default startup gcode