### PR TITLE
[CURA-9548] The engine now operates on the area _before_ the offset.

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -70,7 +70,7 @@
         },
         "meshfix_maximum_deviation": { "value": "machine_nozzle_size / 10" },
         "meshfix_maximum_resolution": { "value": "max(speed_wall_0 / 75, 0.5)" },
-        "minimum_support_area": { "value": "(2 + support_offset)**2" },
+        "minimum_support_area": { "value": "4.0" },
         "raft_base_speed": { "value": "raft_speed" },
         "raft_base_thickness": { "value": "min(machine_nozzle_size * 0.75, 0.3)" },
         "raft_interface_fan_speed": { "value": "(raft_base_fan_speed + raft_surface_fan_speed) / 2" },


### PR DESCRIPTION
The frontend should compensate for that: Do _not_ apply the formula, as this now happens implicitly.

See also backend: https://github.com/Ultimaker/CuraEngine/pull/1765
