### PR TITLE
[CURA-10310] Less jitters in support: Walls make a lot of difference.

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -120,7 +120,7 @@
         "support_line_distance": { "minimum_value_warning": "0 if support_structure == 'tree' else support_line_width" },
         "support_tower_maximum_supported_diameter": { "value": "support_tower_diameter" },
         "support_tower_roof_angle": { "value": "0 if support_interface_enable else 65" },
-        "support_wall_count": { "value": "1 if support_structure == 'tree' else 0" },
+        "support_wall_count": { "value": "1" },
         "support_xy_distance_overhang": { "value": "0.2" },
         "support_z_distance": { "value": "0" },
         "top_layers": { "value": "math.ceil(round(top_thickness / resolveOrValue('layer_height'), 4))" },
@@ -130,6 +130,6 @@
         "xy_offset": { "value": "-layer_height * 0.1" },
         "xy_offset_layer_0": { "value": "-wall_line_width_0 / 5 + xy_offset" },
         "z_seam_corner": { "value": "'z_seam_corner_none'" },
-        "zig_zaggify_support": { "value": true }
+        "zig_zaggify_support": { "value": "false" }
     }
 }


### PR DESCRIPTION
__NOTE__: Frontend 'support' (haha) for [this backend ticket](https://github.com/Ultimaker/CuraEngine/pull/1836).

---

Part of wholly missing support was caused by not having walls. You can see that if brim is enabled, brim will have been generated, meaning the areas are there, but support just stops, because the infill pattern has shifted.

Compensate extra material used by not connecting the zigs any more. That shouldn't be necessary, since, hey, walls.

---

_EDIT: Converted to draft for safety w.r.t. multiple possible solutions, but otherwise 'finished'._