### PR TITLE
Update CITATION.cff to 5.2.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,8 +18,8 @@ url: 'https://ultimaker.com/software/ultimaker-cura'
 repository-code: 'https://github.com/Ultimaker/Cura'
 license: LGPL-3.0
 license-url: "https://github.com/Ultimaker/Cura/blob/main/LICENSE"
-version: 5.0.0
-date-released: '2022-05-17'
+version: 5.2.1
+date-released: '2022-10-19'
 keywords:
   - Ultimaker
   - Cura

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,17 +14,17 @@ authors:
 contact:
   - email: info@ultimaker.com
     name: "Ultimaker B.V."
-url: 'https://ultimaker.com/software/ultimaker-cura'
-repository-code: 'https://github.com/Ultimaker/Cura'
+url: "https://ultimaker.com/software/ultimaker-cura"
+repository-code: "https://github.com/Ultimaker/Cura"
 license: LGPL-3.0
 license-url: "https://github.com/Ultimaker/Cura/blob/main/LICENSE"
 version: 5.2.1
-date-released: '2022-10-19'
+date-released: "2022-10-19"
 keywords:
   - Ultimaker
   - Cura
+  - Slicer
   - Uranium
   - Arachne
-  - 3DPrinting
-  - Slicer
-...
+  - 3D Printing
+  - Additive Manufacturing


### PR DESCRIPTION
Hey there!

This is just a simple update to the `CITATION.cff` file, to update it to the latest version of Cura and clean up formatting and keywords.

 - As you can verify by browsing to the PR branch, all changes are correctly reflected in the sidebar of the repo.

 - All changes have been successfully validated with [cffconvert](https://pypi.org/project/cffconvert/). See output below:

![image](https://user-images.githubusercontent.com/53015230/196881658-a887059d-c51e-4cf6-88d1-74122a5190da.png)

In the future, I will keep this updated with new releases of both Cura and `.cff` since it's fairly easy for me to test and deploy.

Going forward, we might consider a simple [GitHub action for validation](https://github.com/citation-file-format/cffconvert-github-action) and a pre-release hook that bumps the version in CITATION.cff, but it's not really urgent atm since it takes all of 10 minutes for me to set up a PR similar to this one.
I also want to hear your opinion before drafting up a PR to add automation.

Thanks for your time,
Have a great day!
_~S²_