### PR TITLE
Clarify linter steps for running locally

### DIFF
--- a/printer-linter/README.md
+++ b/printer-linter/README.md
@@ -3,9 +3,9 @@ Printer linter is a python package that does linting on Cura definitions files.
 Running this on your definition files will get them ready for a pull request.
 
 ## Running Locally
-From the Cura root folder.
+From the Cura root folder and pointing to the relative paths of the wanted definition files:
 
-```python3 printer-linter/src/terminal.py "flashforge_dreamer_nx.def.json" "flashforge_base.def.json" --fix  --format```
+```python3 printer-linter/src/terminal.py "resources/definitions/flashforge_dreamer_nx.def.json" "resources/definitions/flashforge_base.def.json" --fix --format```
 
 ## Developing
 ### Printer Linter Rules


### PR DESCRIPTION
Updated the README to clarify that Cura defintion files should be their relative paths from the root of the project; I just realized by doing #13967 that running it with an invalid file path yields an empty result instead of an error (although that is a separate issue from this PR):

```shell
XXX@pop-os:~/DEV/Cura$ python3 printer-linter/src/terminal.py "path/to/nowhere" --format --fix
Diagnostics: []
```