### PR TITLE
Prevent execution of spurious clean-up step, which then crashes.

### DIFF
--- a/.github/workflows/printer-linter-format.yml
+++ b/.github/workflows/printer-linter-format.yml
@@ -18,6 +18,12 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v3
 
+            -   uses: technote-space/get-diff-action@v6
+                with:
+                    PATTERNS: |
+                        resources/+(definitions|extruders)/*.def.json
+                        resources/+(intent|quality|variants)/**/*.inst.cfg
+
             -   name: Setup Python and pip
                 if: env.GIT_DIFF && !env.MATCHED_FILES  # If nothing happens with python and/or pip after, the clean-up crashes.
                 uses: actions/setup-python@v4
@@ -25,12 +31,6 @@ jobs:
                     python-version: 3.11.x
                     cache: 'pip'
                     cache-dependency-path: .github/workflows/requirements-printer-linter.txt
-
-            -   uses: technote-space/get-diff-action@v6
-                with:
-                    PATTERNS: |
-                        resources/+(definitions|extruders)/*.def.json
-                        resources/+(intent|quality|variants)/**/*.inst.cfg
 
             -   name: Install Python requirements for runner
                 if: env.GIT_DIFF && !env.MATCHED_FILES

--- a/.github/workflows/printer-linter-format.yml
+++ b/.github/workflows/printer-linter-format.yml
@@ -19,6 +19,7 @@ jobs:
                 uses: actions/checkout@v3
 
             -   name: Setup Python and pip
+                if: env.GIT_DIFF && !env.MATCHED_FILES  # If nothing happens with python and/or pip after, the clean-up crashes.
                 uses: actions/setup-python@v4
                 with:
                     python-version: 3.11.x

--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -17,6 +17,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Python and pip
+        if: env.GIT_DIFF && !env.MATCHED_FILES  # If nothing happens with python and/or pip after, the clean-up crashes.
         uses: actions/setup-python@v4
         with:
           python-version: 3.11.x

--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -16,6 +16,12 @@ jobs:
         with:
           fetch-depth: 2
 
+      - uses: technote-space/get-diff-action@v6
+        with:
+          PATTERNS: |
+            resources/+(extruders|definitions)/*.def.json
+            resources/+(intent|quality|variants)/**/*.inst.cfg
+
       - name: Setup Python and pip
         if: env.GIT_DIFF && !env.MATCHED_FILES  # If nothing happens with python and/or pip after, the clean-up crashes.
         uses: actions/setup-python@v4
@@ -23,12 +29,6 @@ jobs:
           python-version: 3.11.x
           cache: "pip"
           cache-dependency-path: .github/workflows/requirements-printer-linter.txt
-
-      - uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            resources/+(extruders|definitions)/*.def.json
-            resources/+(intent|quality|variants)/**/*.inst.cfg
 
       - name: Install Python requirements for runner
         if: env.GIT_DIFF && !env.MATCHED_FILES


### PR DESCRIPTION
The clean-up step for setting up Python and pip assumes that you do at least something with those programs -- and so that cache folders have been made, that need to be cleaned up. If nothing happens, the clean-up step then crashes on the non-existent cache folder.
