### PR TITLE
[CURA-10290] workaround for conflicting packages on 'linux-modern'

### DIFF
--- a/.github/workflows/cura-installer.yml
+++ b/.github/workflows/cura-installer.yml
@@ -122,6 +122,10 @@ jobs:
                 if:  ${{ runner.os == 'Macos' }}
                 run: brew install autoconf automake ninja create-dmg # Delete create-dmg when deprecating dmg
 
+            -   name: Hack needed specifically for ubuntu-22.04 from mid-Feb 2023 onwards
+                if: ${{ runner.os == 'Linux' && startsWith(inputs.platform, 'ubuntu-22.04') }}
+                run: sudo apt remove libodbc2 libodbcinst2 unixodbc-common -y
+
             -   name: Install Linux system requirements
                 if: ${{ runner.os == 'Linux' }}
                 run: |


### PR DESCRIPTION
Packages conflict. The same commit worked fine the previous day, so it's likely not our fault. We should probably inform maintainers, but until then, try to work around the problem without a blanket ignore of all 'overwrite' type errors. The only clear thing is that this all has to do with 'odbc', which is database related. We use that to cache certain things on start-up, so likely we actually need it.
