### PR TITLE
[CURA-10168] Add Interlocking to settings visibility

### DIFF
--- a/resources/setting_visibility/advanced.cfg
+++ b/resources/setting_visibility/advanced.cfg
@@ -139,6 +139,7 @@ magic_spiralize
 smooth_spiralized_contours
 
 [experimental]
+interlocking_enable
 conical_overhang_enabled
 support_conical_enabled
 adaptive_layer_height_enabled

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -384,6 +384,12 @@ roofing_angles
 infill_enable_travel_optimization
 material_flow_dependent_temperature
 material_flow_temp_graph
+interlocking_enable
+interlocking_beam_width
+interlocking_orientation
+interlocking_beam_layer_count
+interlocking_dept
+interlocking_boundary_avoidance
 support_skip_some_zags
 support_skip_zag_per_mm
 support_zag_skip_count


### PR DESCRIPTION
Have Interlocking visible in Advanced, but the sub-settings in Expert Setting Visibility