### PR TITLE
[CURA-10233] switching support extruder switches model extruder

### DIFF
--- a/resources/qml/ExtruderButton.qml
+++ b/resources/qml/ExtruderButton.qml
@@ -22,10 +22,4 @@ UM.ToolbarButton
         font: extruderNumberFont
         property int index: extruder.index
     }
-
-    onClicked:
-    {
-        forceActiveFocus() //First grab focus, so all the text fields are updated
-        CuraActions.setExtruderForSelection(extruder.id)
-    }
 }


### PR DESCRIPTION
# Description

Switching support extruder while a model is selected also changes the models extruder. This is a fix for that issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

- [ ] Swap support extruders in recommended mode while having a model selected

**Test Configuration**:
* Operating System:

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change