### PR TITLE
PP-275-increase-initial-layer-skin-flow

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -93,7 +93,7 @@
         "skin_angles": { "value": "[] if infill_pattern not in ['cross', 'cross_3d'] else [20, 110]" },
         "skin_edge_support_thickness": { "value": "4 * layer_height if infill_sparse_density < 30 else 0" },
         "skin_material_flow": { "value": "0.95 * material_flow" },
-        "skin_material_flow_layer_0": { "value": "0.80 * material_flow_layer_0" },
+        "skin_material_flow_layer_0": { "value": "0.85 * material_flow_layer_0" },
         "skin_monotonic" : { "value": "roofing_layer_count == 0" },
         "speed_equalize_flow_width_factor": { "value": "110.0" },
         "speed_layer_0": { "value": "min(30, layer_height / layer_height_0 * speed_wall_0)" },


### PR DESCRIPTION
For large prints the initial layer skin flow turns out to be too low. PP-275