### PR TITLE
Make Creality Ender 3 S1 consistent

### DIFF
--- a/resources/definitions/creality_ender3s1.def.json
+++ b/resources/definitions/creality_ender3s1.def.json
@@ -24,13 +24,13 @@
         },
         "machine_height": { "default_value": 270 },
         "machine_name": { "default_value": "Creality Ender-3 S1" },
-        "machine_start_gcode": { "default_value": "; Ender 3 S1 Start G-code\nG92 E0 ; Reset Extruder\nG28 ; Home all axes\nG1 Z10.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0 Y0\n\nM104 S{material_print_temperature_layer_0}\nM190 S{material_bed_temperature_layer_0}\nM109 S{material_print_temperature_layer_0}\n\nG1 X0.1 Y20 Z0.3 F5000.0 ; Move to start position\nG1 X0.1 Y200.0 Z0.3 F1500.0 E15 ; Draw the first line\nG1 X0.4 Y200.0 Z0.3 F5000.0 ; Move to side a little\nG1 X0.4 Y20 Z0.3 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.3 F5000.0 ; Move over to prevent blob squish\n" },
+        "machine_start_gcode": { "default_value": "; Ender 3 S1 Start G-code\n; M413 S0 ; Disable power loss recovery\nG92 E0 ; Reset Extruder\n\n; Prep surfaces before auto home for better accuracy\nM140 S{material_bed_temperature_layer_0}\nM104 S{material_print_temperature_layer_0}\n\nG28 O ; Home all untrusted axes\nG1 Z10.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0 Y0\n\nM190 S{material_bed_temperature_layer_0}\nM109 S{material_print_temperature_layer_0}\n\nG1 X0.1 Y20 Z0.3 F5000.0 ; Move to start position\nG1 X0.1 Y200.0 Z0.3 F1500.0 E15 ; Draw the first line\nG1 X0.4 Y200.0 Z0.3 F5000.0 ; Move to side a little\nG1 X0.4 Y20 Z0.3 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.3 F5000.0 ; Move over to prevent blob squish\n" },
         "machine_width": { "default_value": 220 },
         "retraction_amount": { "value": 0.8 },
         "retraction_extrusion_window": { "value": 1.5 },
         "retraction_speed": { "default_value": 40 },
         "speed_layer_0": { "value": 25 },
-        "speed_print": { "value": 50 },
-        "speed_travel": { "value": 150 }
+        "speed_print": { "value": 60 },
+        "speed_travel": { "value": "120.0 if speed_print < 60 else 250.0 if speed_print > 100 else speed_print * 2.5" }
     }
 }

--- a/resources/definitions/creality_ender3s1plus.def.json
+++ b/resources/definitions/creality_ender3s1plus.def.json
@@ -9,6 +9,8 @@
     },
     "overrides":
     {
+        "acceleration_enabled": { "value": true },
+        "acceleration_travel": { "value": 2000 },
         "gantry_height": { "value": 25 },
         "machine_depth": { "default_value": 300 },
         "machine_head_with_fans_polygon":
@@ -22,11 +24,13 @@
         },
         "machine_height": { "default_value": 300 },
         "machine_name": { "default_value": "Creality Ender-3 S1 Plus" },
-        "machine_start_gcode": { "default_value": "; Ender 3 S1 Plus Start G-code\nG28 ;Home\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position\nG1 X10.1 Y200.0 Z0.28 F1500.0 E15 ;Draw the first line\nG1 X10.4 Y200.0 Z0.28 F5000.0 ;Move to side a little\nG1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\n" },
+        "machine_start_gcode": { "default_value": "; Ender 3 S1 Plus Start G-code\n; M413 S0 ; Disable power loss recovery\nG92 E0 ; Reset Extruder\n\n; Prep surfaces before auto home for better accuracy\nM140 S{material_bed_temperature_layer_0}\nM104 S{material_print_temperature_layer_0}\n\nG28 O ; Home all untrusted axes\nG1 Z10.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0 Y0\n\nM190 S{material_bed_temperature_layer_0}\nM109 S{material_print_temperature_layer_0}\n\nG1 X0.1 Y20 Z0.3 F5000.0 ; Move to start position\nG1 X0.1 Y200.0 Z0.3 F1500.0 E15 ; Draw the first line\nG1 X0.4 Y200.0 Z0.3 F5000.0 ; Move to side a little\nG1 X0.4 Y20 Z0.3 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.3 F5000.0 ; Move over to prevent blob squish\n" },
         "machine_width": { "default_value": 300 },
         "retraction_amount": { "value": 0.8 },
+        "retraction_extrusion_window": { "value": 1.5 },
         "retraction_speed": { "default_value": 40 },
         "speed_layer_0": { "value": 25 },
+        "speed_print": { "value": 60 },
         "speed_travel": { "value": "120.0 if speed_print < 60 else 250.0 if speed_print > 100 else speed_print * 2.5" }
     }
 }

--- a/resources/definitions/creality_ender3s1pro.def.json
+++ b/resources/definitions/creality_ender3s1pro.def.json
@@ -9,6 +9,8 @@
     },
     "overrides":
     {
+        "acceleration_enabled": { "value": true },
+        "acceleration_travel": { "value": 2000 },
         "gantry_height": { "value": 25 },
         "machine_depth": { "default_value": 220 },
         "machine_head_with_fans_polygon":
@@ -22,10 +24,13 @@
         },
         "machine_height": { "default_value": 270 },
         "machine_name": { "default_value": "Creality Ender-3 S1 Pro" },
-        "machine_start_gcode": { "default_value": "; Ender 3 S1 Pro Start G-code\nG28 ;Home\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 X10.1 Y20 Z0.28 F5000.0 ;Move to start position\nG1 X10.1 Y200.0 Z0.28 F1500.0 E15 ;Draw the first line\nG1 X10.4 Y200.0 Z0.28 F5000.0 ;Move to side a little\nG1 X10.4 Y20 Z0.28 F1500.0 E30 ;Draw the second line\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\n" },
+        "machine_start_gcode": { "default_value": "; Ender 3 S1 Pro Start G-code\n; M413 S0 ; Disable power loss recovery\nG92 E0 ; Reset Extruder\n\n; Prep surfaces before auto home for better accuracy\nM140 S{material_bed_temperature_layer_0}\nM104 S{material_print_temperature_layer_0}\n\nG28 O ; Home all untrusted axes\nG1 Z10.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X0 Y0\n\nM190 S{material_bed_temperature_layer_0}\nM109 S{material_print_temperature_layer_0}\n\nG1 X0.1 Y20 Z0.3 F5000.0 ; Move to start position\nG1 X0.1 Y200.0 Z0.3 F1500.0 E15 ; Draw the first line\nG1 X0.4 Y200.0 Z0.3 F5000.0 ; Move to side a little\nG1 X0.4 Y20 Z0.3 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X5 Y20 Z0.3 F5000.0 ; Move over to prevent blob squish\n" },
         "machine_width": { "default_value": 220 },
         "retraction_amount": { "value": 0.8 },
+        "retraction_extrusion_window": { "value": 1.5 },
         "retraction_speed": { "default_value": 40 },
+        "speed_layer_0": { "value": 25 },
+        "speed_print": { "value": 60 },
         "speed_travel": { "value": "120.0 if speed_print < 60 else 250.0 if speed_print > 100 else speed_print * 2.5" }
     }
 }

--- a/resources/variants/creality/creality_ender3s1pro_0.2.inst.cfg
+++ b/resources/variants/creality/creality_ender3s1pro_0.2.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = creality_ender3s1pro
+name = 0.2mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 20
+type = variant
+
+[values]
+machine_nozzle_size = 0.2
+

--- a/resources/variants/creality/creality_ender3s1pro_0.3.inst.cfg
+++ b/resources/variants/creality/creality_ender3s1pro_0.3.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = creality_ender3s1pro
+name = 0.3mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 20
+type = variant
+
+[values]
+machine_nozzle_size = 0.3
+

--- a/resources/variants/creality/creality_ender3s1pro_0.5.inst.cfg
+++ b/resources/variants/creality/creality_ender3s1pro_0.5.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = creality_ender3s1pro
+name = 0.5mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 20
+type = variant
+
+[values]
+machine_nozzle_size = 0.5
+

--- a/resources/variants/creality/creality_ender3s1pro_0.6.inst.cfg
+++ b/resources/variants/creality/creality_ender3s1pro_0.6.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = creality_ender3s1pro
+name = 0.6mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 20
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/creality/creality_ender3s1pro_0.8.inst.cfg
+++ b/resources/variants/creality/creality_ender3s1pro_0.8.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = creality_ender3s1pro
+name = 0.8mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 20
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+

--- a/resources/variants/creality/creality_ender3s1pro_1.0.inst.cfg
+++ b/resources/variants/creality/creality_ender3s1pro_1.0.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = creality_ender3s1pro
+name = 1.0mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 20
+type = variant
+
+[values]
+machine_nozzle_size = 1.0
+


### PR DESCRIPTION
# Description

Make the 3 Ender 3 S1 profiles more consistent with each other as well as defining the missing variants for the pro model.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Tested configuration on my Ender 3 S1 pro by printing multiple items.
