### PR TITLE
[CURA-10167] - Fix Typo in Japanese mention of Extensions

### DIFF
--- a/resources/i18n/ja_JP/cura.po
+++ b/resources/i18n/ja_JP/cura.po
@@ -5313,7 +5313,7 @@ msgstr "ローカルプリンター"
 #: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ExtensionMenu.qml:13
 msgctxt "@title:menu menubar:toplevel"
 msgid "E&xtensions"
-msgstr "拡張子"
+msgstr "拡張"
 
 #: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/OpenFilesMenu.qml:15
 msgctxt "@title:menu menubar:file"
@@ -6415,7 +6415,7 @@ msgstr "Curaプロファイルリーダー"
 #: /PostProcessingPlugin/plugin.json
 msgctxt "description"
 msgid "Extension that allows for user created scripts for post processing"
-msgstr "後処理のためにユーザーが作成したスクリプト用拡張子"
+msgstr "後処理のためにユーザーが作成したスクリプト用拡張"
 
 #: /PostProcessingPlugin/plugin.json
 msgctxt "name"


### PR DESCRIPTION
Fixes Typo with extensions mentioned here: https://github.com/Ultimaker/Cura/issues/14290

## Type of change
Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I checked the translation files of mentions of 拡張子 and changed them

**Test Configuration**:
Windows 11
Changed with Github Desktop and Notepad++

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change