### PR TITLE
[CURA-9522] Material list styled oddly 

### DIFF
--- a/resources/qml/Menus/MaterialBrandMenu.qml
+++ b/resources/qml/Menus/MaterialBrandMenu.qml
@@ -94,6 +94,8 @@ Cura.MenuItem
         // We have to keep a count of itemHovered (instead of just a bool)
         property int itemHovered: 0
 
+        implicitX: parent.width - UM.Theme.getSize("default_lining").width
+
         MouseArea
         {
             id: submenuArea

--- a/resources/qml/Menus/MaterialBrandMenu.qml
+++ b/resources/qml/Menus/MaterialBrandMenu.qml
@@ -94,8 +94,6 @@ Cura.MenuItem
         // We have to keep a count of itemHovered (instead of just a bool)
         property int itemHovered: 0
 
-        implicitX: parent.width - UM.Theme.getSize("default_lining").width
-
         MouseArea
         {
             id: submenuArea
@@ -217,6 +215,8 @@ Cura.MenuItem
                     MaterialBrandSubMenu
                     {
                         id: colorPopup
+                        implicitX: parent.width
+
                         property int itemHovered: 0
 
                         Column

--- a/resources/qml/Menus/MaterialBrandSubMenu.qml
+++ b/resources/qml/Menus/MaterialBrandSubMenu.qml
@@ -67,6 +67,10 @@ Popup
             }
         }
 
+        // Changing the height causes implicitWidth to change because of the scrollbar appearing/disappearing
+        // Reassign it here to update the value
+        materialBrandSubMenu.width = implicitWidth;
+
         if (globalPosition.x > mainWindow.width - materialBrandSubMenu.width)
         {
             if (mainWindow.width > materialBrandSubMenu.width)
@@ -81,10 +85,6 @@ Popup
                 materialBrandSubMenu.width = mainWindow.width;
             }
         }
-
-
-        // This function can cause the scrollbar.width to update but this won't update the width (bug?) so it is done explicitly here.
-        width = scrollViewContent.width + scrollbar.width + leftPadding + rightPadding
     }
 
     padding: background.border.width

--- a/resources/qml/Menus/MaterialBrandSubMenu.qml
+++ b/resources/qml/Menus/MaterialBrandSubMenu.qml
@@ -19,7 +19,7 @@ Popup
     implicitHeight: scrollViewContent.height + bottomPadding + topPadding
 
     // offset position relative to the parent
-    property int implicitX: parent.width
+    property int implicitX: parent.width - UM.Theme.getSize("default_lining").width
     property int implicitY: -UM.Theme.getSize("thin_margin").height
 
     default property alias contents: scrollViewContent.children

--- a/resources/qml/Menus/MaterialBrandSubMenu.qml
+++ b/resources/qml/Menus/MaterialBrandSubMenu.qml
@@ -81,6 +81,10 @@ Popup
                 materialBrandSubMenu.width = mainWindow.width;
             }
         }
+
+
+        // This function can cause the scrollbar.width to update but this won't update the width (bug?) so it is done explicitly here.
+        width = scrollViewContent.width + scrollbar.width + leftPadding + rightPadding
     }
 
     padding: background.border.width


### PR DESCRIPTION
This PR fixes two issues. 

1.  The material popups were not overlapping the brand popup. The lining of both were visible. This overlaps them slighly so we only see a single lining width.
2.  The materials list being too wide by one scrollbar width when opened for the first time. When opening the materials list the size of the popup is adjusted, this causes the scrollbar to disappear. For some reason this does not update the width/implicitWidth of the popup even though it is defined based using the scrollbar width. The fix here is to force the width adjustments in the onOpened function.