### PR TITLE
Add hash for PyQt6-NetworkAuth-Qt6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ PyQt6-NetworkAuth==6.2.0 \
 PyQt6-NetworkAuth-Qt6==6.2.4 \
     --hash=sha256:c7996a9d8c4ce024529ec37981fbfd525ab1a2d497af1281f81f2b6054452d2e \
     --hash=sha256:1ae9e08e03bd9d5ebdb42dfaccf484a9cc62eeea7504621fe42c005ff1745e66 \
+    --hash=sha256:1363ea81e5c6ac10bfd643e41ba0d215c0d031a57ff1e5972cc4c2a918efe712 \
     --hash=sha256:8ed4e5e0eaaa42a6f91aba6745eea23fb3ffcbddc6b162016936530ed28dd0ad
 PyQt6-sip==13.2.1 \
     --hash=sha256:b7bce59900b2e0a04f70246de2ccf79ee7933036b6b9183cf039b62eeae2b858 \


### PR DESCRIPTION
# Description

Fixes compilation in MacOS by adding a hash of `PyQt6-NetworkAuth-Qt6==6.2.4` to `requirements.txt`.

Fixes issue https://github.com/Ultimaker/Cura/issues/14504.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Successfully built and ran Cura.

**Test Configuration**:
* Operating System: MacOS Monterrey

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change