### PR TITLE
PP-183 Enable zigzag support interface

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -104,7 +104,7 @@
         "support_interface_height": { "value": "2 * layer_height" },
         "support_interface_material_flow": { "value": "skin_material_flow" },
         "support_interface_offset": { "value": "support_offset" },
-        "support_interface_pattern": { "value": "'concentric'" },
+        "support_interface_pattern": { "value": "'zigzag'" },
         "support_interface_skip_height": { "value": "layer_height" },
         "support_line_distance": { "minimum_value_warning": "0 if support_structure == 'tree' else support_line_width" },
         "support_offset": { "value": "support_xy_distance if support_interface_enable else 0" },


### PR DESCRIPTION
The zigzag pattern gives a nicer model surface compared to the concentric pattern. With CURA-9350 merged it will also automatically put a wall around the zigzag support interface.

Relates to PP-183 and CURA-9945