### PR TITLE
Use ARGV0 to select the executable to execute from AppRun. Intended to run CuraEngine

### DIFF
--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -17,4 +17,9 @@ export OPENSSL_CONF="$scriptdir/openssl.cnf"
 # unset `QT_STYLE_OVERRIDE` as a precaution
 unset QT_STYLE_OVERRIDE
 
-$scriptdir/UltiMaker-Cura "$@"
+BIN=`basename "$ARGV0" .AppImage`
+if [ -f $scriptdir/$BIN ]; then
+    $scriptdir/$BIN "$@"
+else
+    $scriptdir/UltiMaker-Cura "$@"
+fi;


### PR DESCRIPTION
I wanted to run `CuraEngine` from within the AppImage. Since `AppRun` only executes `Ultimaker-Cura`, I modified it to use AppImage's `ARGV0` environment variable to allow users to select the executable to run.

The use, download the AppImage as usual and create a symlink:

```
ln -s Ultimaker-Cura-5.0.0-Linux.AppImage CuraEngine.AppImage
```

Now, running `CuraEngine.AppImage` will launch `CuraEngine` instead of `Ultimaker-Cura`

If the name of the AppImage does not match a file inside the AppImage, `Ultimaker-Cura` will run by default.
