### PR TITLE
Fix decimals on heated bed temperature monitor (HeatedBedBox.qml)

### DIFF
--- a/resources/qml/PrinterOutput/HeatedBedBox.qml
+++ b/resources/qml/PrinterOutput/HeatedBedBox.qml
@@ -32,7 +32,7 @@ Item
         UM.Label
         {
             id: bedTargetTemperature
-            text: printerModel != null ? printerModel.targetBedTemperature + "°C" : ""
+            text: printerModel != null ? Math.round(printerModel.targetBedTemperature) + "°C" : ""
             font: UM.Theme.getFont("default_bold")
             color: UM.Theme.getColor("text_inactive")
             anchors.right: parent.right
@@ -66,7 +66,7 @@ Item
         UM.Label
         {
             id: bedCurrentTemperature
-            text: printerModel != null ? printerModel.bedTemperature + "°C" : ""
+            text: printerModel != null ? Math.round(printerModel.bedTemperature) + "°C" : ""
             font: UM.Theme.getFont("large_bold")
             anchors.right: bedTargetTemperature.left
             anchors.top: parent.top


### PR DESCRIPTION
# Description
The fix rounds heated bed temperature values when printer sends them with decimal digits.  Same roundings already exist on the extruder temperatures (see ExtruderBox.qml line 50 and 85)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Very stupid fix.

**Test Configuration**:
* Operating System: indows 10 22H2

