### PR TITLE
Updated strings for pt_BR

### DIFF
--- a/resources/i18n/pt_BR/cura.po
+++ b/resources/i18n/pt_BR/cura.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cura 5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-27 14:50+0200\n"
-"PO-Revision-Date: 2022-10-10 08:19+0200\n"
+"POT-Creation-Date: 2023-01-31 16:46+0100\n"
+"PO-Revision-Date: 2023-02-17 17:37+0100\n"
 "Last-Translator: Cláudio Sampaio <patola@gmail.com>\n"
 "Language-Team: Cláudio Sampaio <patola@gmail.com>\n"
 "Language: pt_BR\n"
@@ -16,451 +16,78 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.2.2\n"
 
-#: /3MFReader/plugin.json
-msgctxt "name"
-msgid "3MF Reader"
-msgstr "Leitor de 3MF"
-
-#: /3MFReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading 3MF files."
-msgstr "Provê suporte à leitura de arquivos 3MF."
-
-#: /3MFWriter/plugin.json
-msgctxt "name"
-msgid "3MF Writer"
-msgstr "Gerador de 3MF"
-
-#: /3MFWriter/plugin.json
-msgctxt "description"
-msgid "Provides support for writing 3MF files."
-msgstr "Provê suporte à escrita de arquivos 3MF."
-
-#: /AMFReader/plugin.json
-msgctxt "name"
-msgid "AMF Reader"
-msgstr "Leitor AMF"
-
-#: /AMFReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading AMF files."
-msgstr "Provê suporta à leitura de arquivos AMF."
-
-#: /CuraDrive/plugin.json
-msgctxt "description"
-msgid "Backup and restore your configuration."
-msgstr "Permite backup e restauração da configuração."
-
-#: /CuraDrive/plugin.json
-msgctxt "name"
-msgid "Cura Backups"
-msgstr "Backups Cura"
-
-#: /CuraEngineBackend/plugin.json
-msgctxt "name"
-msgid "CuraEngine Backend"
-msgstr "CuraEngine Backend"
-
-#: /CuraEngineBackend/plugin.json
-msgctxt "description"
-msgid "Provides the link to the CuraEngine slicing backend."
-msgstr "Provê a ligação ao backend de fatiamento CuraEngine."
-
-#: /CuraProfileReader/plugin.json
-msgctxt "name"
-msgid "Cura Profile Reader"
-msgstr "Leitor de Perfis do Cura"
-
-#: /CuraProfileReader/plugin.json
-msgctxt "description"
-msgid "Provides support for importing Cura profiles."
-msgstr "Provê suporte à importação de perfis do Cura."
-
-#: /CuraProfileWriter/plugin.json
-msgctxt "name"
-msgid "Cura Profile Writer"
-msgstr "Gravador de Perfis do Cura"
-
-#: /CuraProfileWriter/plugin.json
-msgctxt "description"
-msgid "Provides support for exporting Cura profiles."
-msgstr "Provê suporte à exportação de perfis do Cura."
-
-#: /DigitalLibrary/plugin.json
-msgctxt "description"
-msgid "Connects to the Digital Library, allowing Cura to open files from and save files to the Digital Library."
-msgstr "Conecta-se à Digital Library, permitindo ao Cura abrir arquivos dela e gravar arquivos nela."
-
-#: /DigitalLibrary/plugin.json
-msgctxt "name"
-msgid "Ultimaker Digital Library"
-msgstr "Digital Library da UltiMaker"
-
-#: /FirmwareUpdateChecker/plugin.json
-msgctxt "description"
-msgid "Checks for firmware updates."
-msgstr "Verifica por atualizações de firmware."
-
-#: /FirmwareUpdateChecker/plugin.json
-msgctxt "name"
-msgid "Firmware Update Checker"
-msgstr "Verificador de Atualizações de Firmware"
-
-#: /FirmwareUpdater/plugin.json
-msgctxt "name"
-msgid "Firmware Updater"
-msgstr "Atualizador de Firmware"
-
-#: /FirmwareUpdater/plugin.json
-msgctxt "description"
-msgid "Provides a machine actions for updating firmware."
-msgstr "Provê ações de máquina para atualização do firmware."
-
-#: /GCodeGzReader/plugin.json
-msgctxt "name"
-msgid "Compressed G-code Reader"
-msgstr "Leitor de G-Code Comprimido"
-
-#: /GCodeGzReader/plugin.json
-msgctxt "description"
-msgid "Reads g-code from a compressed archive."
-msgstr "Lê G-Code de um arquivo comprimido."
-
-#: /GCodeGzWriter/plugin.json
-msgctxt "name"
-msgid "Compressed G-code Writer"
-msgstr "Gerador de G-Code Comprimido"
-
-#: /GCodeGzWriter/plugin.json
-msgctxt "description"
-msgid "Writes g-code to a compressed archive."
-msgstr "Escreve em formato G-Code comprimido."
-
-#: /GCodeProfileReader/plugin.json
-msgctxt "name"
-msgid "G-code Profile Reader"
-msgstr "Leitor de Perfil de G-Code"
-
-#: /GCodeProfileReader/plugin.json
-msgctxt "description"
-msgid "Provides support for importing profiles from g-code files."
-msgstr "Provê suporte a importar perfis de arquivos G-Code."
-
-#: /GCodeReader/plugin.json
-msgctxt "description"
-msgid "Allows loading and displaying G-code files."
-msgstr "Permite carregar e exibir arquivos G-Code."
-
-#: /GCodeReader/plugin.json
-msgctxt "name"
-msgid "G-code Reader"
-msgstr "Leitor de G-Code"
-
-#: /GCodeWriter/plugin.json
-msgctxt "name"
-msgid "G-code Writer"
-msgstr "Gerador de G-Code"
-
-#: /GCodeWriter/plugin.json
-msgctxt "description"
-msgid "Writes g-code to a file."
-msgstr "Escreve em formato G-Code."
-
-#: /ImageReader/plugin.json
-msgctxt "description"
-msgid "Enables ability to generate printable geometry from 2D image files."
-msgstr "Habilita a geração de geometria imprimível de arquivos de imagem 2D."
-
-#: /ImageReader/plugin.json
-msgctxt "name"
-msgid "Image Reader"
-msgstr "Leitor de Imagens"
-
-#: /LegacyProfileReader/plugin.json
-msgctxt "name"
-msgid "Legacy Cura Profile Reader"
-msgstr "Leitor de Perfis de Cura Legado"
-
-#: /LegacyProfileReader/plugin.json
-msgctxt "description"
-msgid "Provides support for importing profiles from legacy Cura versions."
-msgstr "Provê suporte a importação de perfis de versões legadas do Cura."
-
-#: /MachineSettingsAction/plugin.json
-msgctxt "name"
-msgid "Machine Settings Action"
-msgstr "Ação de Ajustes de Máquina"
-
-#: /MachineSettingsAction/plugin.json
-msgctxt "description"
-msgid "Provides a way to change machine settings (such as build volume, nozzle size, etc.)."
-msgstr "Provê uma maneira de alterar ajustes de máquina (tais como volume de impressão, tamanho do bico, etc.)."
-
-#: /Marketplace/plugin.json
-msgctxt "description"
-msgid "Manages extensions to the application and allows browsing extensions from the UltiMaker website."
-msgstr "Gerencia extensões à aplicação e permite navegar extensões do sítio web da UltiMaker."
-
-#: /Marketplace/plugin.json
-msgctxt "name"
-msgid "Marketplace"
-msgstr "Marketplace"
-
-#: /ModelChecker/plugin.json
-msgctxt "description"
-msgid "Checks models and print configuration for possible printing issues and give suggestions."
-msgstr "Verifica modelos e configurações de impressão por possíveis problema e dá sugestões."
-
-#: /ModelChecker/plugin.json
-msgctxt "name"
-msgid "Model Checker"
-msgstr "Verificador de Modelo"
-
-#: /MonitorStage/plugin.json
-msgctxt "name"
-msgid "Monitor Stage"
-msgstr "Estágio de Monitor"
-
-#: /MonitorStage/plugin.json
-msgctxt "description"
-msgid "Provides a monitor stage in Cura."
-msgstr "Provê um estágio de monitor no Cura."
-
-#: /PerObjectSettingsTool/plugin.json
-msgctxt "name"
-msgid "Per Model Settings Tool"
-msgstr "Ferramenta de Ajustes Por Modelo"
-
-#: /PerObjectSettingsTool/plugin.json
-msgctxt "description"
-msgid "Provides the Per Model Settings."
-msgstr "Provê Ajustes Por Modelo."
-
-#: /PostProcessingPlugin/plugin.json
-msgctxt "description"
-msgid "Extension that allows for user created scripts for post processing"
-msgstr "Extensão que permite scripts criados por usuários para pós-processamento"
-
-#: /PostProcessingPlugin/plugin.json
-msgctxt "name"
-msgid "Post Processing"
-msgstr "Pós-processamento"
-
-#: /PrepareStage/plugin.json
-msgctxt "name"
-msgid "Prepare Stage"
-msgstr "Estágio de Preparação"
-
-#: /PrepareStage/plugin.json
-msgctxt "description"
-msgid "Provides a prepare stage in Cura."
-msgstr "Provê um estágio de preparação no Cura."
-
-#: /PreviewStage/plugin.json
-msgctxt "name"
-msgid "Preview Stage"
-msgstr "Estágio de Pré-visualização"
-
-#: /PreviewStage/plugin.json
-msgctxt "description"
-msgid "Provides a preview stage in Cura."
-msgstr "Provê uma etapa de pré-visualização ao Cura."
-
-#: /RemovableDriveOutputDevice/plugin.json
-msgctxt "description"
-msgid "Provides removable drive hotplugging and writing support."
-msgstr "Provê suporte a escrita e reconhecimento de drives a quente."
-
-#: /RemovableDriveOutputDevice/plugin.json
-msgctxt "name"
-msgid "Removable Drive Output Device Plugin"
-msgstr "Complemento de Dispositivo de Escrita Removível"
-
-#: /SentryLogger/plugin.json
-msgctxt "description"
-msgid "Logs certain events so that they can be used by the crash reporter"
-msgstr "Registra certos eventos de forma que possam ser usados pelo relator de acidentes"
-
-#: /SentryLogger/plugin.json
-msgctxt "name"
-msgid "Sentry Logger"
-msgstr "Sentinela para Registro"
-
-#: /SimulationView/plugin.json
-msgctxt "description"
-msgid "Provides the preview of sliced layerdata."
-msgstr "Provê a pré-visualização de dados de camada fatiados."
-
-#: /SimulationView/plugin.json
-msgctxt "name"
-msgid "Simulation View"
-msgstr "Visão Simulada"
-
-#: /SliceInfoPlugin/plugin.json
-msgctxt "name"
-msgid "Slice info"
-msgstr "Informação de fatiamento"
-
-#: /SliceInfoPlugin/plugin.json
-msgctxt "description"
-msgid "Submits anonymous slice info. Can be disabled through preferences."
-msgstr "Submete informações de fatiamento anônimas. Pode ser desabilitado nas preferências."
-
-#: /SolidView/plugin.json
-msgctxt "description"
-msgid "Provides a normal solid mesh view."
-msgstr "Provê uma visualização de malha sólida normal."
-
-#: /SolidView/plugin.json
-msgctxt "name"
-msgid "Solid View"
-msgstr "Visão Sólida"
-
-#: /SupportEraser/plugin.json
-msgctxt "description"
-msgid "Creates an eraser mesh to block the printing of support in certain places"
-msgstr "Cria uma malha apagadora para bloquear a impressão de suporte em certos lugares"
-
-#: /SupportEraser/plugin.json
-msgctxt "name"
-msgid "Support Eraser"
-msgstr "Apagador de Suporte"
-
-#: /TrimeshReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading model files."
-msgstr "Provê suporta a ler arquivos de modelo."
-
-#: /TrimeshReader/plugin.json
-msgctxt "name"
-msgid "Trimesh Reader"
-msgstr "Leitor Trimesh"
-
-#: /UFPReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading UltiMaker Format Packages."
-msgstr "Provê suporte a leitura de Pacotes de Formato UltiMaker (UFP)."
-
-#: /UFPReader/plugin.json
-msgctxt "name"
-msgid "UFP Reader"
-msgstr "Leitor UFP"
-
-#: /UFPWriter/plugin.json
-msgctxt "description"
-msgid "Provides support for writing UltiMaker Format Packages."
-msgstr "Provê suporte para a escrita de UltiMaker Format Packages (Pacotes de Formato da Ultimaker)."
-
-#: /UFPWriter/plugin.json
-msgctxt "name"
-msgid "UFP Writer"
-msgstr "Gerador de UFP"
-
-#: /UM3NetworkPrinting/plugin.json
-msgctxt "description"
-msgid "Manages network connections to UltiMaker networked printers."
-msgstr "Administra conexões de rede a impressora UltiMaker conectadas."
-
-#: /UM3NetworkPrinting/plugin.json
-msgctxt "name"
-msgid "UltiMaker Network Connection"
-msgstr "Conexão de Rede UltiMaker"
-
-#: /USBPrinting/plugin.json
-msgctxt "description"
-msgid "Accepts G-Code and sends them to a printer. Plugin can also update firmware."
-msgstr "Aceita G-Code e o envia a uma impressora. O complemento também pode atualizar o firmware."
-
-#: /USBPrinting/plugin.json
-msgctxt "name"
-msgid "USB printing"
-msgstr "Impressão USB"
-
-#: /UltimakerMachineActions/plugin.json
-msgctxt "description"
-msgid "Provides machine actions for UltiMaker machines (such as bed leveling wizard, selecting upgrades, etc.)."
-msgstr "Provê ações de máquina para impressoras da UltiMaker (tais como assistente de nivelamento de mesa, seleção de atualizações, etc.)."
-
-#: /UltimakerMachineActions/plugin.json
-msgctxt "name"
-msgid "UltiMaker machine actions"
-msgstr "Ações de máquina UltiMaker"
-
-#: /Users/c.lamboo/ultimaker/Cura/cura/API/Account.py:199
+#: cura/API/Account.py:199
 msgctxt "@info:title"
 msgid "Login failed"
 msgstr "Login falhou"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Arranging/ArrangeObjectsJob.py:25
+#: cura/Arranging/ArrangeObjectsJob.py:25
 msgctxt "@info:status"
 msgid "Finding new location for objects"
 msgstr "Achando novos lugares para objetos"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Arranging/ArrangeObjectsJob.py:29
+#: cura/Arranging/ArrangeObjectsJob.py:29
 msgctxt "@info:title"
 msgid "Finding Location"
 msgstr "Buscando Localização"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Arranging/ArrangeObjectsJob.py:42
-#: /Users/c.lamboo/ultimaker/Cura/cura/MultiplyObjectsJob.py:99
+#: cura/Arranging/ArrangeObjectsJob.py:42 cura/MultiplyObjectsJob.py:99
 msgctxt "@info:status"
 msgid "Unable to find a location within the build volume for all objects"
 msgstr "Não foi possível achar um lugar dentro do volume de construção para todos os objetos"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Arranging/ArrangeObjectsJob.py:43
+#: cura/Arranging/ArrangeObjectsJob.py:43
 msgctxt "@info:title"
 msgid "Can't Find Location"
 msgstr "Não Foi Encontrada Localização"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Backups/Backup.py:115
+#: cura/Backups/Backup.py:115
 msgctxt "@info:backup_failed"
 msgid "Could not create archive from user data directory: {}"
 msgstr "Não pude criar arquivo do diretório de dados de usuário: {}"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Backups/Backup.py:122
-#: /Users/c.lamboo/ultimaker/Cura/cura/Backups/Backup.py:159
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:118
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:126
+#: cura/Backups/Backup.py:122 cura/Backups/Backup.py:159 plugins/CuraDrive/src/DrivePluginExtension.py:118 plugins/CuraDrive/src/DrivePluginExtension.py:126
 msgctxt "@info:title"
 msgid "Backup"
 msgstr "Backup"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Backups/Backup.py:134
+#: cura/Backups/Backup.py:134
 msgctxt "@info:backup_failed"
 msgid "Tried to restore a Cura backup without having proper data or meta data."
 msgstr "Tentativa de restauração de backup do Cura sem dados ou metadados apropriados."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Backups/Backup.py:145
+#: cura/Backups/Backup.py:145
 msgctxt "@info:backup_failed"
 msgid "Tried to restore a Cura backup that is higher than the current version."
 msgstr "Tentativa de restauração de backup do Cura de versão maior que a atual."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Backups/Backup.py:158
+#: cura/Backups/Backup.py:158
 msgctxt "@info:backup_failed"
 msgid "The following error occurred while trying to restore a Cura backup:"
 msgstr "O seguinte erro ocorreu ao tentar restaurar um backup do Cura:"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/BuildVolume.py:100
+#: cura/BuildVolume.py:100
 msgctxt "@info:status"
 msgid "The build volume height has been reduced due to the value of the \"Print Sequence\" setting to prevent the gantry from colliding with printed models."
 msgstr "A altura do volume de impressão foi reduzida para que o valor da \"Sequência de Impressão\" impeça o eixo de colidir com os modelos impressos."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/BuildVolume.py:103
+#: cura/BuildVolume.py:103
 msgctxt "@info:title"
 msgid "Build Volume"
 msgstr "Volume de Impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:107
+#: cura/CrashHandler.py:107
 msgctxt "@title:window"
 msgid "Cura can't start"
 msgstr "O Cura não consegue iniciar"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:113
+#: cura/CrashHandler.py:113
+#, fuzzy
 msgctxt "@label crash message"
 msgid ""
-"<p><b>Oops, Ultimaker Cura has encountered something that doesn't seem right.</p></b>\n"
+"<p><b>Oops, UltiMaker Cura has encountered something that doesn't seem right.</p></b>\n"
 "                    <p>We encountered an unrecoverable error during start up. It was possibly caused by some incorrect configuration files. We suggest to backup and reset your configuration.</p>\n"
 "                    <p>Backups can be found in the configuration folder.</p>\n"
 "                    <p>Please send us this Crash Report to fix the problem.</p>\n"
@@ -472,32 +99,32 @@ msgstr ""
 "                    <p>Por favor nos envie este Relatório de Falha para consertar o problema.</p>\n"
 "                "
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:122
+#: cura/CrashHandler.py:122
 msgctxt "@action:button"
 msgid "Send crash report to UltiMaker"
 msgstr "Enviar relatório de falha à UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:125
+#: cura/CrashHandler.py:125
 msgctxt "@action:button"
 msgid "Show detailed crash report"
 msgstr "Exibir relatório de falha detalhado"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:129
+#: cura/CrashHandler.py:129
 msgctxt "@action:button"
 msgid "Show configuration folder"
 msgstr "Mostrar a pasta de configuração"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:140
+#: cura/CrashHandler.py:140
 msgctxt "@action:button"
 msgid "Backup and Reset Configuration"
 msgstr "Salvar e Restabelecer Configuração"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:171
+#: cura/CrashHandler.py:171
 msgctxt "@title:window"
 msgid "Crash Report"
 msgstr "Relatório de Problema"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:190
+#: cura/CrashHandler.py:190
 msgctxt "@label crash message"
 msgid ""
 "<p><b>A fatal error has occurred in Cura. Please send us this Crash Report to fix the problem</p></b>\n"
@@ -508,1153 +135,1729 @@ msgstr ""
 "            <p>Por favor use o botão \"Enviar relatório\" para publicar um relatório de erro automaticamente em nossos servidores</p>\n"
 "        "
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:198
+#: cura/CrashHandler.py:198
 msgctxt "@title:groupbox"
 msgid "System information"
 msgstr "Informação do Sistema"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:207
+#: cura/CrashHandler.py:207
 msgctxt "@label unknown version of Cura"
 msgid "Unknown"
 msgstr "Desconhecida"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:228
+#: cura/CrashHandler.py:228
 msgctxt "@label Cura version number"
 msgid "Cura version"
 msgstr "Versão do Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:229
+#: cura/CrashHandler.py:229
 msgctxt "@label"
 msgid "Cura language"
 msgstr "Linguagem do Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:230
+#: cura/CrashHandler.py:230
 msgctxt "@label"
 msgid "OS language"
 msgstr "Linguagem do SO"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:231
+#: cura/CrashHandler.py:231
 msgctxt "@label Type of platform"
 msgid "Platform"
 msgstr "Plataforma"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:232
+#: cura/CrashHandler.py:232
 msgctxt "@label"
 msgid "Qt version"
 msgstr "Versão do Qt"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:233
+#: cura/CrashHandler.py:233
 msgctxt "@label"
 msgid "PyQt version"
 msgstr "Versão do PyQt"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:234
+#: cura/CrashHandler.py:234
 msgctxt "@label OpenGL version"
 msgid "OpenGL"
 msgstr "OpenGL"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:264
+#: cura/CrashHandler.py:264
 msgctxt "@label"
 msgid "Not yet initialized"
 msgstr "Ainda não inicializado"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:267
+#: cura/CrashHandler.py:267
 #, python-brace-format
 msgctxt "@label OpenGL version"
 msgid "<li>OpenGL Version: {version}</li>"
 msgstr "<li>Versão da OpenGL: {version}</li>"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:268
+#: cura/CrashHandler.py:268
 #, python-brace-format
 msgctxt "@label OpenGL vendor"
 msgid "<li>OpenGL Vendor: {vendor}</li>"
 msgstr "<li>Fornecedor da OpenGL: {vendor}</li>"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:269
+#: cura/CrashHandler.py:269
 #, python-brace-format
 msgctxt "@label OpenGL renderer"
 msgid "<li>OpenGL Renderer: {renderer}</li>"
 msgstr "<li>Renderizador da OpenGL: {renderer}</li>"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:304
+#: cura/CrashHandler.py:304
 msgctxt "@title:groupbox"
 msgid "Error traceback"
 msgstr "Traceback do erro"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:390
+#: cura/CrashHandler.py:390
 msgctxt "@title:groupbox"
 msgid "Logs"
 msgstr "Registros"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CrashHandler.py:418
+#: cura/CrashHandler.py:418
 msgctxt "@action:button"
 msgid "Send report"
 msgstr "Enviar relatório"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:540
+#: cura/CuraApplication.py:540
 msgctxt "@info:progress"
 msgid "Loading machines..."
 msgstr "Carregando máquinas..."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:547
+#: cura/CuraApplication.py:547
 msgctxt "@info:progress"
 msgid "Setting up preferences..."
 msgstr "Ajustando preferências..."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:692
+#: cura/CuraApplication.py:692
 msgctxt "@info:progress"
 msgid "Initializing Active Machine..."
 msgstr "Inicializando Máquina Ativa..."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:838
+#: cura/CuraApplication.py:839
 msgctxt "@info:progress"
 msgid "Initializing machine manager..."
 msgstr "Inicializando gestor de máquinas..."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:852
+#: cura/CuraApplication.py:853
 msgctxt "@info:progress"
 msgid "Initializing build volume..."
 msgstr "Inicializando volume de impressão..."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:920
+#: cura/CuraApplication.py:921
 msgctxt "@info:progress"
 msgid "Setting up scene..."
 msgstr "Configurando cena..."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:956
+#: cura/CuraApplication.py:957
 msgctxt "@info:progress"
 msgid "Loading interface..."
 msgstr "Carregando interface..."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:961
+#: cura/CuraApplication.py:962
 msgctxt "@info:progress"
 msgid "Initializing engine..."
 msgstr "Inicializando motor..."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:1289
+#: cura/CuraApplication.py:1290
 #, python-format
 msgctxt "@info 'width', 'depth' and 'height' are variable names that must NOT be translated; just translate the format of ##x##x## mm."
 msgid "%(width).1f x %(depth).1f x %(height).1f mm"
 msgstr "%(width).1f x %(depth).1f x %(height).1f mm"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:1815
+#: cura/CuraApplication.py:1816
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Only one G-code file can be loaded at a time. Skipped importing {0}"
 msgstr "Somente um arquivo G-Code pode ser carregado por vez. Pulando importação de {0}"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:1817
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationService.py:217
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:189
+#: cura/CuraApplication.py:1818 cura/OAuth2/AuthorizationService.py:217 plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:189
 msgctxt "@info:title"
 msgid "Warning"
 msgstr "Aviso"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:1827
+#: cura/CuraApplication.py:1828
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Can't open any other file if G-code is loading. Skipped importing {0}"
 msgstr "Não é possível abrir nenhum outro arquivo se G-Code estiver sendo carregado. Pulando importação de {0}"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/CuraApplication.py:1829
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:156
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:166
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:153
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:173
+#: cura/CuraApplication.py:1830 cura/Settings/CuraContainerRegistry.py:156 cura/Settings/CuraContainerRegistry.py:166 plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:153 plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:173
 msgctxt "@info:title"
 msgid "Error"
 msgstr "Erro"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:83
+#: cura/Machines/Models/DiscoveredPrintersModel.py:83
 msgctxt "@label"
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:113
+#: cura/Machines/Models/DiscoveredPrintersModel.py:113
 msgctxt "@label"
 msgid "The printer(s) below cannot be connected because they are part of a group"
 msgstr "As impressoras abaixo não podem ser conectadas por serem parte de um grupo"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/DiscoveredPrintersModel.py:115
+#: cura/Machines/Models/DiscoveredPrintersModel.py:115
 msgctxt "@label"
 msgid "Available networked printers"
 msgstr "Impressoras de rede disponíveis"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/ExtrudersModel.py:219
+#: cura/Machines/Models/ExtrudersModel.py:219
 msgctxt "@menuitem"
 msgid "Not overridden"
 msgstr "Não sobreposto"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/GlobalStacksModel.py:160
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineSelectorList.qml:24
+#: cura/Machines/Models/GlobalStacksModel.py:160 resources/qml/PrinterSelector/MachineSelectorList.qml:28
 msgctxt "@label"
 msgid "Connected printers"
 msgstr "Impressoras conectadas"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/GlobalStacksModel.py:160
+#: cura/Machines/Models/GlobalStacksModel.py:160
 msgctxt "@label"
 msgid "Preset printers"
 msgstr "Impressoras pré-ajustadas"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/GlobalStacksModel.py:165
+#: cura/Machines/Models/GlobalStacksModel.py:165
 #, python-brace-format
 msgctxt "@label {0} is the name of a printer that's about to be deleted."
 msgid "Are you sure you wish to remove {0}? This cannot be undone!"
 msgstr "Tem certeza que deseja remover {0}? Isto não pode ser defeito!"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentCategoryModel.py:42
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentSelectionModel.py:61
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentTranslations.py:11
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/QualityManagementModel.py:338
+#: cura/Machines/Models/IntentCategoryModel.py:42 cura/Machines/Models/IntentSelectionModel.py:61 cura/Machines/Models/IntentTranslations.py:11 cura/Machines/Models/QualityManagementModel.py:347
 msgctxt "@label"
 msgid "Default"
 msgstr "Default"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentCategoryModel.py:45
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentSelectionModel.py:65
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentTranslations.py:14
+#: cura/Machines/Models/IntentCategoryModel.py:45 cura/Machines/Models/IntentSelectionModel.py:65 cura/Machines/Models/IntentTranslations.py:14
 msgctxt "@label"
 msgid "Visual"
 msgstr "Visual"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentCategoryModel.py:46
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentSelectionModel.py:66
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentTranslations.py:15
+#: cura/Machines/Models/IntentCategoryModel.py:46 cura/Machines/Models/IntentSelectionModel.py:66 cura/Machines/Models/IntentTranslations.py:15
 msgctxt "@text"
 msgid "The visual profile is designed to print visual prototypes and models with the intent of high visual and surface quality."
 msgstr "O perfil visual é projetado para imprimir protótipos e modelos virtuais com o objetivo de alta qualidade visual e de superfície."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentCategoryModel.py:49
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentSelectionModel.py:70
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentTranslations.py:18
+#: cura/Machines/Models/IntentCategoryModel.py:49 cura/Machines/Models/IntentSelectionModel.py:70 cura/Machines/Models/IntentTranslations.py:18
 msgctxt "@label"
 msgid "Engineering"
 msgstr "Engenharia"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentCategoryModel.py:50
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentSelectionModel.py:71
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentTranslations.py:19
+#: cura/Machines/Models/IntentCategoryModel.py:50 cura/Machines/Models/IntentSelectionModel.py:71 cura/Machines/Models/IntentTranslations.py:19
 msgctxt "@text"
 msgid "The engineering profile is designed to print functional prototypes and end-use parts with the intent of better accuracy and for closer tolerances."
 msgstr "O perfil de engenharia é projetado para imprimir protótipos funcionais e partes de uso final com o objetivo de melhor precisão e tolerâncias mais estritas."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentCategoryModel.py:53
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentSelectionModel.py:75
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentTranslations.py:22
+#: cura/Machines/Models/IntentCategoryModel.py:53 cura/Machines/Models/IntentSelectionModel.py:75 cura/Machines/Models/IntentTranslations.py:22
 msgctxt "@label"
 msgid "Draft"
 msgstr "Rascunho"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentCategoryModel.py:54
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentSelectionModel.py:76
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/IntentTranslations.py:23
+#: cura/Machines/Models/IntentCategoryModel.py:54 cura/Machines/Models/IntentSelectionModel.py:76 cura/Machines/Models/IntentTranslations.py:23
 msgctxt "@text"
 msgid "The draft profile is designed to print initial prototypes and concept validation with the intent of significant print time reduction."
 msgstr "O perfil de rascunho é projetado para imprimir protótipos iniciais e validações de conceito com o objetivo de redução significativa de tempo de impressão."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/MaterialManagementModel.py:232
+#: cura/Machines/Models/MaterialManagementModel.py:232
 msgctxt "@label"
 msgid "Custom Material"
 msgstr "Material Personalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/MaterialManagementModel.py:233
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:340
+#: cura/Machines/Models/MaterialManagementModel.py:233 resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:340
 msgctxt "@label"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/QualityManagementModel.py:391
+#: cura/Machines/Models/QualityManagementModel.py:400
 msgctxt "@label"
 msgid "Custom profiles"
 msgstr "Perfis personalizados"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/QualityManagementModel.py:426
+#: cura/Machines/Models/QualityManagementModel.py:435
 #, python-brace-format
 msgctxt "@item:inlistbox"
 msgid "All Supported Types ({0})"
 msgstr "Todos Os Tipos Suportados ({0})"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/QualityManagementModel.py:427
+#: cura/Machines/Models/QualityManagementModel.py:436
 msgctxt "@item:inlistbox"
 msgid "All Files (*)"
 msgstr "Todos Os Arquivos (*)"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Machines/Models/QualitySettingsModel.py:182
+#: cura/Machines/Models/QualitySettingsModel.py:182
 msgctxt "@info:status"
 msgid "Calculated"
 msgstr "Calculado"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/MultiplyObjectsJob.py:30
+#: cura/MultiplyObjectsJob.py:30
 msgctxt "@info:status"
 msgid "Multiplying and placing objects"
 msgstr "Multiplicando e colocando objetos"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/MultiplyObjectsJob.py:32
+#: cura/MultiplyObjectsJob.py:32
 msgctxt "@info:title"
 msgid "Placing Objects"
 msgstr "Colocando Objetos"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/MultiplyObjectsJob.py:100
+#: cura/MultiplyObjectsJob.py:100
 msgctxt "@info:title"
 msgid "Placing Object"
 msgstr "Colocando Objeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationHelpers.py:89
+#: cura/OAuth2/AuthorizationHelpers.py:89
 msgctxt "@message"
 msgid "Could not read response."
 msgstr "Não foi possível ler a resposta."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationRequestHandler.py:75
+#: cura/OAuth2/AuthorizationRequestHandler.py:75
 msgctxt "@message"
 msgid "The provided state is not correct."
 msgstr "O estado provido não está correto."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationRequestHandler.py:80
+#: cura/OAuth2/AuthorizationRequestHandler.py:80
 msgctxt "@message"
 msgid "Timeout when authenticating with the account server."
 msgstr "Tempo esgotado ao autenticar com o servidor da conta."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationRequestHandler.py:97
+#: cura/OAuth2/AuthorizationRequestHandler.py:97
 msgctxt "@message"
 msgid "Please give the required permissions when authorizing this application."
 msgstr "Por favor dê as permissões requeridas ao autorizar esta aplicação."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationRequestHandler.py:104
+#: cura/OAuth2/AuthorizationRequestHandler.py:104
 msgctxt "@message"
 msgid "Something unexpected happened when trying to log in, please try again."
 msgstr "Algo inesperado aconteceu ao tentar login, por favor tente novamente."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationService.py:216
+#: cura/OAuth2/AuthorizationService.py:216
 msgctxt "@info"
 msgid "Unable to start a new sign in process. Check if another sign in attempt is still active."
 msgstr "Não foi possível iniciar processo de sign-in. Verifique se outra tentativa de sign-in ainda está ativa."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationService.py:277
+#: cura/OAuth2/AuthorizationService.py:277
 msgctxt "@info"
 msgid "Unable to reach the UltiMaker account server."
 msgstr "Não foi possível contactar o servidor de contas da UltiMaker."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/OAuth2/AuthorizationService.py:278
+#: cura/OAuth2/AuthorizationService.py:278
 msgctxt "@info:title"
 msgid "Log-in failed"
 msgstr "Login falhou"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:104
+#: cura/PrinterOutput/UploadMaterialsJob.py:104
 msgctxt "@text:error"
 msgid "Failed to create archive of materials to sync with printers."
 msgstr "Falha em criar arquivo de materiais para sincronizar com impressoras."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:111
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:165
+#: cura/PrinterOutput/UploadMaterialsJob.py:111 cura/PrinterOutput/UploadMaterialsJob.py:165
 msgctxt "@text:error"
 msgid "Failed to load the archive of materials to sync it with printers."
 msgstr "Falha em carregar o arquivo de materiais para sincronizar com impressoras."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:143
+#: cura/PrinterOutput/UploadMaterialsJob.py:143
 msgctxt "@text:error"
 msgid "The response from Digital Factory appears to be corrupted."
 msgstr "A resposta da Digital Factory parece estar corrompida."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:147
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:151
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:155
+#: cura/PrinterOutput/UploadMaterialsJob.py:147 cura/PrinterOutput/UploadMaterialsJob.py:151 cura/PrinterOutput/UploadMaterialsJob.py:155
 msgctxt "@text:error"
 msgid "The response from Digital Factory is missing important information."
 msgstr "A resposta da Digital Factory veio sem informações importantes."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:218
+#: cura/PrinterOutput/UploadMaterialsJob.py:218
 msgctxt "@text:error"
 msgid "Failed to connect to Digital Factory to sync materials with some of the printers."
 msgstr "Falha em conectar com a Digital Factory para sincronizar materiais com algumas das impressoras."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/PrinterOutput/UploadMaterialsJob.py:232
+#: cura/PrinterOutput/UploadMaterialsJob.py:232
 msgctxt "@text:error"
 msgid "Failed to connect to Digital Factory."
 msgstr "Falha em conectar à Digital Factory."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/ContainerManager.py:207
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:140
+#: cura/Settings/ActiveQuality.py:43
+msgctxt "@label"
+msgid "Experimental"
+msgstr "Experimental"
+
+#: cura/Settings/ContainerManager.py:207 cura/Settings/CuraContainerRegistry.py:140
 msgctxt "@title:window"
 msgid "File Already Exists"
 msgstr "O Arquivo Já Existe"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/ContainerManager.py:208
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:141
+#: cura/Settings/ContainerManager.py:208 cura/Settings/CuraContainerRegistry.py:141
 #, python-brace-format
 msgctxt "@label Don't translate the XML tag <filename>!"
 msgid "The file <filename>{0}</filename> already exists. Are you sure you want to overwrite it?"
 msgstr "O arquivo <filename>{0}</filename> já existe. Tem certeza que quer sobrescrevê-lo?"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/ContainerManager.py:459
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/ContainerManager.py:462
+#: cura/Settings/ContainerManager.py:459 cura/Settings/ContainerManager.py:462
 msgctxt "@info:status"
 msgid "Invalid file URL:"
 msgstr "URL de arquivo inválida:"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:153
+#: cura/Settings/CuraContainerRegistry.py:153
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
 msgid "Failed to export profile to <filename>{0}</filename>: <message>{1}</message>"
 msgstr "Falha ao exportar perfil para <filename>{0}</filename>: <message>{1}</message>"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:163
+#: cura/Settings/CuraContainerRegistry.py:163
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid "Failed to export profile to <filename>{0}</filename>: Writer plugin reported failure."
 msgstr "Falha ao exportar perfil para <filename>{0}</filename>: complemento escritor relatou erro."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:171
+#: cura/Settings/CuraContainerRegistry.py:171
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid "Exported profile to <filename>{0}</filename>"
 msgstr "Perfil exportado para <filename>{0}</filename>"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:173
+#: cura/Settings/CuraContainerRegistry.py:173
 msgctxt "@info:title"
 msgid "Export succeeded"
 msgstr "Exportação concluída"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:205
+#: cura/Settings/CuraContainerRegistry.py:205
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid "Failed to import profile from <filename>{0}</filename>: {1}"
 msgstr "Falha ao importar perfil de <filename>{0}</filename>: {1}"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:209
+#: cura/Settings/CuraContainerRegistry.py:209
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid "Can't import profile from <filename>{0}</filename> before a printer is added."
 msgstr "Não foi possível importar perfil de <filename>{0}</filename> antes de uma impressora ser adicionada."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:224
+#: cura/Settings/CuraContainerRegistry.py:224
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid "No custom profile to import in file <filename>{0}</filename>"
 msgstr "Não há perfil personalizado a importar no arquivo <filename>{0}</filename>"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:228
+#: cura/Settings/CuraContainerRegistry.py:228
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid "Failed to import profile from <filename>{0}</filename>:"
 msgstr "Erro ao importar perfil de <filename>{0}</filename>:"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:252
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:262
+#: cura/Settings/CuraContainerRegistry.py:252 cura/Settings/CuraContainerRegistry.py:262
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename>!"
 msgid "This profile <filename>{0}</filename> contains incorrect data, could not import it."
 msgstr "Este perfil <filename>{0}</filename> contém dados incorretos, não foi possível importá-lo."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:355
+#: cura/Settings/CuraContainerRegistry.py:355
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid "Failed to import profile from <filename>{0}</filename>:"
 msgstr "Erro ao importar perfil de <filename>{0}</filename>:"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:359
+#: cura/Settings/CuraContainerRegistry.py:359
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Successfully imported profile {0}."
 msgstr "Perfil {0} importado com sucesso."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:366
+#: cura/Settings/CuraContainerRegistry.py:366
 #, python-brace-format
 msgctxt "@info:status"
 msgid "File {0} does not contain any valid profile."
 msgstr "Arquivo {0} não contém nenhum perfil válido."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:369
+#: cura/Settings/CuraContainerRegistry.py:369
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Profile {0} has an unknown file type or is corrupted."
 msgstr "O Perfil {0} tem tipo de arquivo desconhecido ou está corrompido."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:443
+#: cura/Settings/CuraContainerRegistry.py:443
 msgctxt "@label"
 msgid "Custom profile"
 msgstr "Perfil personalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:459
+#: cura/Settings/CuraContainerRegistry.py:459
 msgctxt "@info:status"
 msgid "Profile is missing a quality type."
 msgstr "Falta um tipo de qualidade ao Perfil."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:463
+#: cura/Settings/CuraContainerRegistry.py:463
 msgctxt "@info:status"
 msgid "There is no active printer yet."
 msgstr "Não há impressora ativa ainda."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:469
+#: cura/Settings/CuraContainerRegistry.py:469
 msgctxt "@info:status"
 msgid "Unable to add the profile."
 msgstr "Não foi possível adicionar o perfil."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:483
+#: cura/Settings/CuraContainerRegistry.py:483
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Quality type '{0}' is not compatible with the current active machine definition '{1}'."
 msgstr "Tipo de qualidade '{0}' não é compatível com a definição de máquina ativa atual '{1}'."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/CuraContainerRegistry.py:488
+#: cura/Settings/CuraContainerRegistry.py:488
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Warning: The profile is not visible because its quality type '{0}' is not available for the current configuration. Switch to a material/nozzle combination that can use this quality type."
 msgstr "Alerta: o perfil não está visível porque seu tipo de qualidade '{0}' não está disponível para a configuração atual. Altere para uma combinação de material/bico que possa usar este tipo de qualidade."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/MachineManager.py:745
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:219
+#: cura/Settings/MachineManager.py:746 plugins/3MFReader/ThreeMFWorkspaceReader.py:221
 msgctxt "@label"
 msgid "Nozzle"
 msgstr "Bico"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/MachineManager.py:889
+#: cura/Settings/MachineManager.py:890
 msgctxt "@info:message Followed by a list of settings."
 msgid "Settings have been changed to match the current availability of extruders:"
 msgstr "Os ajustes foram alterados para seguir a disponibilidade de extrusores atuais:"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/MachineManager.py:890
+#: cura/Settings/MachineManager.py:891
 msgctxt "@info:title"
 msgid "Settings updated"
 msgstr "Ajustes atualizados"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/MachineManager.py:1512
+#: cura/Settings/MachineManager.py:1514
 msgctxt "@info:title"
 msgid "Extruder(s) Disabled"
 msgstr "Extrusor(es) Desabilitado(s)"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/cura_empty_instance_containers.py:36
+#: cura/Settings/cura_empty_instance_containers.py:36
 msgctxt "@info:not supported profile"
 msgid "Not supported"
 msgstr "Não Suportado"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/Settings/cura_empty_instance_containers.py:55
+#: cura/Settings/cura_empty_instance_containers.py:55
 msgctxt "@info:No intent profile selected"
 msgid "Default"
 msgstr "Default"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/AddPrinterPagesModel.py:17
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:61
+#: cura/UI/AddPrinterPagesModel.py:17 plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:61
 msgctxt "@action:button"
 msgid "Add"
 msgstr "Adicionar"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/AddPrinterPagesModel.py:26
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/WelcomePagesModel.py:290
+#: cura/UI/AddPrinterPagesModel.py:26 cura/UI/WelcomePagesModel.py:290
 msgctxt "@action:button"
 msgid "Finish"
 msgstr "Finalizar"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/AddPrinterPagesModel.py:33
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:509
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:323
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:147
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:27
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:43
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ColorDialog.qml:139
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:59
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:293
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/RenameDialog.qml:74
+#: cura/UI/AddPrinterPagesModel.py:33 plugins/3MFReader/WorkspaceDialog.qml:386 plugins/ImageReader/ConfigUI.qml:323 plugins/SliceInfoPlugin/MoreInfoWindow.qml:147 plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:27 plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:43
+#: resources/qml/ColorDialog.qml:143 resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:59 resources/qml/Dialogs/RenameDialog.qml:103 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:293
 msgctxt "@action:button"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/ObjectsModel.py:69
+#: cura/UI/ObjectsModel.py:69
 #, python-brace-format
 msgctxt "@label"
 msgid "Group #{group_nr}"
 msgstr "Grupo #{group_nr}"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:87
+#: cura/UI/PrintInformation.py:87
 msgctxt "@tooltip"
 msgid "Outer Wall"
 msgstr "Parede Externa"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:88
+#: cura/UI/PrintInformation.py:88
 msgctxt "@tooltip"
 msgid "Inner Walls"
 msgstr "Paredes Internas"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:89
+#: cura/UI/PrintInformation.py:89
 msgctxt "@tooltip"
 msgid "Skin"
 msgstr "Contorno"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:90
+#: cura/UI/PrintInformation.py:90
 msgctxt "@tooltip"
 msgid "Infill"
 msgstr "Preenchimento"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:91
+#: cura/UI/PrintInformation.py:91
 msgctxt "@tooltip"
 msgid "Support Infill"
 msgstr "Preenchimento de Suporte"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:92
+#: cura/UI/PrintInformation.py:92
 msgctxt "@tooltip"
 msgid "Support Interface"
 msgstr "Interface de Suporte"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:93
+#: cura/UI/PrintInformation.py:93
 msgctxt "@tooltip"
 msgid "Support"
 msgstr "Suporte"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:94
+#: cura/UI/PrintInformation.py:94
 msgctxt "@tooltip"
 msgid "Skirt"
 msgstr "Skirt (Saia)"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:95
+#: cura/UI/PrintInformation.py:95
 msgctxt "@tooltip"
 msgid "Prime Tower"
 msgstr "Torre de Prime"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:96
+#: cura/UI/PrintInformation.py:96
 msgctxt "@tooltip"
 msgid "Travel"
 msgstr "Percurso"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:97
+#: cura/UI/PrintInformation.py:97
 msgctxt "@tooltip"
 msgid "Retractions"
 msgstr "Retrações"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/PrintInformation.py:98
+#: cura/UI/PrintInformation.py:98
 msgctxt "@tooltip"
 msgid "Other"
 msgstr "Outros"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/TextManager.py:37
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/TextManager.py:63
+#: cura/UI/TextManager.py:37 cura/UI/TextManager.py:63
 msgctxt "@text:window"
 msgid "The release notes could not be opened."
 msgstr "As notas de lançamento não puderam ser abertas."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/WelcomePagesModel.py:57
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/WelcomePagesModel.py:277
+#: cura/UI/WelcomePagesModel.py:57 cura/UI/WelcomePagesModel.py:277
 msgctxt "@action:button"
 msgid "Next"
 msgstr "Próximo"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/WelcomePagesModel.py:286
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/WhatsNewPagesModel.py:68
+#: cura/UI/WelcomePagesModel.py:286 cura/UI/WhatsNewPagesModel.py:68
 msgctxt "@action:button"
 msgid "Skip"
 msgstr "Pular"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UI/WhatsNewPagesModel.py:76
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:175
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:135
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:444
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:188
+#: cura/UI/WhatsNewPagesModel.py:76 plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:175 plugins/PerObjectSettingsTool/SettingPickDialog.qml:135 plugins/PostProcessingPlugin/PostProcessingPlugin.qml:444 resources/qml/Dialogs/AboutDialog.qml:188
 msgctxt "@action:button"
 msgid "Close"
 msgstr "Fechar"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UltimakerCloud/CloudMaterialSync.py:66
+#: cura/UltimakerCloud/CloudMaterialSync.py:66
 msgctxt "@action:button"
 msgid "Please sync the material profiles with your printers before starting to print."
 msgstr "Por favor sincronize os perfis de material com suas impressoras antes de começar a imprimir."
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UltimakerCloud/CloudMaterialSync.py:67
+#: cura/UltimakerCloud/CloudMaterialSync.py:67
 msgctxt "@action:button"
 msgid "New materials installed"
 msgstr "Novos materiais instalados"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UltimakerCloud/CloudMaterialSync.py:74
+#: cura/UltimakerCloud/CloudMaterialSync.py:74
 msgctxt "@action:button"
 msgid "Sync materials"
 msgstr "Sincronizar materiais"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UltimakerCloud/CloudMaterialSync.py:82
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.py:397
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SolidView/SolidView.py:80
+#: cura/UltimakerCloud/CloudMaterialSync.py:82 plugins/3MFReader/WorkspaceDialog.py:418 plugins/SolidView/SolidView.py:80
 msgctxt "@action:button"
 msgid "Learn more"
 msgstr "Saiba mais"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UltimakerCloud/CloudMaterialSync.py:135
+#: cura/UltimakerCloud/CloudMaterialSync.py:135
 msgctxt "@message:text"
 msgid "Could not save material archive to {}:"
 msgstr "Não foi possível salvar o arquivo de materiais para {}:"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UltimakerCloud/CloudMaterialSync.py:136
+#: cura/UltimakerCloud/CloudMaterialSync.py:136
 msgctxt "@message:title"
 msgid "Failed to save material archive"
 msgstr "Falha em salvar o arquivo de materiais"
 
-#: /Users/c.lamboo/ultimaker/Cura/cura/UltimakerCloud/CloudMaterialSync.py:188
+#: cura/UltimakerCloud/CloudMaterialSync.py:188
 msgctxt "@text"
 msgid "Unknown error."
 msgstr "Erro desconhecido."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:545
+#: plugin.json
+msgctxt "name"
+msgid "3MF Reader"
+msgstr "Leitor de 3MF"
+
+#: plugin.json
+msgctxt "name"
+msgid "3MF Writer"
+msgstr "Gerador de 3MF"
+
+#: plugin.json
+msgctxt "name"
+msgid "AMF Reader"
+msgstr "Leitor AMF"
+
+#: plugin.json
+msgctxt "description"
+msgid "Accepts G-Code and sends them to a printer. Plugin can also update firmware."
+msgstr "Aceita G-Code e o envia a uma impressora. O complemento também pode atualizar o firmware."
+
+#: plugin.json
+msgctxt "description"
+msgid "Allows loading and displaying G-code files."
+msgstr "Permite carregar e exibir arquivos G-Code."
+
+#: plugin.json
+msgctxt "description"
+msgid "Backup and restore your configuration."
+msgstr "Permite backup e restauração da configuração."
+
+#: plugin.json
+msgctxt "description"
+msgid "Checks for firmware updates."
+msgstr "Verifica por atualizações de firmware."
+
+#: plugin.json
+msgctxt "description"
+msgid "Checks models and print configuration for possible printing issues and give suggestions."
+msgstr "Verifica modelos e configurações de impressão por possíveis problema e dá sugestões."
+
+#: plugin.json
+msgctxt "name"
+msgid "Compressed G-code Reader"
+msgstr "Leitor de G-Code Comprimido"
+
+#: plugin.json
+msgctxt "name"
+msgid "Compressed G-code Writer"
+msgstr "Gerador de G-Code Comprimido"
+
+#: plugin.json
+msgctxt "description"
+msgid "Connects to the Digital Library, allowing Cura to open files from and save files to the Digital Library."
+msgstr "Conecta-se à Digital Library, permitindo ao Cura abrir arquivos dela e gravar arquivos nela."
+
+#: plugin.json
+msgctxt "description"
+msgid "Creates an eraser mesh to block the printing of support in certain places"
+msgstr "Cria uma malha apagadora para bloquear a impressão de suporte em certos lugares"
+
+#: plugin.json
+msgctxt "name"
+msgid "Cura Backups"
+msgstr "Backups Cura"
+
+#: plugin.json
+msgctxt "name"
+msgid "Cura Profile Reader"
+msgstr "Leitor de Perfis do Cura"
+
+#: plugin.json
+msgctxt "name"
+msgid "Cura Profile Writer"
+msgstr "Gravador de Perfis do Cura"
+
+#: plugin.json
+msgctxt "name"
+msgid "CuraEngine Backend"
+msgstr "CuraEngine Backend"
+
+#: plugin.json
+msgctxt "description"
+msgid "Enables ability to generate printable geometry from 2D image files."
+msgstr "Habilita a geração de geometria imprimível de arquivos de imagem 2D."
+
+#: plugin.json
+msgctxt "description"
+msgid "Extension that allows for user created scripts for post processing"
+msgstr "Extensão que permite scripts criados por usuários para pós-processamento"
+
+#: plugin.json
+msgctxt "name"
+msgid "Firmware Update Checker"
+msgstr "Verificador de Atualizações de Firmware"
+
+#: plugin.json
+msgctxt "name"
+msgid "Firmware Updater"
+msgstr "Atualizador de Firmware"
+
+#: plugin.json
+msgctxt "name"
+msgid "G-code Profile Reader"
+msgstr "Leitor de Perfil de G-Code"
+
+#: plugin.json
+msgctxt "name"
+msgid "G-code Reader"
+msgstr "Leitor de G-Code"
+
+#: plugin.json
+msgctxt "name"
+msgid "G-code Writer"
+msgstr "Gerador de G-Code"
+
+#: plugin.json
+msgctxt "name"
+msgid "Image Reader"
+msgstr "Leitor de Imagens"
+
+#: plugin.json
+msgctxt "name"
+msgid "Legacy Cura Profile Reader"
+msgstr "Leitor de Perfis de Cura Legado"
+
+#: plugin.json
+msgctxt "description"
+msgid "Logs certain events so that they can be used by the crash reporter"
+msgstr "Registra certos eventos de forma que possam ser usados pelo relator de acidentes"
+
+#: plugin.json
+msgctxt "name"
+msgid "Machine Settings Action"
+msgstr "Ação de Ajustes de Máquina"
+
+#: plugin.json
+#, fuzzy
+msgctxt "description"
+msgid "Manages extensions to the application and allows browsing extensions from the Ultimaker website."
+msgstr "Gerencia extensões à aplicação e permite navegar extensões do sítio web da UltiMaker."
+
+#: plugin.json
+#, fuzzy
+msgctxt "description"
+msgid "Manages network connections to Ultimaker networked printers."
+msgstr "Administra conexões de rede a impressora UltiMaker conectadas."
+
+#: plugin.json
+msgctxt "name"
+msgid "Marketplace"
+msgstr "Marketplace"
+
+#: plugin.json
+msgctxt "name"
+msgid "Material Profiles"
+msgstr "Perfis de Material"
+
+#: plugin.json
+msgctxt "name"
+msgid "Model Checker"
+msgstr "Verificador de Modelo"
+
+#: plugin.json
+msgctxt "name"
+msgid "Monitor Stage"
+msgstr "Estágio de Monitor"
+
+#: plugin.json
+msgctxt "name"
+msgid "Per Model Settings Tool"
+msgstr "Ferramenta de Ajustes Por Modelo"
+
+#: plugin.json
+msgctxt "name"
+msgid "Post Processing"
+msgstr "Pós-processamento"
+
+#: plugin.json
+msgctxt "name"
+msgid "Prepare Stage"
+msgstr "Estágio de Preparação"
+
+#: plugin.json
+msgctxt "name"
+msgid "Preview Stage"
+msgstr "Estágio de Pré-visualização"
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides a machine actions for updating firmware."
+msgstr "Provê ações de máquina para atualização do firmware."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides a monitor stage in Cura."
+msgstr "Provê um estágio de monitor no Cura."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides a normal solid mesh view."
+msgstr "Provê uma visualização de malha sólida normal."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides a prepare stage in Cura."
+msgstr "Provê um estágio de preparação no Cura."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides a preview stage in Cura."
+msgstr "Provê uma etapa de pré-visualização ao Cura."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides a way to change machine settings (such as build volume, nozzle size, etc.)."
+msgstr "Provê uma maneira de alterar ajustes de máquina (tais como volume de impressão, tamanho do bico, etc.)."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides capabilities to read and write XML-based material profiles."
+msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
+
+#: plugin.json
+#, fuzzy
+msgctxt "description"
+msgid "Provides machine actions for Ultimaker machines (such as bed leveling wizard, selecting upgrades, etc.)."
+msgstr "Provê ações de máquina para impressoras da UltiMaker (tais como assistente de nivelamento de mesa, seleção de atualizações, etc.)."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides removable drive hotplugging and writing support."
+msgstr "Provê suporte a escrita e reconhecimento de drives a quente."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for exporting Cura profiles."
+msgstr "Provê suporte à exportação de perfis do Cura."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for importing Cura profiles."
+msgstr "Provê suporte à importação de perfis do Cura."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for importing profiles from g-code files."
+msgstr "Provê suporte a importar perfis de arquivos G-Code."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for importing profiles from legacy Cura versions."
+msgstr "Provê suporte a importação de perfis de versões legadas do Cura."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for reading 3MF files."
+msgstr "Provê suporte à leitura de arquivos 3MF."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for reading AMF files."
+msgstr "Provê suporta à leitura de arquivos AMF."
+
+#: plugin.json
+#, fuzzy
+msgctxt "description"
+msgid "Provides support for reading Ultimaker Format Packages."
+msgstr "Provê suporte a leitura de Pacotes de Formato UltiMaker (UFP)."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for reading X3D files."
+msgstr "Provê suporte à leitura de arquivos X3D."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for reading model files."
+msgstr "Provê suporta a ler arquivos de modelo."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides support for writing 3MF files."
+msgstr "Provê suporte à escrita de arquivos 3MF."
+
+#: plugin.json
+#, fuzzy
+msgctxt "description"
+msgid "Provides support for writing Ultimaker Format Packages."
+msgstr "Provê suporte para a escrita de UltiMaker Format Packages (Pacotes de Formato da Ultimaker)."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides the Per Model Settings."
+msgstr "Provê Ajustes Por Modelo."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides the X-Ray view."
+msgstr "Provê a visão de Raios-X."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides the link to the CuraEngine slicing backend."
+msgstr "Provê a ligação ao backend de fatiamento CuraEngine."
+
+#: plugin.json
+msgctxt "description"
+msgid "Provides the preview of sliced layerdata."
+msgstr "Provê a pré-visualização de dados de camada fatiados."
+
+#: plugin.json
+msgctxt "description"
+msgid "Reads g-code from a compressed archive."
+msgstr "Lê G-Code de um arquivo comprimido."
+
+#: plugin.json
+msgctxt "name"
+msgid "Removable Drive Output Device Plugin"
+msgstr "Complemento de Dispositivo de Escrita Removível"
+
+#: plugin.json
+msgctxt "name"
+msgid "Sentry Logger"
+msgstr "Sentinela para Registro"
+
+#: plugin.json
+msgctxt "name"
+msgid "Simulation View"
+msgstr "Visão Simulada"
+
+#: plugin.json
+msgctxt "name"
+msgid "Slice info"
+msgstr "Informação de fatiamento"
+
+#: plugin.json
+msgctxt "name"
+msgid "Solid View"
+msgstr "Visão Sólida"
+
+#: plugin.json
+msgctxt "description"
+msgid "Submits anonymous slice info. Can be disabled through preferences."
+msgstr "Submete informações de fatiamento anônimas. Pode ser desabilitado nas preferências."
+
+#: plugin.json
+msgctxt "name"
+msgid "Support Eraser"
+msgstr "Apagador de Suporte"
+
+#: plugin.json
+msgctxt "name"
+msgid "Trimesh Reader"
+msgstr "Leitor Trimesh"
+
+#: plugin.json
+msgctxt "name"
+msgid "UFP Reader"
+msgstr "Leitor UFP"
+
+#: plugin.json
+msgctxt "name"
+msgid "UFP Writer"
+msgstr "Gerador de UFP"
+
+#: plugin.json
+msgctxt "name"
+msgid "USB printing"
+msgstr "Impressão USB"
+
+#: plugin.json
+msgctxt "name"
+msgid "Ultimaker Digital Library"
+msgstr "Digital Library da UltiMaker"
+
+#: plugin.json
+#, fuzzy
+msgctxt "name"
+msgid "Ultimaker Network Connection"
+msgstr "Conexão de Rede UltiMaker"
+
+#: plugin.json
+#, fuzzy
+msgctxt "name"
+msgid "Ultimaker machine actions"
+msgstr "Ações de máquina UltiMaker"
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.1 to Cura 2.2."
+msgstr "Atualiza configurações do Cura 2.1 para o Cura 2.2."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.2 to Cura 2.4."
+msgstr "Atualiza configurações do Cura 2.2 para o Cura 2.4."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.5 to Cura 2.6."
+msgstr "Atualiza configurações do Cura 2.5 para o Cura 2.6."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.6 to Cura 2.7."
+msgstr "Atualiza configurações do Cura 2.6 para o Cura 2.7."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 2.7 to Cura 3.0."
+msgstr "Atualiza configuração do Cura 2.7 para o Cura 3.0."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.0 to Cura 3.1."
+msgstr "Atualiza configurações do Cura 3.0 para o Cura 3.1."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.2 to Cura 3.3."
+msgstr "Atualiza configurações do Cura 3.2 para o Cura 3.3."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.3 to Cura 3.4."
+msgstr "Atualiza configuração do Cura 3.3 para o Cura 3.4."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.4 to Cura 3.5."
+msgstr "Atualiza configurações do Cura 3.4 para o Cura 3.5."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 3.5 to Cura 4.0."
+msgstr "Atualiza configuração do Cura 3.5 para o Cura 4.0."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.0 to Cura 4.1."
+msgstr "Atualiza configurações do Cura 4.0 para o Cura 4.1."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.1 to Cura 4.2."
+msgstr "Atualiza configurações do Cura 4.1 para o Cura 4.2."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.11 to Cura 4.12."
+msgstr "Atualiza configurações do Cura 4.11 para o Cura 4.12."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.13 to Cura 5.0."
+msgstr "Atualiza configurações do Cura 4.13 para o Cura 5.0."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.2 to Cura 4.3."
+msgstr "Atualiza configurações do Cura 4.2 para o Cura 4.3."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.3 to Cura 4.4."
+msgstr "Atualiza configurações do Cura 4.3 para o Cura 4.4."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.4 to Cura 4.5."
+msgstr "Atualiza configurações do Cura 4.4 para o Cura 4.5."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.5 to Cura 4.6."
+msgstr "Atualiza configurações do Cura 4.5 para o Cura 4.6."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.6.0 to Cura 4.6.2."
+msgstr "Atualiza configurações do Cura 4.6.0 para o Cura 4.6.2."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.6.2 to Cura 4.7."
+msgstr "Atualiza configurações do Cura 4.6.2 para o Cura 4.7."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.7 to Cura 4.8."
+msgstr "Atualiza configurações do Cura 4.7 para o Cura 4.8."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.8 to Cura 4.9."
+msgstr "Atualiza configurações do Cura 4.8 para o Cura 4.9."
+
+#: plugin.json
+msgctxt "description"
+msgid "Upgrades configurations from Cura 4.9 to Cura 4.10."
+msgstr "Atualiza configurações do Cura 4.9 para o Cura 4.10."
+
+#: plugin.json
+#, fuzzy
+msgctxt "description"
+msgid "Upgrades configurations from Cura 5.2 to Cura 5.3."
+msgstr "Atualiza configurações do Cura 3.2 para o Cura 3.3."
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.1 to 2.2"
+msgstr "Atualização de Versão de 2.1 para 2.2"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.2 to 2.4"
+msgstr "Atualização de Versão de 2.2 para 2.4"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.5 to 2.6"
+msgstr "Atualização de Versão de 2.5 para 2.6"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.6 to 2.7"
+msgstr "Atualização de Versão de 2.6 para 2.7"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 2.7 to 3.0"
+msgstr "Atualização de Versão de 2.7 para 3.0"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.0 to 3.1"
+msgstr "Atualização de Versão 3.0 para 3.1"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.2 to 3.3"
+msgstr "Atualização de Versão de 3.2 para 3.3"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.3 to 3.4"
+msgstr "Atualização de Versão de 3.3 para 3.4"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.4 to 3.5"
+msgstr "Atualização de Versão de 3.4 para 3.5"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 3.5 to 4.0"
+msgstr "Atualização de Versão de 3.5 para 4.0"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.0 to 4.1"
+msgstr "Atualização de Versão de 4.0 para 4.1"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.1 to 4.2"
+msgstr "Atualização de Versão de 4.1 para 4.2"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.11 to 4.12"
+msgstr "Atualização de Versão de 4.11 para 4.12"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.13 to 5.0"
+msgstr "Atualização de Versão de 4.13 para 5.0"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.2 to 4.3"
+msgstr "Atualização de Versão de 4.2 para 4.3"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.3 to 4.4"
+msgstr "Atualização de Versão de 4.3 para 4.4"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.4 to 4.5"
+msgstr "Atualização de Versão de 4.4 para 4.5"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.5 to 4.6"
+msgstr "Atualização de Versão de 4.5 para 4.6"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.6.0 to 4.6.2"
+msgstr "Atualização de Versão de 4.6.0 para 4.6.2"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.6.2 to 4.7"
+msgstr "Atualização de Versão de 4.6.2 para 4.7"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.7 to 4.8"
+msgstr "Atualização de Versão de 4.7 para 4.8"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.8 to 4.9"
+msgstr "Atualização de Versão de 4.8 para 4.9"
+
+#: plugin.json
+msgctxt "name"
+msgid "Version Upgrade 4.9 to 4.10"
+msgstr "Atualização de Versão de 4.9 para 4.10"
+
+#: plugin.json
+#, fuzzy
+msgctxt "name"
+msgid "Version Upgrade 5.2 to 5.3"
+msgstr "Atualização de Versão de 3.2 para 3.3"
+
+#: plugin.json
+msgctxt "description"
+msgid "Writes g-code to a compressed archive."
+msgstr "Escreve em formato G-Code comprimido."
+
+#: plugin.json
+msgctxt "description"
+msgid "Writes g-code to a file."
+msgstr "Escreve em formato G-Code."
+
+#: plugin.json
+msgctxt "name"
+msgid "X-Ray View"
+msgstr "Visão de Raios-X"
+
+#: plugin.json
+msgctxt "name"
+msgid "X3D Reader"
+msgstr "Leitor de X3D"
+
+#: plugins/3MFReader/ThreeMFWorkspaceReader.py:547
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
 msgid "Project file <filename>{0}</filename> contains an unknown machine type <message>{1}</message>. Cannot import the machine. Models will be imported instead."
 msgstr "O arquivo de projeto <filename>{0}</filename> contém um tipo de máquina desconhecido <message>{1}</message>. Não foi possível importar a máquina. Os modelos serão importados ao invés dela."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:548
+#: plugins/3MFReader/ThreeMFWorkspaceReader.py:550
 msgctxt "@info:title"
 msgid "Open Project File"
 msgstr "Abrir Arquivo de Projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:650
+#: plugins/3MFReader/ThreeMFWorkspaceReader.py:631 plugins/3MFReader/WorkspaceDialog.qml:99 plugins/3MFReader/WorkspaceDialog.qml:127 plugins/3MFReader/WorkspaceDialog.qml:134
+#, fuzzy
+msgctxt "@button"
+msgid "Create new"
+msgstr "Criar novos"
+
+#: plugins/3MFReader/ThreeMFWorkspaceReader.py:681
 #, python-brace-format
 msgctxt "@info:error Don't translate the XML tags <filename> or <message>!"
 msgid "Project file <filename>{0}</filename> is suddenly inaccessible: <message>{1}</message>."
 msgstr "O arquivo de projeto <filename>{0}</filename> tornou-se subitamente inacessível: <message>{1}</message>."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:651
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:659
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:678
+#: plugins/3MFReader/ThreeMFWorkspaceReader.py:682 plugins/3MFReader/ThreeMFWorkspaceReader.py:690 plugins/3MFReader/ThreeMFWorkspaceReader.py:709
 msgctxt "@info:title"
 msgid "Can't Open Project File"
 msgstr "Não Foi Possível Abrir o Arquivo de Projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:658
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:676
+#: plugins/3MFReader/ThreeMFWorkspaceReader.py:689 plugins/3MFReader/ThreeMFWorkspaceReader.py:707
 #, python-brace-format
 msgctxt "@info:error Don't translate the XML tags <filename> or <message>!"
 msgid "Project file <filename>{0}</filename> is corrupt: <message>{1}</message>."
 msgstr "Arquivo de projeto <filename>{0}</filename> está corrompido: <message>{1}</message>."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/ThreeMFWorkspaceReader.py:723
-#, python-brace-format
+#: plugins/3MFReader/ThreeMFWorkspaceReader.py:754
+#, fuzzy, python-brace-format
 msgctxt "@info:error Don't translate the XML tag <filename>!"
-msgid "Project file <filename>{0}</filename> is made using profiles that are unknown to this version of UltiMaker Cura."
+msgid "Project file <filename>{0}</filename> is made using profiles that are unknown to this version of Ultimaker Cura."
 msgstr "O arquivo de projeto <filename>{0}</filename> foi feito usando perfis que são desconhecidos para esta versão do UltiMaker Cura."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.py:212
+#: plugins/3MFReader/WorkspaceDialog.py:233
 msgctxt "@title:tab"
 msgid "Recommended"
 msgstr "Recomendado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.py:214
+#: plugins/3MFReader/WorkspaceDialog.py:235
 msgctxt "@title:tab"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.py:390
+#: plugins/3MFReader/WorkspaceDialog.py:411
 msgctxt "@info:status"
 msgid "The material used in this project relies on some material definitions not available in Cura, this might produce undesirable print results. We highly recommend installing the full material package from the Marketplace."
 msgstr "O material usado neste projeto depende de algumas definições de material não disponíveis no Cura e isto pode produzir resultados de impressão indesejáveis. Recomendamos altamente instalar o pacote completo de material do Marketplace."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.py:392
+#: plugins/3MFReader/WorkspaceDialog.py:413
 msgctxt "@info:title"
 msgid "Material profiles not installed"
 msgstr "Perfis de material não instalados"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.py:405
+#: plugins/3MFReader/WorkspaceDialog.py:426
 msgctxt "@action:button"
 msgid "Install Materials"
 msgstr "Instalar Materiais"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:15
+#: plugins/3MFReader/WorkspaceDialog.qml:15
 msgctxt "@title:window"
 msgid "Open Project"
 msgstr "Abrir Projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:64
-msgctxt "@action:ComboBox Update/override existing profile"
-msgid "Update existing"
-msgstr "Atualizar existentes"
-
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:65
-msgctxt "@action:ComboBox Save settings in a new profile"
-msgid "Create new"
-msgstr "Criar novos"
-
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:83
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:61
+#: plugins/3MFReader/WorkspaceDialog.qml:31 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:61
 msgctxt "@action:title"
 msgid "Summary - Cura Project"
 msgstr "Resumo - Projeto do Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:109
-msgctxt "@info:tooltip"
-msgid "How should the conflict in the machine be resolved?"
-msgstr "Como o conflito na máquina deve ser resolvido?"
+#: plugins/3MFReader/WorkspaceDialog.qml:65
+msgctxt "@action:ComboBox Update/override existing profile"
+msgid "Update existing"
+msgstr "Atualizar existentes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:165
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:97
+#: plugins/3MFReader/WorkspaceDialog.qml:66
+msgctxt "@action:ComboBox Save settings in a new profile"
+msgid "Create new"
+msgstr "Criar novos"
+
+#: plugins/3MFReader/WorkspaceDialog.qml:83 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:97
 msgctxt "@action:label"
 msgid "Printer settings"
 msgstr "Ajustes da impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:176
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:106
+#: plugins/3MFReader/WorkspaceDialog.qml:92 plugins/3MFReader/WorkspaceRow.qml:23 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:106
 msgctxt "@action:label"
 msgid "Type"
 msgstr "Tipo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:193
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:121
+#: plugins/3MFReader/WorkspaceDialog.qml:98 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:121
 msgctxt "@action:label"
 msgid "Printer Group"
 msgstr "Grupo de Impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:218
-msgctxt "@info:tooltip"
-msgid "How should the conflict in the profile be resolved?"
-msgstr "Como o conflito no perfil deve ser resolvido?"
+#: plugins/3MFReader/WorkspaceDialog.qml:103
+#, fuzzy
+msgctxt "@action:label"
+msgid "Open With"
+msgstr "Abrir arquivo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:240
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:222
+#: plugins/3MFReader/WorkspaceDialog.qml:104
+msgctxt "@info:tooltip"
+msgid "Printer settings will be updated to match the settings saved with the project."
+msgstr "Os ajustes de impressora serão atualizados para concordar com os ajustes salvos com o projeto."
+
+#: plugins/3MFReader/WorkspaceDialog.qml:156 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:222
 msgctxt "@action:label"
 msgid "Profile settings"
 msgstr "Ajustes de perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:251
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:376
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:121
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:246
+#: plugins/3MFReader/WorkspaceDialog.qml:166 plugins/3MFReader/WorkspaceDialog.qml:238 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:121 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:246
 msgctxt "@action:label"
 msgid "Name"
 msgstr "Nome"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:269
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:263
+#: plugins/3MFReader/WorkspaceDialog.qml:172 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:263
 msgctxt "@action:label"
 msgid "Intent"
 msgstr "Objetivo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:287
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:230
+#: plugins/3MFReader/WorkspaceDialog.qml:178 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:230
 msgctxt "@action:label"
 msgid "Not in profile"
 msgstr "Ausente no perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:293
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:235
+#: plugins/3MFReader/WorkspaceDialog.qml:179 resources/qml/Dialogs/WorkspaceSummaryDialog.qml:235
 msgctxt "@action:label"
 msgid "%1 override"
 msgid_plural "%1 overrides"
 msgstr[0] "%1 sobreposto"
 msgstr[1] "%1 sobrepostos"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:306
+#: plugins/3MFReader/WorkspaceDialog.qml:185
 msgctxt "@action:label"
 msgid "Derivative from"
 msgstr "Derivado de"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:312
+#: plugins/3MFReader/WorkspaceDialog.qml:186
 msgctxt "@action:label"
 msgid "%1, %2 override"
 msgid_plural "%1, %2 overrides"
 msgstr[0] "%1, %2 sobreposição"
 msgstr[1] "%1, %2 sobreposições"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:334
-msgctxt "@info:tooltip"
-msgid "How should the conflict in the material be resolved?"
-msgstr "Como o conflito no material deve ser resolvido?"
-
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:361
+#: plugins/3MFReader/WorkspaceDialog.qml:226
 msgctxt "@action:label"
 msgid "Material settings"
 msgstr "Ajustes de material"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:397
+#: plugins/3MFReader/WorkspaceDialog.qml:280
 msgctxt "@action:label"
 msgid "Setting visibility"
 msgstr "Visibilidade dos ajustes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:406
+#: plugins/3MFReader/WorkspaceDialog.qml:290
 msgctxt "@action:label"
 msgid "Mode"
 msgstr "Modo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:422
-msgctxt "@action:label"
-msgid "Visible settings:"
-msgstr "Ajustes visíveis:"
-
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:427
+#: plugins/3MFReader/WorkspaceDialog.qml:296
 msgctxt "@action:label"
 msgid "%1 out of %2"
 msgstr "%1 de %2"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:448
+#: plugins/3MFReader/WorkspaceDialog.qml:321
 msgctxt "@action:warning"
 msgid "Loading a project will clear all models on the build plate."
 msgstr "Carregar um projeto limpará todos os modelos da mesa de impressão."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:490
+#: plugins/3MFReader/WorkspaceDialog.qml:367
 msgctxt "@label"
 msgid "The material used in this project is currently not installed in Cura.<br/>Install the material profile and reopen the project."
 msgstr "O material usado neste projeto não está instalado atualmente no Cura.<br/>Instale o perfil de material e reabra o projeto."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:515
+#: plugins/3MFReader/WorkspaceDialog.qml:392
 msgctxt "@action:button"
 msgid "Open"
 msgstr "Abrir"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:521
+#: plugins/3MFReader/WorkspaceDialog.qml:398
 msgctxt "@action:button"
 msgid "Open project anyway"
 msgstr "Abrir o projeto mesmo assim"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/WorkspaceDialog.qml:530
+#: plugins/3MFReader/WorkspaceDialog.qml:407
 msgctxt "@action:button"
 msgid "Install missing material"
 msgstr "Instalar material faltante"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/__init__.py:27
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFReader/__init__.py:33
+#: plugins/3MFReader/__init__.py:27 plugins/3MFReader/__init__.py:33
 msgctxt "@item:inlistbox"
 msgid "3MF File"
 msgstr "Arquivo 3MF"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:31
+#: plugins/3MFWriter/ThreeMFWorkspaceWriter.py:31
 msgctxt "@error:zip"
 msgid "3MF Writer plug-in is corrupt."
 msgstr "O complemento de Escrita 3MF está corrompido."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:37
+#: plugins/3MFWriter/ThreeMFWorkspaceWriter.py:37
 msgctxt "@error"
 msgid "There is no workspace yet to write. Please add a printer first."
 msgstr "Não existe espaço de trabalho ainda para a escrita. Por favor adicione uma impressora primeiro."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:64
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:97
+#: plugins/3MFWriter/ThreeMFWorkspaceWriter.py:64 plugins/3MFWriter/ThreeMFWorkspaceWriter.py:97
 msgctxt "@error:zip"
 msgid "No permission to write the workspace here."
 msgstr "Sem permissão para gravar o espaço de trabalho aqui."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFWriter/ThreeMFWorkspaceWriter.py:101
+#: plugins/3MFWriter/ThreeMFWorkspaceWriter.py:101
 msgctxt "@error:zip"
 msgid "The operating system does not allow saving a project file to this location or with this file name."
 msgstr "O sistema operacional não permite salvar um arquivo de projeto nesta localização ou com este nome de arquivo."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFWriter/ThreeMFWriter.py:240
+#: plugins/3MFWriter/ThreeMFWriter.py:240
 msgctxt "@error:zip"
 msgid "Error writing 3mf file."
 msgstr "Erro ao escrever arquivo 3mf."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFWriter/__init__.py:28
+#: plugins/3MFWriter/__init__.py:28
 msgctxt "@item:inlistbox"
 msgid "3MF file"
 msgstr "Arquivo 3MF"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/3MFWriter/__init__.py:36
+#: plugins/3MFWriter/__init__.py:36
 msgctxt "@item:inlistbox"
 msgid "Cura Project 3MF file"
 msgstr "Arquivo de Projeto 3MF do Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/AMFReader/__init__.py:15
+#: plugins/AMFReader/__init__.py:15
 msgctxt "@item:inlistbox"
 msgid "AMF File"
 msgstr "Arquivo AMF"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/CreateBackupJob.py:25
+#: plugins/CuraDrive/src/CreateBackupJob.py:25
 msgctxt "@info:title"
 msgid "Backups"
 msgstr "Backups"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/CreateBackupJob.py:26
+#: plugins/CuraDrive/src/CreateBackupJob.py:26
 msgctxt "@info:backup_status"
 msgid "There was an error while uploading your backup."
 msgstr "Houve um erro ao transferir seu backup."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/CreateBackupJob.py:46
+#: plugins/CuraDrive/src/CreateBackupJob.py:46
 msgctxt "@info:backup_status"
 msgid "Creating your backup..."
 msgstr "Criando seu backup..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/CreateBackupJob.py:55
+#: plugins/CuraDrive/src/CreateBackupJob.py:55
 msgctxt "@info:backup_status"
 msgid "There was an error while creating your backup."
 msgstr "Houve um erro ao criar seu backup."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/CreateBackupJob.py:59
+#: plugins/CuraDrive/src/CreateBackupJob.py:59
 msgctxt "@info:backup_status"
 msgid "Uploading your backup..."
 msgstr "Enviando seu backup..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/CreateBackupJob.py:69
+#: plugins/CuraDrive/src/CreateBackupJob.py:69
 msgctxt "@info:backup_status"
 msgid "Your backup has finished uploading."
 msgstr "Seu backup terminou de ser enviado."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/CreateBackupJob.py:103
+#: plugins/CuraDrive/src/CreateBackupJob.py:103
 msgctxt "@error:file_size"
 msgid "The backup exceeds the maximum file size."
 msgstr "O backup excede o tamanho máximo de arquivo."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/DriveApiService.py:86
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/RestoreBackupJob.py:26
+#: plugins/CuraDrive/src/DriveApiService.py:86 plugins/CuraDrive/src/RestoreBackupJob.py:26
 msgctxt "@info:backup_status"
 msgid "There was an error trying to restore your backup."
 msgstr "Houve um erro ao tentar restaurar seu backup."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/DrivePluginExtension.py:69
+#: plugins/CuraDrive/src/DrivePluginExtension.py:69
 msgctxt "@item:inmenu"
 msgid "Manage backups"
 msgstr "Gerenciar backups"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:22
+#: plugins/CuraDrive/src/qml/components/BackupListFooter.qml:22
 msgctxt "@button"
 msgid "Want more?"
 msgstr "Quer mais?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:31
+#: plugins/CuraDrive/src/qml/components/BackupListFooter.qml:31
 msgctxt "@button"
 msgid "Backup Now"
 msgstr "Backup Agora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:43
+#: plugins/CuraDrive/src/qml/components/BackupListFooter.qml:43
 msgctxt "@checkbox:description"
 msgid "Auto Backup"
 msgstr "Auto Backup"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListFooter.qml:44
+#: plugins/CuraDrive/src/qml/components/BackupListFooter.qml:44
 msgctxt "@checkbox:description"
 msgid "Automatically create a backup each day that Cura is started."
 msgstr "Criar um backup automaticamente toda vez que o Cura iniciar."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:64
+#: plugins/CuraDrive/src/qml/components/BackupListItem.qml:64
 msgctxt "@button"
 msgid "Restore"
 msgstr "Restaurar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:93
+#: plugins/CuraDrive/src/qml/components/BackupListItem.qml:93
 msgctxt "@dialog:title"
 msgid "Delete Backup"
 msgstr "Apagar o Backup"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:94
+#: plugins/CuraDrive/src/qml/components/BackupListItem.qml:94
 msgctxt "@dialog:info"
 msgid "Are you sure you want to delete this backup? This cannot be undone."
 msgstr "Você tem certeza que deseja apagar este backup? Isto não pode ser desfeito."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:102
+#: plugins/CuraDrive/src/qml/components/BackupListItem.qml:102
 msgctxt "@dialog:title"
 msgid "Restore Backup"
 msgstr "Restaurar Backup"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItem.qml:103
+#: plugins/CuraDrive/src/qml/components/BackupListItem.qml:103
 msgctxt "@dialog:info"
 msgid "You will need to restart Cura before your backup is restored. Do you want to close Cura now?"
 msgstr "Você precisará reiniciar o Cura antes que seu backup seja restaurado. Deseja fechar o Cura agora?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:21
+#: plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:21
 msgctxt "@backuplist:label"
 msgid "Cura Version"
 msgstr "Versão do Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:29
+#: plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:29
 msgctxt "@backuplist:label"
 msgid "Machines"
 msgstr "Máquinas"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:37
+#: plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:37
 msgctxt "@backuplist:label"
 msgid "Materials"
 msgstr "Materiais"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:45
+#: plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:45
 msgctxt "@backuplist:label"
 msgid "Profiles"
 msgstr "Perfis"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:53
+#: plugins/CuraDrive/src/qml/components/BackupListItemDetails.qml:53
 msgctxt "@backuplist:label"
 msgid "Plugins"
 msgstr "Complementos"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/main.qml:25
+#: plugins/CuraDrive/src/qml/main.qml:25
 msgctxt "@title:window"
 msgid "Cura Backups"
 msgstr "Backups do Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:28
+#: plugins/CuraDrive/src/qml/pages/BackupsPage.qml:28
 msgctxt "@title"
 msgid "My Backups"
 msgstr "Meus backups"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:36
+#: plugins/CuraDrive/src/qml/pages/BackupsPage.qml:36
 msgctxt "@empty_state"
 msgid "You don't have any backups currently. Use the 'Backup Now' button to create one."
 msgstr "Você não tem nenhum backup atualmente. Use o botão 'Backup Agora' para criar um."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/pages/BackupsPage.qml:55
+#: plugins/CuraDrive/src/qml/pages/BackupsPage.qml:55
 msgctxt "@backup_limit_info"
 msgid "During the preview phase, you'll be limited to 5 visible backups. Remove a backup to see older ones."
 msgstr "Durante a fase de pré-visualização, você estará limitado a 5 backups visíveis. Remova um backup para ver os mais antigos."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/pages/WelcomePage.qml:34
+#: plugins/CuraDrive/src/qml/pages/WelcomePage.qml:34
 msgctxt "@description"
 msgid "Backup and synchronize your Cura settings."
 msgstr "Fazer backup e sincronizar os ajustes do Cura."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraDrive/src/qml/pages/WelcomePage.qml:47
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/GeneralOperations.qml:49
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:180
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/CloudContent.qml:212
+#: plugins/CuraDrive/src/qml/pages/WelcomePage.qml:47 resources/qml/Account/GeneralOperations.qml:49 resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:180 resources/qml/WelcomePages/CloudContent.qml:212
 msgctxt "@button"
 msgid "Sign in"
 msgstr "Entrar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:162
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:162
 msgctxt "@message"
 msgid "Slicing failed with an unexpected error. Please consider reporting a bug on our issue tracker."
 msgstr "O fatiamento falhou com um erro não esperado. Por favor considere relatar um bug em nosso issue tracker."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:163
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:163
 msgctxt "@message:title"
 msgid "Slicing failed"
 msgstr "Fatiamento falhado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:168
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:168
 msgctxt "@message:button"
 msgid "Report a bug"
 msgstr "Relatar um bug"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:169
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:169
 msgctxt "@message:description"
 msgid "Report a bug on UltiMaker Cura's issue tracker."
 msgstr "Relatar um bug no issue tracker do UltiMaker Cura."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:401
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:401
 msgctxt "@info:status"
 msgid "Unable to slice with the current material as it is incompatible with the selected machine or configuration."
 msgstr "Não foi possível fatiar com o material atual visto que é incompatível com a máquina ou configuração selecionada."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:402
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:435
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:462
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:474
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:486
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:499
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:402 plugins/CuraEngineBackend/CuraEngineBackend.py:435 plugins/CuraEngineBackend/CuraEngineBackend.py:462 plugins/CuraEngineBackend/CuraEngineBackend.py:474 plugins/CuraEngineBackend/CuraEngineBackend.py:486 plugins/CuraEngineBackend/CuraEngineBackend.py:499
 msgctxt "@info:title"
 msgid "Unable to slice"
 msgstr "Não foi possível fatiar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:434
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:434
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Unable to slice with the current settings. The following settings have errors: {0}"
 msgstr "Não foi possível fatiar com os ajustes atuais. Os seguintes ajustes têm erros: {0}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:461
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:461
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Unable to slice due to some per-model settings. The following settings have errors on one or more models: {error_labels}"
 msgstr "Não foi possível fatiar devido a alguns ajustes por modelo. Os seguintes ajustes têm erros em um dos modelos ou mais: {error_labels}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:473
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:473
 msgctxt "@info:status"
 msgid "Unable to slice because the prime tower or prime position(s) are invalid."
 msgstr "Não foi possível fatiar porque a torre de purga ou posição de purga são inválidas."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:485
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:485
 #, python-format
 msgctxt "@info:status"
 msgid "Unable to slice because there are objects associated with disabled Extruder %s."
 msgstr "Não foi possível fatiar porque há objetos associados com o Extrusor desabilitado %s."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/CuraEngineBackend.py:495
+#: plugins/CuraEngineBackend/CuraEngineBackend.py:495
 msgctxt "@info:status"
 msgid ""
 "Please review settings and check if your models:\n"
@@ -1667,890 +1870,867 @@ msgstr ""
 "- Estão associados a um extrusor habilitado\n"
 "- Não estão todos configurados como malhas de modificação"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:52
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:260
+#: plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:52 plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:260
 msgctxt "@info:status"
 msgid "Processing Layers"
 msgstr "Processando Camadas"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:261
+#: plugins/CuraEngineBackend/ProcessSlicedLayersJob.py:261
 msgctxt "@info:title"
 msgid "Information"
 msgstr "Informação"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraProfileReader/__init__.py:14
-#: /Users/c.lamboo/ultimaker/Cura/plugins/CuraProfileWriter/__init__.py:14
+#: plugins/CuraProfileReader/__init__.py:14 plugins/CuraProfileWriter/__init__.py:14
 msgctxt "@item:inlistbox"
 msgid "Cura Profile"
 msgstr "Perfil do Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/DigitalLibrary/resources/qml/SaveProjectFilesPage.qml:216
+#: plugins/DigitalLibrary/resources/qml/SaveProjectFilesPage.qml:216
 msgctxt "@option"
 msgid "Save Cura project and print file"
 msgstr "Salvar o projeto Cura e imprimir o arquivo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/DigitalLibrary/resources/qml/SaveProjectFilesPage.qml:217
+#: plugins/DigitalLibrary/resources/qml/SaveProjectFilesPage.qml:217
 msgctxt "@option"
 msgid "Save Cura project"
 msgstr "Salvar o projeto Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/DigitalLibrary/src/DigitalFactoryProjectResponse.py:19
+#: plugins/DigitalLibrary/src/DigitalFactoryProjectResponse.py:19
 msgctxt "@text Placeholder for the username if it has been deleted"
 msgid "deleted user"
 msgstr "usuário removido"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerJob.py:127
+#: plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerJob.py:127
 msgctxt "@info"
 msgid "Could not access update information."
 msgstr "Não foi possível acessar informação de atualização."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:17
+#: plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:17
 #, python-brace-format
 msgctxt "@info Don't translate {machine_name}, since it gets replaced by a printer name!"
 msgid "New features or bug-fixes may be available for your {machine_name}! If you haven't done so already, it is recommended to update the firmware on your printer to version {latest_version}."
 msgstr "Novos recursos ou consertos de bugs podem estar disponíveis para sua {machine_name}! Se você não o fez ainda, recomenda-se que atualize o firmware de sua impressora para a versão {latest_version}."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:22
+#: plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:22
 #, python-format
 msgctxt "@info:title The %s gets replaced with the printer name."
 msgid "New %s stable firmware available"
 msgstr "Novo firmware estável de %s disponível"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:28
+#: plugins/FirmwareUpdateChecker/FirmwareUpdateCheckerMessage.py:28
 msgctxt "@action:button"
 msgid "How to update"
 msgstr "Como atualizar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.py:27
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.py:27
 msgctxt "@action"
 msgid "Update Firmware"
 msgstr "Atualizar Firmware"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:31
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:31
 msgctxt "@title"
 msgid "Update Firmware"
 msgstr "Atualizar Firmware"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:37
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:37
 msgctxt "@label"
 msgid "Firmware is the piece of software running directly on your 3D printer. This firmware controls the step motors, regulates the temperature and ultimately makes your printer work."
 msgstr "O firmware é o software rodando diretamente no maquinário de sua impressora 3D. Este firmware controla os motores de passo, regula a temperatura e é o que faz a sua impressora funcionar."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:43
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:43
 msgctxt "@label"
 msgid "The firmware shipping with new printers works, but new versions tend to have more features and improvements."
 msgstr "O firmware que já vêm embutido nas novas impressoras funciona, mas novas versões costumam ter mais recursos, correções e melhorias."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:55
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:55
 msgctxt "@action:button"
 msgid "Automatically upgrade Firmware"
 msgstr "Automaticamente atualizar Firmware"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:66
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:66
 msgctxt "@action:button"
 msgid "Upload custom Firmware"
 msgstr "Carregar Firmware personalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:79
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:79
 msgctxt "@label"
 msgid "Firmware can not be updated because there is no connection with the printer."
 msgstr "O firmware não pode ser atualizado porque não há conexão com a impressora."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:86
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:86
 msgctxt "@label"
 msgid "Firmware can not be updated because the connection with the printer does not support upgrading firmware."
 msgstr "O firmware não pode ser atualizado porque a conexão com a impressora não suporta atualização de firmware."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:93
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:93
 msgctxt "@title:window"
 msgid "Select custom firmware"
 msgstr "Selecionar firmware personalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:113
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:113
 msgctxt "@title:window"
 msgid "Firmware Update"
 msgstr "Atualização do Firmware"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:137
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:137
 msgctxt "@label"
 msgid "Updating firmware."
 msgstr "Atualizando firmware."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:139
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:139
 msgctxt "@label"
 msgid "Firmware update completed."
 msgstr "Atualização do Firmware completada."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:141
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:141
 msgctxt "@label"
 msgid "Firmware update failed due to an unknown error."
 msgstr "A atualização de Firmware falhou devido a um erro desconhecido."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:143
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:143
 msgctxt "@label"
 msgid "Firmware update failed due to an communication error."
 msgstr "A atualização de firmware falhou devido a um erro de comunicação."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:145
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:145
 msgctxt "@label"
 msgid "Firmware update failed due to an input/output error."
 msgstr "A atualização de firmware falhou devido a um erro de entrada e saída."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:147
+#: plugins/FirmwareUpdater/FirmwareUpdaterMachineAction.qml:147
 msgctxt "@label"
 msgid "Firmware update failed due to missing firmware."
 msgstr "A atualização de firmware falhou devido a firmware não encontrado."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeGzReader/__init__.py:17
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeGzWriter/__init__.py:17
+#: plugins/GCodeGzReader/__init__.py:17 plugins/GCodeGzWriter/__init__.py:17
 msgctxt "@item:inlistbox"
 msgid "Compressed G-code File"
 msgstr "Arquivo de G-Code Comprimido"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeGzWriter/GCodeGzWriter.py:43
+#: plugins/GCodeGzWriter/GCodeGzWriter.py:43
 msgctxt "@error:not supported"
 msgid "GCodeGzWriter does not support text mode."
 msgstr "O GCodeGzWriter não suporta modo binário."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeProfileReader/__init__.py:14
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeReader/__init__.py:14
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeWriter/__init__.py:16
+#: plugins/GCodeProfileReader/__init__.py:14 plugins/GCodeReader/__init__.py:14 plugins/GCodeWriter/__init__.py:16
 msgctxt "@item:inlistbox"
 msgid "G-code File"
 msgstr "Arquivo G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeReader/FlavorParser.py:350
+#: plugins/GCodeReader/FlavorParser.py:350
 msgctxt "@info:status"
 msgid "Parsing G-code"
 msgstr "Interpretando G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeReader/FlavorParser.py:352
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeReader/FlavorParser.py:506
+#: plugins/GCodeReader/FlavorParser.py:352 plugins/GCodeReader/FlavorParser.py:506
 msgctxt "@info:title"
 msgid "G-code Details"
 msgstr "Detalhes do G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeReader/FlavorParser.py:504
+#: plugins/GCodeReader/FlavorParser.py:504
 msgctxt "@info:generic"
 msgid "Make sure the g-code is suitable for your printer and printer configuration before sending the file to it. The g-code representation may not be accurate."
 msgstr "Certifique que o g-code é adequado para sua impressora e configuração antes de enviar o arquivo. A representação de g-code pode não ser acurada."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeReader/__init__.py:18
+#: plugins/GCodeReader/__init__.py:18
 msgctxt "@item:inlistbox"
 msgid "G File"
 msgstr "Arquivo G"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeWriter/GCodeWriter.py:75
+#: plugins/GCodeWriter/GCodeWriter.py:75
 msgctxt "@error:not supported"
 msgid "GCodeWriter does not support non-text mode."
 msgstr "O GCodeWriter não suporta modo binário."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeWriter/GCodeWriter.py:81
-#: /Users/c.lamboo/ultimaker/Cura/plugins/GCodeWriter/GCodeWriter.py:97
+#: plugins/GCodeWriter/GCodeWriter.py:81 plugins/GCodeWriter/GCodeWriter.py:97
 msgctxt "@warning:status"
 msgid "Please prepare G-code before exporting."
 msgstr "Por favor prepare o G-Code antes de exportar."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:14
+#: plugins/ImageReader/ConfigUI.qml:14
 msgctxt "@title:window"
 msgid "Convert Image"
 msgstr "Converter Imagem"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:33
+#: plugins/ImageReader/ConfigUI.qml:33
 msgctxt "@action:label"
 msgid "Height (mm)"
 msgstr "Altura (mm)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:56
+#: plugins/ImageReader/ConfigUI.qml:56
 msgctxt "@info:tooltip"
 msgid "The maximum distance of each pixel from \"Base.\""
 msgstr "A distância máxima de cada pixel da \"Base\"."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:66
+#: plugins/ImageReader/ConfigUI.qml:66
 msgctxt "@action:label"
 msgid "Base (mm)"
 msgstr "Base (mm)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:90
+#: plugins/ImageReader/ConfigUI.qml:90
 msgctxt "@info:tooltip"
 msgid "The base height from the build plate in millimeters."
 msgstr "A altura-base da mesa de impressão em milímetros."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:100
+#: plugins/ImageReader/ConfigUI.qml:100
 msgctxt "@action:label"
 msgid "Width (mm)"
 msgstr "Largura (mm)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:124
+#: plugins/ImageReader/ConfigUI.qml:124
 msgctxt "@info:tooltip"
 msgid "The width in millimeters on the build plate"
 msgstr "A largura em milímetros na plataforma de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:134
+#: plugins/ImageReader/ConfigUI.qml:134
 msgctxt "@action:label"
 msgid "Depth (mm)"
 msgstr "Profundidade (mm)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:158
+#: plugins/ImageReader/ConfigUI.qml:158
 msgctxt "@info:tooltip"
 msgid "The depth in millimeters on the build plate"
 msgstr "A profundidade da mesa de impressão em milímetros"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:187
+#: plugins/ImageReader/ConfigUI.qml:187
 msgctxt "@item:inlistbox"
 msgid "Darker is higher"
 msgstr "Mais escuro é mais alto"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:188
+#: plugins/ImageReader/ConfigUI.qml:188
 msgctxt "@item:inlistbox"
 msgid "Lighter is higher"
 msgstr "Mais claro é mais alto"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:195
+#: plugins/ImageReader/ConfigUI.qml:195
 msgctxt "@info:tooltip"
 msgid "For lithophanes dark pixels should correspond to thicker locations in order to block more light coming through. For height maps lighter pixels signify higher terrain, so lighter pixels should correspond to thicker locations in the generated 3D model."
 msgstr "Para litofanos, pixels escuros devem corresponder a locais mais espessos para conseguir bloquear mais luz. Para mapas de altura, pixels mais claros significam terreno mais alto, portanto tais pixels devem corresponder a locais mais espessos no modelo 3d gerado."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:205
+#: plugins/ImageReader/ConfigUI.qml:205
 msgctxt "@action:label"
 msgid "Color Model"
 msgstr "Modelo de Cor"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:224
+#: plugins/ImageReader/ConfigUI.qml:224
 msgctxt "@item:inlistbox"
 msgid "Linear"
 msgstr "Linear"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:225
+#: plugins/ImageReader/ConfigUI.qml:225
 msgctxt "@item:inlistbox"
 msgid "Translucency"
 msgstr "Translucidez"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:232
+#: plugins/ImageReader/ConfigUI.qml:232
 msgctxt "@info:tooltip"
 msgid "For lithophanes a simple logarithmic model for translucency is available. For height maps the pixel values correspond to heights linearly."
 msgstr "Para litofanos, um modelo logarítmico simples para translucidez está disponível. Para mapas de altura os valores de pixels correspondem a alturas, linearmente."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:242
+#: plugins/ImageReader/ConfigUI.qml:242
 msgctxt "@action:label"
 msgid "1mm Transmittance (%)"
 msgstr "Transmitância de 1mm (%)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:263
+#: plugins/ImageReader/ConfigUI.qml:263
 msgctxt "@info:tooltip"
 msgid "The percentage of light penetrating a print with a thickness of 1 millimeter. Lowering this value increases the contrast in dark regions and decreases the contrast in light regions of the image."
 msgstr "A porcentagem de luz penetrando uma impressão com espessura de 1 milímetro. Abaixar este valor aumenta o contraste em regiões escuras e diminui o contraste em regiões claras da imagem."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:274
+#: plugins/ImageReader/ConfigUI.qml:274
 msgctxt "@action:label"
 msgid "Smoothing"
 msgstr "Suavização"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:298
+#: plugins/ImageReader/ConfigUI.qml:298
 msgctxt "@info:tooltip"
 msgid "The amount of smoothing to apply to the image."
 msgstr "A quantidade de suavização para aplicar na imagem."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/ConfigUI.qml:329
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:136
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ColorDialog.qml:143
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/RenameDialog.qml:80
+#: plugins/ImageReader/ConfigUI.qml:329 plugins/SliceInfoPlugin/MoreInfoWindow.qml:136 resources/qml/ColorDialog.qml:148 resources/qml/Dialogs/RenameDialog.qml:25
 msgctxt "@action:button"
 msgid "OK"
 msgstr "Ok"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/__init__.py:14
+#: plugins/ImageReader/__init__.py:14
 msgctxt "@item:inlistbox"
 msgid "JPG Image"
 msgstr "Imagem JPG"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/__init__.py:18
+#: plugins/ImageReader/__init__.py:18
 msgctxt "@item:inlistbox"
 msgid "JPEG Image"
 msgstr "Imagem JPEG"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/__init__.py:22
+#: plugins/ImageReader/__init__.py:22
 msgctxt "@item:inlistbox"
 msgid "PNG Image"
 msgstr "Imagem PNG"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/__init__.py:26
+#: plugins/ImageReader/__init__.py:26
 msgctxt "@item:inlistbox"
 msgid "BMP Image"
 msgstr "Imagem BMP"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ImageReader/__init__.py:30
+#: plugins/ImageReader/__init__.py:30
 msgctxt "@item:inlistbox"
 msgid "GIF Image"
 msgstr "Imagem GIF"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/LegacyProfileReader/__init__.py:14
+#: plugins/LegacyProfileReader/__init__.py:14
 msgctxt "@item:inlistbox"
 msgid "Cura 15.04 profiles"
 msgstr "Perfis do Cura 15.04"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsAction.py:32
+#: plugins/MachineSettingsAction/MachineSettingsAction.py:32
 msgctxt "@action"
 msgid "Machine Settings"
 msgstr "Ajustes da Máquina"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsAction.qml:42
+#: plugins/MachineSettingsAction/MachineSettingsAction.qml:42
 msgctxt "@title:tab"
 msgid "Printer"
 msgstr "Impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:63
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:63
 msgctxt "@title:label"
 msgid "Nozzle Settings"
 msgstr "Ajustes do Bico"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:74
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:74
 msgctxt "@label"
 msgid "Nozzle size"
 msgstr "Tamanho do bico"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:78
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:92
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:108
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:123
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:72
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:87
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:102
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:201
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:221
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:241
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:261
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:279
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:78 plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:92 plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:108 plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:123
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:72 plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:87 plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:102 plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:201
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:221 plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:241 plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:261 plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:279
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:85 resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:99
 msgctxt "@label"
 msgid "mm"
 msgstr "mm"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:88
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:88
 msgctxt "@label"
 msgid "Compatible material diameter"
 msgstr "Diâmetro de material compatível"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:104
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:104
 msgctxt "@label"
 msgid "Nozzle offset X"
 msgstr "Deslocamento X do Bico"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:119
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:119
 msgctxt "@label"
 msgid "Nozzle offset Y"
 msgstr "Deslocamento Y do Bico"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:134
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:134
 msgctxt "@label"
 msgid "Cooling Fan Number"
 msgstr "Número da Ventoinha de Resfriamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:162
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:162
 msgctxt "@title:label"
 msgid "Extruder Start G-code"
 msgstr "G-Code Inicial do Extrusor"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:176
+#: plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml:176
 msgctxt "@title:label"
 msgid "Extruder End G-code"
 msgstr "G-Code Final do Extrusor"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:56
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:56
 msgctxt "@title:label"
 msgid "Printer Settings"
 msgstr "Ajustes de Impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:68
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:68
 msgctxt "@label"
 msgid "X (Width)"
 msgstr "X (largura)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:83
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:83
 msgctxt "@label"
 msgid "Y (Depth)"
 msgstr "Y (Profundidade)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:98
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:98
 msgctxt "@label"
 msgid "Z (Height)"
 msgstr "Z (Altura)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:112
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:112
 msgctxt "@label"
 msgid "Build plate shape"
 msgstr "Forma da plataforma de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:125
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:125
 msgctxt "@label"
 msgid "Origin at center"
 msgstr "Origem no centro"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:137
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:137
 msgctxt "@label"
 msgid "Heated bed"
 msgstr "Mesa aquecida"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:149
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:149
 msgctxt "@label"
 msgid "Heated build volume"
 msgstr "Volume de construção aquecido"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:161
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:161
 msgctxt "@label"
 msgid "G-code flavor"
 msgstr "Sabor de G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:185
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:185
 msgctxt "@title:label"
 msgid "Printhead Settings"
 msgstr "Ajustes da Cabeça de Impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:197
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:197
 msgctxt "@label"
 msgid "X min"
 msgstr "X mín"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:217
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:217
 msgctxt "@label"
 msgid "Y min"
 msgstr "Y mín"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:237
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:237
 msgctxt "@label"
 msgid "X max"
 msgstr "X máx"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:257
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:257
 msgctxt "@label"
 msgid "Y max"
 msgstr "Y máx"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:275
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:275
 msgctxt "@label"
 msgid "Gantry Height"
 msgstr "Altura do Eixo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:289
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:289
 msgctxt "@label"
 msgid "Number of Extruders"
 msgstr "Número de Extrusores"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:341
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:341
 msgctxt "@label"
 msgid "Apply Extruder offsets to GCode"
 msgstr "Aplicar deslocamentos de Extrusão ao G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:389
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:389
 msgctxt "@title:label"
 msgid "Start G-code"
 msgstr "G-Code Inicial"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:400
+#: plugins/MachineSettingsAction/MachineSettingsPrinterTab.qml:400
 msgctxt "@title:label"
 msgid "End G-code"
 msgstr "G-Code Final"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
+#: plugins/Marketplace/CloudSync/CloudPackageChecker.py:144
 msgctxt "@info:generic"
 msgid "Do you want to sync material and software packages with your account?"
 msgstr "Você quer sincronizar os pacotes de material e software com sua conta?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:145
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:95
+#: plugins/Marketplace/CloudSync/CloudPackageChecker.py:145 plugins/Marketplace/CloudSync/DownloadPresenter.py:95
 msgctxt "@info:title"
 msgid "Changes detected from your UltiMaker account"
 msgstr "Alterações detectadas de sua conta UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/CloudPackageChecker.py:147
+#: plugins/Marketplace/CloudSync/CloudPackageChecker.py:147
 msgctxt "@action:button"
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/DownloadPresenter.py:91
+#: plugins/Marketplace/CloudSync/DownloadPresenter.py:91
 msgctxt "@info:generic"
 msgid "Syncing..."
 msgstr "Sincronizando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:12
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:79
+#: plugins/Marketplace/CloudSync/LicenseModel.py:12 plugins/Marketplace/resources/qml/LicenseDialog.qml:79
 msgctxt "@button"
 msgid "Decline"
 msgstr "Recusar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:13
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:53
+#: plugins/Marketplace/CloudSync/LicenseModel.py:13 resources/qml/WelcomePages/UserAgreementContent.qml:53
 msgctxt "@button"
 msgid "Agree"
 msgstr "Concordar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/LicenseModel.py:77
+#: plugins/Marketplace/CloudSync/LicenseModel.py:77
 msgctxt "@title:window"
 msgid "Plugin License Agreement"
 msgstr "Acordo de Licença do Complemento"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/LicensePresenter.py:42
+#: plugins/Marketplace/CloudSync/LicensePresenter.py:42
 msgctxt "@button"
 msgid "Decline and remove from account"
 msgstr "Recusar e remover da conta"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
+#: plugins/Marketplace/CloudSync/RestartApplicationPresenter.py:22
 msgctxt "@info:generic"
 msgid "You need to quit and restart {} before changes have effect."
 msgstr "Você precisa sair e reiniciar {} para que as alterações tenham efeito."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
+#: plugins/Marketplace/CloudSync/SyncOrchestrator.py:79
 msgctxt "@info:generic"
 msgid "{} plugins failed to download"
 msgstr "{} complementos falharam em baixar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/LocalPackageList.py:28
+#: plugins/Marketplace/LocalPackageList.py:28
 msgctxt "@label"
 msgid "Installed Plugins"
 msgstr "Complementos Instalados"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/LocalPackageList.py:29
+#: plugins/Marketplace/LocalPackageList.py:29
 msgctxt "@label"
 msgid "Installed Materials"
 msgstr "Materiais Instalados"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/LocalPackageList.py:33
+#: plugins/Marketplace/LocalPackageList.py:33
 msgctxt "@label"
 msgid "Bundled Plugins"
 msgstr "Complementos Empacotados"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/LocalPackageList.py:34
+#: plugins/Marketplace/LocalPackageList.py:34
 msgctxt "@label"
 msgid "Bundled Materials"
 msgstr "Materiais Empacotados"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/PackageModel.py:43
+#: plugins/Marketplace/PackageModel.py:43
 msgctxt "@label:property"
 msgid "Unknown Package"
 msgstr "Pacote Desconhecido"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/PackageModel.py:66
+#: plugins/Marketplace/PackageModel.py:66
 msgctxt "@label:property"
 msgid "Unknown Author"
 msgstr "Autor Desconhecido"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/RemotePackageList.py:117
+#: plugins/Marketplace/PackageModel.py:95
+msgctxt "@label:label Ultimaker Marketplace is a brand name, don't translate"
+msgid "The material package associated with the Cura project could not be found on the Ultimaker Marketplace. Use the partial material profile definition stored in the Cura project file at your own risk."
+msgstr "O pacote de material associado com este projeto Cura não pôde ser encontrado no Ultimaker Marketplace. Use a definição parcial de perfil de material gravada no arquivo de projeto Cura por seu próprio risco."
+
+#: plugins/Marketplace/RemotePackageList.py:117
 msgctxt "@info:error"
 msgid "Could not interpret the server's response."
 msgstr "Não foi possível interpretar a resposta de servidor."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/RemotePackageList.py:148
+#: plugins/Marketplace/RemotePackageList.py:148
 msgctxt "@info:error"
 msgid "Could not reach Marketplace."
 msgstr "Não foi possível conectar ao Marketplace."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
+#: plugins/Marketplace/resources/qml/CompatibilityDialog.qml:15
 msgctxt "@title"
 msgid "Changes from your account"
 msgstr "Alterações da sua conta"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
+#: plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
 msgctxt "@button"
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:118
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/FirstStartMachineActionsContent.qml:76
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/WhatsNewContent.qml:175
+#: plugins/Marketplace/resources/qml/CompatibilityDialog.qml:24 resources/qml/WelcomePages/DataCollectionsContent.qml:118 resources/qml/WelcomePages/FirstStartMachineActionsContent.qml:76 resources/qml/WelcomePages/WhatsNewContent.qml:175
 msgctxt "@button"
 msgid "Next"
 msgstr "Próximo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
+#: plugins/Marketplace/resources/qml/CompatibilityDialog.qml:52
 msgctxt "@label"
 msgid "The following packages will be added:"
 msgstr "Os seguintes pacotes serão adicionados:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/CompatibilityDialog.qml:94
+#: plugins/Marketplace/resources/qml/CompatibilityDialog.qml:94
 msgctxt "@label"
 msgid "The following packages can not be installed because of an incompatible Cura version:"
 msgstr "Os seguintes pacotes não podem ser instalados por incompatibilidade de versão do Cura:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/InstallMissingPackagesDialog.qml:15
+#: plugins/Marketplace/resources/qml/InstallMissingPackagesDialog.qml:15
 msgctxt "@title"
 msgid "Install missing Materials"
 msgstr "Instalar Materiais faltantes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:15
+#: plugins/Marketplace/resources/qml/LicenseDialog.qml:15
 msgctxt "@button"
 msgid "Plugin license agreement"
 msgstr "Acordo de licença do complemento"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:47
+#: plugins/Marketplace/resources/qml/LicenseDialog.qml:47
 msgctxt "@text"
 msgid "Please read and agree with the plugin licence."
 msgstr "Por favor leia e concorde com a licença do complemento."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/LicenseDialog.qml:70
+#: plugins/Marketplace/resources/qml/LicenseDialog.qml:70
 msgctxt "@button"
 msgid "Accept"
 msgstr "Aceitar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/ManagePackagesButton.qml:32
+#: plugins/Marketplace/resources/qml/ManagePackagesButton.qml:32
 msgctxt "@info:tooltip"
 msgid "Manage packages"
 msgstr "Gerir pacotes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/ManagedPackages.qml:11
+#: plugins/Marketplace/resources/qml/ManagedPackages.qml:12
 msgctxt "@header"
 msgid "Manage packages"
 msgstr "Gerir pacotes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/ManagedPackages.qml:15
+#: plugins/Marketplace/resources/qml/ManagedPackages.qml:16
 msgctxt "@text"
 msgid "Manage your UltiMaker Cura plugins and material profiles here. Make sure to keep your plugins up to date and backup your setup regularly."
 msgstr "Gerencie seu complementos e perfis de materiais do Cura aqui. Se assegure de manter seus complementos atualizados e fazer backup de sua configuração regularmente."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:87
+#: plugins/Marketplace/resources/qml/Marketplace.qml:87
 msgctxt "@title"
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:148
+#: plugins/Marketplace/resources/qml/Marketplace.qml:148
 msgctxt "@button"
 msgid "Plugins"
 msgstr "Complementos"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:156
+#: plugins/Marketplace/resources/qml/Marketplace.qml:156
 msgctxt "@button"
 msgid "Materials"
 msgstr "Materiais"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:193
+#: plugins/Marketplace/resources/qml/Marketplace.qml:193
 msgctxt "@info"
 msgid "Search in the browser"
 msgstr "Buscar no navegador"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:271
+#: plugins/Marketplace/resources/qml/Marketplace.qml:271
 msgctxt "@button"
 msgid "In order to use the package you will need to restart Cura"
 msgstr "Para usar o pacote você precisará reiniciar o Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Marketplace.qml:279
+#: plugins/Marketplace/resources/qml/Marketplace.qml:279
 msgctxt "@info:button, %1 is the application name"
 msgid "Quit %1"
 msgstr "Sair de %1"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Materials.qml:8
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/MissingPackages.qml:8
+#: plugins/Marketplace/resources/qml/Materials.qml:8 plugins/Marketplace/resources/qml/MissingPackages.qml:8
 msgctxt "@header"
 msgid "Install Materials"
 msgstr "Instalar Materiais"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Materials.qml:12
+#: plugins/Marketplace/resources/qml/Materials.qml:12
 msgctxt "@text"
 msgid "Select and install material profiles optimised for your UltiMaker 3D printers."
 msgstr "Selecione e instale perfis de material otimizados para suas impressoras 3D UltiMaker."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
+#: plugins/Marketplace/resources/qml/MultipleLicenseDialog.qml:35
 msgctxt "@label"
 msgid "You need to accept the license to install the package"
 msgstr "Você precisa aceitar a licença para que o pacote possa ser instalado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/OnboardBanner.qml:101
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:207
+#: plugins/Marketplace/resources/qml/OnboardBanner.qml:101 plugins/Marketplace/resources/qml/PackageCardHeader.qml:205
 msgctxt "@button:label"
 msgid "Learn More"
 msgstr "Saiba mais"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:172
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:170
 msgctxt "@label Is followed by the name of an author"
 msgid "By"
 msgstr "Por"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:226
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:224
 msgctxt "@button"
 msgid "Disable"
 msgstr "Desabilitar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:226
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:224
 msgctxt "@button"
 msgid "Enable"
 msgstr "Habilitar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:244
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:242
 msgctxt "@button"
 msgid "Downgrading..."
 msgstr "Fazendo downgrade..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:245
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:243
 msgctxt "@button"
 msgid "Downgrade"
 msgstr "Downgrade"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:249
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:247
 msgctxt "@button"
 msgid "Installing..."
 msgstr "Instalando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:250
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:248
 msgctxt "@button"
 msgid "Install"
 msgstr "Instalar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:254
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:252
 msgctxt "@button"
 msgid "Uninstall"
 msgstr "Desinstalar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:269
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:267
 msgctxt "@button"
 msgid "Update"
 msgstr "Atualizar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageCardHeader.qml:269
+#: plugins/Marketplace/resources/qml/PackageCardHeader.qml:267
 msgctxt "@button"
 msgid "Updating..."
 msgstr "Atualizando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageDetails.qml:15
+#: plugins/Marketplace/resources/qml/PackageDetails.qml:15
 msgctxt "@header"
 msgid "Package details"
 msgstr "Detalhes do pacote"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackageDetails.qml:40
+#: plugins/Marketplace/resources/qml/PackageDetails.qml:40
 msgctxt "@button:tooltip"
 msgid "Back"
 msgstr "Voltar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:81
+#: plugins/Marketplace/resources/qml/PackagePage.qml:81
 msgctxt "@header"
 msgid "Description"
 msgstr "Descrição"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:110
+#: plugins/Marketplace/resources/qml/PackagePage.qml:110
 msgctxt "@header"
 msgid "Compatible printers"
 msgstr "Impressoras compatíveis"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:134
+#: plugins/Marketplace/resources/qml/PackagePage.qml:134
 msgctxt "@info"
 msgid "No compatibility information"
 msgstr "Sem informação de compatibilidade"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:152
+#: plugins/Marketplace/resources/qml/PackagePage.qml:152
 msgctxt "@header"
 msgid "Compatible support materials"
 msgstr "Materiais de suporte compatíveis"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:176
+#: plugins/Marketplace/resources/qml/PackagePage.qml:176
 msgctxt "@info No materials"
 msgid "None"
 msgstr "Nenhum"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:193
+#: plugins/Marketplace/resources/qml/PackagePage.qml:193
 msgctxt "@header"
 msgid "Compatible with Material Station"
 msgstr "Compatível com Material Station"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:202
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:228
+#: plugins/Marketplace/resources/qml/PackagePage.qml:202 plugins/Marketplace/resources/qml/PackagePage.qml:228
 msgctxt "@info"
 msgid "No"
 msgstr "Não"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:202
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:228
+#: plugins/Marketplace/resources/qml/PackagePage.qml:202 plugins/Marketplace/resources/qml/PackagePage.qml:228
 msgctxt "@info"
 msgid "Yes"
 msgstr "Sim"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:219
+#: plugins/Marketplace/resources/qml/PackagePage.qml:219
 msgctxt "@header"
 msgid "Optimized for Air Manager"
 msgstr "Otimizado para o Air Manager"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:243
+#: plugins/Marketplace/resources/qml/PackagePage.qml:243
 msgctxt "@button"
 msgid "Visit plug-in website"
 msgstr "Visitar sítio web de complementos"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:243
+#: plugins/Marketplace/resources/qml/PackagePage.qml:243
 msgctxt "@button"
 msgid "Website"
 msgstr "Sítio web"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:252
+#: plugins/Marketplace/resources/qml/PackagePage.qml:252
 msgctxt "@button"
 msgid "Buy spool"
 msgstr "Comprar carretel"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:261
+#: plugins/Marketplace/resources/qml/PackagePage.qml:261
 msgctxt "@button"
 msgid "Safety datasheet"
 msgstr "Ficha de segurança"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/PackagePage.qml:270
+#: plugins/Marketplace/resources/qml/PackagePage.qml:270
 msgctxt "@button"
 msgid "Technical datasheet"
 msgstr "Ficha técnica"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Packages.qml:151
+#: plugins/Marketplace/resources/qml/Packages.qml:151
 msgctxt "@button"
 msgid "Failed to load packages:"
 msgstr "Falha em carregar pacotes:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Packages.qml:151
+#: plugins/Marketplace/resources/qml/Packages.qml:151
 msgctxt "@button"
 msgid "Retry?"
 msgstr "Tentar novamente?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Packages.qml:167
+#: plugins/Marketplace/resources/qml/Packages.qml:167
 msgctxt "@button"
 msgid "Loading"
 msgstr "Carregando"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Packages.qml:183
+#: plugins/Marketplace/resources/qml/Packages.qml:183
 msgctxt "@message"
 msgid "No more results to load"
 msgstr "Não há mais resultados a carregar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Packages.qml:183
+#: plugins/Marketplace/resources/qml/Packages.qml:183
 msgctxt "@message"
 msgid "No results found with current filter"
 msgstr "Não há resultados encontrados com o filtro atual"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Packages.qml:226
+#: plugins/Marketplace/resources/qml/Packages.qml:226
 msgctxt "@button"
 msgid "Load more"
 msgstr "Carregar mais"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Plugins.qml:8
+#: plugins/Marketplace/resources/qml/Plugins.qml:8
 msgctxt "@header"
 msgid "Install Plugins"
 msgstr "Instalar Complementos"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/Plugins.qml:12
+#: plugins/Marketplace/resources/qml/Plugins.qml:12
 msgctxt "@text"
 msgid "Streamline your workflow and customize your UltiMaker Cura experience with plugins contributed by our amazing community of users."
 msgstr "Simplifique seu fluxo de trabalho e personalize sua experiência do UltiMaker Cura com complementos contribuídos por nossa fantástica comunidade de usuários."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:21
+#: plugins/Marketplace/resources/qml/VerifiedIcon.qml:21
 msgctxt "@info"
 msgid "UltiMaker Verified Plug-in"
 msgstr "Complemento Verificado UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:22
+#: plugins/Marketplace/resources/qml/VerifiedIcon.qml:22
 msgctxt "@info"
 msgid "UltiMaker Certified Material"
 msgstr "Material Certificado UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/Marketplace/resources/qml/VerifiedIcon.qml:23
+#: plugins/Marketplace/resources/qml/VerifiedIcon.qml:23
 msgctxt "@info"
 msgid "UltiMaker Verified Package"
 msgstr "Pacote Verificado UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ModelChecker/ModelChecker.py:31
+#: plugins/ModelChecker/ModelChecker.py:31
 msgctxt "@info:title"
 msgid "3D Model Assistant"
 msgstr "Assistente de Modelo 3D"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/ModelChecker/ModelChecker.py:97
+#: plugins/ModelChecker/ModelChecker.py:97
 #, python-brace-format
 msgctxt "@info:status"
 msgid ""
@@ -2564,7 +2744,7 @@ msgstr ""
 "<p>Descubra como assegurar a melhor qualidade de impressão e confiabilidade possível.</p>\n"
 "<p><a href=\"https://ultimaker.com/3D-model-assistant\">Ver guia de qualidade de impressão</a></p>"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MonitorStage/MonitorMain.qml:100
+#: plugins/MonitorStage/MonitorMain.qml:100
 msgctxt "@info"
 msgid ""
 "Please make sure your printer has a connection:\n"
@@ -2577,942 +2757,895 @@ msgstr ""
 "- Verifique se ela está conectada à rede.\n"
 "- Verifique se você está logado para descobrir impressoras conectadas à nuvem."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MonitorStage/MonitorMain.qml:113
+#: plugins/MonitorStage/MonitorMain.qml:113
 msgctxt "@info"
 msgid "Please connect your printer to the network."
 msgstr "Por favor conecte sua impressora à rede."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MonitorStage/MonitorMain.qml:148
+#: plugins/MonitorStage/MonitorMain.qml:148
 msgctxt "@label link to technical assistance"
 msgid "View user manuals online"
 msgstr "Ver manuais de usuário online"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MonitorStage/MonitorMain.qml:164
+#: plugins/MonitorStage/MonitorMain.qml:164
 msgctxt "@info"
 msgid "In order to monitor your print from Cura, please connect the printer."
 msgstr "Para monitorar sua impressão pelo Cura, por favor conecte a impressora."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/MonitorStage/__init__.py:14
+#: plugins/MonitorStage/__init__.py:14
 msgctxt "@item:inmenu"
 msgid "Monitor"
 msgstr "Monitor"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:41
+#: plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:41
 msgctxt "@label"
 msgid "Mesh Type"
 msgstr "Tipo de Malha"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:81
+#: plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:81
 msgctxt "@label"
 msgid "Normal model"
 msgstr "Modelo normal"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:96
+#: plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:96
 msgctxt "@label"
 msgid "Print as support"
 msgstr "Imprimir como suporte"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:111
+#: plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:111
 msgctxt "@label"
 msgid "Modify settings for overlaps"
 msgstr "Modificar ajustes para sobreposições"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:126
+#: plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:126
 msgctxt "@label"
 msgid "Don't support overlaps"
 msgstr "Não suportar sobreposições"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:159
+#: plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:160
 msgctxt "@item:inlistbox"
 msgid "Infill mesh only"
 msgstr "Somente malha de preenchimento"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:160
+#: plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:161
 msgctxt "@item:inlistbox"
 msgid "Cutting mesh"
 msgstr "Malha de corte"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:385
+#: plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml:386
 msgctxt "@action:button"
 msgid "Select settings"
 msgstr "Selecionar ajustes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:17
+#: plugins/PerObjectSettingsTool/SettingPickDialog.qml:17
 msgctxt "@title:window"
 msgid "Select Settings to Customize for this model"
 msgstr "Selecionar Ajustes a Personalizar para este modelo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:61
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:102
+#: plugins/PerObjectSettingsTool/SettingPickDialog.qml:61 resources/qml/Preferences/SettingVisibilityPage.qml:102
 msgctxt "@label:textbox"
 msgid "Filter..."
 msgstr "Filtrar..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/SettingPickDialog.qml:75
+#: plugins/PerObjectSettingsTool/SettingPickDialog.qml:75
 msgctxt "@label:checkbox"
 msgid "Show all"
 msgstr "Exibir tudo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/__init__.py:14
+#: plugins/PerObjectSettingsTool/__init__.py:14
 msgctxt "@label"
 msgid "Per Model Settings"
 msgstr "Ajustes por Modelo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PerObjectSettingsTool/__init__.py:15
+#: plugins/PerObjectSettingsTool/__init__.py:15
 msgctxt "@info:tooltip"
 msgid "Configure Per Model Settings"
 msgstr "Configurar ajustes por Modelo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:35
+#: plugins/PostProcessingPlugin/PostProcessingPlugin.py:35
 msgctxt "@item:inmenu"
 msgid "Post Processing"
 msgstr "Pós-Processamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.py:36
+#: plugins/PostProcessingPlugin/PostProcessingPlugin.py:36
 msgctxt "@item:inmenu"
 msgid "Modify G-Code"
 msgstr "Modificar G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:17
+#: plugins/PostProcessingPlugin/PostProcessingPlugin.qml:17
 msgctxt "@title:window"
 msgid "Post Processing Plugin"
 msgstr "Complemento de Pós-Processamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:57
+#: plugins/PostProcessingPlugin/PostProcessingPlugin.qml:57
 msgctxt "@label"
 msgid "Post Processing Scripts"
 msgstr "Scripts de Pós-Processamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:215
+#: plugins/PostProcessingPlugin/PostProcessingPlugin.qml:215
 msgctxt "@action"
 msgid "Add a script"
 msgstr "Adicionar um script"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:251
+#: plugins/PostProcessingPlugin/PostProcessingPlugin.qml:251
 msgctxt "@label"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:460
+#: plugins/PostProcessingPlugin/PostProcessingPlugin.qml:460
 msgctxt "@info:tooltip"
 msgid "Change active post-processing scripts."
 msgstr "Alterar scripts de pós-processamento ativos."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PostProcessingPlugin/PostProcessingPlugin.qml:464
+#: plugins/PostProcessingPlugin/PostProcessingPlugin.qml:464
 msgctxt "@info:tooltip"
 msgid "The following script is active:"
 msgid_plural "The following scripts are active:"
 msgstr[0] "O seguinte script está ativo:"
 msgstr[1] "Os seguintes scripts estão ativos:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PrepareStage/__init__.py:12
+#: plugins/PrepareStage/PrepareMenu.qml:74
+msgctxt "@button"
+msgid "Add printer"
+msgstr "Adicionar impressora"
+
+#: plugins/PrepareStage/PrepareMenu.qml:90
+msgctxt "@button"
+msgid "Manage printers"
+msgstr "Gerenciar impressoras"
+
+#: plugins/PrepareStage/__init__.py:12
 msgctxt "@item:inmenu"
 msgid "Prepare"
 msgstr "Preparar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/PreviewStage/__init__.py:13
+#: plugins/PreviewStage/__init__.py:13
 msgctxt "@item:inmenu"
 msgid "Preview"
 msgstr "Pré-visualização"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:23
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:23
 msgctxt "@action:button Preceded by 'Ready to'."
 msgid "Save to Removable Drive"
 msgstr "Salvar em Unidade Removível"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:24
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:24
 #, python-brace-format
 msgctxt "@item:inlistbox"
 msgid "Save to Removable Drive {0}"
 msgstr "Salvar em Unidade Removível {0}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:66
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/MeshFormatHandler.py:118
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:66 plugins/UM3NetworkPrinting/src/MeshFormatHandler.py:118
 msgctxt "@info:status"
 msgid "There are no file formats available to write with!"
 msgstr "Não há formatos de arquivo disponíveis com os quais escrever!"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:109
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:109
 #, python-brace-format
 msgctxt "@info:progress Don't translate the XML tags <filename>!"
 msgid "Saving to Removable Drive <filename>{0}</filename>"
 msgstr "Salvando na Unidade Removível <filename>{0}</filename>"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:110
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:110
 msgctxt "@info:title"
 msgid "Saving"
 msgstr "Salvando"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:120
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:123
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:120 plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:123
 #, python-brace-format
 msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
 msgid "Could not save to <filename>{0}</filename>: <message>{1}</message>"
 msgstr "Não foi possível salvar em <filename>{0}</filename>: <message>{1}</message>"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:139
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:139
 #, python-brace-format
 msgctxt "@info:status Don't translate the tag {device}!"
 msgid "Could not find a file name when trying to write to {device}."
 msgstr "Não foi possível encontrar nome de arquivo ao tentar escrever em {device}."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:152
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:171
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:152 plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:171
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Could not save to removable drive {0}: {1}"
 msgstr "Não foi possível salvar em unidade removível {0}: {1}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:162
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:162
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Saved to Removable Drive {0} as {1}"
 msgstr "Salvo em Unidade Removível {0} como {1}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:163
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:163
 msgctxt "@info:title"
 msgid "File Saved"
 msgstr "Arquivo Salvo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:165
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:165
 msgctxt "@action:button"
 msgid "Eject"
 msgstr "Ejetar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:165
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:165
 #, python-brace-format
 msgctxt "@action"
 msgid "Eject removable device {0}"
 msgstr "Ejetar dispositivo removível {0}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:184
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:184
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Ejected {0}. You can now safely remove the drive."
 msgstr "{0} ejetado. A unidade agora pode ser removida de forma segura."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:185
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:185
 msgctxt "@info:title"
 msgid "Safely Remove Hardware"
 msgstr "Remover Hardware com Segurança"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:188
+#: plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py:188
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Failed to eject {0}. Another program may be using the drive."
 msgstr "Erro ao ejetar {0}. Outro programa pode estar usando a unidade."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/RemovableDriveOutputDevice/WindowsRemovableDrivePlugin.py:76
+#: plugins/RemovableDriveOutputDevice/WindowsRemovableDrivePlugin.py:76
 msgctxt "@item:intext"
 msgid "Removable Drive"
 msgstr "Unidade Removível"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationView.py:129
+#: plugins/SimulationView/SimulationView.py:129
 msgctxt "@info:status"
 msgid "Cura does not accurately display layers when Wire Printing is enabled."
 msgstr "O Cura não exibe camadas de forma precisa quando Impressão em Arame está habilitada."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationView.py:130
+#: plugins/SimulationView/SimulationView.py:130
 msgctxt "@info:title"
 msgid "Simulation View"
 msgstr "Visão Simulada"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationView.py:133
+#: plugins/SimulationView/SimulationView.py:133
 msgctxt "@info:status"
 msgid "Nothing is shown because you need to slice first."
 msgstr "Nada está exibido porque você precisa fatiar primeiro."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationView.py:134
+#: plugins/SimulationView/SimulationView.py:134
 msgctxt "@info:title"
 msgid "No layers to show"
 msgstr "Não há camadas a exibir"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationView.py:136
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SolidView/SolidView.py:74
+#: plugins/SimulationView/SimulationView.py:136 plugins/SolidView/SolidView.py:74
 msgctxt "@info:option_text"
 msgid "Do not show this message again"
 msgstr "Não mostrar essa mensagem novamente"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:18
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:47
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:18 plugins/SimulationView/SimulationViewMenuComponent.qml:47
 msgctxt "@label"
 msgid "Color scheme"
 msgstr "Esquema de Cores"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:104
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:104
 msgctxt "@label:listbox"
 msgid "Material Color"
 msgstr "Cor do Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:108
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:108
 msgctxt "@label:listbox"
 msgid "Line Type"
 msgstr "Tipo de Linha"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:112
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:112
 msgctxt "@label:listbox"
 msgid "Speed"
 msgstr "Velocidade"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:116
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:116
 msgctxt "@label:listbox"
 msgid "Layer Thickness"
 msgstr "Espessura de Camada"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:120
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:120
 msgctxt "@label:listbox"
 msgid "Line Width"
 msgstr "Largura de Extrusão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:124
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:124
 msgctxt "@label:listbox"
 msgid "Flow"
 msgstr "Fluxo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:164
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:164
 msgctxt "@label"
 msgid "Compatibility Mode"
 msgstr "Modo de Compatibilidade"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:231
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:231
 msgctxt "@label"
 msgid "Travels"
 msgstr "Percursos"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:237
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:237
 msgctxt "@label"
 msgid "Helpers"
 msgstr "Assistentes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:243
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:243
 msgctxt "@label"
 msgid "Shell"
 msgstr "Perímetro"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:249
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:74
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:249
 msgctxt "@label"
 msgid "Infill"
 msgstr "Preenchimento"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:257
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:257
 msgctxt "@label"
 msgid "Starts"
 msgstr "Inícios"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:304
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:304
 msgctxt "@label"
 msgid "Only Show Top Layers"
 msgstr "Somente Exibir Camadas Superiores"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:313
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:313
 msgctxt "@label"
 msgid "Show 5 Detailed Layers On Top"
 msgstr "Exibir 5 Camadas Superiores Detalhadas"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:326
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:326
 msgctxt "@label"
 msgid "Top / Bottom"
 msgstr "Topo / Base"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:330
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:330
 msgctxt "@label"
 msgid "Inner Wall"
 msgstr "Parede Interna"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:397
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:397
 msgctxt "@label"
 msgid "min"
 msgstr "mín"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/SimulationViewMenuComponent.qml:462
+#: plugins/SimulationView/SimulationViewMenuComponent.qml:462
 msgctxt "@label"
 msgid "max"
 msgstr "máx"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SimulationView/__init__.py:15
+#: plugins/SimulationView/__init__.py:15
 msgctxt "@item:inlistbox"
 msgid "Layer view"
 msgstr "Visão de Camadas"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:16
+#: plugins/SliceInfoPlugin/MoreInfoWindow.qml:16
 msgctxt "@title:window"
 msgid "More information on anonymous data collection"
 msgstr "Mais informações em coleção anônima de dados"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:73
+#: plugins/SliceInfoPlugin/MoreInfoWindow.qml:73
 msgctxt "@text:window"
 msgid "UltiMaker Cura collects anonymous data in order to improve the print quality and user experience. Below is an example of all the data that is shared:"
 msgstr "O UltiMaker Cura coleta dados anônimos para poder aprimorar a qualidade de impressão e experiência do usuário. Abaixo segue um exemplo de todos os dados que são compartilhados:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:107
+#: plugins/SliceInfoPlugin/MoreInfoWindow.qml:107
 msgctxt "@text:window"
 msgid "I don't want to send anonymous data"
 msgstr "Recusar enviar dados anônimos"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SliceInfoPlugin/MoreInfoWindow.qml:116
+#: plugins/SliceInfoPlugin/MoreInfoWindow.qml:116
 msgctxt "@text:window"
 msgid "Allow sending anonymous data"
 msgstr "Permitir enviar dados anônimos"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SliceInfoPlugin/SliceInfo.py:95
+#: plugins/SliceInfoPlugin/SliceInfo.py:95
 msgctxt "@text"
 msgid "Unable to read example data file."
 msgstr "Não foi possível ler o arquivo de dados de exemplo."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SolidView/SolidView.py:71
+#: plugins/SolidView/SolidView.py:71
 msgctxt "@info:status"
 msgid "The highlighted areas indicate either missing or extraneous surfaces. Fix your model and open it again into Cura."
 msgstr "As áreas ressaltadas indicam superfícies faltantes ou incorretas. Conserte seu modelo e o abra novamente no Cura."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SolidView/SolidView.py:73
+#: plugins/SolidView/SolidView.py:73
 msgctxt "@info:title"
 msgid "Model Errors"
 msgstr "Erros de Modelo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SolidView/__init__.py:12
+#: plugins/SolidView/__init__.py:12
 msgctxt "@item:inmenu"
 msgid "Solid view"
 msgstr "Visão sólida"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SupportEraser/__init__.py:12
+#: plugins/SupportEraser/__init__.py:12
 msgctxt "@label"
 msgid "Support Blocker"
 msgstr "Bloqueador de Suporte"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/SupportEraser/__init__.py:13
+#: plugins/SupportEraser/__init__.py:13
 msgctxt "@info:tooltip"
 msgid "Create a volume in which supports are not printed."
 msgstr "Cria um volume em que os suportes não são impressos."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/TrimeshReader/__init__.py:15
+#: plugins/TrimeshReader/__init__.py:15
 msgctxt "@item:inlistbox 'Open' is part of the name of this file format."
 msgid "Open Compressed Triangle Mesh"
 msgstr "Open Compressed Triangle Mesh"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/TrimeshReader/__init__.py:19
+#: plugins/TrimeshReader/__init__.py:19
 msgctxt "@item:inlistbox"
 msgid "COLLADA Digital Asset Exchange"
 msgstr "Câmbio de Ativos Digitais COLLADA"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/TrimeshReader/__init__.py:23
+#: plugins/TrimeshReader/__init__.py:23
 msgctxt "@item:inlistbox"
 msgid "glTF Binary"
 msgstr "Binário glTF"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/TrimeshReader/__init__.py:27
+#: plugins/TrimeshReader/__init__.py:27
 msgctxt "@item:inlistbox"
 msgid "glTF Embedded JSON"
 msgstr "glTF Embutido JSON"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/TrimeshReader/__init__.py:36
+#: plugins/TrimeshReader/__init__.py:36
 msgctxt "@item:inlistbox"
 msgid "Stanford Triangle Format"
 msgstr "Formato de Triângulos de Stanford"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/TrimeshReader/__init__.py:40
+#: plugins/TrimeshReader/__init__.py:40
 msgctxt "@item:inlistbox"
 msgid "Compressed COLLADA Digital Asset Exchange"
 msgstr "Câmbio de Ativos Digitais COLLADA Comprimido"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UFPReader/__init__.py:22
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UFPWriter/__init__.py:28
+#: plugins/UFPReader/__init__.py:22 plugins/UFPWriter/__init__.py:28
 msgctxt "@item:inlistbox"
 msgid "UltiMaker Format Package"
 msgstr "Pacote de Formato da UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UFPWriter/UFPWriter.py:62
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UFPWriter/UFPWriter.py:78
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UFPWriter/UFPWriter.py:91
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UFPWriter/UFPWriter.py:113
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UFPWriter/UFPWriter.py:168
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UFPWriter/UFPWriter.py:178
+#: plugins/UFPWriter/UFPWriter.py:64 plugins/UFPWriter/UFPWriter.py:80 plugins/UFPWriter/UFPWriter.py:93 plugins/UFPWriter/UFPWriter.py:115 plugins/UFPWriter/UFPWriter.py:170 plugins/UFPWriter/UFPWriter.py:180
 msgctxt "@info:error"
 msgid "Can't write to UFP file:"
 msgstr "Não foi possível escrever no arquivo UFP:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:44
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:44
 msgctxt "@title:window"
 msgid "Connect to Networked Printer"
 msgstr "Conectar a Impressora de Rede"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:51
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:51
 msgctxt "@label"
 msgid "Select your printer from the list below:"
 msgstr "Selecione sua impressora da lista abaixo:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:51
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:51
 msgctxt "@label"
 msgid "To print directly to your printer over the network, please make sure your printer is connected to the network using a network cable or by connecting your printer to your WIFI network. If you don't connect Cura with your printer, you can still use a USB drive to transfer g-code files to your printer."
 msgstr "Para imprimir diretamente na sua impressora pela rede, certifique-se que ela esteja conectada à rede usando um cabo de rede ou conectando sua impressora à sua WIFI. Se você não conectar Cura à sua impressora, você ainda pode usar um drive USB ou SDCard para transferir arquivos G-Code a ela."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:71
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:71
 msgctxt "@action:button"
 msgid "Edit"
 msgstr "Editar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:82
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/MachinesPage.qml:148
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:186
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:321
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:82 resources/qml/Preferences/MachinesPage.qml:153 resources/qml/Preferences/Materials/MaterialsPage.qml:186 resources/qml/Preferences/ProfilesPage.qml:321
 msgctxt "@action:button"
 msgid "Remove"
 msgstr "Remover"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:90
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:90
 msgctxt "@action:button"
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:161
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:161
 msgctxt "@label"
 msgid "If your printer is not listed, read the <a href='%1'>network printing troubleshooting guide</a>"
 msgstr "Se sua impressora não está listada, leia o <a href='%1'>guia de resolução de problemas de impressão em rede</a>"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:186
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:247
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:186 resources/qml/WelcomePages/AddPrinterByIpContent.qml:247
 msgctxt "@label"
 msgid "Type"
 msgstr "Tipo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:202
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:256
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:202 resources/qml/WelcomePages/AddPrinterByIpContent.qml:256
 msgctxt "@label"
 msgid "Firmware version"
 msgstr "Versão do firmware"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:212
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:266
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:212 resources/qml/WelcomePages/AddPrinterByIpContent.qml:266
 msgctxt "@label"
 msgid "Address"
 msgstr "Endereço"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:232
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:232
 msgctxt "@label"
 msgid "This printer is not set up to host a group of printers."
 msgstr "Esta impressora não está configurada para hospedar um grupo de impressoras."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:236
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:236
 msgctxt "@label"
 msgid "This printer is the host for a group of %1 printers."
 msgstr "Esta impressora é a hospedeira de um grupo de %1 impressoras."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:245
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:245
 msgctxt "@label"
 msgid "The printer at this address has not yet responded."
 msgstr "A impressora neste endereço ainda não respondeu."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:250
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:250
 msgctxt "@action:button"
 msgid "Connect"
 msgstr "Conectar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:261
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:261
 msgctxt "@title:window"
 msgid "Invalid IP address"
 msgstr "Endereço IP inválido"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:262
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:141
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:262 resources/qml/WelcomePages/AddPrinterByIpContent.qml:141
 msgctxt "@text"
 msgid "Please enter a valid IP address."
 msgstr "Por favor entre um endereço IP válido."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:272
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:272
 msgctxt "@title:window"
 msgid "Printer Address"
 msgstr "Endereço da Impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:297
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:97
+#: plugins/UM3NetworkPrinting/resources/qml/DiscoverUM3Action.qml:297 resources/qml/WelcomePages/AddPrinterByIpContent.qml:97
 msgctxt "@label"
 msgid "Enter the IP address of your printer on the network."
 msgstr "Entre o endereço IP da sua impressora na rede."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:20
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:20
 msgctxt "@title:window"
 msgid "Configuration Changes"
 msgstr "Alterações de Configuração"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:36
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:36
 msgctxt "@action:button"
 msgid "Override"
 msgstr "Sobrepor"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:83
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:83
 msgctxt "@label"
 msgid "The assigned printer, %1, requires the following configuration change:"
 msgid_plural "The assigned printer, %1, requires the following configuration changes:"
 msgstr[0] "A impressora associada, %1, requer a seguinte alteração de configuração:"
 msgstr[1] "A impressora associada, %1, requer as seguintes alterações de configuração:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:87
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:87
 msgctxt "@label"
 msgid "The printer %1 is assigned, but the job contains an unknown material configuration."
 msgstr "A impressora %1 está associada, mas o trabalho contém configuração de material desconhecida."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:97
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:97
 msgctxt "@label"
 msgid "Change material %1 from %2 to %3."
 msgstr "Alterar material %1 de %2 para %3."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:100
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:100
 msgctxt "@label"
 msgid "Load %3 as material %1 (This cannot be overridden)."
 msgstr "Carregar %3 como material %1 (isto não pode ser sobreposto)."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:103
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:103
 msgctxt "@label"
 msgid "Change print core %1 from %2 to %3."
 msgstr "Alterar núcleo de impressão %1 de %2 para %3."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:106
-msgctxt "@label"
-msgid "Change build plate to %1 (This cannot be overridden)."
-msgstr "Alterar mesa de impressão para %1 (Isto não pode ser sobreposto)."
-
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:113
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:110
 msgctxt "@label"
 msgid "Override will use the specified settings with the existing printer configuration. This may result in a failed print."
 msgstr "Sobrepor irá usar os ajustes especificados com a configuração existente da impressora. Isto pode causar falha da impressão."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:151
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:178
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:181
-msgctxt "@label"
-msgid "Glass"
-msgstr "Vidro"
-
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorConfigOverrideDialog.qml:154
-msgctxt "@label"
-msgid "Aluminum"
-msgstr "Alumínio"
-
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:144
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:144
 msgctxt "@label"
 msgid "Move to top"
 msgstr "Mover para o topo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:155
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:155
 msgctxt "@label"
 msgid "Delete"
 msgstr "Remover"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:186
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:284
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:186 resources/qml/MonitorButton.qml:284
 msgctxt "@label"
 msgid "Resume"
 msgstr "Continuar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:188
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:188
 msgctxt "@label"
 msgid "Pausing..."
 msgstr "Pausando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:190
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:190
 msgctxt "@label"
 msgid "Resuming..."
 msgstr "Continuando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:192
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:279
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:288
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:192 resources/qml/MonitorButton.qml:279 resources/qml/MonitorButton.qml:288
 msgctxt "@label"
 msgid "Pause"
 msgstr "Pausar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:206
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:206
 msgctxt "@label"
 msgid "Abort"
 msgstr "Abortar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:206
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:206
 msgctxt "@label"
 msgid "Aborting..."
 msgstr "Abortando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:218
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:218
 msgctxt "@label %1 is the name of a print job."
 msgid "Are you sure you want to move %1 to the top of the queue?"
 msgstr "Você tem certeza que quer mover %1 para o topo da fila?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:219
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:219
 msgctxt "@window:title"
 msgid "Move print job to top"
 msgstr "Move o trabalho de impressão para o topo da fila"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:227
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:227
 msgctxt "@label %1 is the name of a print job."
 msgid "Are you sure you want to delete %1?"
 msgstr "Você tem certeza que quer remover %1?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:228
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:228
 msgctxt "@window:title"
 msgid "Delete print job"
 msgstr "Remover trabalho de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:236
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:236
 msgctxt "@label %1 is the name of a print job."
 msgid "Are you sure you want to abort %1?"
 msgstr "Você tem certeza que quer abortar %1?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:237
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:326
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorContextMenu.qml:237 resources/qml/MonitorButton.qml:326
 msgctxt "@window:title"
 msgid "Abort print"
 msgstr "Abortar impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:126
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:126
 msgctxt "@label"
 msgid "Unavailable printer"
 msgstr "Impressora indisponível"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:128
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:128
 msgctxt "@label"
 msgid "First available"
 msgstr "Primeira disponível"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:250
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:253
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:479
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobCard.qml:242 plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:246 plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:472
 msgctxt "@info"
 msgid "Please update your printer's firmware to manage the queue remotely."
 msgstr "Por favor atualize o firmware de sua impressora parar gerir a fila remotamente."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:70
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:82
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:84
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:86
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:88
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:70 plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:82 plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:84 plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:86
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:88
 msgctxt "@label:status"
 msgid "Aborted"
 msgstr "Abortado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:72
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:74
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:72 plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:74
 msgctxt "@label:status"
 msgid "Finished"
 msgstr "Finalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:76
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:78
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:363
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:76 plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:78 plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:356
 msgctxt "@label:status"
 msgid "Preparing..."
 msgstr "Preparando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:80
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:80
 msgctxt "@label:status"
 msgid "Aborting..."
 msgstr "Abortando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:90
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:92
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:94
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:96
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:90 plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:92 plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:94 plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:96
 msgctxt "@label:status"
 msgid "Failed"
 msgstr "Falhado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:98
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:98
 msgctxt "@label:status"
 msgid "Pausing..."
 msgstr "Pausando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:100
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:100
 msgctxt "@label:status"
 msgid "Paused"
 msgstr "Pausado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:102
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:102
 msgctxt "@label:status"
 msgid "Resuming..."
 msgstr "Continuando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:104
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:104
 msgctxt "@label:status"
 msgid "Action required"
 msgstr "Necessária uma ação"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:106
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrintJobProgressBar.qml:106
 msgctxt "@label:status"
 msgid "Finishes %1 at %2"
 msgstr "Termina %1 em %2"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:148
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:148
 msgctxt "@label link to Connect and Cloud interfaces"
 msgid "Manage printer"
 msgstr "Gerir Impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:287
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:280
 msgctxt "@info"
 msgid "Webcam feeds for cloud printers cannot be viewed from UltiMaker Cura. Click \"Manage printer\" to visit Ultimaker Digital Factory and view this webcam."
 msgstr "Fontes de webcam para impressoras de nuvem não podem ser vistas pelo UltiMaker Cura. Clique em \"Gerenciar impressora\" para visitar a Ultimaker Digital Factory e visualizar esta webcam."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:347
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:340
 msgctxt "@label:status"
 msgid "Loading..."
 msgstr "Carregando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:351
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:344
 msgctxt "@label:status"
 msgid "Unavailable"
 msgstr "Indisponível"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:355
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:348
 msgctxt "@label:status"
 msgid "Unreachable"
 msgstr "Inacessivel"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:359
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:352
 msgctxt "@label:status"
 msgid "Idle"
 msgstr "Ocioso"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:368
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:361
 msgctxt "@label:status"
 msgid "Printing"
 msgstr "Imprimindo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:409
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:402
 msgctxt "@label"
 msgid "Untitled"
 msgstr "Sem Título"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:424
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:417
 msgctxt "@label"
 msgid "Anonymous"
 msgstr "Anônimo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:445
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:438
 msgctxt "@label:status"
 msgid "Requires configuration changes"
 msgstr "Requer mudanças na configuração"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:459
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml:452
 msgctxt "@action:button"
 msgid "Details"
 msgstr "Detalhes"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:29
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:29
 msgctxt "@label"
 msgid "Queued"
 msgstr "Enfileirados"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:64
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:64
 msgctxt "@label link to connect manager"
 msgid "Manage in browser"
 msgstr "Gerir no navegador"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:91
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:91
 msgctxt "@label"
 msgid "There are no print jobs in the queue. Slice and send a job to add one."
 msgstr "Não há trabalhos de impressão na fila. Fatie e envie um trabalho para adicioná-lo."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:99
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:99
 msgctxt "@label"
 msgid "Print jobs"
 msgstr "Trabalhos de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:108
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:108
 msgctxt "@label"
 msgid "Total print time"
 msgstr "Tempo total de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:117
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorQueue.qml:117
 msgctxt "@label"
 msgid "Waiting for"
 msgstr "Esperando por"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorStage.qml:117
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorStage.qml:117
 msgctxt "@info"
 msgid "Monitor your printers from everywhere using Ultimaker Digital Factory"
 msgstr "Monitora suas impressoras de todo lugar usando a Ultimaker Digital Factory"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/MonitorStage.qml:129
+#: plugins/UM3NetworkPrinting/resources/qml/MonitorStage.qml:129
 msgctxt "@button"
 msgid "View printers in Digital Factory"
 msgstr "Ver impressoras na Digital Factory"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:12
+#: plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:12
 msgctxt "@title:window"
 msgid "Print over network"
 msgstr "Imprimir pela rede"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:53
+#: plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:53
 msgctxt "@action:button"
 msgid "Print"
 msgstr "Imprimir"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:81
+#: plugins/UM3NetworkPrinting/resources/qml/PrintWindow.qml:81
 msgctxt "@label"
 msgid "Printer selection"
 msgstr "Seleção de impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/AbstractCloudOutputDevice.py:80
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:162
+#: plugins/UM3NetworkPrinting/src/Cloud/AbstractCloudOutputDevice.py:80 plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:162
 msgctxt "@action:button"
 msgid "Print via cloud"
 msgstr "Imprimir pela nuvem"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/AbstractCloudOutputDevice.py:81
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:163
+#: plugins/UM3NetworkPrinting/src/Cloud/AbstractCloudOutputDevice.py:81 plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:163
 msgctxt "@properties:tooltip"
 msgid "Print via cloud"
 msgstr "Imprimir pela nuvem"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/AbstractCloudOutputDevice.py:82
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:164
+#: plugins/UM3NetworkPrinting/src/Cloud/AbstractCloudOutputDevice.py:82 plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:164
 msgctxt "@info:status"
 msgid "Connected via cloud"
 msgstr "Conectado pela nuvem"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:276
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:276
 msgctxt "@action:button"
 msgid "Monitor print"
 msgstr "Monitorar impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:278
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:278
 msgctxt "@action:tooltip"
 msgid "Track the print in Ultimaker Digital Factory"
 msgstr "Rastrear a impressão na Ultimaker Digital Factory"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:298
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py:298
 #, python-brace-format
 msgctxt "@error:send"
 msgid "Unknown error code when uploading print job: {0}"
 msgstr "Código de erro desconhecido ao transferir trabalho de impressão: {0}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:422
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:22
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:422 plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:23
 msgctxt "info:name"
 msgid "Ultimaker Digital Factory"
 msgstr "Ultimaker Digital Factory"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:425
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:425
 #, python-brace-format
 msgctxt "@message {printer_name} is replaced with the name of the printer"
 msgid "{printer_name} will be removed until the next account sync."
 msgstr "{printer_name} será removida até a próxima sincronização de conta."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:426
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:426
 #, python-brace-format
 msgctxt "@message {printer_name} is replaced with the name of the printer"
 msgid "To remove {printer_name} permanently, visit {digital_factory_link}"
 msgstr "Para remover {printer_name} permanentemente, visite {digital_factory_link}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:427
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:427
 #, python-brace-format
 msgctxt "@message {printer_name} is replaced with the name of the printer"
 msgid "Are you sure you want to remove {printer_name} temporarily?"
 msgstr "Tem certeza que quer remover {printer_name} temporariamente?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:474
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:474
 msgctxt "@title:window"
 msgid "Remove printers?"
 msgstr "Remover impressoras?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:477
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:477
 #, python-brace-format
 msgctxt "@label"
 msgid ""
@@ -3528,7 +3661,7 @@ msgstr[1] ""
 "Você está prestes a remover {0} impressoras do Cura. Esta ação não pode ser desfeita.\n"
 "Tem certeza que quer continuar?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:484
+#: plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDeviceManager.py:484
 msgctxt "@label"
 msgid ""
 "You are about to remove all printers from Cura. This action cannot be undone.\n"
@@ -3537,7 +3670,7 @@ msgstr ""
 "Você está prestes a remover todas as impressoras do Cura. Esta ação não pode ser desfeita.\n"
 "Tem certeza que quer continuar?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:25
+#: plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:25
 #, python-brace-format
 msgctxt "@info:status"
 msgid ""
@@ -3547,57 +3680,58 @@ msgstr ""
 "Sua impressora <b>{printer_name}</b> poderia estar conectada via nuvem.\n"
 " Gerencie sua fila de impressão e monitore suas impressoras de qualquer lugar conectando sua impressora à Digital Factory"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:26
+#: plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:26
 msgctxt "@info:title"
 msgid "Are you ready for cloud printing?"
 msgstr "Você está pronto para a impressão de nuvem?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:30
+#: plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:30
 msgctxt "@action"
 msgid "Get started"
 msgstr "Começar"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:31
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobAwaitingApprovalMessage.py:24
+#: plugins/UM3NetworkPrinting/src/Messages/CloudFlowMessage.py:31 plugins/UM3NetworkPrinting/src/Messages/PrintJobAwaitingApprovalMessage.py:24
 msgctxt "@action"
 msgid "Learn more"
 msgstr "Saiba mais"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/LegacyDeviceNoLongerSupportedMessage.py:18
+#: plugins/UM3NetworkPrinting/src/Messages/LegacyDeviceNoLongerSupportedMessage.py:18
+#, fuzzy
 msgctxt "@info:status"
-msgid "You are attempting to connect to a printer that is not running UltiMaker Connect. Please update the printer to the latest firmware."
+msgid "You are attempting to connect to a printer that is not running Ultimaker Connect. Please update the printer to the latest firmware."
 msgstr "Você está tentando conectar a uma impressora que não está rodando UltiMaker Connect. Por favor atualiza a impressora para o firmware mais recente."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/LegacyDeviceNoLongerSupportedMessage.py:21
+#: plugins/UM3NetworkPrinting/src/Messages/LegacyDeviceNoLongerSupportedMessage.py:21
 msgctxt "@info:title"
 msgid "Update your printer"
 msgstr "Atualize sua impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/MaterialSyncMessage.py:24
+#: plugins/UM3NetworkPrinting/src/Messages/MaterialSyncMessage.py:24
 #, python-brace-format
 msgctxt "@info:status"
 msgid "Cura has detected material profiles that were not yet installed on the host printer of group {0}."
 msgstr "O Cura detectou perfis de material que não estão instalados ainda na impressora host do grupo {0}."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/MaterialSyncMessage.py:26
+#: plugins/UM3NetworkPrinting/src/Messages/MaterialSyncMessage.py:26
 msgctxt "@info:title"
 msgid "Sending materials to printer"
 msgstr "Enviando material para a impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/NewPrinterDetectedMessage.py:13
+#: plugins/UM3NetworkPrinting/src/Messages/NewPrinterDetectedMessage.py:13
+#, fuzzy
 msgctxt "info:status"
-msgid "New printer detected from your UltiMaker account"
+msgid "New printer detected from your Ultimaker account"
 msgid_plural "New printers detected from your Ultimaker account"
 msgstr[0] "Nova impressora detectada na sua conta Ultimaker"
 msgstr[1] "Novas impressoras detectadas na sua conta Ultimaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/NewPrinterDetectedMessage.py:29
+#: plugins/UM3NetworkPrinting/src/Messages/NewPrinterDetectedMessage.py:29
 #, python-brace-format
 msgctxt "info:status Filled in with printer name and printer model."
 msgid "Adding printer {name} ({model}) from your account"
 msgstr "Adicionando impressora {name} ({model}) da sua conta"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/NewPrinterDetectedMessage.py:48
+#: plugins/UM3NetworkPrinting/src/Messages/NewPrinterDetectedMessage.py:48
 #, python-brace-format
 msgctxt "info:{0} gets replaced by a number of printers"
 msgid "... and {0} other"
@@ -3605,767 +3739,795 @@ msgid_plural "... and {0} others"
 msgstr[0] "... e {0} outra"
 msgstr[1] "... e {0} outras"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/NewPrinterDetectedMessage.py:57
+#: plugins/UM3NetworkPrinting/src/Messages/NewPrinterDetectedMessage.py:57
 msgctxt "info:status"
 msgid "Printers added from Digital Factory:"
 msgstr "Impressoras adicionadas da Digital Factory:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:27
+#: plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:27
 #, python-brace-format
 msgctxt "@info:status"
 msgid "You are attempting to connect to {0} but it is not the host of a group. You can visit the web page to configure it as a group host."
 msgstr "Você está tentando conectar a {0} mas ele não é host de um grupo. Você pode visitar a página web para configurá-lo como host de grupo."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:30
+#: plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:30
 msgctxt "@info:title"
 msgid "Not a group host"
 msgstr "Não é host de grupo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:36
+#: plugins/UM3NetworkPrinting/src/Messages/NotClusterHostMessage.py:36
 msgctxt "@action"
 msgid "Configure group"
 msgstr "Configurar grupo"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobAwaitingApprovalMessage.py:18
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobAwaitingApprovalMessage.py:18
 msgctxt "@info:status"
 msgid "You will receive a confirmation via email when the print job is approved"
 msgstr "Você receberá uma confirmação por email quando o trabalho de impressão for aprovado"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobAwaitingApprovalMessage.py:19
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobAwaitingApprovalMessage.py:19
 msgctxt "@info:title"
 msgid "The print job was successfully submitted"
 msgstr "O trabalho de impressão foi submetido com sucesso"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobAwaitingApprovalMessage.py:22
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobAwaitingApprovalMessage.py:22
 msgctxt "@action"
 msgid "Manage print jobs"
 msgstr "Gerenciar trabalhos de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadBlockedMessage.py:15
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadBlockedMessage.py:15
 msgctxt "@info:status"
 msgid "Please wait until the current job has been sent."
 msgstr "Por favor espere até que o trabalho atual tenha sido enviado."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadBlockedMessage.py:16
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadBlockedMessage.py:16
 msgctxt "@info:title"
 msgid "Print error"
 msgstr "Erro de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py:15
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py:15
 msgctxt "@info:text"
 msgid "Could not upload the data to the printer."
 msgstr "Não foi possível transferir os dados para a impressora."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py:16
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadErrorMessage.py:16
 msgctxt "@info:title"
 msgid "Network error"
 msgstr "Erro de rede"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadProgressMessage.py:15
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadProgressMessage.py:15
 msgctxt "@info:status"
 msgid "Sending Print Job"
 msgstr "Enviando Trabalho de Impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadProgressMessage.py:16
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadProgressMessage.py:16
 msgctxt "@info:status"
 msgid "Uploading print job to printer."
 msgstr "Transferindo trabalho de impressão para a impressora."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadQueueFullMessage.py:16
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadQueueFullMessage.py:16
 msgctxt "@info:status"
 msgid "Print job queue is full. The printer can't accept a new job."
 msgstr "A fila de trabalhos de impressão está cheia. A impressora não pode aceitar novo trabalho."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadQueueFullMessage.py:17
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadQueueFullMessage.py:17
 msgctxt "@info:title"
 msgid "Queue Full"
 msgstr "Fila Cheia"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadSuccessMessage.py:15
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadSuccessMessage.py:15
 msgctxt "@info:status"
 msgid "Print job was successfully sent to the printer."
 msgstr "Trabalho de impressão enviado à impressora com sucesso."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadSuccessMessage.py:16
+#: plugins/UM3NetworkPrinting/src/Messages/PrintJobUploadSuccessMessage.py:16
 msgctxt "@info:title"
 msgid "Data Sent"
 msgstr "Dados Enviados"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:16
+#: plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:17
 msgctxt "info:status"
 msgid "This printer is not linked to the Digital Factory:"
 msgid_plural "These printers are not linked to the Digital Factory:"
 msgstr[0] "Esta impressora não está ligada à Digital Factory:"
 msgstr[1] "Estas impressoras não estão ligadas à Digital Factory:"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:28
+#: plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:29
 #, python-brace-format
 msgctxt "info:status"
 msgid "To establish a connection, please visit the {website_link}"
 msgstr "Para estabelecer uma conexão, por favor visite o {website_link}"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:32
+#: plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:33
 msgctxt "info:status"
 msgid "A cloud connection is not available for a printer"
 msgid_plural "A cloud connection is not available for some printers"
 msgstr[0] "Conexão de nuvem não está disponível para uma impressora"
 msgstr[1] "Conexão de nuvem não está disponível para algumas impressoras"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:40
+#: plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:41
 msgctxt "@action:button"
 msgid "Keep printer configurations"
 msgstr "Manter configurações da impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:45
+#: plugins/UM3NetworkPrinting/src/Messages/RemovedPrintersMessage.py:46
 msgctxt "@action:button"
 msgid "Remove printers"
 msgstr "Remover impressoras"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:62
+#: plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:62
 msgctxt "@action:button Preceded by 'Ready to'."
 msgid "Print over network"
 msgstr "Imprimir pela rede"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:63
+#: plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:63
 msgctxt "@properties:tooltip"
 msgid "Print over network"
 msgstr "Imprime pela rede"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:64
+#: plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py:64
 msgctxt "@info:status"
 msgid "Connected over the network"
 msgstr "Conectado pela rede"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterAction.py:28
+#: plugins/UM3NetworkPrinting/src/UltimakerNetworkedPrinterAction.py:28
 msgctxt "@action"
 msgid "Connect via Network"
 msgstr "Conectar pela rede"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Utils.py:27
+#: plugins/UM3NetworkPrinting/src/Utils.py:27
 msgctxt "@info:status"
 msgid "tomorrow"
 msgstr "amanhã"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UM3NetworkPrinting/src/Utils.py:30
+#: plugins/UM3NetworkPrinting/src/Utils.py:30
 msgctxt "@info:status"
 msgid "today"
 msgstr "hoje"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:42
+#: plugins/USBPrinting/USBPrinterOutputDevice.py:42
 msgctxt "@item:inmenu"
 msgid "USB printing"
 msgstr "Impressão USB"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:43
+#: plugins/USBPrinting/USBPrinterOutputDevice.py:43
 msgctxt "@action:button Preceded by 'Ready to'."
 msgid "Print via USB"
 msgstr "Imprimir pela USB"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:44
+#: plugins/USBPrinting/USBPrinterOutputDevice.py:44
 msgctxt "@info:tooltip"
 msgid "Print via USB"
 msgstr "Imprimir pela USB"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:80
+#: plugins/USBPrinting/USBPrinterOutputDevice.py:80
 msgctxt "@info:status"
 msgid "Connected via USB"
 msgstr "Conectado via USB"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:110
+#: plugins/USBPrinting/USBPrinterOutputDevice.py:110
 msgctxt "@label"
 msgid "A USB print is in progress, closing Cura will stop this print. Are you sure?"
 msgstr "Uma impressão USB está em progresso, fechar o Cura interromperá esta impressão. Tem certeza?"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:135
+#: plugins/USBPrinting/USBPrinterOutputDevice.py:135
 msgctxt "@message"
 msgid "A print is still in progress. Cura cannot start another print via USB until the previous print has completed."
 msgstr "Uma impressão ainda está em progresso. O Cura não pode iniciar outra impressão via USB até que a impressão anterior tenha completado."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/USBPrinting/USBPrinterOutputDevice.py:136
+#: plugins/USBPrinting/USBPrinterOutputDevice.py:136
 msgctxt "@message"
 msgid "Print in Progress"
 msgstr "Impressão em Progresso"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.py:24
+#: plugins/UltimakerMachineActions/BedLevelMachineAction.py:24
 msgctxt "@action"
 msgid "Level build plate"
 msgstr "Nivelar mesa"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:30
+#: plugins/UltimakerMachineActions/BedLevelMachineAction.qml:30
 msgctxt "@title"
 msgid "Build Plate Leveling"
 msgstr "Nivelamento da mesa de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:42
+#: plugins/UltimakerMachineActions/BedLevelMachineAction.qml:42
 msgctxt "@label"
 msgid "To make sure your prints will come out great, you can now adjust your buildplate. When you click 'Move to Next Position' the nozzle will move to the different positions that can be adjusted."
 msgstr "Para garantir que suas impressões saiam ótimas, você deve agora ajustar sua mesa de impressão. Quando você clicar em 'Mover para a Posição Seguinte', o bico se moverá para posições diferentes que podem ser ajustadas."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:52
+#: plugins/UltimakerMachineActions/BedLevelMachineAction.qml:52
 msgctxt "@label"
 msgid "For every position; insert a piece of paper under the nozzle and adjust the print build plate height. The print build plate height is right when the paper is slightly gripped by the tip of the nozzle."
 msgstr "Para cada posição; insira um pedaço de papel abaixo do bico e ajuste a altura da mesa de impressão. A altura da mesa de impressão está adequada quando o papel for levemente pressionado pela ponta do bico."
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:67
+#: plugins/UltimakerMachineActions/BedLevelMachineAction.qml:67
 msgctxt "@action:button"
 msgid "Start Build Plate Leveling"
 msgstr "Iniciar Nivelamento da Mesa de Impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/BedLevelMachineAction.qml:79
+#: plugins/UltimakerMachineActions/BedLevelMachineAction.qml:79
 msgctxt "@action:button"
 msgid "Move to Next Position"
 msgstr "Mover pra a Posição Seguinte"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelection.py:21
+#: plugins/UltimakerMachineActions/UMOUpgradeSelection.py:21
 msgctxt "@action"
 msgid "Select upgrades"
 msgstr "Selecionar Atualizações"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml:30
+#: plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml:30
 msgctxt "@label"
 msgid "Please select any upgrades made to this UltiMaker Original"
 msgstr "Por favor selecionar quaisquer atualizações feitas nesta UltiMaker Original"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml:39
+#: plugins/UltimakerMachineActions/UMOUpgradeSelectionMachineAction.qml:39
 msgctxt "@label"
 msgid "Heated Build Plate (official kit or self-built)"
 msgstr "Mesa de Impressão Aquecida (kit Oficial ou auto-construído)"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/X3DReader/__init__.py:13
+#: plugins/X3DReader/__init__.py:13
 msgctxt "@item:inlistbox"
 msgid "X3D File"
 msgstr "Arquivo X3D"
 
-#: /Users/c.lamboo/ultimaker/Cura/plugins/XRayView/__init__.py:12
+#: plugins/XRayView/__init__.py:12
 msgctxt "@item:inlistbox"
 msgid "X-Ray view"
 msgstr "Visão de Raios-X"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/AccountWidget.qml:24
+#: resources/qml/Account/AccountWidget.qml:24
 msgctxt "@action:button"
 msgid "Sign in"
 msgstr "Entrar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/GeneralOperations.qml:19
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/CloudContent.qml:64
+#: resources/qml/Account/GeneralOperations.qml:19 resources/qml/WelcomePages/CloudContent.qml:64
 msgctxt "@label"
 msgid "Sign in to the UltiMaker platform"
 msgstr "Entre na plataforma UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/GeneralOperations.qml:39
+#: resources/qml/Account/GeneralOperations.qml:39
+#, fuzzy
 msgctxt "@text"
 msgid ""
 "- Add material profiles and plug-ins from the Marketplace\n"
 "- Back-up and sync your material profiles and plug-ins\n"
-"- Share ideas and get help from 48,000+ users in the Ultimaker community"
+"- Share ideas and get help from 48,000+ users in the UltiMaker community"
 msgstr ""
 "- Adicione perfis de material e plug-ins do Marketplace\n"
 "- Faça backup e sincronize seus perfis de materiais e plugins\n"
 "- Compartilhe ideias e consiga ajuda de mais de 48.000 usuários da comunidade Ultimaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/GeneralOperations.qml:58
+#: resources/qml/Account/GeneralOperations.qml:58
 msgctxt "@button"
 msgid "Create a free UltiMaker account"
 msgstr "Criar uma conta UltiMaker gratuita"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/SyncState.qml:35
+#: resources/qml/Account/SyncState.qml:35
 msgctxt "@label"
 msgid "Checking..."
 msgstr "Verificando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/SyncState.qml:42
+#: resources/qml/Account/SyncState.qml:42
 msgctxt "@label"
 msgid "Account synced"
 msgstr "Conta sincronizada"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/SyncState.qml:49
+#: resources/qml/Account/SyncState.qml:49
 msgctxt "@label"
 msgid "Something went wrong..."
 msgstr "Alguma coisa deu errado..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/SyncState.qml:102
+#: resources/qml/Account/SyncState.qml:102
 msgctxt "@button"
 msgid "Install pending updates"
 msgstr "Instalação aguardando atualizações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/SyncState.qml:123
+#: resources/qml/Account/SyncState.qml:123
 msgctxt "@button"
 msgid "Check for account updates"
 msgstr "Verificar atualizações da conta"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/UserOperations.qml:78
+#: resources/qml/Account/UserOperations.qml:78
 msgctxt "@label The argument is a timestamp"
 msgid "Last update: %1"
 msgstr "Última atualização: %1"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/UserOperations.qml:107
+#: resources/qml/Account/UserOperations.qml:107
 msgctxt "@button"
 msgid "UltiMaker Account"
 msgstr "Conta na UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Account/UserOperations.qml:126
+#: resources/qml/Account/UserOperations.qml:126
 msgctxt "@button"
 msgid "Sign Out"
 msgstr "Deslogar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:59
+#: resources/qml/ActionPanel/OutputProcessWidget.qml:59
 msgctxt "@label"
 msgid "No time estimation available"
 msgstr "Sem estimativa de tempo disponível"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:77
+#: resources/qml/ActionPanel/OutputProcessWidget.qml:77
 msgctxt "@label"
 msgid "No cost estimation available"
 msgstr "Sem estimativa de custo disponível"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/OutputProcessWidget.qml:127
+#: resources/qml/ActionPanel/OutputProcessWidget.qml:127
 msgctxt "@button"
 msgid "Preview"
 msgstr "Pré-visualização"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:31
+#: resources/qml/ActionPanel/PrintJobInformation.qml:31
 msgctxt "@label"
 msgid "Time estimation"
 msgstr "Estimativa de tempo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:107
+#: resources/qml/ActionPanel/PrintJobInformation.qml:107
 msgctxt "@label"
 msgid "Material estimation"
 msgstr "Estimativa de material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:156
+#: resources/qml/ActionPanel/PrintJobInformation.qml:156
 msgctxt "@label m for meter"
 msgid "%1m"
 msgstr "%1m"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/PrintJobInformation.qml:157
+#: resources/qml/ActionPanel/PrintJobInformation.qml:157
 msgctxt "@label g for grams"
 msgid "%1g"
 msgstr "%1g"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:54
+#: resources/qml/ActionPanel/SliceProcessWidget.qml:54
 msgctxt "@label:PrintjobStatus"
 msgid "Slicing..."
 msgstr "Fatiando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:78
+#: resources/qml/ActionPanel/SliceProcessWidget.qml:78
 msgctxt "@label:PrintjobStatus"
 msgid "Unable to slice"
 msgstr "Não foi possível fatiar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:114
+#: resources/qml/ActionPanel/SliceProcessWidget.qml:114
 msgctxt "@button"
 msgid "Processing"
 msgstr "Processando"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:114
+#: resources/qml/ActionPanel/SliceProcessWidget.qml:114
 msgctxt "@button"
 msgid "Slice"
 msgstr "Fatiar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:115
+#: resources/qml/ActionPanel/SliceProcessWidget.qml:115
 msgctxt "@label"
 msgid "Start the slicing process"
 msgstr "Inicia o processo de fatiamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ActionPanel/SliceProcessWidget.qml:132
+#: resources/qml/ActionPanel/SliceProcessWidget.qml:132
 msgctxt "@button"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:81
+#: resources/qml/Actions.qml:81
 msgctxt "@action:inmenu"
 msgid "Show Online Troubleshooting"
 msgstr "Mostrar Resolução de Problemas Online"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:88
+#: resources/qml/Actions.qml:88
 msgctxt "@action:inmenu"
 msgid "Toggle Full Screen"
 msgstr "Alternar Tela Cheia"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:96
+#: resources/qml/Actions.qml:96
 msgctxt "@action:inmenu"
 msgid "Exit Full Screen"
 msgstr "Sair da Tela Cheia"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:103
+#: resources/qml/Actions.qml:103
 msgctxt "@action:inmenu menubar:edit"
 msgid "&Undo"
 msgstr "Desfazer (&U)"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:113
+#: resources/qml/Actions.qml:113
 msgctxt "@action:inmenu menubar:edit"
 msgid "&Redo"
 msgstr "&Refazer"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:131
+#: resources/qml/Actions.qml:131
 msgctxt "@action:inmenu menubar:file"
 msgid "&Quit"
 msgstr "Sair (&Q)"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:139
+#: resources/qml/Actions.qml:139
 msgctxt "@action:inmenu menubar:view"
 msgid "3D View"
 msgstr "Visão &3D"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:146
+#: resources/qml/Actions.qml:146
 msgctxt "@action:inmenu menubar:view"
 msgid "Front View"
 msgstr "Visão Frontal"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:153
+#: resources/qml/Actions.qml:153
 msgctxt "@action:inmenu menubar:view"
 msgid "Top View"
 msgstr "Visão Superior"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:160
+#: resources/qml/Actions.qml:160
 msgctxt "@action:inmenu menubar:view"
 msgid "Bottom View"
 msgstr "Visão de Baixo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:167
+#: resources/qml/Actions.qml:167
 msgctxt "@action:inmenu menubar:view"
 msgid "Left Side View"
 msgstr "Visão do Lado Esquerdo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:174
+#: resources/qml/Actions.qml:174
 msgctxt "@action:inmenu menubar:view"
 msgid "Right Side View"
 msgstr "Visão do Lado Direito"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:188
+#: resources/qml/Actions.qml:188
 msgctxt "@action:inmenu"
 msgid "Configure Cura..."
 msgstr "Configurar Cura..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:195
+#: resources/qml/Actions.qml:197
 msgctxt "@action:inmenu menubar:printer"
 msgid "&Add Printer..."
 msgstr "&Adicionar Impressora..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:201
+#: resources/qml/Actions.qml:203
 msgctxt "@action:inmenu menubar:printer"
 msgid "Manage Pr&inters..."
 msgstr "Adm&inistrar Impressoras..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:208
+#: resources/qml/Actions.qml:210
 msgctxt "@action:inmenu"
 msgid "Manage Materials..."
 msgstr "Administrar Materiais..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:216
-msgctxt "@action:inmenu Marketplace is a brand name of Ultimaker's, so don't translate."
+#: resources/qml/Actions.qml:218
+#, fuzzy
+msgctxt "@action:inmenu Marketplace is a brand name of UltiMaker's, so don't translate."
 msgid "Add more materials from Marketplace"
 msgstr "Adicionar mais materiais ao Marketplace"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:223
+#: resources/qml/Actions.qml:225
 msgctxt "@action:inmenu menubar:profile"
 msgid "&Update profile with current settings/overrides"
 msgstr "At&ualizar perfil com valores e sobreposições atuais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:231
+#: resources/qml/Actions.qml:233
 msgctxt "@action:inmenu menubar:profile"
 msgid "&Discard current changes"
 msgstr "&Descartar ajustes atuais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:243
+#: resources/qml/Actions.qml:245
 msgctxt "@action:inmenu menubar:profile"
 msgid "&Create profile from current settings/overrides..."
 msgstr "&Criar perfil a partir de ajustes/sobreposições atuais..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:249
+#: resources/qml/Actions.qml:251
 msgctxt "@action:inmenu menubar:profile"
 msgid "Manage Profiles..."
 msgstr "Administrar perfis..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:257
+#: resources/qml/Actions.qml:259
 msgctxt "@action:inmenu menubar:help"
 msgid "Show Online &Documentation"
 msgstr "Exibir &Documentação Online"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:265
+#: resources/qml/Actions.qml:267
 msgctxt "@action:inmenu menubar:help"
 msgid "Report a &Bug"
 msgstr "Relatar um &Bug"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:273
+#: resources/qml/Actions.qml:275
 msgctxt "@action:inmenu menubar:help"
 msgid "What's New"
 msgstr "Novidades"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:287
+#: resources/qml/Actions.qml:289
 msgctxt "@action:inmenu menubar:help"
 msgid "About..."
 msgstr "Sobre..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:294
+#: resources/qml/Actions.qml:296
 msgctxt "@action:inmenu menubar:edit"
 msgid "Delete Selected"
 msgstr "Remover Selecionados"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:304
+#: resources/qml/Actions.qml:306
 msgctxt "@action:inmenu menubar:edit"
 msgid "Center Selected"
 msgstr "Centralizar Selecionados"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:313
+#: resources/qml/Actions.qml:315
 msgctxt "@action:inmenu menubar:edit"
 msgid "Multiply Selected"
 msgstr "Multiplicar Selecionados"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:322
+#: resources/qml/Actions.qml:324
 msgctxt "@action:inmenu"
 msgid "Delete Model"
 msgstr "Remover Modelo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:330
+#: resources/qml/Actions.qml:332
 msgctxt "@action:inmenu"
 msgid "Ce&nter Model on Platform"
 msgstr "Ce&ntralizar Modelo na Mesa"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:336
+#: resources/qml/Actions.qml:338
 msgctxt "@action:inmenu menubar:edit"
 msgid "&Group Models"
 msgstr "A&grupar Modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:356
+#: resources/qml/Actions.qml:358
 msgctxt "@action:inmenu menubar:edit"
 msgid "Ungroup Models"
 msgstr "Desagrupar Modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:366
+#: resources/qml/Actions.qml:368
 msgctxt "@action:inmenu menubar:edit"
 msgid "&Merge Models"
 msgstr "Co&mbinar Modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:376
+#: resources/qml/Actions.qml:378
 msgctxt "@action:inmenu"
 msgid "&Multiply Model..."
 msgstr "&Multiplicar Modelo..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:383
+#: resources/qml/Actions.qml:385
 msgctxt "@action:inmenu menubar:edit"
 msgid "Select All Models"
 msgstr "Selecionar Todos Os Modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:393
+#: resources/qml/Actions.qml:395
 msgctxt "@action:inmenu menubar:edit"
 msgid "Clear Build Plate"
 msgstr "Esvaziar a Mesa de Impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:403
+#: resources/qml/Actions.qml:405
 msgctxt "@action:inmenu menubar:file"
 msgid "Reload All Models"
 msgstr "Recarregar Todos Os Modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:412
+#: resources/qml/Actions.qml:414
 msgctxt "@action:inmenu menubar:edit"
 msgid "Arrange All Models"
 msgstr "Posicionar Todos os Modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:420
+#: resources/qml/Actions.qml:422
 msgctxt "@action:inmenu menubar:edit"
 msgid "Arrange Selection"
 msgstr "Posicionar Seleção"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:427
+#: resources/qml/Actions.qml:429
 msgctxt "@action:inmenu menubar:edit"
 msgid "Reset All Model Positions"
 msgstr "Reestabelecer as Posições de Todos Os Modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:434
+#: resources/qml/Actions.qml:436
 msgctxt "@action:inmenu menubar:edit"
 msgid "Reset All Model Transformations"
 msgstr "Remover as Transformações de Todos Os Modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:443
+#: resources/qml/Actions.qml:445
 msgctxt "@action:inmenu menubar:file"
 msgid "&Open File(s)..."
 msgstr "Abrir Arquiv&o(s)..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:453
+#: resources/qml/Actions.qml:455
 msgctxt "@action:inmenu menubar:file"
 msgid "&New Project..."
 msgstr "&Novo Projeto..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:460
+#: resources/qml/Actions.qml:462
 msgctxt "@action:inmenu menubar:help"
 msgid "Show Configuration Folder"
 msgstr "Exibir Pasta de Configuração"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Actions.qml:467
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingView.qml:476
+#: resources/qml/Actions.qml:469 resources/qml/Settings/SettingView.qml:476
 msgctxt "@action:menu"
 msgid "Configure setting visibility..."
 msgstr "Configurar a visibilidade dos ajustes..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:32
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:32
 msgctxt "@label:button"
 msgid "My printers"
 msgstr "Minhas impressoras"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:34
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:34
 msgctxt "@tooltip:button"
 msgid "Monitor printers in Ultimaker Digital Factory."
 msgstr "Monitora as impressoras na Ultimaker Digital Factory."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:41
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:41
 msgctxt "@tooltip:button"
 msgid "Create print projects in Digital Library."
 msgstr "Cria projetos de impressão na Digital Library."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:46
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:46
 msgctxt "@label:button"
 msgid "Print jobs"
 msgstr "Trabalhos de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:48
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:48
 msgctxt "@tooltip:button"
 msgid "Monitor print jobs and reprint from your print history."
 msgstr "Monitora trabalhos de impressão e reimprime a partir do histórico."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:55
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:55
 msgctxt "@tooltip:button"
 msgid "Extend UltiMaker Cura with plugins and material profiles."
 msgstr "Estende o UltiMaker Cura com complementos e perfis de material."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:62
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:62
 msgctxt "@tooltip:button"
 msgid "Become a 3D printing expert with UltiMaker e-learning."
 msgstr "Torne-se um especialista em impressão 3D com UltiMaker e-learning."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:67
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:67
 msgctxt "@label:button"
 msgid "UltiMaker support"
 msgstr "Suporte UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:69
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:69
 msgctxt "@tooltip:button"
 msgid "Learn how to get started with UltiMaker Cura."
 msgstr "Saiba como começar com o UltiMaker Cura."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:74
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:74
 msgctxt "@label:button"
 msgid "Ask a question"
 msgstr "Fazer uma pergunta"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:76
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:76
 msgctxt "@tooltip:button"
 msgid "Consult the UltiMaker Community."
 msgstr "Consultar a Comunidade UltiMaker."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:81
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:81
 msgctxt "@label:button"
 msgid "Report a bug"
 msgstr "Relatar um problema"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:83
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:83
 msgctxt "@tooltip:button"
 msgid "Let developers know that something is going wrong."
 msgstr "Deixe os desenvolvedores saberem que algo está errado."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:90
+#: resources/qml/ApplicationSwitcher/ApplicationSwitcherPopup.qml:90
 msgctxt "@tooltip:button"
 msgid "Visit the UltiMaker website."
 msgstr "Visita o website da UltiMaker."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ColorDialog.qml:107
+#: resources/qml/ColorDialog.qml:110
 msgctxt "@label"
 msgid "Hex"
 msgstr "Hexa"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:250
+#: resources/qml/Cura.qml:256
 msgctxt "@label"
 msgid "This package will be installed after restarting."
 msgstr "Este pacote será instalado após o reinício."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:461
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:14
+#: resources/qml/Cura.qml:467 resources/qml/Preferences/GeneralPage.qml:14
 msgctxt "@title:tab"
 msgid "General"
 msgstr "Geral"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:464
+#: resources/qml/Cura.qml:470
 msgctxt "@title:tab"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:466
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/MachinesPage.qml:17
+#: resources/qml/Cura.qml:472 resources/qml/Preferences/MachinesPage.qml:17
 msgctxt "@title:tab"
 msgid "Printers"
 msgstr "Impressoras"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:468
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:70
+#: resources/qml/Cura.qml:474 resources/qml/Preferences/Materials/MaterialsPage.qml:70
 msgctxt "@title:tab"
 msgid "Materials"
 msgstr "Materiais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:470
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:57
+#: resources/qml/Cura.qml:476 resources/qml/Preferences/ProfilesPage.qml:57
 msgctxt "@title:tab"
 msgid "Profiles"
 msgstr "Perfis"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:587
+#: resources/qml/Cura.qml:581
 msgctxt "@title:window %1 is the application name"
 msgid "Closing %1"
 msgstr "Fechando %1"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:588
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:597
+#: resources/qml/Cura.qml:582 resources/qml/Cura.qml:591
 msgctxt "@label %1 is the application name"
 msgid "Are you sure you want to exit %1?"
 msgstr "Tem certeza que quer sair de %1?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:635
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:16
+#: resources/qml/Cura.qml:629 resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:16
 msgctxt "@title:window"
 msgid "Open file(s)"
 msgstr "Abrir arquivo(s)"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:740
+#: resources/qml/Cura.qml:734
 msgctxt "@window:title"
 msgid "Install Package"
 msgstr "Instalar Pacote"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:747
+#: resources/qml/Cura.qml:741
 msgctxt "@title:window"
 msgid "Open File(s)"
 msgstr "Abrir Arquivo(s)"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:749
+#: resources/qml/Cura.qml:743
 msgctxt "@text:window"
 msgid "We have found one or more G-Code files within the files you have selected. You can only open one G-Code file at a time. If you want to open a G-Code file, please just select only one."
 msgstr "Encontramos um ou mais arquivos de G-Code entre os arquivos que você selecionou. Você só pode abrir um arquivo de G-Code por vez. Se você quiser abrir um arquivo de G-Code, por favor selecione somente um."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:829
+#: resources/qml/Cura.qml:828
 msgctxt "@title:window"
 msgid "Add Printer"
 msgstr "Adicionar Impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Cura.qml:837
+#: resources/qml/Cura.qml:836
 msgctxt "@title:window"
 msgid "What's New"
 msgstr "Novidades"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:15
+#: resources/qml/Cura.qml:890
+#, fuzzy
+msgctxt "@title:window"
+msgid "Save Custom Profile"
+msgstr "Perfil personalizado"
+
+#: resources/qml/Cura.qml:891
+#, fuzzy
+msgctxt "@textfield:placeholder"
+msgid "New Custom Profile"
+msgstr "Perfil personalizado"
+
+#: resources/qml/Cura.qml:892
+#, fuzzy
+msgctxt "@info"
+msgid "Custom profile name:"
+msgstr "Perfil personalizado"
+
+#: resources/qml/Cura.qml:909
+msgctxt "@label %i will be replaced with a profile name"
+msgid "<b>Only user changed settings will be saved in the custom profile.</b><br/>For materials that support it, the new custom profile will inherit properties from <b>%1</b>."
+msgstr "<b>Somente ajuste alterados por usuário serão salvos no perfil personalizado.</b><br/>Para materiais que o suportam, este novo perfil personalizado herdará propriedades de <b>%1</b>."
+
+#: resources/qml/Cura.qml:917
+msgctxt "@action:button"
+msgid "Learn more about Cura print profiles"
+msgstr "Saber mais sobre perfis de impressão do Cura"
+
+#: resources/qml/Cura.qml:926
+#, fuzzy
+msgctxt "@button"
+msgid "Save new profile"
+msgstr "Criar Novo Perfil"
+
+#: resources/qml/Dialogs/AboutDialog.qml:15
 msgctxt "@title:window The argument is the application name."
 msgid "About %1"
 msgstr "Sobre %1"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:59
+#: resources/qml/Dialogs/AboutDialog.qml:59
 msgctxt "@label"
 msgid "version: %1"
 msgstr "versão: %1"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:74
+#: resources/qml/Dialogs/AboutDialog.qml:74
 msgctxt "@label"
 msgid "End-to-end solution for fused filament 3D printing."
 msgstr "Solução completa para impressão 3D com filamento fundido."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:87
+#: resources/qml/Dialogs/AboutDialog.qml:87
 msgctxt "@info:credit"
 msgid ""
 "Cura is developed by UltiMaker in cooperation with the community.\n"
@@ -4374,1512 +4536,1490 @@ msgstr ""
 "Cura é desenvolvido pela Ultimaker B.V. em cooperação com a comunidade.\n"
 "Cura orgulhosamente usa os seguintes projetos open-source:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:138
+#: resources/qml/Dialogs/AboutDialog.qml:138
 msgctxt "@label Description for application component"
 msgid "Graphical user interface"
 msgstr "Interface Gráfica de usuário"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:139
+#: resources/qml/Dialogs/AboutDialog.qml:139
 msgctxt "@label Description for application component"
 msgid "Application framework"
 msgstr "Framework de Aplicações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:140
+#: resources/qml/Dialogs/AboutDialog.qml:140
 msgctxt "@label Description for application component"
 msgid "G-code generator"
 msgstr "Gerador de G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:141
+#: resources/qml/Dialogs/AboutDialog.qml:141
 msgctxt "@label Description for application component"
 msgid "Interprocess communication library"
 msgstr "Biblioteca de comunicação interprocessos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:142
+#: resources/qml/Dialogs/AboutDialog.qml:142
 msgctxt "@label Description for application component"
 msgid "Python bindings for libnest2d"
 msgstr "Ligações de Python para a libnest2d"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:143
+#: resources/qml/Dialogs/AboutDialog.qml:143
 msgctxt "@label Description for application component"
 msgid "Polygon packing library, developed by Prusa Research"
 msgstr "Biblioteca de empacotamento Polygon, desenvolvido pela Prusa Research"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:144
+#: resources/qml/Dialogs/AboutDialog.qml:144
 msgctxt "@label Description for application component"
 msgid "Support library for handling 3MF files"
 msgstr "Biblioteca de suporte para manuseamento de arquivos 3MF"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:145
+#: resources/qml/Dialogs/AboutDialog.qml:145
 msgctxt "@label Description for application component"
 msgid "Support library for file metadata and streaming"
 msgstr "Biblioteca de suporte para streaming e metadados de arquivo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:148
+#: resources/qml/Dialogs/AboutDialog.qml:148
 msgctxt "@label Description for application dependency"
 msgid "Programming language"
 msgstr "Linguagem de Programação"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:149
+#: resources/qml/Dialogs/AboutDialog.qml:149
 msgctxt "@label Description for application dependency"
 msgid "GUI framework"
 msgstr "Framework Gráfica"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:150
+#: resources/qml/Dialogs/AboutDialog.qml:150
 msgctxt "@label Description for application dependency"
 msgid "GUI framework bindings"
 msgstr "Ligações da Framework Gráfica"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:151
+#: resources/qml/Dialogs/AboutDialog.qml:151
 msgctxt "@label Description for application dependency"
 msgid "C/C++ Binding library"
 msgstr "Biblioteca de Ligações C/C++"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:152
+#: resources/qml/Dialogs/AboutDialog.qml:152
 msgctxt "@label Description for application dependency"
 msgid "Data interchange format"
 msgstr "Formato de Intercâmbio de Dados"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:153
+#: resources/qml/Dialogs/AboutDialog.qml:153
 msgctxt "@label"
 msgid "Font"
 msgstr "Fonte"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:156
+#: resources/qml/Dialogs/AboutDialog.qml:156
 msgctxt "@label Description for application dependency"
 msgid "Polygon clipping library"
 msgstr "Biblioteca de recorte de polígonos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:157
+#: resources/qml/Dialogs/AboutDialog.qml:157
 msgctxt "@label Description for application dependency"
 msgid "JSON parser"
 msgstr "Parser JSON"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:158
+#: resources/qml/Dialogs/AboutDialog.qml:158
 msgctxt "@label Description for application dependency"
 msgid "Utility functions, including an image loader"
 msgstr "Funções de utilidade, incluindo um carregador de imagem"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:159
+#: resources/qml/Dialogs/AboutDialog.qml:159
 msgctxt "@label Description for application dependency"
 msgid "Utility library, including Voronoi generation"
 msgstr "Biblioteca de utilidade, incluindo geração Voronoi"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:162
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:163
+#: resources/qml/Dialogs/AboutDialog.qml:162 resources/qml/Dialogs/AboutDialog.qml:163
 msgctxt "@label Description for application dependency"
 msgid "Root Certificates for validating SSL trustworthiness"
 msgstr "Certificados-Raiz para validar confiança SSL"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:164
+#: resources/qml/Dialogs/AboutDialog.qml:164
 msgctxt "@label Description for application dependency"
 msgid "Compatibility between Python 2 and 3"
 msgstr "Compatibilidade entre Python 2 e 3"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:165
+#: resources/qml/Dialogs/AboutDialog.qml:165
 msgctxt "@label Description for application dependency"
 msgid "Support library for system keyring access"
 msgstr "Biblioteca de suporte para acesso ao chaveiro do sistema"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:166
+#: resources/qml/Dialogs/AboutDialog.qml:166
 msgctxt "@label Description for application dependency"
 msgid "Support library for faster math"
 msgstr "Biblioteca de suporte para matemática acelerada"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:167
+#: resources/qml/Dialogs/AboutDialog.qml:167
 msgctxt "@label Description for application dependency"
 msgid "Support library for handling STL files"
 msgstr "Biblioteca de suporte para manuseamento de arquivos STL"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:168
+#: resources/qml/Dialogs/AboutDialog.qml:168
 msgctxt "@label Description for application dependency"
 msgid "Python bindings for Clipper"
 msgstr "Ligações de Python pra Clipper"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:169
+#: resources/qml/Dialogs/AboutDialog.qml:169
 msgctxt "@label Description for application dependency"
 msgid "Serial communication library"
 msgstr "Biblioteca de comunicação serial"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:170
+#: resources/qml/Dialogs/AboutDialog.qml:170
 msgctxt "@label Description for application dependency"
 msgid "Support library for scientific computing"
 msgstr "Biblioteca de suporte para computação científica"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:171
+#: resources/qml/Dialogs/AboutDialog.qml:171
 msgctxt "@Label Description for application dependency"
 msgid "Python Error tracking library"
 msgstr "Biblioteca de rastreamento de Erros Python"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:172
+#: resources/qml/Dialogs/AboutDialog.qml:172
 msgctxt "@label Description for application dependency"
 msgid "Support library for handling triangular meshes"
 msgstr "Biblioteca de suporte para manuseamento de malhas triangulares"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:173
+#: resources/qml/Dialogs/AboutDialog.qml:173
 msgctxt "@label Description for application dependency"
 msgid "ZeroConf discovery library"
 msgstr "Biblioteca de descoberta 'ZeroConf'"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:176
+#: resources/qml/Dialogs/AboutDialog.qml:176
 msgctxt "@label Description for development tool"
 msgid "Universal build system configuration"
 msgstr "Configuração de sistema universal de construção"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:177
+#: resources/qml/Dialogs/AboutDialog.qml:177
 msgctxt "@label Description for development tool"
 msgid "Dependency and package manager"
 msgstr "Gestor de pacote e dependência"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:178
+#: resources/qml/Dialogs/AboutDialog.qml:178
 msgctxt "@label Description for development tool"
 msgid "Packaging Python-applications"
 msgstr "Empacotamento de aplicações Python"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:179
+#: resources/qml/Dialogs/AboutDialog.qml:179
 msgctxt "@label Description for development tool"
 msgid "Linux cross-distribution application deployment"
 msgstr "Implementação de aplicação multidistribuição em Linux"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AboutDialog.qml:180
+#: resources/qml/Dialogs/AboutDialog.qml:180
 msgctxt "@label Description for development tool"
 msgid "Generating Windows installers"
 msgstr "Gerando instaladores Windows"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:17
+#: resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:17
 msgctxt "@title:window"
 msgid "Open project file"
 msgstr "Abrir arquivo de projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:84
+#: resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:84
 msgctxt "@text:window"
 msgid "This is a Cura project file. Would you like to open it as a project or import the models from it?"
 msgstr "Este é um arquivo de projeto do Cura. Gostaria de abri-lo como um projeto ou importar os modelos dele?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:91
+#: resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:91
 msgctxt "@text:window"
 msgid "Remember my choice"
 msgstr "Lembrar minha escolha"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:105
+#: resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:105
 msgctxt "@action:button"
 msgid "Open as project"
 msgstr "Abrir como projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:110
+#: resources/qml/Dialogs/AskOpenAsProjectOrModelsDialog.qml:110
 msgctxt "@action:button"
 msgid "Import models"
 msgstr "Importar modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/ChoosePrinterDialog.qml:17
+#: resources/qml/Dialogs/ChoosePrinterDialog.qml:17
 msgctxt "@title:window"
 msgid "Select Printer"
 msgstr "Selecione Impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/ChoosePrinterDialog.qml:54
+#: resources/qml/Dialogs/ChoosePrinterDialog.qml:54
 msgctxt "@title:label"
 msgid "Compatible Printers"
 msgstr "Impressoras Compatíveis"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/ChoosePrinterDialog.qml:94
+#: resources/qml/Dialogs/ChoosePrinterDialog.qml:110
 msgctxt "@description"
 msgid "No compatible printers, that are currently online, where found."
 msgstr "Não foram encontradas impressoras compatíveis que estivessem online no momento."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:13
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:13
 msgctxt "@title:window"
 msgid "Discard or Keep changes"
 msgstr "Descartar ou Manter alterações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:59
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:64
 msgctxt "@text:window, %1 is a profile name"
 msgid "You have customized some profile settings. Would you like to Keep these changed settings after switching profiles? Alternatively, you can discard the changes to load the defaults from '%1'."
 msgstr "Você personalizou alguns ajustes de perfil. Gostaria de manter estes ajustes alterados após trocar perfis? Alternativamente, você pode descartar as alterações para carregar os defaults de '%1'."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:85
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:90
 msgctxt "@title:column"
 msgid "Profile settings"
 msgstr "Ajustes de perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:87
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:92
 msgctxt "@title:column"
 msgid "Current changes"
 msgstr "Alterações atuais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:115
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:820
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:123 resources/qml/Preferences/GeneralPage.qml:820
 msgctxt "@option:discardOrKeep"
 msgid "Always ask me this"
 msgstr "Sempre perguntar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:116
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:124
 msgctxt "@option:discardOrKeep"
 msgid "Discard and never ask again"
 msgstr "Descartar e não perguntar novamente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:117
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:125
 msgctxt "@option:discardOrKeep"
 msgid "Keep and never ask again"
 msgstr "Manter e não perguntar novamente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:147
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:157
 msgctxt "@action:button"
 msgid "Discard changes"
 msgstr "Descartar alterações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:153
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:164
 msgctxt "@action:button"
 msgid "Keep changes"
 msgstr "Manter alterações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:47
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:171
+#, fuzzy
+msgctxt "@action:button"
+msgid "Save as new custom profile"
+msgstr "Perfil personalizado"
+
+#: resources/qml/Dialogs/DiscardOrKeepProfileChangesDialog.qml:178
+#, fuzzy
+msgctxt "@action:button"
+msgid "Save changes"
+msgstr "Manter alterações"
+
+#: resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:47
 msgctxt "@text:window"
 msgid "We have found one or more project file(s) within the files you have selected. You can open only one project file at a time. We suggest to only import models from those files. Would you like to proceed?"
 msgstr "Encontramos um ou mais arquivo(s) de projeto entre os arquivos que você selecionou. Você só pode abrir um arquivo de projeto por vez. Sugerimos que somente importe modelos destes arquivos. Gostaria de prosseguir?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:64
+#: resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml:64
 msgctxt "@action:button"
 msgid "Import all as models"
 msgstr "Importar todos como modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:14
+#: resources/qml/Dialogs/RenameDialog.qml:23
+msgctxt "@title:window"
+msgid "Rename"
+msgstr "Renomear"
+
+#: resources/qml/Dialogs/RenameDialog.qml:24
+msgctxt "@info"
+msgid "Please provide a new name."
+msgstr "Por favor, escolha um novo nome."
+
+#: resources/qml/Dialogs/WorkspaceSummaryDialog.qml:14
 msgctxt "@title:window"
 msgid "Save Project"
 msgstr "Salvar Projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:177
+#: resources/qml/Dialogs/WorkspaceSummaryDialog.qml:177
 msgctxt "@action:label"
 msgid "Extruder %1"
 msgstr "Extrusor %1"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:193
+#: resources/qml/Dialogs/WorkspaceSummaryDialog.qml:193
 msgctxt "@action:label"
 msgid "%1 & material"
 msgstr "%1 & material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:195
+#: resources/qml/Dialogs/WorkspaceSummaryDialog.qml:195
 msgctxt "@action:label"
 msgid "Material"
 msgstr "Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:284
+#: resources/qml/Dialogs/WorkspaceSummaryDialog.qml:284
 msgctxt "@action:label"
 msgid "Don't show project summary on save again"
 msgstr "Não exibir resumo do projeto ao salvar novamente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Dialogs/WorkspaceSummaryDialog.qml:298
+#: resources/qml/Dialogs/WorkspaceSummaryDialog.qml:298
 msgctxt "@action:button"
 msgid "Save"
 msgstr "Salvar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ExtruderButton.qml:16
-msgctxt "@label %1 is filled in with the name of an extruder"
-msgid "Print Selected Model with %1"
-msgid_plural "Print Selected Models with %1"
-msgstr[0] "Imprimir Modelo Selecionado com %1"
-msgstr[1] "Imprimir Modelos Selecionados com %1"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/JobSpecs.qml:93
+#: resources/qml/JobSpecs.qml:93
 msgctxt "@text Print job name"
 msgid "Untitled"
 msgstr "Sem Título"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MainWindow/ApplicationMenu.qml:63
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SettingsMenu.qml:13
+#: resources/qml/MainWindow/ApplicationMenu.qml:63 resources/qml/Menus/SettingsMenu.qml:13
 msgctxt "@title:menu menubar:toplevel"
 msgid "&Settings"
 msgstr "Aju&stes"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MainWindow/ApplicationMenu.qml:87
+#: resources/qml/MainWindow/ApplicationMenu.qml:87
 msgctxt "@title:window"
 msgid "New project"
 msgstr "Novo projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MainWindow/ApplicationMenu.qml:88
+#: resources/qml/MainWindow/ApplicationMenu.qml:88
 msgctxt "@info:question"
 msgid "Are you sure you want to start a new project? This will clear the build plate and any unsaved settings."
 msgstr "Tem certeza que quer iniciar novo projeto? Isto esvaziará a mesa de impressão e quaisquer ajustes não salvos."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MainWindow/MainWindowHeader.qml:135
+#: resources/qml/MainWindow/MainWindowHeader.qml:135
 msgctxt "@action:button"
 msgid "Marketplace"
 msgstr "Mercado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/AutoConfiguration.qml:18
+#: resources/qml/Menus/ConfigurationMenu/AutoConfiguration.qml:18
 msgctxt "@header"
 msgid "Configurations"
 msgstr "Configurações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml:137
+#: resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml:137
 msgctxt "@label"
 msgid "This configuration is not available because %1 is not recognized. Please visit %2 to download the correct material profile."
 msgstr "Esta configuração não está disponível porque %1 não foi reconhecido. Por favor visite %2 para baixar o perfil de materil correto."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml:138
+#: resources/qml/Menus/ConfigurationMenu/ConfigurationItem.qml:138
 msgctxt "@label"
 msgid "Marketplace"
 msgstr "Mercado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml:52
+#: resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml:52
 msgctxt "@label"
 msgid "Loading available configurations from the printer..."
 msgstr "Carregando configurações disponíveis da impressora..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml:53
+#: resources/qml/Menus/ConfigurationMenu/ConfigurationListView.qml:53
 msgctxt "@label"
 msgid "The configurations are not available because the printer is disconnected."
 msgstr "As configurações não estão disponíveis porque a impressora está desconectada."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:106
+#: resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:106
 msgctxt "@tooltip"
 msgid "The configuration of this extruder is not allowed, and prohibits slicing."
 msgstr "A configuração deste extrusor não é permitida e proíbe o fatiamento."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:110
+#: resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:110
 msgctxt "@tooltip"
 msgid "There are no profiles matching the configuration of this extruder."
 msgstr "Não há perfis correspondendo à configuração deste extrusor."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:250
+#: resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:250
 msgctxt "@label"
 msgid "Select configuration"
 msgstr "Selecione configuração"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:358
+#: resources/qml/Menus/ConfigurationMenu/ConfigurationMenu.qml:358
 msgctxt "@label"
 msgid "Configurations"
 msgstr "Configurações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:27
+#: resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:27
 msgctxt "@header"
 msgid "Custom"
 msgstr "Personalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:173
+#: resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:173
 msgctxt "@label"
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:222
+#: resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:222
 msgctxt "@label"
 msgid "Material"
 msgstr "Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:348
+#: resources/qml/Menus/ConfigurationMenu/CustomConfiguration.qml:348
 msgctxt "@label"
 msgid "Use glue for better adhesion with this material combination."
 msgstr "Use cola para melhor aderência com essa combinação de materiais."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ContextMenu.qml:29
+#: resources/qml/Menus/ContextMenu.qml:29
 msgctxt "@label"
 msgid "Print Selected Model With:"
 msgid_plural "Print Selected Models With:"
 msgstr[0] "Imprimir Modelo Selecionado Com:"
 msgstr[1] "Imprimir Modelos Selecionados Com:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ContextMenu.qml:92
+#: resources/qml/Menus/ContextMenu.qml:92
 msgctxt "@title:window"
 msgid "Multiply Selected Model"
 msgid_plural "Multiply Selected Models"
 msgstr[0] "Multiplicar Modelo Selecionado"
 msgstr[1] "Multiplicar Modelos Selecionados"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ContextMenu.qml:123
+#: resources/qml/Menus/ContextMenu.qml:123
 msgctxt "@label"
 msgid "Number of Copies"
 msgstr "Número de Cópias"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/EditMenu.qml:12
+#: resources/qml/Menus/EditMenu.qml:12
 msgctxt "@title:menu menubar:toplevel"
 msgid "&Edit"
 msgstr "&Editar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ExtensionMenu.qml:13
+#: resources/qml/Menus/ExtensionMenu.qml:13
 msgctxt "@title:menu menubar:toplevel"
 msgid "E&xtensions"
 msgstr "E&xtensões"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/FileMenu.qml:13
+#: resources/qml/Menus/FileMenu.qml:13
 msgctxt "@title:menu menubar:toplevel"
 msgid "&File"
 msgstr "Arquivo (&F)"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/FileMenu.qml:45
+#: resources/qml/Menus/FileMenu.qml:45
 msgctxt "@title:menu menubar:file"
 msgid "&Save Project..."
 msgstr "&Salvar Projeto..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/FileMenu.qml:78
+#: resources/qml/Menus/FileMenu.qml:78
 msgctxt "@title:menu menubar:file"
 msgid "&Export..."
 msgstr "&Exportar..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/FileMenu.qml:89
+#: resources/qml/Menus/FileMenu.qml:89
 msgctxt "@action:inmenu menubar:file"
 msgid "Export Selection..."
 msgstr "Exportar Seleção..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/HelpMenu.qml:14
+#: resources/qml/Menus/HelpMenu.qml:14
 msgctxt "@title:menu menubar:toplevel"
 msgid "&Help"
 msgstr "Ajuda (&H)"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/MaterialMenu.qml:13
+#: resources/qml/Menus/MaterialMenu.qml:13
 msgctxt "@label:category menu label"
 msgid "Material"
 msgstr "Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/MaterialMenu.qml:53
+#: resources/qml/Menus/MaterialMenu.qml:53
 msgctxt "@label:category menu label"
 msgid "Favorites"
 msgstr "Favoritos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/MaterialMenu.qml:78
+#: resources/qml/Menus/MaterialMenu.qml:78
 msgctxt "@label:category menu label"
 msgid "Generic"
 msgstr "Genérico"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/OpenFilesMenu.qml:15
+#: resources/qml/Menus/OpenFilesMenu.qml:15
 msgctxt "@title:menu menubar:file"
 msgid "Open File(s)..."
 msgstr "Abrir Arquivo(s)..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/PreferencesMenu.qml:21
+#: resources/qml/Menus/PreferencesMenu.qml:21
 msgctxt "@title:menu menubar:toplevel"
 msgid "P&references"
 msgstr "P&referências"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/PrinterMenu.qml:13
+#: resources/qml/Menus/PrinterMenu.qml:13
 msgctxt "@title:menu menubar:settings"
 msgid "&Printer"
 msgstr "Im&pressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/PrinterMenu.qml:17
+#: resources/qml/Menus/PrinterMenu.qml:17
 msgctxt "@label:category menu label"
 msgid "Network enabled printers"
 msgstr "Impressoras habilitadas pela rede"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/PrinterMenu.qml:50
+#: resources/qml/Menus/PrinterMenu.qml:50
 msgctxt "@label:category menu label"
 msgid "Local printers"
 msgstr "Impressoras locais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/RecentFilesMenu.qml:15
+#: resources/qml/Menus/RecentFilesMenu.qml:15
 msgctxt "@title:menu menubar:file"
 msgid "Open &Recent"
 msgstr "Abrir &Recente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SaveProjectMenu.qml:15
+#: resources/qml/Menus/SaveProjectMenu.qml:15
 msgctxt "@title:menu menubar:file"
 msgid "Save Project..."
 msgstr "Salvar Projeto..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:16
+#: resources/qml/Menus/SettingVisibilityPresetsMenu.qml:16
 msgctxt "@action:inmenu"
 msgid "Visible Settings"
 msgstr "Ajustes Visíveis"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:42
+#: resources/qml/Menus/SettingVisibilityPresetsMenu.qml:42
 msgctxt "@action:inmenu"
 msgid "Collapse All Categories"
 msgstr "Encolher Todas As Categorias"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SettingVisibilityPresetsMenu.qml:51
+#: resources/qml/Menus/SettingVisibilityPresetsMenu.qml:51
 msgctxt "@action:inmenu"
 msgid "Manage Setting Visibility..."
 msgstr "Gerenciar Visibilidade dos Ajustes..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SettingsMenu.qml:34
+#: resources/qml/Menus/SettingsMenu.qml:34
 msgctxt "@title:menu"
 msgid "&Material"
 msgstr "&Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SettingsMenu.qml:49
+#: resources/qml/Menus/SettingsMenu.qml:49
 msgctxt "@action:inmenu"
 msgid "Set as Active Extruder"
 msgstr "Definir Como Extrusor Ativo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SettingsMenu.qml:55
+#: resources/qml/Menus/SettingsMenu.qml:55
 msgctxt "@action:inmenu"
 msgid "Enable Extruder"
 msgstr "Habilitar Extrusor"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/SettingsMenu.qml:63
+#: resources/qml/Menus/SettingsMenu.qml:63
 msgctxt "@action:inmenu"
 msgid "Disable Extruder"
 msgstr "Desabilitar Extrusor"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ViewMenu.qml:13
+#: resources/qml/Menus/ViewMenu.qml:13
 msgctxt "@title:menu menubar:toplevel"
 msgid "&View"
 msgstr "&Ver"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ViewMenu.qml:17
+#: resources/qml/Menus/ViewMenu.qml:17
 msgctxt "@action:inmenu menubar:view"
 msgid "&Camera position"
 msgstr "Posição da &câmera"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ViewMenu.qml:30
+#: resources/qml/Menus/ViewMenu.qml:30
 msgctxt "@action:inmenu menubar:view"
 msgid "Camera view"
 msgstr "Visão de câmera"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ViewMenu.qml:48
+#: resources/qml/Menus/ViewMenu.qml:48
 msgctxt "@action:inmenu menubar:view"
 msgid "Perspective"
 msgstr "Perspectiva"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Menus/ViewMenu.qml:59
+#: resources/qml/Menus/ViewMenu.qml:59
 msgctxt "@action:inmenu menubar:view"
 msgid "Orthographic"
 msgstr "Ortográfico"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:115
+#: resources/qml/MonitorButton.qml:115
 msgctxt "@label:MonitorStatus"
 msgid "Not connected to a printer"
 msgstr "Não conectado a nenhuma impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:119
+#: resources/qml/MonitorButton.qml:119
 msgctxt "@label:MonitorStatus"
 msgid "Printer does not accept commands"
 msgstr "A impressora não aceita comandos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:129
+#: resources/qml/MonitorButton.qml:129
 msgctxt "@label:MonitorStatus"
 msgid "In maintenance. Please check the printer"
 msgstr "Em manutenção. Por favor verifique a impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:140
+#: resources/qml/MonitorButton.qml:140
 msgctxt "@label:MonitorStatus"
 msgid "Lost connection with the printer"
 msgstr "A conexão à impressora foi perdida"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:142
+#: resources/qml/MonitorButton.qml:142
 msgctxt "@label:MonitorStatus"
 msgid "Printing..."
 msgstr "Imprimindo..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:145
+#: resources/qml/MonitorButton.qml:145
 msgctxt "@label:MonitorStatus"
 msgid "Paused"
 msgstr "Pausado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:148
+#: resources/qml/MonitorButton.qml:148
 msgctxt "@label:MonitorStatus"
 msgid "Preparing..."
 msgstr "Preparando..."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:150
+#: resources/qml/MonitorButton.qml:150
 msgctxt "@label:MonitorStatus"
 msgid "Please remove the print"
 msgstr "Por favor remova a impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:318
+#: resources/qml/MonitorButton.qml:318
 msgctxt "@label"
 msgid "Abort Print"
 msgstr "Abortar Impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/MonitorButton.qml:327
+#: resources/qml/MonitorButton.qml:327
 msgctxt "@label"
 msgid "Are you sure you want to abort the print?"
 msgstr "Tem certeza que deseja abortar a impressão?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ObjectItemButton.qml:109
+#: resources/qml/ObjectItemButton.qml:109
 msgctxt "@label"
 msgid "Is printed as support."
 msgstr "Está impresso como suporte."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ObjectItemButton.qml:112
+#: resources/qml/ObjectItemButton.qml:112
 msgctxt "@label"
 msgid "Other models overlapping with this model are modified."
 msgstr "Outros modelos se sobrepondo a esse modelo foram modificados."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ObjectItemButton.qml:115
+#: resources/qml/ObjectItemButton.qml:115
 msgctxt "@label"
 msgid "Infill overlapping with this model is modified."
 msgstr "Preenchimento se sobrepondo a este modelo foi modificado."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ObjectItemButton.qml:118
+#: resources/qml/ObjectItemButton.qml:118
 msgctxt "@label"
 msgid "Overlaps with this model are not supported."
 msgstr "Sobreposições neste modelo não são suportadas."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ObjectItemButton.qml:125
+#: resources/qml/ObjectItemButton.qml:125
 msgctxt "@label %1 is the number of settings it overrides."
 msgid "Overrides %1 setting."
 msgid_plural "Overrides %1 settings."
 msgstr[0] "Sobrepõe %1 ajuste."
 msgstr[1] "Sobrepõe %1 ajustes."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ObjectSelector.qml:59
+#: resources/qml/ObjectSelector.qml:59
 msgctxt "@label"
 msgid "Object list"
 msgstr "Lista de objetos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:134
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:24
+#: resources/qml/Preferences/GeneralPage.qml:134 resources/qml/Preferences/SettingVisibilityPage.qml:24
 msgctxt "@action:button"
 msgid "Defaults"
 msgstr "Defaults"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:172
+#: resources/qml/Preferences/GeneralPage.qml:172
 msgctxt "@label"
 msgid "Interface"
 msgstr "Interface"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:215
+#: resources/qml/Preferences/GeneralPage.qml:215
 msgctxt "@heading"
 msgid "-- incomplete --"
 msgstr "-- incompleto --"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:261
+#: resources/qml/Preferences/GeneralPage.qml:261
 msgctxt "@label"
 msgid "Currency:"
 msgstr "Moeda:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:277
+#: resources/qml/Preferences/GeneralPage.qml:277
 msgctxt "@label: Please keep the asterix, it's to indicate that a restart is needed."
 msgid "Theme*:"
 msgstr "Tema*:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:323
+#: resources/qml/Preferences/GeneralPage.qml:323
 msgctxt "@info:tooltip"
 msgid "Slice automatically when changing settings."
 msgstr "Fatiar automaticamente quando mudar ajustes."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:331
+#: resources/qml/Preferences/GeneralPage.qml:331
 msgctxt "@option:check"
 msgid "Slice automatically"
 msgstr "Fatiar automaticamente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:340
+#: resources/qml/Preferences/GeneralPage.qml:340
 msgctxt "@info:tooltip"
 msgid "Show an icon and notifications in the system notification area."
-msgstr ""
+msgstr "Mostrar um ícone e notificações na área de notificações do sistema."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:348
+#: resources/qml/Preferences/GeneralPage.qml:348
 msgctxt "@option:check"
 msgid "Add icon to system tray *"
 msgstr "Adicionar ícone à bandeja do sistema *"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:357
+#: resources/qml/Preferences/GeneralPage.qml:357
 msgctxt "@label"
 msgid "*You will need to restart the application for these changes to have effect."
 msgstr "*Você precisa reiniciar a aplicação para que estas alterações tenham efeito."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:373
+#: resources/qml/Preferences/GeneralPage.qml:373
 msgctxt "@label"
 msgid "Viewport behavior"
 msgstr "Comportamento da área de visualização"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:381
+#: resources/qml/Preferences/GeneralPage.qml:381
 msgctxt "@info:tooltip"
 msgid "Highlight unsupported areas of the model in red. Without support these areas will not print properly."
 msgstr "Ressaltar áreas sem suporte do modelo em vermelho. Sem suporte, estas áreas não serão impressas corretamente."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:390
+#: resources/qml/Preferences/GeneralPage.qml:390
 msgctxt "@option:check"
 msgid "Display overhang"
 msgstr "Exibir seções pendentes"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:400
+#: resources/qml/Preferences/GeneralPage.qml:400
 msgctxt "@info:tooltip"
 msgid "Highlight missing or extraneous surfaces of the model using warning signs. The toolpaths will often be missing parts of the intended geometry."
 msgstr "Ressalta superfícies faltantes ou incorretas do modelo usando sinais de alerta. Os caminhos de extrusão frequentemente terão partes da geometria pretendida ausentes."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:409
+#: resources/qml/Preferences/GeneralPage.qml:409
 msgctxt "@option:check"
 msgid "Display model errors"
 msgstr "Exibir erros de modelo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:417
+#: resources/qml/Preferences/GeneralPage.qml:417
 msgctxt "@info:tooltip"
 msgid "Moves the camera so the model is in the center of the view when a model is selected"
 msgstr "Move a câmera de modo que o modelo fique no centro da visão quando for selecionado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:422
+#: resources/qml/Preferences/GeneralPage.qml:422
 msgctxt "@action:button"
 msgid "Center camera when item is selected"
 msgstr "Centralizar câmera quanto o item é selecionado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:432
+#: resources/qml/Preferences/GeneralPage.qml:432
 msgctxt "@info:tooltip"
 msgid "Should the default zoom behavior of cura be inverted?"
 msgstr "O comportamento default de ampliação deve ser invertido?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:437
+#: resources/qml/Preferences/GeneralPage.qml:437
 msgctxt "@action:button"
 msgid "Invert the direction of camera zoom."
 msgstr "Inverter a direção da ampliação de câmera."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:453
+#: resources/qml/Preferences/GeneralPage.qml:453
 msgctxt "@info:tooltip"
 msgid "Should zooming move in the direction of the mouse?"
 msgstr "A ampliação (zoom) deve se mover na direção do mouse?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:453
+#: resources/qml/Preferences/GeneralPage.qml:453
 msgctxt "@info:tooltip"
 msgid "Zooming towards the mouse is not supported in the orthographic perspective."
 msgstr "Ampliar com o mouse não é suportado na perspectiva ortográfica."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:458
+#: resources/qml/Preferences/GeneralPage.qml:458
 msgctxt "@action:button"
 msgid "Zoom toward mouse direction"
 msgstr "Ampliar na direção do mouse"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:484
+#: resources/qml/Preferences/GeneralPage.qml:484
 msgctxt "@info:tooltip"
 msgid "Should models on the platform be moved so that they no longer intersect?"
 msgstr "Os modelos devem ser movidos na plataforma de modo que não se sobreponham?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:489
+#: resources/qml/Preferences/GeneralPage.qml:489
 msgctxt "@option:check"
 msgid "Ensure models are kept apart"
 msgstr "Assegurar que os modelos sejam mantidos separados"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:498
+#: resources/qml/Preferences/GeneralPage.qml:498
 msgctxt "@info:tooltip"
 msgid "Should models on the platform be moved down to touch the build plate?"
 msgstr "Os modelos devem ser movidos pra baixo pra se assentar na plataforma de impressão?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:503
+#: resources/qml/Preferences/GeneralPage.qml:503
 msgctxt "@option:check"
 msgid "Automatically drop models to the build plate"
 msgstr "Automaticamente fazer os modelos caírem na mesa de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:515
+#: resources/qml/Preferences/GeneralPage.qml:515
 msgctxt "@info:tooltip"
 msgid "Show caution message in g-code reader."
 msgstr "Exibir mensagem de alerta no leitor de G-Code."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:524
+#: resources/qml/Preferences/GeneralPage.qml:524
 msgctxt "@option:check"
 msgid "Caution message in g-code reader"
 msgstr "Mensagem de alera no leitor de G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:532
+#: resources/qml/Preferences/GeneralPage.qml:532
 msgctxt "@info:tooltip"
 msgid "Should layer be forced into compatibility mode?"
 msgstr "A Visão de Camada deve ser forçada a ficar em modo de compatibilidade?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:537
+#: resources/qml/Preferences/GeneralPage.qml:537
 msgctxt "@option:check"
 msgid "Force layer view compatibility mode (restart required)"
 msgstr "Forçar modo de compatibilidade da visão de camadas (requer reinício)"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:547
+#: resources/qml/Preferences/GeneralPage.qml:547
 msgctxt "@info:tooltip"
 msgid "Should Cura open at the location it was closed?"
 msgstr "O Cura deve abrir no lugar onde foi fechado?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:552
+#: resources/qml/Preferences/GeneralPage.qml:552
 msgctxt "@option:check"
 msgid "Restore window position on start"
 msgstr "Restaurar posição da janela no início"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:562
+#: resources/qml/Preferences/GeneralPage.qml:562
 msgctxt "@info:tooltip"
 msgid "What type of camera rendering should be used?"
 msgstr "Que tipo de renderização de câmera deve ser usada?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:569
+#: resources/qml/Preferences/GeneralPage.qml:569
 msgctxt "@window:text"
 msgid "Camera rendering:"
 msgstr "Renderização de câmera:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:576
+#: resources/qml/Preferences/GeneralPage.qml:576
 msgid "Perspective"
 msgstr "Perspectiva"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:577
+#: resources/qml/Preferences/GeneralPage.qml:577
 msgid "Orthographic"
 msgstr "Ortográfica"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:617
+#: resources/qml/Preferences/GeneralPage.qml:617
 msgctxt "@label"
 msgid "Opening and saving files"
 msgstr "Abrindo e salvando arquivos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:624
+#: resources/qml/Preferences/GeneralPage.qml:624
 msgctxt "@info:tooltip"
 msgid "Should opening files from the desktop or external applications open in the same instance of Cura?"
 msgstr "Arquivos da área de trabalho ou de aplicações externas devem ser abertos na mesma instância do Cura?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:629
+#: resources/qml/Preferences/GeneralPage.qml:629
 msgctxt "@option:check"
 msgid "Use a single instance of Cura"
 msgstr "Usar uma única instância do Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:640
+#: resources/qml/Preferences/GeneralPage.qml:640
 msgctxt "@info:tooltip"
 msgid "Should the build plate be cleared before loading a new model in the single instance of Cura?"
 msgstr "A plataforma de construção deve ser esvaziada antes de carregar um modelo novo na instância única do Cura?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:646
+#: resources/qml/Preferences/GeneralPage.qml:646
 msgctxt "@option:check"
 msgid "Clear buildplate before loading model into the single instance"
 msgstr "Limpar a plataforma de impressão antes de carregar modelo em instância única"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:656
+#: resources/qml/Preferences/GeneralPage.qml:656
 msgctxt "@info:tooltip"
 msgid "Should models be scaled to the build volume if they are too large?"
 msgstr "Os modelos devem ser redimensionados dentro do volume de impressão se forem muito grandes?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:661
+#: resources/qml/Preferences/GeneralPage.qml:661
 msgctxt "@option:check"
 msgid "Scale large models"
 msgstr "Redimensionar modelos grandes"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:671
+#: resources/qml/Preferences/GeneralPage.qml:671
 msgctxt "@info:tooltip"
 msgid "An model may appear extremely small if its unit is for example in meters rather than millimeters. Should these models be scaled up?"
 msgstr "Um modelo pode ser carregado diminuto se sua unidade for por exemplo em metros ao invés de milímetros. Devem esses modelos ser redimensionados?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:676
+#: resources/qml/Preferences/GeneralPage.qml:676
 msgctxt "@option:check"
 msgid "Scale extremely small models"
 msgstr "Redimensionar modelos minúsculos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:686
+#: resources/qml/Preferences/GeneralPage.qml:686
 msgctxt "@info:tooltip"
 msgid "Should models be selected after they are loaded?"
 msgstr "Os modelos devem ser selecionados após serem carregados?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:691
+#: resources/qml/Preferences/GeneralPage.qml:691
 msgctxt "@option:check"
 msgid "Select models when loaded"
 msgstr "Selecionar modelos ao carregar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:701
+#: resources/qml/Preferences/GeneralPage.qml:701
 msgctxt "@info:tooltip"
 msgid "Should a prefix based on the printer name be added to the print job name automatically?"
 msgstr "Um prefixo baseado no nome da impressora deve ser adicionado ao nome do trabalho de impressão automaticamente?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:706
+#: resources/qml/Preferences/GeneralPage.qml:706
 msgctxt "@option:check"
 msgid "Add machine prefix to job name"
 msgstr "Adicionar prefixo de máquina ao nome do trabalho"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:716
+#: resources/qml/Preferences/GeneralPage.qml:716
 msgctxt "@info:tooltip"
 msgid "Should a summary be shown when saving a project file?"
 msgstr "Um resumo deve ser exibido ao salvar um arquivo de projeto?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:720
+#: resources/qml/Preferences/GeneralPage.qml:720
 msgctxt "@option:check"
 msgid "Show summary dialog when saving project"
 msgstr "Exibir diálogo de resumo ao salvar projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:730
+#: resources/qml/Preferences/GeneralPage.qml:730
 msgctxt "@info:tooltip"
 msgid "Default behavior when opening a project file"
 msgstr "Comportamento default ao abrir um arquivo de projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:738
+#: resources/qml/Preferences/GeneralPage.qml:738
 msgctxt "@window:text"
 msgid "Default behavior when opening a project file: "
 msgstr "Comportamento default ao abrir um arquivo de projeto: "
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:753
+#: resources/qml/Preferences/GeneralPage.qml:753
 msgctxt "@option:openProject"
 msgid "Always ask me this"
 msgstr "Sempre me perguntar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:754
+#: resources/qml/Preferences/GeneralPage.qml:754
 msgctxt "@option:openProject"
 msgid "Always open as a project"
 msgstr "Sempre abrir como projeto"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:755
+#: resources/qml/Preferences/GeneralPage.qml:755
 msgctxt "@option:openProject"
 msgid "Always import models"
 msgstr "Sempre importar modelos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:792
+#: resources/qml/Preferences/GeneralPage.qml:792
 msgctxt "@info:tooltip"
 msgid "When you have made changes to a profile and switched to a different one, a dialog will be shown asking whether you want to keep your modifications or not, or you can choose a default behaviour and never show that dialog again."
 msgstr "Quando você faz alterações em um perfil e troca para um diferent, um diálogo aparecerá perguntando se você quer manter ou aplicar suas modificações, ou você pode forçar um comportamento default e não ter o diálogo."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:801
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml:36
+#: resources/qml/Preferences/GeneralPage.qml:801 resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml:46
 msgctxt "@label"
 msgid "Profiles"
 msgstr "Perfis"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:806
+#: resources/qml/Preferences/GeneralPage.qml:806
 msgctxt "@window:text"
 msgid "Default behavior for changed setting values when switching to a different profile: "
 msgstr "Comportamento default para valores de configuração alterados ao mudar para um perfil diferente: "
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:821
+#: resources/qml/Preferences/GeneralPage.qml:821
 msgctxt "@option:discardOrKeep"
 msgid "Always discard changed settings"
 msgstr "Sempre descartar alterações da configuração"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:822
+#: resources/qml/Preferences/GeneralPage.qml:822
 msgctxt "@option:discardOrKeep"
 msgid "Always transfer changed settings to new profile"
 msgstr "Sempre transferir as alterações para o novo perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:856
+#: resources/qml/Preferences/GeneralPage.qml:856
 msgctxt "@label"
 msgid "Privacy"
 msgstr "Privacidade"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:862
+#: resources/qml/Preferences/GeneralPage.qml:862
 msgctxt "@info:tooltip"
 msgid "Should anonymous data about your print be sent to UltiMaker? Note, no models, IP addresses or other personally identifiable information is sent or stored."
 msgstr "Dados anônimos sobre sua impressão podem ser enviados para a UltiMaker? Nota: nenhuma informação pessoalmente identificável, modelos ou endereços IP são enviados ou armazenados."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:867
+#: resources/qml/Preferences/GeneralPage.qml:867
 msgctxt "@option:check"
 msgid "Send (anonymous) print information"
 msgstr "Enviar informação (anônima) de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:897
+#: resources/qml/Preferences/GeneralPage.qml:897
 msgctxt "@label"
 msgid "Updates"
 msgstr "Atualizações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:904
+#: resources/qml/Preferences/GeneralPage.qml:904
 msgctxt "@info:tooltip"
 msgid "Should Cura check for updates when the program is started?"
 msgstr "O Cura deve verificar novas atualizações quando o programa for iniciado?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:909
+#: resources/qml/Preferences/GeneralPage.qml:909
 msgctxt "@option:check"
 msgid "Check for updates on start"
 msgstr "Verificar atualizações na inicialização"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:925
+#: resources/qml/Preferences/GeneralPage.qml:925
 msgctxt "@info:tooltip"
 msgid "When checking for updates, only check for stable releases."
 msgstr "Ao procurar por atualizações, somente o fazer para versões estáveis."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:931
+#: resources/qml/Preferences/GeneralPage.qml:931
 msgctxt "@option:radio"
 msgid "Stable releases only"
 msgstr "Versões estáveis somente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:941
+#: resources/qml/Preferences/GeneralPage.qml:941
 msgctxt "@info:tooltip"
 msgid "When checking for updates, check for both stable and for beta releases."
 msgstr "Ao procurar por atualizações, fazer para versões estáveis ou beta."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:947
+#: resources/qml/Preferences/GeneralPage.qml:947
 msgctxt "@option:radio"
 msgid "Stable and Beta releases"
 msgstr "Versões estáveis ou beta"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:957
+#: resources/qml/Preferences/GeneralPage.qml:957
 msgctxt "@info:tooltip"
 msgid "Should an automatic check for new plugins be done every time Cura is started? It is highly recommended that you do not disable this!"
 msgstr "Uma verificação automática por novos complementos deve ser feita toda vez que o Cura iniciar? É altamente recomendado que não desabilite esta opção!"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/GeneralPage.qml:962
+#: resources/qml/Preferences/GeneralPage.qml:962
 msgctxt "@option:check"
 msgid "Get notifications for plugin updates"
 msgstr "Ter notificações para atualizações de complementos"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/MachinesPage.qml:50
+#: resources/qml/Preferences/MachinesPage.qml:50
 msgctxt "@action:button"
 msgid "Add New"
 msgstr "Adicionar Novo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/MachinesPage.qml:142
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:160
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:294
+#: resources/qml/Preferences/MachinesPage.qml:147 resources/qml/Preferences/Materials/MaterialsPage.qml:160 resources/qml/Preferences/ProfilesPage.qml:294
 msgctxt "@action:button"
 msgid "Activate"
 msgstr "Ativar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/MachinesPage.qml:154
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:331
+#: resources/qml/Preferences/MachinesPage.qml:159 resources/qml/Preferences/ProfilesPage.qml:331
 msgctxt "@action:button"
 msgid "Rename"
 msgstr "Renomear"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:72
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:72
 msgctxt "@label"
 msgid "Materials compatible with active printer:"
 msgstr "Materiais compatíveis com a impressora ativa:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:78
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:94
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:78 resources/qml/Preferences/ProfilesPage.qml:94
 msgctxt "@action:button"
 msgid "Create new"
 msgstr "Criar novo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:90
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:88
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:90 resources/qml/Preferences/ProfilesPage.qml:88
 msgctxt "@action:button"
 msgid "Import"
 msgstr "Importar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:101
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:101
 msgctxt "@action:button"
 msgid "Sync with Printers"
 msgstr "Sincronizar com Impressoras"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:174
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:311
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:174 resources/qml/Preferences/ProfilesPage.qml:311
 msgctxt "@action:button"
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:198
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:342
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:198 resources/qml/Preferences/ProfilesPage.qml:342
 msgctxt "@action:button"
 msgid "Export"
 msgstr "Exportar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:212
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:392
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:212 resources/qml/Preferences/ProfilesPage.qml:392
 msgctxt "@title:window"
 msgid "Confirm Remove"
 msgstr "Confirmar Remoção"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:215
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:393
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:215 resources/qml/Preferences/ProfilesPage.qml:393
 msgctxt "@label (%1 is object name)"
 msgid "Are you sure you wish to remove %1? This cannot be undone!"
 msgstr "Tem certeza que deseja remover %1? Isto não poderá ser desfeito!"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:228
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:238
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:228 resources/qml/Preferences/Materials/MaterialsPage.qml:238
 msgctxt "@title:window"
 msgid "Import Material"
 msgstr "Importar Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:242
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:242
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid "Successfully imported material <filename>%1</filename>"
 msgstr "Material <filename>%1</filename> importado com sucesso"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:245
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:245
 msgctxt "@info:status Don't translate the XML tags <filename> or <message>!"
 msgid "Could not import material <filename>%1</filename>: <message>%2</message>"
 msgstr "Não foi possível importar material <filename>%1</filename>: <message>%2</message>"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:256
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:267
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:256 resources/qml/Preferences/Materials/MaterialsPage.qml:267
 msgctxt "@title:window"
 msgid "Export Material"
 msgstr "Exportar Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:272
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:272
 msgctxt "@info:status Don't translate the XML tags <filename> and <message>!"
 msgid "Failed to export material to <filename>%1</filename>: <message>%2</message>"
 msgstr "Falha em exportar material para <filename>%1</filename>: <message>%2</message>"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsPage.qml:275
+#: resources/qml/Preferences/Materials/MaterialsPage.qml:275
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid "Successfully exported material to <filename>%1</filename>"
 msgstr "Material exportado para <filename>%1</filename> com sucesso"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:18
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:18
 msgctxt "@title:window"
 msgid "Sync materials with printers"
 msgstr "Sincronizar materiais com impressoras"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:49
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:49
 msgctxt "@title:header"
 msgid "Sync materials with printers"
 msgstr "Sincronizar materiais com impressoras"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:55
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:55
 msgctxt "@text"
 msgid "Following a few simple steps, you will be able to synchronize all your material profiles with your printers."
 msgstr "Seguindo alguns passos simples, você conseguirá sincronizar todos os seus perfis de material com suas impressoras."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:77
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:77
 msgctxt "@button"
 msgid "Why do I need to sync material profiles?"
 msgstr "Por que eu preciso sincronizar perfis de material?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:86
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:86
 msgctxt "@button"
 msgid "Start"
 msgstr "Iniciar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:144
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:144
 msgctxt "@title:header"
 msgid "Sign in"
 msgstr "Entrar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:150
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:150
 msgctxt "@text"
 msgid "To automatically sync the material profiles with all your printers connected to Digital Factory you need to be signed in in Cura."
 msgstr "Para automaticamente sincronizar os perfis de material com todas as suas impressoras conectadas à Digital Factory, você precisa estar logado pelo Cura."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:174
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:462
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:602
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:174 resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:462 resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:602
 msgctxt "@button"
 msgid "Sync materials with USB"
 msgstr "Sincronizar materiais usando USB"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:207
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:207
 msgctxt "@title:header"
 msgid "The following printers will receive the new material profiles:"
 msgstr "Os seguintes materiais receberão novos perfis de material:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:214
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:214
 msgctxt "@title:header"
 msgid "Something went wrong when sending the materials to the printers."
 msgstr "Algo de errado aconteceu ao enviar os materiais às impressoras."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:221
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:221
 msgctxt "@title:header"
 msgid "Material profiles successfully synced with the following printers:"
 msgstr "Perfis de material sincronizados com sucesso com as seguintes impressoras:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:258
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:445
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:258 resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:445
 msgctxt "@button"
 msgid "Troubleshooting"
 msgstr "Resolução de problemas"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:422
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:422
 msgctxt "@text Asking the user whether printers are missing in a list."
 msgid "Printers missing?"
 msgstr "Impressoras faltando?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:424
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:424
 msgctxt "@text"
 msgid "Make sure all your printers are turned ON and connected to Digital Factory."
 msgstr "Certifique-se de que todas as suas impressoras estejam LIGADAS e conectadas à Digital Factory."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:433
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:433
 msgctxt "@button"
 msgid "Refresh List"
 msgstr "Atualizar Lista"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:473
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:473
 msgctxt "@button"
 msgid "Try again"
 msgstr "Tentar novamente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:477
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:712
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:477 resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:712
 msgctxt "@button"
 msgid "Done"
 msgstr "Feito"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:479
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:622
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:479 resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:622
 msgctxt "@button"
 msgid "Sync"
 msgstr "Sincronizar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:535
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:535
 msgctxt "@button"
 msgid "Syncing"
 msgstr "Sincronizando"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:553
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:553
 msgctxt "@title:header"
 msgid "No printers found"
 msgstr "Nenhuma impressora encontrada"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:574
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:574
 msgctxt "@text"
 msgid "It seems like you don't have any compatible printers connected to Digital Factory. Make sure your printer is connected and it's running the latest firmware."
 msgstr "Parece que você não tem impressoras compatíveis conectadas à Digital Factory. Certifique-se que sua impressora esteja conectada e rodando o firmware mais recente."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:585
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:585
 msgctxt "@button"
 msgid "Learn how to connect your printer to Digital Factory"
 msgstr "Aprenda como conectar sua impressora à Digital Factory"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:613
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:613
 msgctxt "@button"
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:642
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:642
 msgctxt "@title:header"
 msgid "Sync material profiles via USB"
 msgstr "Sincronizar perfis de material via USB"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:648
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:648
 msgctxt "@text In the UI this is followed by a list of steps the user needs to take."
 msgid "Follow the following steps to load the new material profiles to your printer."
 msgstr "Siga os passos seguintes para carregar os perfis de material novos na sua impressora."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:679
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:679
 msgctxt "@text"
 msgid "Click the export material archive button."
 msgstr "Clique no botão de exportar arquivo de material."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:680
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:680
 msgctxt "@text"
 msgid "Save the .umm file on a USB stick."
 msgstr "Grava o arquivo .umm em um pendrive USB."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:681
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:681
 msgctxt "@text"
 msgid "Insert the USB stick into your printer and launch the procedure to load new material profiles."
 msgstr "Insira o pendrive USB na sua impressora e faça o procedimento de carregar novos perfis de material."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:689
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:689
 msgctxt "@button"
 msgid "How to load new material profiles to my printer"
 msgstr "Como carregar novos perfis de material na minha impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:703
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:299
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:703 resources/qml/WelcomePages/AddPrinterByIpContent.qml:299
 msgctxt "@button"
 msgid "Back"
 msgstr "Voltar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:712
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:712
 msgctxt "@button"
 msgid "Export material archive"
 msgstr "Exportar arquivo de material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:747
+#: resources/qml/Preferences/Materials/MaterialsSyncDialog.qml:747
 msgctxt "@title:window"
 msgid "Export All Materials"
 msgstr "Exportar Todos Os Materiais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:121
+#: resources/qml/Preferences/Materials/MaterialsView.qml:121
 msgctxt "@title:window"
 msgid "Confirm Diameter Change"
 msgstr "Confirmar Mudança de Diâmetro"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:122
+#: resources/qml/Preferences/Materials/MaterialsView.qml:122
 msgctxt "@label (%1 is a number)"
 msgid "The new filament diameter is set to %1 mm, which is not compatible with the current extruder. Do you wish to continue?"
 msgstr "O novo diâmetro de filamento está ajustado em %1 mm, que não é compatível com o extrusor atual. Você deseja continuar?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:152
+#: resources/qml/Preferences/Materials/MaterialsView.qml:152
 msgctxt "@label"
 msgid "Display Name"
 msgstr "Exibir Nome"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:171
+#: resources/qml/Preferences/Materials/MaterialsView.qml:171
 msgctxt "@label"
 msgid "Brand"
 msgstr "Marca"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:190
+#: resources/qml/Preferences/Materials/MaterialsView.qml:190
 msgctxt "@label"
 msgid "Material Type"
 msgstr "Tipo de Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:210
+#: resources/qml/Preferences/Materials/MaterialsView.qml:210
 msgctxt "@label"
 msgid "Color"
 msgstr "Cor"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:262
+#: resources/qml/Preferences/Materials/MaterialsView.qml:262
 msgctxt "@title"
 msgid "Material color picker"
 msgstr "Seletor de cores do material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:275
+#: resources/qml/Preferences/Materials/MaterialsView.qml:275
 msgctxt "@label"
 msgid "Properties"
 msgstr "Propriedades"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:286
+#: resources/qml/Preferences/Materials/MaterialsView.qml:286
 msgctxt "@label"
 msgid "Density"
 msgstr "Densidade"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:319
+#: resources/qml/Preferences/Materials/MaterialsView.qml:319
 msgctxt "@label"
 msgid "Diameter"
 msgstr "Diâmetro"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:369
+#: resources/qml/Preferences/Materials/MaterialsView.qml:369
 msgctxt "@label"
 msgid "Filament Cost"
 msgstr "Custo do Filamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:401
+#: resources/qml/Preferences/Materials/MaterialsView.qml:401
 msgctxt "@label"
 msgid "Filament weight"
 msgstr "Peso do Filamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:433
+#: resources/qml/Preferences/Materials/MaterialsView.qml:433
 msgctxt "@label"
 msgid "Filament length"
 msgstr "Comprimento do Filamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:451
+#: resources/qml/Preferences/Materials/MaterialsView.qml:451
 msgctxt "@label"
 msgid "Cost per Meter"
 msgstr "Custo por Metro"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:465
+#: resources/qml/Preferences/Materials/MaterialsView.qml:465
 msgctxt "@label"
 msgid "This material is linked to %1 and shares some of its properties."
 msgstr "Este material está vinculado a %1 e compartilha algumas de suas propriedades."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:472
+#: resources/qml/Preferences/Materials/MaterialsView.qml:472
 msgctxt "@label"
 msgid "Unlink Material"
 msgstr "Desvincular Material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:485
+#: resources/qml/Preferences/Materials/MaterialsView.qml:485
 msgctxt "@label"
 msgid "Description"
 msgstr "Descrição"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:503
+#: resources/qml/Preferences/Materials/MaterialsView.qml:503
 msgctxt "@label"
 msgid "Adhesion Information"
 msgstr "Informação sobre Aderência"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:642
+#: resources/qml/Preferences/Materials/MaterialsView.qml:642
 msgctxt "@title"
 msgid "Information"
 msgstr "Informação"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/Materials/MaterialsView.qml:647
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/PrintSetupSelector.qml:18
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml:82
+#: resources/qml/Preferences/Materials/MaterialsView.qml:647 resources/qml/PrintSetupSelector/PrintSetupSelector.qml:18
 msgctxt "@label"
 msgid "Print settings"
 msgstr "Ajustes de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:59
+#: resources/qml/Preferences/ProfilesPage.qml:59
 msgctxt "@label"
 msgid "Profiles compatible with active printer:"
 msgstr "Perfis compatíveis com a impressora ativa:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:98
+#: resources/qml/Preferences/ProfilesPage.qml:98
 msgctxt "@action:tooltip"
 msgid "Create new profile from current settings/overrides"
 msgstr "Criar novo perfil a partir dos ajustes/sobreposições atuais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:125
+#: resources/qml/Preferences/ProfilesPage.qml:125
 msgctxt "@action:label"
 msgid "Some settings from current profile were overwritten."
 msgstr "Alguns ajustes do perfil atual foram sobrescritos."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:140
+#: resources/qml/Preferences/ProfilesPage.qml:140
 msgctxt "@action:button"
 msgid "Update profile."
 msgstr "Atualizar perfil."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:143
+#: resources/qml/Preferences/ProfilesPage.qml:143
 msgctxt "@action:tooltip"
 msgid "Update profile with current settings/overrides"
 msgstr "Atualizar perfil com ajustes/sobreposições atuais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:148
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Custom/QualitiesWithIntentMenu.qml:256
+#: resources/qml/Preferences/ProfilesPage.qml:148
 msgctxt "@action:button"
 msgid "Discard current changes"
 msgstr "Descartar ajustes atuais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:158
+#: resources/qml/Preferences/ProfilesPage.qml:158
 msgctxt "@action:label"
 msgid "This profile uses the defaults specified by the printer, so it has no settings/overrides in the list below."
 msgstr "Este perfil usa os defaults especificados pela impressora, portanto não tem ajustes/sobreposições na lista abaixo."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:165
+#: resources/qml/Preferences/ProfilesPage.qml:165
 msgctxt "@action:label"
 msgid "Your current settings match the selected profile."
 msgstr "Seus ajustes atuais coincidem com o perfil selecionado."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:175
+#: resources/qml/Preferences/ProfilesPage.qml:175
 msgctxt "@title:tab"
 msgid "Global Settings"
 msgstr "Ajustes globais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:278
+#: resources/qml/Preferences/ProfilesPage.qml:278
 msgctxt "@title:window"
 msgid "Create Profile"
 msgstr "Criar Perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:280
+#: resources/qml/Preferences/ProfilesPage.qml:280
 msgctxt "@info"
 msgid "Please provide a name for this profile."
 msgstr "Por favor dê um nome a este perfil."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:352
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:368
+#: resources/qml/Preferences/ProfilesPage.qml:352 resources/qml/Preferences/ProfilesPage.qml:368
 msgctxt "@title:window"
 msgid "Export Profile"
 msgstr "Exportar Perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:382
+#: resources/qml/Preferences/ProfilesPage.qml:382
 msgctxt "@title:window"
 msgid "Duplicate Profile"
 msgstr "Duplicar Perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:409
+#: resources/qml/Preferences/ProfilesPage.qml:409
 msgctxt "@title:window"
 msgid "Rename Profile"
 msgstr "Renomear Perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:422
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/ProfilesPage.qml:429
+#: resources/qml/Preferences/ProfilesPage.qml:422 resources/qml/Preferences/ProfilesPage.qml:429
 msgctxt "@title:window"
 msgid "Import Profile"
 msgstr "Importar Perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/RenameDialog.qml:22
-msgctxt "@title:window"
-msgid "Rename"
-msgstr "Renomear"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/RenameDialog.qml:23
-msgctxt "@info"
-msgid "Please provide a new name."
-msgstr "Por favor, escolha um novo nome."
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/SettingVisibilityItem.qml:56
+#: resources/qml/Preferences/SettingVisibilityItem.qml:56
 msgctxt "@item:tooltip"
 msgid "This setting has been hidden by the active machine and will not be visible."
 msgstr "Este ajuste foi omitido para a máquina ativa e não ficará visível."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/SettingVisibilityItem.qml:73
+#: resources/qml/Preferences/SettingVisibilityItem.qml:73
 msgctxt "@item:tooltip %1 is list of setting names"
 msgid "This setting has been hidden by the value of %1. Change the value of that setting to make this setting visible."
 msgid_plural "This setting has been hidden by the values of %1. Change the values of those settings to make this setting visible."
 msgstr[0] "Este ajuste foi mantido invisível pelo valor de %1. Altere o valor desse ajuste para tornar este ajuste visível."
 msgstr[1] "Este ajuste foi mantido invisível pelos valores de %1. Altere o valor desses ajustes para tornar este ajuste visível."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:13
+#: resources/qml/Preferences/SettingVisibilityPage.qml:13
 msgctxt "@title:tab"
 msgid "Setting Visibility"
 msgstr "Visibilidade dos Ajustes"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Preferences/SettingVisibilityPage.qml:55
+#: resources/qml/Preferences/SettingVisibilityPage.qml:55
 msgctxt "@label:textbox"
 msgid "Check all"
 msgstr "Verificar tudo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintMonitor.qml:156
+#: resources/qml/PrintMonitor.qml:156
 msgctxt "@label"
 msgid "Active print"
 msgstr "Impressão ativa"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintMonitor.qml:164
+#: resources/qml/PrintMonitor.qml:164
 msgctxt "@label"
 msgid "Job Name"
 msgstr "Nome do Trabalho"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintMonitor.qml:172
+#: resources/qml/PrintMonitor.qml:172
 msgctxt "@label"
 msgid "Printing Time"
 msgstr "Tempo de Impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintMonitor.qml:180
+#: resources/qml/PrintMonitor.qml:180
 msgctxt "@label"
 msgid "Estimated time left"
 msgstr "Tempo restante estimado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml:46
+#: resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml:46
 msgctxt "@label"
 msgid "Profile"
 msgstr "Perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml:145
+#: resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml:136
 msgctxt "@tooltip"
 msgid ""
 "Some setting/override values are different from the values stored in the profile.\n"
@@ -5890,296 +6030,390 @@ msgstr ""
 "\n"
 "Clique para abrir o gerenciador de perfis."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Custom/QualitiesWithIntentMenu.qml:158
+#: resources/qml/PrintSetupSelector/Custom/QualitiesWithIntentMenu.qml:158
 msgctxt "@label:header"
 msgid "Custom profiles"
 msgstr "Perfis personalizados"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/PrintSetupSelector.qml:20
+#: resources/qml/PrintSetupSelector/PrintSetupSelector.qml:20
 msgctxt "@label shown when we load a Gcode file"
 msgid "Print setup disabled. G-code file can not be modified."
 msgstr "Configuração de Impressão desabilitada. O arquivo de G-Code não pode ser modificado."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml:142
+#: resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml:160
 msgctxt "@button"
 msgid "Recommended"
 msgstr "Recomendado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorContents.qml:156
-msgctxt "@button"
-msgid "Custom"
-msgstr "Personalizado"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:13
+#: resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:13
 msgctxt "@label:Should be short"
 msgid "On"
 msgstr "On"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:14
+#: resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:14
 msgctxt "@label:Should be short"
 msgid "Off"
 msgstr "Off"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml:34
-msgctxt "@label"
-msgid "Experimental"
-msgstr "Experimental"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/ProfileWarningReset.qml:54
+#: resources/qml/PrintSetupSelector/ProfileWarningReset.qml:65
 msgctxt "@info, %1 is the name of the custom profile"
 msgid "<b>%1</b> custom profile is active and you overwrote some settings."
 msgstr "<b>%1</b> perfil personalizado está ativo e alguns ajustes foram sobrescritos."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/ProfileWarningReset.qml:68
+#: resources/qml/PrintSetupSelector/ProfileWarningReset.qml:78
 msgctxt "@info, %1 is the name of the custom profile"
 msgid "<b>%1</b> custom profile is overriding some settings."
 msgstr "<b>%1</b> perfil personalizado está sobrepondo alguns ajustes."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/ProfileWarningReset.qml:79
-msgctxt "@info"
-msgid "Some settings were changed."
-msgstr "Alguns ajustes foram alterados."
+#: resources/qml/PrintSetupSelector/ProfileWarningReset.qml:92
+msgctxt "@info %1 is the name of a profile"
+msgid "Recommended settings (for <b>%1</b>) were altered."
+msgstr "Ajustes recomendados (para <b>%1</b>) foram alterados."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml:27
+#: resources/qml/PrintSetupSelector/ProfileWarningReset.qml:106
+#, fuzzy
+msgctxt "@info %1 is the name of a profile"
+msgid "Some setting-values defined in <b>%1</b> were overridden."
+msgstr "Alguns ajustes do perfil atual foram sobrescritos."
+
+#: resources/qml/PrintSetupSelector/ProfileWarningReset.qml:137
+msgctxt "@info"
+msgid "Reset to defaults."
+msgstr "Restaurar aos defaults."
+
+#: resources/qml/PrintSetupSelector/ProfileWarningReset.qml:178
+msgctxt "@info"
+msgid "Compare and save."
+msgstr "Comparar e salvar."
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml:15
 msgctxt "@label"
 msgid "Adhesion"
 msgstr "Aderência"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml:76
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedAdhesionSelector.qml:20
 msgctxt "@label"
 msgid "Enable printing a brim or raft. This will add a flat area around or under your object which is easy to cut off afterwards."
 msgstr "Habilita imprimir um brim (bainha) ou raft (jangada). Adicionará uma área chata em volta ou sob o objeto que é fácil de remover após a impressão ter finalizado."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:78
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:254
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml:102
+#, fuzzy
 msgctxt "@label"
-msgid "Gradual infill will gradually increase the amount of infill towards the top."
-msgstr "Preenchimento gradual aumentará gradualmente a quantidade de preenchimento em direção ao topo."
+msgid "Recommended print settings"
+msgstr "Ajustes de conversão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedInfillDensitySelector.qml:216
-msgctxt "@label"
-msgid "Gradual infill"
-msgstr "Preenchimento gradual"
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml:111
+#, fuzzy
+msgctxt "@button"
+msgid "Show Custom"
+msgstr "Personalizado"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedResolutionSelector.qml:27
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedResolutionSelector.qml:27
 msgctxt "@label"
 msgid "Resolution"
 msgstr "Resolução"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:40
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:16
+msgctxt "@label"
+msgid "Strength"
+msgstr "Força"
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:20
+msgctxt "@label"
+msgid "The following settings define the strength of your part."
+msgstr "Os seguintes ajustes definem a força de sua peça."
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:34
+#, fuzzy
+msgctxt "infill_sparse_density description"
+msgid "Infill Density"
+msgstr "Preenchimento apenas"
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:35
+msgctxt "@label"
+msgid "Adjusts the density of infill of the print."
+msgstr "Ajusta a densidade do preenchimento da impressão."
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:54
+#, fuzzy
+msgctxt "@action:label"
+msgid "Infill Pattern"
+msgstr "Preenchimento apenas"
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:56
+msgctxt "@label"
+msgid ""
+"The pattern of the infill material of the print:\n"
+"\n"
+"For quick prints of non functional model choose line, zig zag or lighting infill.\n"
+"\n"
+"For functional part not subjected to a lot of stress we reccomend grid or triangle or tri hexagon.\n"
+"\n"
+"For functional 3D prints which require high strenght in multiple directions use cubic, cubic subdivision, quarter cubic, octet, and gyroid."
+msgstr ""
+"O padrão do material de preenchimento da impressão:\n"
+"\n"
+"Para impressões rápidas de modelos não-funcionais escolha preenchimento de linha, ziguezague ou relâmpago.\n"
+"\n"
+"Para partes funcionais não sujeitas a muito stress, recomandos preenchimento de grade, triângulo ou tri-hexágono.\n"
+"\n"
+"Para impressões 3D funcionais que requeiram bastante força em múltiplas direções use cúbico, subdivisão cúbica, quarto cúbico, octeto e giroide."
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:67
+#, fuzzy
+msgctxt "@action:label"
+msgid "Shell Thickness"
+msgstr "Espessura de Camada"
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedStrengthSelector.qml:68
+msgctxt "@label"
+msgid "Defines the tickness of your part side walls, roof and floor."
+msgstr "Define a espessura das paredes laterais, teto e base da sua peça."
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:16
 msgctxt "@label"
 msgid "Support"
 msgstr "Suporte"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:44
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:78
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:21
+#, fuzzy
 msgctxt "@label"
-msgid "Generate structures to support parts of the model which have overhangs. Without these structures, such parts would collapse during printing."
+msgid "Generate structures to support parts of the model which have overhangs. Without these structures, these parts would collapse during printing."
 msgstr "Gera estrutura que suportarão partes do modelo que têm seções pendentes. Sem estas estruturas, tais partes desabariam durante a impressão."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/UnsupportedProfileIndication.qml:31
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:40
+#, fuzzy
+msgctxt "@action:label"
+msgid "Support Type"
+msgstr "Suporte"
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:41
+msgctxt "@label"
+msgid ""
+"Chooses between the techniques available to generate support. \n"
+"\n"
+"\"Normal\" support creates a support structure directly below the overhanging parts and drops those areas straight down. \n"
+"\n"
+"\"Tree\" support creates branches towards the overhanging areas that support the model on the tips of those branches, and allows the branches to crawl around the model to support it from the build plate as much as possible."
+msgstr ""
+"Escolhe entre as técnicas disponíveis para a geração de suporte.\n"
+"\n"
+"Suporte \"Normal\"  cria uma estrutura de suporte diretamente abaixo das partes pendentes e continua em linha reta para baixo.\n"
+"\n"
+"Suporte de \"Árvore\" cria galhos em direção às áreas pendentes que suportam o modelo em suas pontas, e permite que os galhos se espalhem em volta do modelo para suportá-lo a partir da plataforma de impressão tanto quanto possível."
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:53
+#, fuzzy
+msgctxt "@action:label"
+msgid "Print with"
+msgstr "Imprimir com "
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:54
+msgctxt "@label"
+msgid "The extruder train to use for printing the support. This is used in multi-extrusion."
+msgstr "O carro extrusor usado para imprimir o suporte. Isto é usado em multi-extrusão."
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:67
+msgctxt "@action:label"
+msgid "Placement"
+msgstr "Posicionamento"
+
+#: resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml:68
+msgctxt "support_type description"
+msgid "Adjusts the placement of the support structures. The placement can be set to touching build plate or everywhere. When set to everywhere the support structures will also be printed on the model."
+msgstr "Ajusta o posicionamento das estruturas de suporte. Este posicionamento pode ser ajustado à plataforma de impressão ou em todo lugar. Se for escolhido em todo lugar, as estruturas de suporte também se apoiarão no próprio modelo."
+
+#: resources/qml/PrintSetupSelector/Recommended/UnsupportedProfileIndication.qml:31
 msgctxt "@error"
 msgid "Configuration not supported"
 msgstr "Configuração não suportada"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/UnsupportedProfileIndication.qml:39
+#: resources/qml/PrintSetupSelector/Recommended/UnsupportedProfileIndication.qml:39
 msgctxt "@message:text %1 is the name the printer uses for 'nozzle'."
 msgid "No profiles are available for the selected material/%1 configuration. Please change your configuration."
 msgstr "Nenhum perfil está disponível para a configuração selecionada de material/%1. Por favor altere sua configuração."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrintSetupSelector/Recommended/UnsupportedProfileIndication.qml:47
+#: resources/qml/PrintSetupSelector/Recommended/UnsupportedProfileIndication.qml:47
 msgctxt "@button:label"
 msgid "Learn more"
 msgstr "Saber mais"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:40
+#: resources/qml/PrinterOutput/ExtruderBox.qml:40
 msgctxt "@label"
 msgid "Extruder"
 msgstr "Extrusor"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:70
+#: resources/qml/PrinterOutput/ExtruderBox.qml:70
 msgctxt "@tooltip"
 msgid "The target temperature of the hotend. The hotend will heat up or cool down towards this temperature. If this is 0, the hotend heating is turned off."
 msgstr "A temperatura-alvo do hotend. O hotend vai aquecer ou esfriar na direção desta temperatura. Se for zero, o aquecimento de hotend é desligado."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:105
+#: resources/qml/PrinterOutput/ExtruderBox.qml:105
 msgctxt "@tooltip"
 msgid "The current temperature of this hotend."
 msgstr "A temperatura atual deste hotend."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:182
+#: resources/qml/PrinterOutput/ExtruderBox.qml:182
 msgctxt "@tooltip of temperature input"
 msgid "The temperature to pre-heat the hotend to."
 msgstr "A temperatura com a qual pré-aquecer o hotend."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:271
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:259
+#: resources/qml/PrinterOutput/ExtruderBox.qml:271 resources/qml/PrinterOutput/HeatedBedBox.qml:259
 msgctxt "@button Cancel pre-heating"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:274
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:263
+#: resources/qml/PrinterOutput/ExtruderBox.qml:274 resources/qml/PrinterOutput/HeatedBedBox.qml:263
 msgctxt "@button"
 msgid "Pre-heat"
 msgstr "Pré-aquecer"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:297
+#: resources/qml/PrinterOutput/ExtruderBox.qml:297
 msgctxt "@tooltip of pre-heat"
 msgid "Heat the hotend in advance before printing. You can continue adjusting your print while it is heating, and you won't have to wait for the hotend to heat up when you're ready to print."
 msgstr "Aquece o hotend com antecedência antes de imprimir. Você pode continuar ajustando sua impressão enquanto está aquecendo e não terá que esperar que o hotend termine o aquecimento quando estiver pronto para imprimir."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:335
+#: resources/qml/PrinterOutput/ExtruderBox.qml:335
 msgctxt "@tooltip"
 msgid "The colour of the material in this extruder."
 msgstr "A cor do material neste extrusor."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:367
+#: resources/qml/PrinterOutput/ExtruderBox.qml:367
 msgctxt "@tooltip"
 msgid "The material in this extruder."
 msgstr "O material neste extrusor."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ExtruderBox.qml:400
+#: resources/qml/PrinterOutput/ExtruderBox.qml:400
 msgctxt "@tooltip"
 msgid "The nozzle inserted in this extruder."
 msgstr "O bico inserido neste extrusor."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:25
+#: resources/qml/PrinterOutput/HeatedBedBox.qml:25
 msgctxt "@label"
 msgid "Build plate"
 msgstr "Mesa de Impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:55
+#: resources/qml/PrinterOutput/HeatedBedBox.qml:55
 msgctxt "@tooltip"
 msgid "The target temperature of the heated bed. The bed will heat up or cool down towards this temperature. If this is 0, the bed heating is turned off."
 msgstr "A temperatura-alvo da mesa aquecida. A mesa aquecerá ou resfriará para esta temperatura. Se for zero, o aquecimento é desligado."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:88
+#: resources/qml/PrinterOutput/HeatedBedBox.qml:88
 msgctxt "@tooltip"
 msgid "The current temperature of the heated bed."
 msgstr "A temperatura atual da mesa aquecida."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:162
+#: resources/qml/PrinterOutput/HeatedBedBox.qml:162
 msgctxt "@tooltip of temperature input"
 msgid "The temperature to pre-heat the bed to."
 msgstr "A temperatura em que pré-aquecer a mesa."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/HeatedBedBox.qml:286
+#: resources/qml/PrinterOutput/HeatedBedBox.qml:286
 msgctxt "@tooltip of pre-heat"
 msgid "Heat the bed in advance before printing. You can continue adjusting your print while it is heating, and you won't have to wait for the bed to heat up when you're ready to print."
 msgstr "Aquecer a mesa antes de imprimir. Você pode continuar ajustando sua impressão enquanto ela está aquecendo, e não terá que esperar o aquecimento quando estiver pronto pra imprimir."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:51
+#: resources/qml/PrinterOutput/ManualPrinterControl.qml:51
 msgctxt "@label"
 msgid "Printer control"
 msgstr "Controle da Impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:66
+#: resources/qml/PrinterOutput/ManualPrinterControl.qml:66
 msgctxt "@label"
 msgid "Jog Position"
 msgstr "Posição de Trote"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:82
+#: resources/qml/PrinterOutput/ManualPrinterControl.qml:82
 msgctxt "@label"
 msgid "X/Y"
 msgstr "X/Y"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:162
+#: resources/qml/PrinterOutput/ManualPrinterControl.qml:162
 msgctxt "@label"
 msgid "Z"
 msgstr "Z"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:217
+#: resources/qml/PrinterOutput/ManualPrinterControl.qml:217
 msgctxt "@label"
 msgid "Jog Distance"
 msgstr "Distância de Trote"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:257
+#: resources/qml/PrinterOutput/ManualPrinterControl.qml:257
 msgctxt "@label"
 msgid "Send G-code"
 msgstr "Enviar G-Code"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/ManualPrinterControl.qml:319
+#: resources/qml/PrinterOutput/ManualPrinterControl.qml:319
 msgctxt "@tooltip of G-code command input"
 msgid "Send a custom G-code command to the connected printer. Press 'enter' to send the command."
 msgstr "Enviar comando G-Code personalizado para a impressora conectada. Pressione 'enter' para enviar o comando."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterOutput/OutputDeviceHeader.qml:55
+#: resources/qml/PrinterOutput/OutputDeviceHeader.qml:55
 msgctxt "@info:status"
 msgid "The printer is not connected."
 msgstr "A impressora não está conectada."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineListButton.qml:34
+#: resources/qml/PrinterSelector/MachineListButton.qml:34
 msgctxt "@label"
 msgid "Hide all connected printers"
 msgstr "Omitir todas as impressoras conectadas"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineListButton.qml:47
+#: resources/qml/PrinterSelector/MachineListButton.qml:47
 msgctxt "@label"
 msgid "Show all connected printers"
 msgstr "Mostrar todas as impressoras conectadas"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineSelector.qml:47
+#: resources/qml/PrinterSelector/MachineSelector.qml:64
 msgctxt "@status"
 msgid "The cloud printer is offline. Please check if the printer is turned on and connected to the internet."
 msgstr "A impressora de nuvem está offline. Por favor verifique se a impressora está ligada e conectada à internet."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineSelector.qml:51
+#: resources/qml/PrinterSelector/MachineSelector.qml:68
 msgctxt "@status"
 msgid "This printer is not linked to your account. Please visit the Ultimaker Digital Factory to establish a connection."
 msgstr "Esta impressora não está vinculada à sua conta. Por favor visite a Ultimaker Digital Factory para estabelecer uma conexão."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineSelector.qml:56
+#: resources/qml/PrinterSelector/MachineSelector.qml:73
 msgctxt "@status"
 msgid "The cloud connection is currently unavailable. Please sign in to connect to the cloud printer."
 msgstr "A conexão de nuvem está indisponível. Por favor se logue para se conectar à impressora de nuvem."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineSelector.qml:60
+#: resources/qml/PrinterSelector/MachineSelector.qml:78
 msgctxt "@status"
 msgid "The cloud connection is currently unavailable. Please check your internet connection."
 msgstr "A conexão de nuvem está indisponível. Por favor verifique sua conexão de internet."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineSelector.qml:237
-msgctxt "@button"
-msgid "Add printer"
-msgstr "Adicionar impressora"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineSelector.qml:254
-msgctxt "@button"
-msgid "Manage printers"
-msgstr "Gerenciar impressoras"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/PrinterSelector/MachineSelectorList.qml:24
+#: resources/qml/PrinterSelector/MachineSelectorList.qml:30 resources/qml/PrinterSelector/MachineSelectorList.qml:32
 msgctxt "@label"
 msgid "Other printers"
 msgstr "Outras impressoras"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ProfileOverview.qml:36
+#: resources/qml/ProfileOverview.qml:36
 msgctxt "@title:column"
 msgid "Setting"
 msgstr "Ajustes"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ProfileOverview.qml:37
+#: resources/qml/ProfileOverview.qml:37
 msgctxt "@title:column"
 msgid "Profile"
 msgstr "Perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ProfileOverview.qml:38
+#: resources/qml/ProfileOverview.qml:38
 msgctxt "@title:column"
 msgid "Current"
 msgstr "Atual"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ProfileOverview.qml:39
+#: resources/qml/ProfileOverview.qml:39
 msgctxt "@title:column Unit of measurement"
 msgid "Unit"
 msgstr "Unidade"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/SearchBar.qml:17
+#: resources/qml/SearchBar.qml:17
 msgctxt "@placeholder"
 msgid "Search"
 msgstr "Buscar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingCategory.qml:115
+#: resources/qml/Settings/SettingCategory.qml:115
 msgctxt "@label"
 msgid ""
 "Some hidden settings use values different from their normal calculated value.\n"
@@ -6190,32 +6424,32 @@ msgstr ""
 "\n"
 "Clique para tornar estes ajustes visíveis."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingItem.qml:84
+#: resources/qml/Settings/SettingItem.qml:84
 msgctxt "@label"
 msgid "This setting is not used because all the settings that it influences are overridden."
 msgstr "Este ajuste não é usado porque todos os ajustes que ele influencia estão sobrepostos."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingItem.qml:89
+#: resources/qml/Settings/SettingItem.qml:89
 msgctxt "@label Header for list of settings."
 msgid "Affects"
 msgstr "Afeta"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingItem.qml:94
+#: resources/qml/Settings/SettingItem.qml:94
 msgctxt "@label Header for list of settings."
 msgid "Affected By"
 msgstr "Afetado Por"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingItem.qml:190
+#: resources/qml/Settings/SettingItem.qml:190
 msgctxt "@label"
 msgid "This setting is always shared between all extruders. Changing it here will change the value for all extruders."
 msgstr "Este ajuste é sempre compartilhado entre todos os extrusores. Modificá-lo aqui mudará o valor para todos."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingItem.qml:194
+#: resources/qml/Settings/SettingItem.qml:194
 msgctxt "@label"
 msgid "This setting is resolved from conflicting extruder-specific values:"
 msgstr "Este ajuste é resolvido dos valores conflitante específicos de extrusor:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingItem.qml:234
+#: resources/qml/Settings/SettingItem.qml:234
 msgctxt "@label"
 msgid ""
 "This setting has a value that is different from the profile.\n"
@@ -6226,7 +6460,7 @@ msgstr ""
 "\n"
 "Clique para restaurar o valor do perfil."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingItem.qml:334
+#: resources/qml/Settings/SettingItem.qml:334
 msgctxt "@label"
 msgid ""
 "This setting is normally calculated, but it currently has an absolute value set.\n"
@@ -6237,561 +6471,388 @@ msgstr ""
 "\n"
 "Clique para restaurar o valor calculado."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingView.qml:48
+#: resources/qml/Settings/SettingView.qml:48
 msgctxt "@label:textbox"
 msgid "Search settings"
 msgstr "Ajustes de busca"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingView.qml:395
+#: resources/qml/Settings/SettingView.qml:395
 msgctxt "@action:menu"
 msgid "Copy value to all extruders"
 msgstr "Copiar valor para todos os extrusores"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingView.qml:404
+#: resources/qml/Settings/SettingView.qml:404
 msgctxt "@action:menu"
 msgid "Copy all changed values to all extruders"
 msgstr "Copiar todos os valores alterados para todos os extrusores"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingView.qml:440
+#: resources/qml/Settings/SettingView.qml:440
 msgctxt "@action:menu"
 msgid "Hide this setting"
 msgstr "Ocultar este ajuste"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingView.qml:453
+#: resources/qml/Settings/SettingView.qml:453
 msgctxt "@action:menu"
 msgid "Don't show this setting"
 msgstr "Não exibir este ajuste"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Settings/SettingView.qml:457
+#: resources/qml/Settings/SettingView.qml:457
 msgctxt "@action:menu"
 msgid "Keep this setting visible"
 msgstr "Manter este ajuste visível"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ViewOrientationControls.qml:25
+#: resources/qml/Toolbar.qml:142
+msgctxt "@label %1 is filled in with the name of an extruder"
+msgid "Print Selected Model with %1"
+msgid_plural "Print Selected Models with %1"
+msgstr[0] "Imprimir Modelo Selecionado com %1"
+msgstr[1] "Imprimir Modelos Selecionados com %1"
+
+#: resources/qml/ViewOrientationControls.qml:25
 msgctxt "@info:tooltip"
 msgid "3D View"
 msgstr "Visão 3D"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ViewOrientationControls.qml:38
+#: resources/qml/ViewOrientationControls.qml:38
 msgctxt "@info:tooltip"
 msgid "Front View"
 msgstr "Viso de Frente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ViewOrientationControls.qml:51
+#: resources/qml/ViewOrientationControls.qml:51
 msgctxt "@info:tooltip"
 msgid "Top View"
 msgstr "Visão de Cima"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ViewOrientationControls.qml:64
+#: resources/qml/ViewOrientationControls.qml:64
 msgctxt "@info:tooltip"
 msgid "Left View"
 msgstr "Visão à Esquerda"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ViewOrientationControls.qml:77
+#: resources/qml/ViewOrientationControls.qml:77
 msgctxt "@info:tooltip"
 msgid "Right View"
 msgstr "Visão à Direita"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/ViewsSelector.qml:50
+#: resources/qml/ViewsSelector.qml:50
 msgctxt "@label"
 msgid "View type"
 msgstr "Tipo de Visão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:47
+#: resources/qml/WelcomePages/AddCloudPrintersView.qml:47
 msgctxt "@label"
 msgid "Add a Cloud printer"
 msgstr "Adicionar uma impressora de Nuvem"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:73
+#: resources/qml/WelcomePages/AddCloudPrintersView.qml:73
 msgctxt "@label"
 msgid "Waiting for Cloud response"
 msgstr "Aguardando resposta da Nuvem"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:83
+#: resources/qml/WelcomePages/AddCloudPrintersView.qml:83
 msgctxt "@label"
 msgid "No printers found in your account?"
 msgstr "Nenhuma impressora encontrada em sua conta?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:117
+#: resources/qml/WelcomePages/AddCloudPrintersView.qml:117
 msgctxt "@label"
 msgid "The following printers in your account have been added in Cura:"
 msgstr "As seguintes impressoras da sua conta foram adicionadas ao Cura:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddCloudPrintersView.qml:186
+#: resources/qml/WelcomePages/AddCloudPrintersView.qml:186
 msgctxt "@button"
 msgid "Add printer manually"
 msgstr "Adicionar impressora manualmente"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:203
+#: resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:203
 msgctxt "@label"
 msgid "Manufacturer"
 msgstr "Fabricante"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:214
+#: resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:214
 msgctxt "@label"
 msgid "Profile author"
 msgstr "Autor do perfil"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:226
+#: resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:226
 msgctxt "@label"
 msgid "Printer name"
 msgstr "Nome da impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:232
+#: resources/qml/WelcomePages/AddLocalPrinterScrollView.qml:232
 msgctxt "@text"
 msgid "Please name your printer"
 msgstr "Por favor dê um nome à sua impressora"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:24
-msgctxt "@label"
-msgid "Add a printer"
-msgstr "Adicionar uma impressora"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:38
-msgctxt "@label"
-msgid "Add a networked printer"
-msgstr "Adicionar uma impressora de rede"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddNetworkOrLocalPrinterContent.qml:87
-msgctxt "@label"
-msgid "Add a non-networked printer"
-msgstr "Adicionar uma impressora local"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:43
+#: resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:43
 msgctxt "@label"
 msgid "There is no printer found over your network."
 msgstr "Não foi encontrada nenhuma impressora em sua rede."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:162
+#: resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:162
 msgctxt "@label"
 msgid "Refresh"
 msgstr "Atualizar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:173
+#: resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:173
 msgctxt "@label"
 msgid "Add printer by IP"
 msgstr "Adicionar impressora por IP"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:184
-msgctxt "@label"
-msgid "Add cloud printer"
-msgstr "Adicionar impressora de nuvem"
-
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:220
+#: resources/qml/WelcomePages/AddNetworkPrinterScrollView.qml:205
 msgctxt "@label"
 msgid "Troubleshooting"
 msgstr "Resolução de problemas"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:70
+#: resources/qml/WelcomePages/AddPrinterByIpContent.qml:70
 msgctxt "@label"
 msgid "Add printer by IP address"
 msgstr "Adicionar impressora por endereço IP"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:128
+#: resources/qml/WelcomePages/AddPrinterByIpContent.qml:128
 msgctxt "@text"
 msgid "Enter your printer's IP address."
 msgstr "Entre o endereço IP de sua impressora."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:150
+#: resources/qml/WelcomePages/AddPrinterByIpContent.qml:150
 msgctxt "@button"
 msgid "Add"
 msgstr "Adicionar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:195
+#: resources/qml/WelcomePages/AddPrinterByIpContent.qml:195
 msgctxt "@label"
 msgid "Could not connect to device."
 msgstr "Não foi possível conectar ao dispositivo."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:196
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:201
+#: resources/qml/WelcomePages/AddPrinterByIpContent.qml:196 resources/qml/WelcomePages/AddPrinterByIpContent.qml:201
 msgctxt "@label"
 msgid "Can't connect to your UltiMaker printer?"
 msgstr "Não consegue conectar à sua impressora UltiMaker?"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:200
+#: resources/qml/WelcomePages/AddPrinterByIpContent.qml:200
 msgctxt "@label"
 msgid "The printer at this address has not responded yet."
 msgstr "A impressora neste endereço ainda não respondeu."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:231
+#: resources/qml/WelcomePages/AddPrinterByIpContent.qml:231
 msgctxt "@label"
 msgid "This printer cannot be added because it's an unknown printer or it's not the host of a group."
 msgstr "Esta impressora não pode ser adicionada porque é uma impressora desconhecida ou porque não é o host do grupo."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/AddPrinterByIpContent.qml:312
+#: resources/qml/WelcomePages/AddPrinterByIpContent.qml:312
 msgctxt "@button"
 msgid "Connect"
 msgstr "Conectar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/ChangelogContent.qml:24
+#: resources/qml/WelcomePages/AddThirdPartyPrinter.qml:29
+msgctxt "@label"
+msgid "Add a networked printer"
+msgstr "Adicionar uma impressora de rede"
+
+#: resources/qml/WelcomePages/AddThirdPartyPrinter.qml:78
+msgctxt "@label"
+msgid "Add a non-networked printer"
+msgstr "Adicionar uma impressora local"
+
+#: resources/qml/WelcomePages/AddThirdPartyPrinter.qml:102
+#, fuzzy
+msgctxt "@button"
+msgid "Add UltiMaker printer via Digital Factory"
+msgstr "Ver impressoras na Digital Factory"
+
+#: resources/qml/WelcomePages/AddUltimakerOrThirdPartyPrinter.qml:29
+#, fuzzy
+msgctxt "@label"
+msgid "In order to start using Cura you will need to configure a printer."
+msgstr "Para usar o pacote você precisará reiniciar o Cura"
+
+#: resources/qml/WelcomePages/AddUltimakerOrThirdPartyPrinter.qml:36
+msgctxt "@label"
+msgid "What printer would you like to setup?"
+msgstr "Que impressora você gostaria de configurar?"
+
+#: resources/qml/WelcomePages/AddUltimakerOrThirdPartyPrinter.qml:55
+#, fuzzy
+msgctxt "@button"
+msgid "UltiMaker printer"
+msgstr "Suporte UltiMaker"
+
+#: resources/qml/WelcomePages/AddUltimakerOrThirdPartyPrinter.qml:64
+#, fuzzy
+msgctxt "@button"
+msgid "Non UltiMaker printer"
+msgstr "Suporte UltiMaker"
+
+#: resources/qml/WelcomePages/AddUltimakerOrThirdPartyPrinter.qml:73
+msgctxt "@button"
+msgid "Learn more about adding printers to Cura"
+msgstr "Saiba mais sobre adicionar impressoras ao Cura"
+
+#: resources/qml/WelcomePages/AddUltimakerOrThirdPartyPrinterStack.qml:29
+#, fuzzy
+msgctxt "@label"
+msgid "Add printer"
+msgstr "Adicionar impressora"
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:33
+#, fuzzy
+msgctxt "@label"
+msgid "New UltiMaker printers can be connected to Digital Factory and monitored remotely."
+msgstr "Certifique-se de que todas as suas impressoras estejam LIGADAS e conectadas à Digital Factory."
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:70
+msgctxt "@label"
+msgid "If you are trying to add a new UltiMaker printer to Cura"
+msgstr "Se você está tentando adicionar uma nova impressora UltiMaker ao Cura"
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:80
+#, fuzzy
+msgctxt "@info"
+msgid "Sign in into UltiMaker Digilal Factory"
+msgstr "Conectar à Ultimaker Digital Factory"
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:81
+msgctxt "@info"
+msgid "Follow the procedure to add a new printer"
+msgstr "Siga o procedimento para adicionar uma nova impressora"
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:82
+msgctxt "@info"
+msgid "Your new printer will automatically appear in Cura"
+msgstr "Sua nova impressora vai automaticamente aparecer no Cura"
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:100
+#, fuzzy
+msgctxt "@button"
+msgid "Learn more"
+msgstr "Saiba mais"
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:121
+#, fuzzy
+msgctxt "@button"
+msgid "Add local printer"
+msgstr "Adicionar uma impressora"
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:129
+#, fuzzy
+msgctxt "@button"
+msgid "Sign in to Digital Factory"
+msgstr "Ver impressoras na Digital Factory"
+
+#: resources/qml/WelcomePages/AddUltimakerPrinter.qml:133
+#, fuzzy
+msgctxt "@button"
+msgid "Waiting for new printers"
+msgstr "Aguardando por: Impressora indisponível"
+
+#: resources/qml/WelcomePages/ChangelogContent.qml:24
 msgctxt "@label"
 msgid "Release Notes"
 msgstr "Notas de lançamento"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/CloudContent.qml:123
+#: resources/qml/WelcomePages/CloudContent.qml:123
 msgctxt "@text"
 msgid "Add material settings and plugins from the Marketplace"
 msgstr "Adicionar ajustes de materiais e plugins do Marketplace"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/CloudContent.qml:149
+#: resources/qml/WelcomePages/CloudContent.qml:149
 msgctxt "@text"
 msgid "Backup and sync your material settings and plugins"
 msgstr "Fazer backup e sincronizar seus ajustes de materiais e plugins"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/CloudContent.qml:175
+#: resources/qml/WelcomePages/CloudContent.qml:175
 msgctxt "@text"
 msgid "Share ideas and get help from 48,000+ users in the UltiMaker Community"
 msgstr "Compartilhe ideias e consiga ajuda de mais de 48.000 usuários da Comunidade UltiMaker"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/CloudContent.qml:189
+#: resources/qml/WelcomePages/CloudContent.qml:189
 msgctxt "@button"
 msgid "Skip"
 msgstr "Pular"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/CloudContent.qml:201
+#: resources/qml/WelcomePages/CloudContent.qml:201
 msgctxt "@text"
 msgid "Create a free UltiMaker Account"
 msgstr "Criar uma conta UltiMaker gratuita"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:24
+#: resources/qml/WelcomePages/DataCollectionsContent.qml:24
 msgctxt "@label"
 msgid "Help us to improve UltiMaker Cura"
 msgstr "Nos ajude a melhor o UltiMaker Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:56
+#: resources/qml/WelcomePages/DataCollectionsContent.qml:56
 msgctxt "@text"
 msgid "UltiMaker Cura collects anonymous data to improve print quality and user experience, including:"
 msgstr "O UltiMaker Cura coleta dados anônimos para melhor a qualidade de impressão e experiência do usuário, incluindo:"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:68
+#: resources/qml/WelcomePages/DataCollectionsContent.qml:68
 msgctxt "@text"
 msgid "Machine types"
 msgstr "Tipos de máquina"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:74
+#: resources/qml/WelcomePages/DataCollectionsContent.qml:74
 msgctxt "@text"
 msgid "Material usage"
 msgstr "Uso do material"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:80
+#: resources/qml/WelcomePages/DataCollectionsContent.qml:80
 msgctxt "@text"
 msgid "Number of slices"
 msgstr "Número de fatias"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:86
+#: resources/qml/WelcomePages/DataCollectionsContent.qml:86
 msgctxt "@text"
 msgid "Print settings"
 msgstr "Ajustes de impressão"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:99
+#: resources/qml/WelcomePages/DataCollectionsContent.qml:99
 msgctxt "@text"
 msgid "Data collected by UltiMaker Cura will not contain any personal information."
 msgstr "Dados coletados pelo UltiMaker Cura não conterão nenhuma informação pessoal."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DataCollectionsContent.qml:100
+#: resources/qml/WelcomePages/DataCollectionsContent.qml:100
 msgctxt "@text"
 msgid "More information"
 msgstr "Mais informações"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/DropDownWidget.qml:93
+#: resources/qml/WelcomePages/DropDownWidget.qml:93
 msgctxt "@label"
 msgid "Empty"
 msgstr "Vazio"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:23
+#: resources/qml/WelcomePages/UserAgreementContent.qml:23
 msgctxt "@label"
 msgid "User Agreement"
 msgstr "Contrato de Usuário"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/UserAgreementContent.qml:67
+#: resources/qml/WelcomePages/UserAgreementContent.qml:67
 msgctxt "@button"
 msgid "Decline and close"
 msgstr "Rejeitar e fechar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/WelcomeContent.qml:56
+#: resources/qml/WelcomePages/WelcomeContent.qml:56
 msgctxt "@label"
 msgid "Welcome to UltiMaker Cura"
 msgstr "Bem-vindo ao UltiMaker Cura"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/WelcomeContent.qml:67
+#: resources/qml/WelcomePages/WelcomeContent.qml:67
 msgctxt "@text"
 msgid "Please follow these steps to set up UltiMaker Cura. This will only take a few moments."
 msgstr "Por favor siga estes passos para configurar o UltiMaker Cura. Isto tomará apenas alguns momentos."
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/WelcomeContent.qml:82
+#: resources/qml/WelcomePages/WelcomeContent.qml:82
 msgctxt "@button"
 msgid "Get started"
 msgstr "Começar"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/WelcomePages/WhatsNewContent.qml:28
+#: resources/qml/WelcomePages/WhatsNewContent.qml:28
 msgctxt "@label"
 msgid "What's New"
 msgstr "O Que Há de Novo"
 
-#: /Users/c.lamboo/ultimaker/Cura/resources/qml/Widgets/ComboBox.qml:18
+#: resources/qml/Widgets/ComboBox.qml:18
 msgctxt "@label"
 msgid "No items to select from"
 msgstr "Sem itens para selecionar"
-
-#: /VersionUpgrade/VersionUpgrade21to22/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.1 to Cura 2.2."
-msgstr "Atualiza configurações do Cura 2.1 para o Cura 2.2."
-
-#: /VersionUpgrade/VersionUpgrade21to22/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.1 to 2.2"
-msgstr "Atualização de Versão de 2.1 para 2.2"
-
-#: /VersionUpgrade/VersionUpgrade22to24/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.2 to Cura 2.4."
-msgstr "Atualiza configurações do Cura 2.2 para o Cura 2.4."
-
-#: /VersionUpgrade/VersionUpgrade22to24/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.2 to 2.4"
-msgstr "Atualização de Versão de 2.2 para 2.4"
-
-#: /VersionUpgrade/VersionUpgrade25to26/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.5 to Cura 2.6."
-msgstr "Atualiza configurações do Cura 2.5 para o Cura 2.6."
-
-#: /VersionUpgrade/VersionUpgrade25to26/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.5 to 2.6"
-msgstr "Atualização de Versão de 2.5 para 2.6"
-
-#: /VersionUpgrade/VersionUpgrade26to27/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.6 to Cura 2.7."
-msgstr "Atualiza configurações do Cura 2.6 para o Cura 2.7."
-
-#: /VersionUpgrade/VersionUpgrade26to27/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.6 to 2.7"
-msgstr "Atualização de Versão de 2.6 para 2.7"
-
-#: /VersionUpgrade/VersionUpgrade27to30/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 2.7 to Cura 3.0."
-msgstr "Atualiza configuração do Cura 2.7 para o Cura 3.0."
-
-#: /VersionUpgrade/VersionUpgrade27to30/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 2.7 to 3.0"
-msgstr "Atualização de Versão de 2.7 para 3.0"
-
-#: /VersionUpgrade/VersionUpgrade30to31/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.0 to Cura 3.1."
-msgstr "Atualiza configurações do Cura 3.0 para o Cura 3.1."
-
-#: /VersionUpgrade/VersionUpgrade30to31/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.0 to 3.1"
-msgstr "Atualização de Versão 3.0 para 3.1"
-
-#: /VersionUpgrade/VersionUpgrade32to33/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.2 to Cura 3.3."
-msgstr "Atualiza configurações do Cura 3.2 para o Cura 3.3."
-
-#: /VersionUpgrade/VersionUpgrade32to33/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.2 to 3.3"
-msgstr "Atualização de Versão de 3.2 para 3.3"
-
-#: /VersionUpgrade/VersionUpgrade33to34/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.3 to Cura 3.4."
-msgstr "Atualiza configuração do Cura 3.3 para o Cura 3.4."
-
-#: /VersionUpgrade/VersionUpgrade33to34/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.3 to 3.4"
-msgstr "Atualização de Versão de 3.3 para 3.4"
-
-#: /VersionUpgrade/VersionUpgrade34to35/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.4 to Cura 3.5."
-msgstr "Atualiza configurações do Cura 3.4 para o Cura 3.5."
-
-#: /VersionUpgrade/VersionUpgrade34to35/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.4 to 3.5"
-msgstr "Atualização de Versão de 3.4 para 3.5"
-
-#: /VersionUpgrade/VersionUpgrade35to40/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 3.5 to Cura 4.0."
-msgstr "Atualiza configuração do Cura 3.5 para o Cura 4.0."
-
-#: /VersionUpgrade/VersionUpgrade35to40/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 3.5 to 4.0"
-msgstr "Atualização de Versão de 3.5 para 4.0"
-
-#: /VersionUpgrade/VersionUpgrade40to41/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.0 to Cura 4.1."
-msgstr "Atualiza configurações do Cura 4.0 para o Cura 4.1."
-
-#: /VersionUpgrade/VersionUpgrade40to41/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.0 to 4.1"
-msgstr "Atualização de Versão de 4.0 para 4.1"
-
-#: /VersionUpgrade/VersionUpgrade411to412/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.11 to Cura 4.12."
-msgstr "Atualiza configurações do Cura 4.11 para o Cura 4.12."
-
-#: /VersionUpgrade/VersionUpgrade411to412/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.11 to 4.12"
-msgstr "Atualização de Versão de 4.11 para 4.12"
-
-#: /VersionUpgrade/VersionUpgrade413to50/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.13 to Cura 5.0."
-msgstr "Atualiza configurações do Cura 4.13 para o Cura 5.0."
-
-#: /VersionUpgrade/VersionUpgrade413to50/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.13 to 5.0"
-msgstr "Atualização de Versão de 4.13 para 5.0"
-
-#: /VersionUpgrade/VersionUpgrade41to42/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.1 to Cura 4.2."
-msgstr "Atualiza configurações do Cura 4.1 para o Cura 4.2."
-
-#: /VersionUpgrade/VersionUpgrade41to42/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.1 to 4.2"
-msgstr "Atualização de Versão de 4.1 para 4.2"
-
-#: /VersionUpgrade/VersionUpgrade42to43/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.2 to Cura 4.3."
-msgstr "Atualiza configurações do Cura 4.2 para o Cura 4.3."
-
-#: /VersionUpgrade/VersionUpgrade42to43/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.2 to 4.3"
-msgstr "Atualização de Versão de 4.2 para 4.3"
-
-#: /VersionUpgrade/VersionUpgrade43to44/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.3 to Cura 4.4."
-msgstr "Atualiza configurações do Cura 4.3 para o Cura 4.4."
-
-#: /VersionUpgrade/VersionUpgrade43to44/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.3 to 4.4"
-msgstr "Atualização de Versão de 4.3 para 4.4"
-
-#: /VersionUpgrade/VersionUpgrade44to45/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.4 to Cura 4.5."
-msgstr "Atualiza configurações do Cura 4.4 para o Cura 4.5."
-
-#: /VersionUpgrade/VersionUpgrade44to45/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.4 to 4.5"
-msgstr "Atualização de Versão de 4.4 para 4.5"
-
-#: /VersionUpgrade/VersionUpgrade45to46/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.5 to Cura 4.6."
-msgstr "Atualiza configurações do Cura 4.5 para o Cura 4.6."
-
-#: /VersionUpgrade/VersionUpgrade45to46/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.5 to 4.6"
-msgstr "Atualização de Versão de 4.5 para 4.6"
-
-#: /VersionUpgrade/VersionUpgrade460to462/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.6.0 to Cura 4.6.2."
-msgstr "Atualiza configurações do Cura 4.6.0 para o Cura 4.6.2."
-
-#: /VersionUpgrade/VersionUpgrade460to462/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.6.0 to 4.6.2"
-msgstr "Atualização de Versão de 4.6.0 para 4.6.2"
-
-#: /VersionUpgrade/VersionUpgrade462to47/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.6.2 to Cura 4.7."
-msgstr "Atualiza configurações do Cura 4.6.2 para o Cura 4.7."
-
-#: /VersionUpgrade/VersionUpgrade462to47/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.6.2 to 4.7"
-msgstr "Atualização de Versão de 4.6.2 para 4.7"
-
-#: /VersionUpgrade/VersionUpgrade47to48/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.7 to Cura 4.8."
-msgstr "Atualiza configurações do Cura 4.7 para o Cura 4.8."
-
-#: /VersionUpgrade/VersionUpgrade47to48/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.7 to 4.8"
-msgstr "Atualização de Versão de 4.7 para 4.8"
-
-#: /VersionUpgrade/VersionUpgrade48to49/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.8 to Cura 4.9."
-msgstr "Atualiza configurações do Cura 4.8 para o Cura 4.9."
-
-#: /VersionUpgrade/VersionUpgrade48to49/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.8 to 4.9"
-msgstr "Atualização de Versão de 4.8 para 4.9"
-
-#: /VersionUpgrade/VersionUpgrade49to410/plugin.json
-msgctxt "description"
-msgid "Upgrades configurations from Cura 4.9 to Cura 4.10."
-msgstr "Atualiza configurações do Cura 4.9 para o Cura 4.10."
-
-#: /VersionUpgrade/VersionUpgrade49to410/plugin.json
-msgctxt "name"
-msgid "Version Upgrade 4.9 to 4.10"
-msgstr "Atualização de Versão de 4.9 para 4.10"
-
-#: /X3DReader/plugin.json
-msgctxt "description"
-msgid "Provides support for reading X3D files."
-msgstr "Provê suporte à leitura de arquivos X3D."
-
-#: /X3DReader/plugin.json
-msgctxt "name"
-msgid "X3D Reader"
-msgstr "Leitor de X3D"
-
-#: /XRayView/plugin.json
-msgctxt "description"
-msgid "Provides the X-Ray view."
-msgstr "Provê a visão de Raios-X."
-
-#: /XRayView/plugin.json
-msgctxt "name"
-msgid "X-Ray View"
-msgstr "Visão de Raios-X"
-
-#: /XmlMaterialProfile/plugin.json
-msgctxt "name"
-msgid "Material Profiles"
-msgstr "Perfis de Material"
-
-#: /XmlMaterialProfile/plugin.json
-msgctxt "description"
-msgid "Provides capabilities to read and write XML-based material profiles."
-msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 
 #~ msgctxt "@info:generic"
 #~ msgid ""
@@ -7183,6 +7244,10 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgid "Add a printer to Cura"
 #~ msgstr "Adiciona uma impressora ao Cura"
 
+#~ msgctxt "@label"
+#~ msgid "Add cloud printer"
+#~ msgstr "Adicionar impressora de nuvem"
+
 #~ msgctxt "@action:inmenu"
 #~ msgid "Add more materials from Marketplace"
 #~ msgstr "Adicionar mais materiais do Mercado"
@@ -7226,6 +7291,10 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgctxt "description"
 #~ msgid "Allows saving the resulting slice as an X3G file, to support printers that read this format (Malyan, Makerbot and other Sailfish-based printers)."
 #~ msgstr "Permite salvar a fatia resultante como um arquivo X3G, para suportar impressoras que leem este formato (Malyan, Makerbot e outras impressoras baseadas em Sailfish)."
+
+#~ msgctxt "@label"
+#~ msgid "Aluminum"
+#~ msgstr "Alumínio"
 
 #~ msgctxt "@option:curaSolidworksStlQuality"
 #~ msgid "Always ask"
@@ -7436,6 +7505,10 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgid "Change active post-processing scripts"
 #~ msgstr "Troca os scripts de pós-processamento ativos"
 
+#~ msgctxt "@label"
+#~ msgid "Change build plate to %1 (This cannot be overridden)."
+#~ msgstr "Alterar mesa de impressão para %1 (Isto não pode ser sobreposto)."
+
 #~ msgctxt "@item:inmenu"
 #~ msgid "Changelog"
 #~ msgstr "Registro de Alterações"
@@ -7547,10 +7620,6 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgid "Connect to UltiMaker Cloud"
 #~ msgstr "Conectar à Nuvem UltiMaker"
 
-#~ msgctxt "@info:status Ultimaker Cloud should not be translated."
-#~ msgid "Connect to Ultimaker Digital Factory"
-#~ msgstr "Conectar à Ultimaker Digital Factory"
-
 #~ msgctxt "@info:tooltip"
 #~ msgid "Connect to a printer"
 #~ msgstr "Conecta a uma impressora"
@@ -7611,10 +7680,6 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgid "Continue"
 #~ msgstr "Continuar"
 
-#~ msgctxt "@title:tab"
-#~ msgid "Conversion settings"
-#~ msgstr "Ajustes de conversão"
-
 #~ msgctxt "@title:window"
 #~ msgid "Convert Image..."
 #~ msgstr "Converter imagem..."
@@ -7666,10 +7731,6 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgctxt "@label"
 #~ msgid "Create"
 #~ msgstr "Criar"
-
-#~ msgctxt "@action:button"
-#~ msgid "Create New Profile"
-#~ msgstr "Criar Novo Perfil"
 
 #~ msgctxt "@info:whatsthis"
 #~ msgid "Create a flattend quality changes profile."
@@ -8318,6 +8379,10 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgid "Gives you the possibility to open certain files via SolidWorks itself. These are then converted and loaded into Cura"
 #~ msgstr "Te dá a possibilidade de abrir certos arquivos via o próprio SolidWorks. Tais são convertidos e carregados no Cura"
 
+#~ msgctxt "@label"
+#~ msgid "Glass"
+#~ msgstr "Vidro"
+
 #~ msgctxt "@menuitem"
 #~ msgid "Global"
 #~ msgstr "Global"
@@ -8341,6 +8406,14 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgctxt "@label"
 #~ msgid "Gradual"
 #~ msgstr "Gradual"
+
+#~ msgctxt "@label"
+#~ msgid "Gradual infill"
+#~ msgstr "Preenchimento gradual"
+
+#~ msgctxt "@label"
+#~ msgid "Gradual infill will gradually increase the amount of infill towards the top."
+#~ msgstr "Preenchimento gradual aumentará gradualmente a quantidade de preenchimento em direção ao topo."
 
 #~ msgctxt "@option:check"
 #~ msgid "Heated Bed"
@@ -8382,6 +8455,18 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgid "Hotend"
 #~ msgstr "Hotend"
 
+#~ msgctxt "@info:tooltip"
+#~ msgid "How should the conflict in the machine be resolved?"
+#~ msgstr "Como o conflito na máquina deve ser resolvido?"
+
+#~ msgctxt "@info:tooltip"
+#~ msgid "How should the conflict in the material be resolved?"
+#~ msgstr "Como o conflito no material deve ser resolvido?"
+
+#~ msgctxt "@info:tooltip"
+#~ msgid "How should the conflict in the profile be resolved?"
+#~ msgstr "Como o conflito no perfil deve ser resolvido?"
+
 #~ msgctxt "@title:window"
 #~ msgid "How to install Cura SolidWorks macro"
 #~ msgstr "Como instalar a macro de SolidWorks do Cura"
@@ -8417,10 +8502,6 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgctxt "@info:title"
 #~ msgid "Incompatible Material"
 #~ msgstr "Material Incompatível"
-
-#~ msgctxt "@action:checkbox"
-#~ msgid "Infill only"
-#~ msgstr "Preenchimento apenas"
 
 #~ msgid "Install"
 #~ msgstr "Instalar"
@@ -8807,10 +8888,6 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgstr "Abrir Connect..."
 
 #~ msgctxt "@action:button"
-#~ msgid "Open File"
-#~ msgstr "Abrir arquivo"
-
-#~ msgctxt "@action:button"
 #~ msgid "Open Web Page"
 #~ msgstr "Abrir Página Web"
 
@@ -9118,10 +9195,6 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgctxt "@properties:tooltip"
 #~ msgid "Print via Cloud"
 #~ msgstr "Imprimir por Nuvem"
-
-#~ msgctxt "@info:tooltip"
-#~ msgid "Print with "
-#~ msgstr "Imprimir com "
 
 #~ msgctxt "@action:button"
 #~ msgid "Print with Doodle3D"
@@ -9727,6 +9800,10 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ "2) Desligue a ventoinha (somente no caso de não haver detalhes pequenos no modelo).\n"
 #~ "3) Use material diferente."
 
+#~ msgctxt "@info"
+#~ msgid "Some settings were changed."
+#~ msgstr "Alguns ajustes foram alterados."
+
 #~ msgctxt "@info:tooltip"
 #~ msgid "Some things could be problematic in this print. Click to see tips for adjustment."
 #~ msgstr "Algumas coisas podem ser problemáticas nesta impressão. Clique para ver dicas de correção."
@@ -10035,7 +10112,8 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ "\n"
 #~ "Select your printer from the list below:"
 #~ msgstr ""
-#~ "Para imprimir diretamente para sua impressora pela rede, por favor se certifique que a impressora esteja conectada na rede usando um cabo de rede ou conectando sua impressora na rede WIFI. Se você não conectar o Cura à sua impressora, você ainda pode usar uma unidade USB para transferir arquivos G-Code para sua impressora.\n"
+#~ "Para imprimir diretamente para sua impressora pela rede, por favor se certifique que a impressora esteja conectada na rede usando um cabo de rede ou conectando sua impressora na rede WIFI. Se você não conectar o Cura à sua impressora, você ainda pode usar uma unidade USB para transferir arquivos G-"
+#~ "Code para sua impressora.\n"
 #~ "\n"
 #~ "Selecione sua impressora da lista abaixo:"
 
@@ -10359,6 +10437,10 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgid "View types"
 #~ msgstr "Ver tipos"
 
+#~ msgctxt "@action:label"
+#~ msgid "Visible settings:"
+#~ msgstr "Ajustes visíveis:"
+
 #~ msgctxt "@label:MonitorStatus"
 #~ msgid "Waiting for a printjob"
 #~ msgstr "Esperando um trabalho de impressão"
@@ -10378,10 +10460,6 @@ msgstr "Provê capacidade de ler e escrever perfis de material baseado em XML."
 #~ msgctxt "@label"
 #~ msgid "Waiting for: First available"
 #~ msgstr "Aguardando por: A primeira disponível"
-
-#~ msgctxt "@label"
-#~ msgid "Waiting for: Unavailable printer"
-#~ msgstr "Aguardando por: Impressora indisponível"
 
 #~ msgctxt "@info:tile"
 #~ msgid "Warning"

--- a/resources/i18n/pt_BR/fdmprinter.def.json.po
+++ b/resources/i18n/pt_BR/fdmprinter.def.json.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Cura 5.0\n"
 "Report-Msgid-Bugs-To: plugins@ultimaker.com\n"
-"POT-Creation-Date: 2022-09-27 14:50+0000\n"
-"PO-Revision-Date: 2022-10-10 07:50+0200\n"
+"POT-Creation-Date: 2023-02-02 16:06+0000\n"
+"PO-Revision-Date: 2023-02-17 16:31+0100\n"
 "Last-Translator: Cláudio Sampaio <patola@gmail.com>\n"
 "Language-Team: Cláudio Sampaio <patola@gmail.com>\n"
 "Language: pt_BR\n"
@@ -15,89 +15,94 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.2.2\n"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_inset description"
 msgid "A distance to keep from the edges of the model. Ironing all the way to the edge of the mesh may result in a jagged edge on your print."
 msgstr "A distância a manter das arestas do modelo. Passar a ferro as arestas da malha podem resultar em um aspecto entalhado da sua peça."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_no_load_move_factor description"
 msgid "A factor indicating how much the filament gets compressed between the feeder and the nozzle chamber, used to determine how far to move the material for a filament switch."
 msgstr "Um fator indicando em quanto o filamento é comprimido entre o alimentador do hotend e o bico, usado para determinar em quanto mover o material na troca de filamento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_angles description"
 msgid "A list of integer line directions to use when the top surface skin layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees)."
 msgstr "Uma lista de direções inteiras de filete a usar quando as camadas superiores usam o padrão de linhas ou ziguezague. Elementos desta lista são usados sequencialmente de acordo com o progresso das camadas e quando se chega ao fim da lista, se volta ao começo. Os itens da lista são separados por vírgulas e a lista inteira é contida em colchetes. O default é uma lista vazia que significa o uso dos ângulos default (45 e 135 graus)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_angles description"
 msgid "A list of integer line directions to use when the top/bottom layers use the lines or zig zag pattern. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees)."
 msgstr "Uma lista de direções de linha inteiras para usar quando as camadas superiores e inferiores usarem os padrões de linha ou ziguezague. Elementos desta lista são usados sequencialmente à medida que as camadas progridem e quando o fim da lista é alcançado, ela inicia novamente. Os itens da lista são separados por vírgulas e a lita inteira é contida em colchetes. O default é uma lista vazia, o que significa usar os ângulos default (45 e 135 graus)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_infill_angles description"
 msgid "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the default angle 0 degrees."
 msgstr "Uma lista de direções inteiras de filete. Elementos da lista são usados sequencialmente à medida que as camadas progridem e quando o fim da lista é alcançado, ela recomeça do início. Os itens da lista são separados por vírgulas e a lista inteira é contida em colchetes. O default é uma lista vazia, o que significa usar o ângulo default de 0 graus."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_angles description"
 msgid "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the default angles (alternates between 45 and 135 degrees if interfaces are quite thick or 90 degrees)."
 msgstr "Uma lista de direções inteiras de filete. Elementos da lista são usados sequencialmente à medida que as camadas progridem e quando o fim da lista é alcançado, ela recomeça do início. Os itens da lista são separados por vírgulas e a lista inteira é contida em colchetes. O default é uma lista vazia, o que significa usar os ângulos default (alternando entre 45 e 135 graus se as interfaces forem grossas, ou 90 se não)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_angles description"
 msgid "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the default angles (alternates between 45 and 135 degrees if interfaces are quite thick or 90 degrees)."
 msgstr "Uma lista de direções inteiras de filete. Elementos da lista são usados sequencialmente à medida que as camadas progridem e quando o fim da lista é alcançado, ela recomeça do início. Os itens da lista são separados por vírgulas e a lista inteira é contida em colchetes. O default é uma lista vazia, o que significa usar os ângulos default (alternando entre 45 e 135 graus se as interfaces forem grossas, ou 90 se não)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_angles description"
 msgid "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the default angles (alternates between 45 and 135 degrees if interfaces are quite thick or 90 degrees)."
 msgstr "Uma lista de direções inteiras de filete. Elementos da lista são usados sequencialmente à medida que as camadas progridem e quando o fim da lista é alcançado, ela recomeça do início. Os itens da lista são separados por vírgulas e a lista inteira é contida em colchetes. O default é uma lista vazia, o que significa usar os ângulos default (alternando entre 45 e 135 graus se as interfaces forem grossas, ou 90 se não)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_angles description"
 msgid "A list of integer line directions to use. Elements from the list are used sequentially as the layers progress and when the end of the list is reached, it starts at the beginning again. The list items are separated by commas and the whole list is contained in square brackets. Default is an empty list which means use the traditional default angles (45 and 135 degrees for the lines and zig zag patterns and 45 degrees for all other patterns)."
 msgstr "Uma lista de direções de filetes em números inteiros a usar. Elementos da lista são usados sequencialmente de acordo com o progresso das camadas e quando o fim da lista é alcançado, ela volta ao começo. Os itens da lista são separados por vírgula e a lista inteira é contida em colchetes. O default é uma lista vazia que implica em usar os ângulos default tradicionais (45 e 135 graus para os padrões linha e ziguezague e 45 graus para todos os outros padrões)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "nozzle_disallowed_areas description"
 msgid "A list of polygons with areas the nozzle is not allowed to enter."
 msgstr "Uma lista de polígonos com áreas em que o bico é proibido de entrar."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_disallowed_areas description"
 msgid "A list of polygons with areas the print head is not allowed to enter."
 msgstr "Uma lista de polígonos com áreas em que a cabeça de impressão é proibida de entrar."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+msgctxt "brim_inside_margin description"
+msgid "A part fully enclosed inside another part can generate an outer brim that touches the inside of the other part. This removes all brim within this distance from internal holes."
+msgstr "Uma peça completamente contida em outra peça pode gerar um brim externo que toca o interior da outra parte. Este ajuste remove todo o brim dentro desta distância dos buracos internos."
+
+#: fdmprinter.def.json
 msgctxt "extruder_prime_pos_abs label"
 msgid "Absolute Extruder Prime Position"
 msgstr "Posição Absoluta de Purga do Extrusor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adaptive_layer_height_variation label"
 msgid "Adaptive Layers Maximum Variation"
 msgstr "Máximo Variação das Camadas Adaptativas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adaptive_layer_height_threshold label"
 msgid "Adaptive Layers Topography Size"
 msgstr "Tamanho da Topografia de Camadas Adaptativas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adaptive_layer_height_variation_step label"
 msgid "Adaptive Layers Variation Step Size"
 msgstr "Tamanho de Passo da Variação das Camadas Adaptativas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adaptive_layer_height_enabled description"
 msgid "Adaptive layers computes the layer heights depending on the shape of the model."
 msgstr "Camadas adaptativas fazem a computação das alturas de camada depender da forma do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_wall_line_count description"
 msgid ""
 "Add extra walls around the infill area. Such walls can make top/bottom skin lines sag down less which means you need less top/bottom skin layers for the same quality at the cost of some extra material.\n"
@@ -106,842 +111,842 @@ msgstr ""
 "Adiciona paredes extras em torno da área de preenchimento. Tais paredes podem fazer filetes de contorno de topo e base afundarem menos, o que significa que você precisará de menos camadas de contorno de topo e base para a mesma qualidade, à custa de algum material extra.\n"
 "Este recurso pode combinar com o Conectar Polígonos de Preenchimento para conectar todo o preenchimento em um único caminho de extrusão sem a necessidade de percursos ou retrações se os ajustes forem consistentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "platform_adhesion description"
 msgid "Adhesion"
 msgstr "Aderência"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_adhesion_tendency label"
 msgid "Adhesion Tendency"
 msgstr "Tendência à Aderência"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_overlap description"
 msgid "Adjust the amount of overlap between the walls and (the endpoints of) the skin-centerlines, as a percentage of the line widths of the skin lines and the innermost wall. A slight overlap allows the walls to connect firmly to the skin. Note that, given an equal skin and wall line-width, any percentage over 50% may already cause any skin to go past the wall, because at that point the position of the nozzle of the skin-extruder may already reach past the middle of the wall."
 msgstr "Ajusta a quantidade de sobreposição entre as paredes e (os extremos de) linhas centrais do contorno, como uma porcentagem das larguras de filete de contorno e a parede mais interna. Uma sobreposição leve permite que as paredes se conectem firmemente ao contorno. Note que, dadas uma largura de contorno e filete de parede iguais, qualquer porcentagem acima de 50% pode fazer com que algum contorno ultrapasse a parede, pois a este ponto a posição do bico do extrusor de contorno pode já ter passado do meio da parede."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_overlap_mm description"
 msgid "Adjust the amount of overlap between the walls and (the endpoints of) the skin-centerlines. A slight overlap allows the walls to connect firmly to the skin. Note that, given an equal skin and wall line-width, any value over half the width of the wall may already cause any skin to go past the wall, because at that point the position of the nozzle of the skin-extruder may already reach past the middle of the wall."
 msgstr "Ajusta a quantidade de sobreposição entre as paredes e (os extermos de) linhas centrais do contorno. Uma sobreposição pequena permite que as paredes se conectem firmemente ao contorno. Note que, dados uma largura de contorno e filete de parede iguais, qualquer valor maior que metade da largura da parede pode fazer com que o contorno ultrapasse a parede, pois a este ponto a posição do bico do extrusor de contorno pode já ter passado do meio da parede."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_sparse_density description"
 msgid "Adjusts the density of infill of the print."
 msgstr "Ajusta a densidade de preenchimento da impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_density description"
 msgid "Adjusts the density of the roofs and floors of the support structure. A higher value results in better overhangs, but the supports are harder to remove."
 msgstr "Ajusta a densidade dos topos e bases da estrutura de suporte. Um valor maior resulta em seções pendentes melhores, mas os suportes são mais difíceis de remover."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_infill_rate description"
 msgid "Adjusts the density of the support structure. A higher value results in better overhangs, but the supports are harder to remove."
 msgstr "Ajusta a densidade da estrutura de suporte. Um valor mais alto resulta em seções pendentes melhores, mas os suportes são mais difíceis de remover."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_diameter description"
 msgid "Adjusts the diameter of the filament used. Match this value with the diameter of the used filament."
 msgstr "Ajusta o diâmetro do filamento utilizado. Acerte este valor com o diâmetro real do filamento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_type description"
 msgid "Adjusts the placement of the support structures. The placement can be set to touching build plate or everywhere. When set to everywhere the support structures will also be printed on the model."
 msgstr "Ajusta a colocação das estruturas de suporte. Pode ser ajustada para suportes que somente tocam a mesa de impressão ou suportes em todos os lugares com seções pendentes (incluindo as que não estão pendentes em relação à mesa)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_wipe_enabled description"
 msgid "After printing the prime tower with one nozzle, wipe the oozed material from the other nozzle off on the prime tower."
 msgstr "Depois de imprimir a torre de purga com um bico, limpar o material escorrendo do outro bico na torre de purga."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop_after_extruder_switch description"
 msgid "After the machine switched from one extruder to the other, the build plate is lowered to create clearance between the nozzle and the print. This prevents the nozzle from leaving oozed material on the outside of a print."
 msgstr "Quando a máquina troca de um extrusor para o outro, sobe-se um pouco em Z para criar um espaço entre o bico e a impressão. Isso impede que o bico escorra material em cima da impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing option all"
 msgid "All"
 msgstr "Tudo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "print_sequence option all_at_once"
 msgid "All at Once"
 msgstr "Todos de Uma Vez"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "resolution description"
 msgid "All settings that influence the resolution of the print. These settings have a large impact on the quality (and print time)"
 msgstr "Todos os ajustes que influenciam a resolução da impressão. Estes ajustes têm um impacto maior na qualidade (e tempo de impressão)"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "alternate_extra_perimeter label"
 msgid "Alternate Extra Wall"
 msgstr "Alternar Parede Adicional"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "alternate_carve_order label"
 msgid "Alternate Mesh Removal"
 msgstr "Alternar a Remoção de Malhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_alternate_walls label"
 msgid "Alternate Wall Directions"
 msgstr "Alternar Direções de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_alternate_walls description"
 msgid "Alternate wall directions every other layer and inset. Useful for materials that can build up stress, like for metal printing."
 msgstr "Alterna direções de parede a cada camada e reentrância. Útil para materiais que podem acumular stress, como em impressão com metal."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_buildplate_type option aluminum"
 msgid "Aluminum"
 msgstr "Alumínio"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_always_write_active_tool label"
 msgid "Always Write Active Tool"
 msgstr "Sempre Escrever a Ferramenta Ativa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel_retract_before_outer_wall description"
 msgid "Always retract when moving to start an outer wall."
 msgstr "Sempre retrair quando se mover para iniciar uma parede externa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "hole_xy_offset description"
 msgid "Amount of offset applied to all holes in each layer. Positive values increase the size of the holes, negative values reduce the size of the holes."
 msgstr "Quantidade de deslocamento aplicado a todos os furos em cada camada. Valores positivos aumentam o tamanho dos furos, valores negativos reduzem o tamanho dos furos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "xy_offset description"
 msgid "Amount of offset applied to all polygons in each layer. Positive values can compensate for too big holes; negative values can compensate for too small holes."
 msgstr "Deslocamento adicional aplicado para todos os polígonos em cada camada. Valores positivos 'engordam' a camada e podem compensar por furos exagerados; valores negativos a 'emagrecem' e podem compensar por furos pequenos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "xy_offset_layer_0 description"
 msgid "Amount of offset applied to all polygons in the first layer. A negative value can compensate for squishing of the first layer known as \"elephant's foot\"."
 msgstr "Deslocamento adicional aplicado a todos os polígonos da primeira camada. Um valor negativo pode compensar pelo esmagamento da primeira camada conhecido como \"pata de elefante\"."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_offset description"
 msgid "Amount of offset applied to all support polygons in each layer. Positive values can smooth out the support areas and result in more sturdy support."
 msgstr "Quantidade de deslocamento aplicado a todos os polígonos do suporte em cada camada. Valores positivos podem amaciar as áreas de suporte e resultar em suporte mais estável."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_offset description"
 msgid "Amount of offset applied to the floors of the support."
 msgstr "Quantidade de deslocamento aplicado às bases do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_offset description"
 msgid "Amount of offset applied to the roofs of the support."
 msgstr "Quantidade de deslocamento aplicado aos tetos do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_offset description"
 msgid "Amount of offset applied to the support interface polygons."
 msgstr "Quantidade de deslocamento aplicado aos polígonos da interface de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_amount description"
 msgid "Amount to retract the filament so it does not ooze during the wipe sequence."
 msgstr "Quantidade a retrair do filamento tal que ele não escorra durante a sequência de limpeza."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "sub_div_rad_add description"
 msgid "An addition to the radius from the center of each cube to check for the boundary of the model, as to decide whether this cube should be subdivided. Larger values lead to a thicker shell of small cubes near the boundary of the model."
 msgstr "Um adicional ao raio do centro de cada cubo para verificar a borda do modelo, de modo a decidir se este cubo deve ser subdividido. Valores maiores levam a uma cobertura mais espessa de pequenos cubos perto da borda do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "anti_overhang_mesh label"
 msgid "Anti Overhang Mesh"
 msgstr "Malha Anti-Pendente"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_anti_ooze_retracted_position label"
 msgid "Anti-ooze Retracted Position"
 msgstr "Posição Retraída Anti-escorrimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_anti_ooze_retraction_speed label"
 msgid "Anti-ooze Retraction Speed"
 msgstr "Velocidade de Retração Anti-escorrimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_use_extruder_offset_to_offset_coords description"
 msgid "Apply the extruder offset to the coordinate system. Affects all extruders."
 msgstr "Aplicar o deslocamento de extrusor ao sistema de coordenadas. Afeta todos os extrusores."
 
-#: /fdmprinter.def.json
-msgctxt "material_flow_dependent_temperature label"
-msgid "Auto Temperature"
-msgstr "Temperatura Automática"
+#: fdmprinter.def.json
+msgctxt "interlocking_enable description"
+msgid "At the locations where models touch, generate an interlocking beam structure. This improves the adhesion between models, especially models printed in different materials."
+msgstr "Nos lugares em que os modelos tocam, gerar uma estrutura de vigas interligada. Isto melhora a aderência entre modelos, especialmente modelos impressos com materiais diferentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel_avoid_other_parts label"
 msgid "Avoid Printed Parts When Traveling"
 msgstr "Evitar Partes Impressas nas Viagens"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel_avoid_supports label"
 msgid "Avoid Supports When Traveling"
 msgstr "Evitar Suportes No Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position option back"
 msgid "Back"
 msgstr "Atrás"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position option backleft"
 msgid "Back Left"
 msgstr "Atrás à Esquerda"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position option backright"
 msgid "Back Right"
 msgstr "Atrás à Direita"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option BFB"
 msgid "Bits from Bytes"
 msgstr "Bits from Bytes"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_mesh_surface_mode option both"
 msgid "Both"
 msgstr "Ambos"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bottom_layers label"
 msgid "Bottom Layers"
 msgstr "Camadas Inferiores"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern_0 label"
 msgid "Bottom Pattern Initial Layer"
 msgstr "Camada Inicial do Padrão da Base"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bottom_skin_expand_distance label"
 msgid "Bottom Skin Expand Distance"
 msgstr "Distância de Expansão do Contorno Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bottom_skin_preshrink label"
 msgid "Bottom Skin Removal Width"
 msgstr "Largura de Remoção do Contorno Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bottom_thickness label"
 msgid "Bottom Thickness"
 msgstr "Espessura Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_preparation_retracted_position label"
 msgid "Break Preparation Retracted Position"
 msgstr "Posição Retraída de Preparação de Quebra"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_preparation_speed label"
 msgid "Break Preparation Retraction Speed"
 msgstr "Velocidade de Retração de Preparação de Quebra"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_preparation_temperature label"
 msgid "Break Preparation Temperature"
 msgstr "Temperatura de Quebra de Preparação"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_retracted_position label"
 msgid "Break Retracted Position"
 msgstr "Posição Retraída de Quebra"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_speed label"
 msgid "Break Retraction Speed"
 msgstr "Velocidade de Retração de Quebra"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_temperature label"
 msgid "Break Temperature"
 msgstr "Temperatura de Quebra"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_skip_some_zags label"
 msgid "Break Up Support In Chunks"
 msgstr "Quebrar Suportes em Pedaços"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_fan_speed label"
 msgid "Bridge Fan Speed"
 msgstr "Velocidade de Ventoinha da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_enable_more_layers label"
 msgid "Bridge Has Multiple Layers"
 msgstr "Ponte Tem Camadas Múltiplas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_density_2 label"
 msgid "Bridge Second Skin Density"
 msgstr "Densidade de Segundo Contorno da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_fan_speed_2 label"
 msgid "Bridge Second Skin Fan Speed"
 msgstr "Velocidade da Ventoinha no Segundo Contorno da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_material_flow_2 label"
 msgid "Bridge Second Skin Flow"
 msgstr "Fluxo de Segundo Contorno da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_speed_2 label"
 msgid "Bridge Second Skin Speed"
 msgstr "Velocidade de Segundo Contorno da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_density label"
 msgid "Bridge Skin Density"
 msgstr "Densidade do Contorno de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_material_flow label"
 msgid "Bridge Skin Flow"
 msgstr "Fluxo do Contorno de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_speed label"
 msgid "Bridge Skin Speed"
 msgstr "Velocidade do Contorno de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_support_threshold label"
 msgid "Bridge Skin Support Threshold"
 msgstr "Limiar de Suporte de Contorno de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_sparse_infill_max_density label"
 msgid "Bridge Sparse Infill Max Density"
 msgstr "Densidade Máxima do Preenchimento Esparso de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_density_3 label"
 msgid "Bridge Third Skin Density"
 msgstr "Densidade de Terceiro Contorno da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_fan_speed_3 label"
 msgid "Bridge Third Skin Fan Speed"
 msgstr "Velocidade da Ventoinha no Terceiro Contorno da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_material_flow_3 label"
 msgid "Bridge Third Skin Flow"
 msgstr "Fluxo de Terceiro Contorno da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_speed_3 label"
 msgid "Bridge Third Skin Speed"
 msgstr "Velocidade de Terceiro Contorno da Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_wall_coast label"
 msgid "Bridge Wall Coasting"
 msgstr "Desengrenagem de Parede de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_wall_material_flow label"
 msgid "Bridge Wall Flow"
 msgstr "Fluxo da Parede de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_wall_speed label"
 msgid "Bridge Wall Speed"
 msgstr "Velocidade da Parede de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adhesion_type option brim"
 msgid "Brim"
 msgstr "Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "brim_gap label"
 msgid "Brim Distance"
 msgstr "Distância do Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+msgctxt "brim_inside_margin label"
+msgid "Brim Inside Avoid Margin"
+msgstr "Brim Dentro da Margem a Evitar"
+
+#: fdmprinter.def.json
 msgctxt "brim_line_count label"
 msgid "Brim Line Count"
 msgstr "Contagem de Linhas do Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "brim_outside_only label"
 msgid "Brim Only on Outside"
 msgstr "Brim Somente Para Fora"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "brim_replaces_support label"
 msgid "Brim Replaces Support"
 msgstr "Brim Substitui Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "brim_width label"
 msgid "Brim Width"
 msgstr "Largura do Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "platform_adhesion label"
 msgid "Build Plate Adhesion"
 msgstr "Aderência à Mesa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adhesion_extruder_nr label"
 msgid "Build Plate Adhesion Extruder"
 msgstr "Extrusor de Aderência à Mesa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adhesion_type label"
 msgid "Build Plate Adhesion Type"
 msgstr "Tipo de Aderência da Mesa de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_buildplate_type label"
 msgid "Build Plate Material"
 msgstr "Material da Plataforma de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_shape label"
 msgid "Build Plate Shape"
 msgstr "Forma da Mesa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_bed_temperature label"
 msgid "Build Plate Temperature"
 msgstr "Temperatura da Mesa de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_bed_temperature_layer_0 label"
 msgid "Build Plate Temperature Initial Layer"
 msgstr "Temperatura da Mesa de Impressão da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "build_volume_temperature label"
 msgid "Build Volume Temperature"
 msgstr "Temperatura do Volume de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "center_object label"
 msgid "Center Object"
 msgstr "Centralizar Objeto"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "conical_overhang_enabled description"
 msgid "Change the geometry of the printed model such that minimal support is required. Steep overhangs will become shallow overhangs. Overhanging areas will drop down to become more vertical."
 msgstr "Altera a geometria do modelo a ser impresso de tal modo que o mínimo de suporte seja exigido. Seções pendentes agudas serão torcidas pra ficar mais verticais. Áreas de seções pendentes profundas se tornarão mais rasas."
 
-#: /fdmprinter.def.json
-msgctxt "material_flow_dependent_temperature description"
-msgid "Change the temperature for each layer automatically with the average flow speed of that layer."
-msgstr "Troca a temperatura para cada camada automaticamente de acordo com a velocidade média de fluxo desta camada."
-
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_structure description"
 msgid "Chooses between the techniques available to generate support. \"Normal\" support creates a support structure directly below the overhanging parts and drops those areas straight down. \"Tree\" support creates branches towards the overhanging areas that support the model on the tips of those branches, and allows the branches to crawl around the model to support it from the build plate as much as possible."
 msgstr "Permite escolher entre as técnicas para geração de suporte. Suporte \"normal\" cria a estrutura de suporte diretamente abaixo das seções pendentes e vai em linha reta pra baixo. Suporte \"em árvore\" cria galhos na direção das seções pendentes, suportando o modelo nas pontas destes, e permitndo que se distribuam em torno do modelo para apoiá-lo na plataforma de impressão tanto quanto possível."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "coasting_speed label"
 msgid "Coasting Speed"
 msgstr "Velocidade de Desengrenagem"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "coasting_volume label"
 msgid "Coasting Volume"
 msgstr "Volume de Desengrenagem"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "coasting_enable description"
 msgid "Coasting replaces the last part of an extrusion path with a travel path. The oozed material is used to print the last piece of the extrusion path in order to reduce stringing."
 msgstr "A desengrenagem ou 'coasting' troca a última parte do caminho de uma extrusão pelo caminho sem extrudar. O material escorrendo é usado para imprimir a última parte do caminho de extrusão de modo a reduzir fiapos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing label"
 msgid "Combing Mode"
 msgstr "Modo de Combing"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing description"
 msgid "Combing keeps the nozzle within already printed areas when traveling. This results in slightly longer travel moves but reduces the need for retractions. If combing is off, the material will retract and the nozzle moves in a straight line to the next point. It is also possible to avoid combing over top/bottom skin areas or to only comb within the infill."
 msgstr "O Combing mantém o bico dentro de áreas já impressas ao fazer o percurso. Isto causa movimentações de percurso um pouco mais demoradas mas reduz a necessidade de retrações. Se o combing estiver desligado, o material sofrerá retração eo bico se moverá em linha reta até o próximo ponto. É possível também evitar combing sobre contornos inferiores e superiores ou somente fazer combing dentro do preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "command_line_settings label"
 msgid "Command Line Settings"
 msgstr "Ajustes de Linha de Comando"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_strategy option compensate"
 msgid "Compensate"
 msgstr "Compensar"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_pattern option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_pattern option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_pattern option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_pattern option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_pattern option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern_0 option concentric"
 msgid "Concentric"
 msgstr "Concêntrico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_conical_angle label"
 msgid "Conical Support Angle"
 msgstr "Ângulo de Suporte Cônico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_conical_min_width label"
 msgid "Conical Support Minimum Width"
 msgstr "Largura Mínima do Suporte Cônico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "zig_zaggify_infill label"
 msgid "Connect Infill Lines"
 msgstr "Conectar Linhas de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "connect_infill_polygons label"
 msgid "Connect Infill Polygons"
 msgstr "Conectar Polígonos do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "zig_zaggify_support label"
 msgid "Connect Support Lines"
 msgstr "Conectar Linhas de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_connect_zigzags label"
 msgid "Connect Support ZigZags"
 msgstr "Conectar os Ziguezagues do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "connect_skin_polygons label"
 msgid "Connect Top/Bottom Polygons"
 msgstr "Conectar Polígonos do Topo e Base"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "connect_infill_polygons description"
 msgid "Connect infill paths where they run next to each other. For infill patterns which consist of several closed polygons, enabling this setting greatly reduces the travel time."
 msgstr "Conecta os caminhos de preenchimentos onde estiverem próximos um ao outro. Para padrões de preenchimento que consistam de vários polígonos fechados, a habilitação deste ajuste reduz bastante o tempo de percurso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_connect_zigzags description"
 msgid "Connect the ZigZags. This will increase the strength of the zig zag support structure."
 msgstr "Conecta os ziguezagues. Isto aumentará a força da estrutura de suporte em ziguezague."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "zig_zaggify_support description"
 msgid "Connect the ends of the support lines together. Enabling this setting can make your support more sturdy and reduce underextrusion, but it will cost more material."
 msgstr "Conecta os extremos das linhas de suporte juntos. Habilitar este ajuste pode tornar seu suporte mais robusto e reduzir subextrusão, mas gastará mais material."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "zig_zaggify_infill description"
 msgid "Connect the ends where the infill pattern meets the inner wall using a line which follows the shape of the inner wall. Enabling this setting can make the infill adhere to the walls better and reduce the effects of infill on the quality of vertical surfaces. Disabling this setting reduces the amount of material used."
 msgstr "Conecta as extremidades onde o padrão de preenchimento toca a parede interna usando uma linha que segue a forma da parede interna. Habilitar este ajuste pode fazer o preenchimento aderir melhor às paredes e reduzir o efeito do preenchimento na qualidade de superfícies verticais. Desabilitar este ajuda diminui a quantidade de material usado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "connect_skin_polygons description"
 msgid "Connect top/bottom skin paths where they run next to each other. For the concentric pattern enabling this setting greatly reduces the travel time, but because the connections can happen midway over infill this feature can reduce the top surface quality."
 msgstr "Conectar caminhos de contorno da base e topo quando estiverem próximos entre si. Para o padrão concêntrico, habilitar este ajuste reduzirá bastante o tempo de percurso, mas por as conexões poderem acontecer no meio do preenchimento, este recurso pode reduzir a qualidade da superfície superior."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_corner description"
 msgid "Control whether corners on the model outline influence the position of the seam. None means that corners have no influence on the seam position. Hide Seam makes the seam more likely to occur on an inside corner. Expose Seam makes the seam more likely to occur on an outside corner. Hide or Expose Seam makes the seam more likely to occur at an inside or outside corner. Smart Hiding allows both inside and outside corners, but chooses inside corners more frequently, if appropriate."
 msgstr "Controla se os cantos do contorno do modelo influenciam a posição da costura. Nenhum significa que os cantos não terão influência na posição da costura. Ocultar Costura torna mais provável que a costura ocorra em um canto interior. Expôr Costura torna mais provável que a costura ocorra em um canto exterior. Ocultar ou Expôr Costura torna mais provável que a costura ocorra em um canto interior ou exterior. Ocultação Inteligente permite tanto cantos interiores quanto exteriores, mas escolhe os interiores mais frequentemente se apropriado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_multiplier description"
 msgid "Convert each infill line to this many lines. The extra lines do not cross over each other, but avoid each other. This makes the infill stiffer, but increases print time and material usage."
 msgstr "Converte cada file de preenchimento para este número de filetes. Os filetes extras não se cruzam, se evitam. Isto torna o preenchimento mais rígido, mas aumenta o tempo de impressão e uso do material."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_cool_down_speed label"
 msgid "Cool Down Speed"
 msgstr "Velocidade de Resfriamento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cooling description"
 msgid "Cooling"
 msgstr "Refrigeração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cooling label"
 msgid "Cooling"
 msgstr "Refrigeração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_top_jump description"
 msgid "Creates a small knot at the top of an upward line, so that the consecutive horizontal layer has a better chance to connect to it. Only applies to Wire Printing."
 msgstr "Cria um pequeno 'nódulo' ou 'nó' no topo do filete ascendente de tal modo que a camada horizontal consecutiva tem melhor chance de se conectar ao filete. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option cross"
 msgid "Cross"
 msgstr "Cruzado"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern option cross"
 msgid "Cross"
 msgstr "Cruzado"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option cross_3d"
 msgid "Cross 3D"
 msgstr "Cruzado 3D"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cross_infill_pocket_size label"
 msgid "Cross 3D Pocket Size"
 msgstr "Tamanho de Bolso do Cruzado 3D"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cross_support_density_image label"
 msgid "Cross Fill Density Image for Support"
 msgstr "Imagem de Densidade de Preenchimento Cruzado para Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cross_infill_density_image label"
 msgid "Cross Infill Density Image"
 msgstr "Imagem de Densidade do Preenchimento Cruzado"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_crystallinity label"
 msgid "Crystalline Material"
 msgstr "Material Cristalino"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option cubic"
 msgid "Cubic"
 msgstr "Cúbico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option cubicsubdiv"
 msgid "Cubic Subdivision"
 msgstr "Subdivisão Cúbica"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "sub_div_rad_add label"
 msgid "Cubic Subdivision Shell"
 msgstr "Cobertura de Subdivisão Cúbica"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cutting_mesh label"
 msgid "Cutting Mesh"
 msgstr "Malha de Corte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flow_temp_graph description"
 msgid "Data linking material flow (in mm3 per second) to temperature (degrees Celsius)."
 msgstr "Dados relacionando fluxo de material (em mm³ por segundo) a temperatura (graus Celsius)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_acceleration label"
 msgid "Default Acceleration"
 msgstr "Aceleração Default"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "default_material_bed_temperature label"
 msgid "Default Build Plate Temperature"
 msgstr "Temperatura Default da Plataforma de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_jerk_e label"
 msgid "Default Filament Jerk"
 msgstr "Jerk Default do Filamento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "default_material_print_temperature label"
 msgid "Default Printing Temperature"
 msgstr "Temperatura Default de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_jerk_xy label"
 msgid "Default X-Y Jerk"
 msgstr "Jerk Default nos eixos X-Y"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_jerk_z label"
 msgid "Default Z Jerk"
 msgstr "O Jerk Default em Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_jerk_xy description"
 msgid "Default jerk for movement in the horizontal plane."
 msgstr "O valor default de jerk para movimentos no plano horizontal."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_jerk_z description"
 msgid "Default jerk for the motor of the Z-direction."
 msgstr "O valor default de jerk para movimento na direção Z."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_jerk_e description"
 msgid "Default jerk for the motor of the filament."
 msgstr "O valor default de jerk para movimentação do filamento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_bottom_delay description"
 msgid "Delay time after a downward move. Only applies to Wire Printing."
 msgstr "Tempo de espera depois de um movimento descendente tal que o filete possa se solidificar. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_top_delay description"
 msgid "Delay time after an upward move, so that the upward line can harden. Only applies to Wire Printing."
 msgstr "Tempo de espera depois de um movimento ascendente tal que o filete ascendente possa se solidifcar. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_flat_delay description"
 msgid "Delay time between two horizontal segments. Introducing such a delay can cause better adhesion to previous layers at the connection points, while too long delays cause sagging. Only applies to Wire Printing."
 msgstr "Tempo de espera entre dois segmentos horizontais. Inserir tal espera pode ocasionar melhor aderência a camadas prévias nos pontos de conexão, mas atrasos muito longos podem causar estruturas murchas. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_settings_enabled description"
 msgid "Detect bridges and modify print speed, flow and fan settings while bridges are printed."
 msgstr "Detectar pontes e modificar a velocidade de impressão, de fluxo e ajustes de fan onde elas forem detectadas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "inset_direction description"
 msgid "Determines the order in which walls are printed. Printing outer walls earlier helps with dimensional accuracy, as faults from inner walls cannot propagate to the outside. However printing them later allows them to stack better when overhangs are printed. When there is an uneven amount of total innner walls, the 'center last line' is always printed last."
 msgstr "Determina a ordem na qual paredes são impressas. Imprimir as paredes externas primeiro ajuda na acuracidade dimensional, visto que falhas das paredes internas não poderão propagar externamente. No entanto, imprimi-las no final ajuda a haver melhor empilhamento quando seções pendentes são impressas. Quando há uma quantidade ímpar de paredes internas totais, a 'última linha central' é sempre impressa por último."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_mesh_order description"
 msgid "Determines the priority of this mesh when considering multiple overlapping infill meshes. Areas where multiple infill meshes overlap will take on the settings of the mesh with the highest rank. An infill mesh with a higher rank will modify the infill of infill meshes with lower rank and normal meshes."
 msgstr "Determina a prioridade desta malha ao considerar múltiplas malhas de preenchimento sobrepostas. Áreas onde múltiplas malhas de preenchimento se sobrepõem terão os ajustes da malha com a maior prioridade. Uma malha de preenchimento com prioridade maior modificará o preenchimento tanto das malhas de preenchimento com prioridade menor quanto das malhas normais."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "lightning_infill_support_angle description"
 msgid "Determines when a lightning infill layer has to support anything above it. Measured in the angle given the thickness of a layer."
 msgstr "Determina quando uma camada do preenchimento relâmpago deve suportar algo sobre si. Medido no ângulo de acordo com a espessura da camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "lightning_infill_overhang_angle description"
 msgid "Determines when a lightning infill layer has to support the model above it. Measured in the angle given the thickness."
 msgstr "Determina quando a camada de preenchimento relâmpago deve suportar o modelo sobre si. Medido no ângulo de acordo com a espessura."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_diameter label"
 msgid "Diameter"
 msgstr "Diâmetro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adhesion_type description"
 msgid "Different options that help to improve both priming your extrusion and adhesion to the build plate. Brim adds a single layer flat area around the base of your model to prevent warping. Raft adds a thick grid with a roof below the model. Skirt is a line printed around the model, but not connected to the model."
 msgstr "Diferentes opções que ajudam a melhorar a extrusão e a aderência à plataforma de impressão. Brim (bainha) adiciona uma camada única e chata em volta da base de seu modelo para impedir warping. Raft (balsa) adiciona uma grade densa com 'teto' abaixo do modelo. Skirt (saia) é uma linha impressa em volta do modelo, mas não conectada ao modelo, para apenas iniciar o processo de extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_disallowed_areas label"
 msgid "Disallowed Areas"
 msgstr "Áreas Proibidas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_nozzle_clearance description"
 msgid "Distance between the nozzle and horizontally downward lines. Larger clearance results in diagonally downward lines with a less steep angle, which in turn results in less upward connections with the next layer. Only applies to Wire Printing."
 msgstr "Distância entre o bico e os filetes descendentes horizontais. Espaços livres maiores resultarão em filetes descendentes diagonais com ângulo menos acentuado, o que por sua vez resulta em menos conexões ascendentes à próxima camada. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_line_distance description"
 msgid "Distance between the printed infill lines. This setting is calculated by the infill density and the infill line width."
 msgstr "Distância entre as linhas de preenchimento impressas. Este ajuste é calculado pela densidade de preenchimento e a largura de extrusão do preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_initial_layer_line_distance description"
 msgid "Distance between the printed initial layer support structure lines. This setting is calculated by the support density."
 msgstr "Distância entre os filetes da camada inicial da camada de suporte. Este ajuste é calculado pela densidade de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_line_distance description"
 msgid "Distance between the printed support floor lines. This setting is calculated by the Support Floor Density, but can be adjusted separately."
 msgstr "Distância entre os filetes de impressão da base de suporte. Este ajuste é calculado pela densidade da Base de Suporte, mas pode ser ajustado separadamente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_line_distance description"
 msgid "Distance between the printed support roof lines. This setting is calculated by the Support Roof Density, but can be adjusted separately."
 msgstr "Distância entre os filetes de impressão do teto de suporte. Este ajuste é calculado pela Densidade do Teto de Suporte mas pode ser ajustado separadamente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_line_distance description"
 msgid "Distance between the printed support structure lines. This setting is calculated by the support density."
 msgstr "Distância entre as linhas impressas da estrutura de suporte. Este ajuste é calculado a partir da densidade de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_distance description"
 msgid "Distance from the print to the bottom of the support."
 msgstr "Distância da parte inferior do suporte até a impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_top_distance description"
 msgid "Distance from the top of the support to the print."
 msgstr "Distância do topo do suporte à impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_z_distance description"
 msgid "Distance from the top/bottom of the support structure to the print. This gap provides clearance to remove the supports after the model is printed. This value is rounded up to a multiple of the layer height."
 msgstr "Distância do topo e base da estrutura de suporte para a impressão. Este vão provê um espaço para remover os suportes depois de o modelo ser impresso. O valor é arredondado para um múltiplo da altura de camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_wipe_dist description"
 msgid "Distance of a travel move inserted after every infill line, to make the infill stick to the walls better. This option is similar to infill overlap, but without extrusion and only on one end of the infill line."
 msgstr "Distância do percurso inserido após cada linha de preenchimento, para fazer o preenchimento aderir melhor às paredes. Esta opção é similar à sobreposição de preenchimento mas sem extrusão e somente em uma extremidade do filete de preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_wipe_dist description"
 msgid "Distance of a travel move inserted after the outer wall, to hide the Z seam better."
 msgstr "Distância do percurso inserido após a parede externa para esconder melhor a costura em Z."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_up_half_speed description"
 msgid ""
 "Distance of an upward move which is extruded with half speed.\n"
@@ -950,517 +955,517 @@ msgstr ""
 "Distância de um movimento ascendente que é extrudado com metade da velocidade.\n"
 "Isto pode resultar em melhor aderência às camadas prévias, ao mesmo tempo em que não aquece demais essas camadas. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_dist description"
 msgid "Distance of the draft shield from the print, in the X/Y directions."
 msgstr "Distância da Cobertura de Trabalho da impressão nas direções X e Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ooze_shield_dist description"
 msgid "Distance of the ooze shield from the print, in the X/Y directions."
 msgstr "Distância da cobertura de escorrimento da impressão nas direções X e Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_xy_distance_overhang description"
 msgid "Distance of the support structure from the overhang in the X/Y directions."
 msgstr "Distância da estrutura de suporte da seção pendente nas direções X/Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_xy_distance description"
 msgid "Distance of the support structure from the print in the X/Y directions."
 msgstr "Distância da estrutura de suporte até a impressão nas direções X e Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_fall_down description"
 msgid "Distance with which the material falls down after an upward extrusion. This distance is compensated for. Only applies to Wire Printing."
 msgstr "Distância na qual o material desaba após uma extrusão ascendente. Esta distância é compensada. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_drag_along description"
 msgid "Distance with which the material of an upward extrusion is dragged along with the diagonally downward extrusion. This distance is compensated for. Only applies to Wire Printing."
 msgstr "Distância na qual o material de uma extrusão ascendente é arrastado com a extrusão descendente diagonal. Esta distância é compensada. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_infill_area description"
 msgid "Don't generate areas of infill smaller than this (use skin instead)."
 msgstr "Não gerar preenchimento para áreas menores que esta (usar contorno)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_height label"
 msgid "Draft Shield Height"
 msgstr "Altura da Cobertura de Trabalho"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_height_limitation label"
 msgid "Draft Shield Limitation"
 msgstr "Limitação da Cobertura de Trabalho"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_dist label"
 msgid "Draft Shield X/Y Distance"
 msgstr "Distância X/Y da Cobertura de Trabalho"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_mesh_drop_down label"
 msgid "Drop Down Support Mesh"
 msgstr "Malha de Suporte Abaixo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "dual label"
 msgid "Dual Extrusion"
 msgstr "Extrusão Dual"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_shape option elliptic"
 msgid "Elliptic"
 msgstr "Elíptica"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_enabled label"
 msgid "Enable Acceleration Control"
 msgstr "Habilitar Controle de Aceleração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_settings_enabled label"
 msgid "Enable Bridge Settings"
 msgstr "Habilitar Ajustes de Ponte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "coasting_enable label"
 msgid "Enable Coasting"
 msgstr "Habilitar Desengrenagem"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_conical_enabled label"
 msgid "Enable Conical Support"
 msgstr "Habilitar Suporte Cônico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_enabled label"
 msgid "Enable Draft Shield"
 msgstr "Habilitar Cobertura de Trabalho"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_enabled label"
 msgid "Enable Ironing"
 msgstr "Habilitar Passar a Ferro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_enabled label"
 msgid "Enable Jerk Control"
 msgstr "Habilitar Controle de Jerk"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_temp_enabled label"
 msgid "Enable Nozzle Temperature Control"
 msgstr "Habilitar Controle de Temperatura do Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ooze_shield_enabled label"
 msgid "Enable Ooze Shield"
 msgstr "Habilitar Cobertura de Escorrimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_blob_enable label"
 msgid "Enable Prime Blob"
 msgstr "Habilitar Massa de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_enable label"
 msgid "Enable Prime Tower"
 msgstr "Habilitar Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_enabled label"
 msgid "Enable Print Cooling"
 msgstr "Habilitar Refrigeração de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_enable label"
 msgid "Enable Retraction"
 msgstr "Habilitar Retração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_brim_enable label"
 msgid "Enable Support Brim"
 msgstr "Habilitar Brim de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_enable label"
 msgid "Enable Support Floor"
 msgstr "Habilitar Base de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_enable label"
 msgid "Enable Support Interface"
 msgstr "Habilitar Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_enable label"
 msgid "Enable Support Roof"
 msgstr "Habilitar Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_travel_enabled label"
 msgid "Enable Travel Acceleration"
 msgstr "Habilitar Aceleração de Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_travel_enabled label"
 msgid "Enable Travel Jerk"
 msgstr "Habilitar Jerk de Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ooze_shield_enabled description"
 msgid "Enable exterior ooze shield. This will create a shell around the model which is likely to wipe a second nozzle if it's at the same height as the first nozzle."
 msgstr "Habilita a cobertura exterior de escorrimento. Isso criará uma casca ou cobertura em volta do modelo que ajudará a limpar o segundo bico se estiver na mesma altura do primeiro bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_enabled description"
 msgid "Enables adjusting the jerk of print head when the velocity in the X or Y axis changes. Increasing the jerk can reduce printing time at the cost of print quality."
 msgstr "Permite ajustar o jerk da cabeça de impressão quando a velocidade nos eixos X ou Y muda. Aumentar o jerk pode reduzir o tempo de impressão ao custo de qualidade de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_enabled description"
 msgid "Enables adjusting the print head acceleration. Increasing the accelerations can reduce printing time at the cost of print quality."
 msgstr "Permite ajustar a aceleração da cabeça de impressão. Aumentar as acelerações pode reduzir tempo de impressão ao custo de qualidade de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_enabled description"
 msgid "Enables the print cooling fans while printing. The fans improve print quality on layers with short layer times and bridging / overhangs."
 msgstr "Habilita as ventoinhas de refrigeração ao imprimir. As ventoinhas aprimoram a qualidade de impressão em camadas de tempo curto de impressão e em pontes e seções pendentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_end_gcode label"
 msgid "End G-code"
 msgstr "G-Code Final"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_end_of_filament_purge_length label"
 msgid "End of Filament Purge Length"
 msgstr "Comprimento de Purga do Fim do Filamento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_end_of_filament_purge_speed label"
 msgid "End of Filament Purge Speed"
 msgstr "Velocidade de Purga do Fim do Filamento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "brim_replaces_support description"
 msgid "Enforce brim to be printed around the model even if that space would otherwise be occupied by support. This replaces some regions of the first layer of support by brim regions."
 msgstr "Força que o brim seja impresso em volta do modelo mesmo se este espaço fosse ser ocupado por suporte. Isto substitui algumas regiões da primeira camada de suporte por regiões de brim."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_type option everywhere"
 msgid "Everywhere"
 msgstr "Em Todo Lugar"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "slicing_tolerance option exclusive"
 msgid "Exclusive"
 msgstr "Exclusivo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "experimental label"
 msgid "Experimental"
 msgstr "Experimental"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_corner option z_seam_corner_outer"
 msgid "Expose Seam"
 msgstr "Expôr Costura"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_extensive_stitching label"
 msgid "Extensive Stitching"
 msgstr "Costura Extensa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_extensive_stitching description"
 msgid "Extensive stitching tries to stitch up open holes in the mesh by closing the hole with touching polygons. This option can introduce a lot of processing time."
 msgstr "Costura Extensa tenta costurar buracos abertos na malha fechando o buraco com polígonos que o tocam. Esta opção pode adicionar bastante tempo ao fatiamento das peças."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_wall_line_count label"
 msgid "Extra Infill Wall Count"
 msgstr "Contagem de Paredes de Preenchimento Extras"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_outline_count label"
 msgid "Extra Skin Wall Count"
 msgstr "Contagem de Paredes Extras de Contorno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_extra_prime_amount description"
 msgid "Extra material to prime after nozzle switching."
 msgstr "Material extra a avançar depois da troca de bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruder_prime_pos_x label"
 msgid "Extruder Prime X Position"
 msgstr "Posição X da Purga do Extrusor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruder_prime_pos_y label"
 msgid "Extruder Prime Y Position"
 msgstr "Posição Y da Purga do Extrusor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruder_prime_pos_z label"
 msgid "Extruder Prime Z Position"
 msgstr "Posição Z de Purga do Extrusor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_extruders_share_heater label"
 msgid "Extruders Share Heater"
 msgstr "Extrusores Compartilham Aquecedor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_extruders_share_nozzle label"
 msgid "Extruders Share Nozzle"
 msgstr "Extrusores Compartilham o Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_extrusion_cool_down_speed label"
 msgid "Extrusion Cool Down Speed Modifier"
 msgstr "Modificador de Velocidade de Resfriamento de Extrusão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_equalize_flow_width_factor description"
 msgid "Extrusion width based correction factor on the speed. At 0% the movement speed is kept constant at the Print Speed. At 100% the movement speed is adjusted so that the flow (in mm³/s) is kept constant, i.e. lines half the normal Line Width are printed twice as fast and lines twice as wide are printed half as fast. A value larger than 100% can help to compensate for the higher pressure required to extrude wide lines."
 msgstr "Fator de correção de largura de extrusão baseada na velocidade. Em 0%, a velocidade de movimento é mantida constante na Velocidade de Impressão. Em 100%, a velocidade de movimento é ajustada de forma que o fluxo (em mm³/s) seja mantido constante, isto é, filetes de metade da Largura de Filete normal são impressos duas vezes mais rápido e filetes duas vezes mais espessos são impressos na metade da velocidade. Um valor mais alto que 100% pode ajudar a compensar pela maior pressão necessária para extrudar filetes espessos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_speed label"
 msgid "Fan Speed"
 msgstr "Velocidade da Ventoinha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_fan_enable label"
 msgid "Fan Speed Override"
 msgstr "Sobrepor Velocidade de Ventoinha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "small_feature_max_length description"
 msgid "Feature outlines that are shorter than this length will be printed using Small Feature Speed."
 msgstr "Contornos de aspectos menores que este comprimento serão impressos usando a Velocidade de Aspecto Pequeno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "experimental description"
 msgid "Features that haven't completely been fleshed out yet."
 msgstr "Recursos que não foram completamente desenvolvidos ainda."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_feeder_wheel_diameter label"
 msgid "Feeder Wheel Diameter"
 msgstr "Diâmetro da Engrenagem de Alimentação"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_final_print_temperature label"
 msgid "Final Printing Temperature"
 msgstr "Temperatura de Impressão Final"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_firmware_retract label"
 msgid "Firmware Retraction"
 msgstr "Retração de Firmware"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_extruder_nr_layer_0 label"
 msgid "First Layer Support Extruder"
 msgstr "Extrusor de Suporte da Primeira Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flow label"
 msgid "Flow"
 msgstr "Fluxo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_equalize_flow_width_factor label"
 msgid "Flow Equalization Ratio"
 msgstr "Raio de Equalização de Fluxo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "flow_rate_extrusion_offset_factor label"
 msgid "Flow Rate Compensation Factor"
 msgstr "Fator de Compensação da Taxa de Fluxo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "flow_rate_max_extrusion_offset label"
 msgid "Flow Rate Compensation Max Extrusion Offset"
 msgstr "Máximo Deslocamento de Extrusão de Compensação de Taxa de Fluxo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flow_temp_graph label"
 msgid "Flow Temperature Graph"
 msgstr "Gráfico de Fluxo de Temperatura"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flow_layer_0 description"
 msgid "Flow compensation for the first layer: the amount of material extruded on the initial layer is multiplied by this value."
 msgstr "Compensação de fluxo para a primeira camada; a quantidade de material extrudado na camada inicial é multiplicada por este valor."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_material_flow_layer_0 description"
 msgid "Flow compensation on bottom lines of the first layer"
 msgstr "Compensação de fluxo nos filetes da base da primeira camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_material_flow description"
 msgid "Flow compensation on infill lines."
 msgstr "Compensação de fluxo em filetes de preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_material_flow description"
 msgid "Flow compensation on lines of support roof or floor."
 msgstr "Compensação de fluxo em filetes do teto ou base do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_material_flow description"
 msgid "Flow compensation on lines of the areas at the top of the print."
 msgstr "Compensação de Fluxo em filetes das áreas no topo da impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_flow description"
 msgid "Flow compensation on prime tower lines."
 msgstr "Compensação de fluxo em filetes de torre de purga."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_material_flow description"
 msgid "Flow compensation on skirt or brim lines."
 msgstr "Compensação de Fluxo em filetes de Skirt e Brim."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_material_flow description"
 msgid "Flow compensation on support floor lines."
 msgstr "Compensação de fluxo nos filetes da base do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_material_flow description"
 msgid "Flow compensation on support roof lines."
 msgstr "Compensação de fluxo em filetes do teto de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_material_flow description"
 msgid "Flow compensation on support structure lines."
 msgstr "Compensação de fluxo em filetes de estruturas de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_material_flow_layer_0 description"
 msgid "Flow compensation on the outermost wall line of the first layer."
 msgstr "Compensação de fluxo no filete de parede mais externo da primeira camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_material_flow description"
 msgid "Flow compensation on the outermost wall line."
 msgstr "Compensação de fluxo no filete de parede mais externo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_material_flow description"
 msgid "Flow compensation on top/bottom lines."
 msgstr "Compensação de fluxo em filetes do topo e base."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_x_material_flow_layer_0 description"
 msgid "Flow compensation on wall lines for all wall lines except the outermost one, but only for the first layer"
 msgstr "Compensação de fluxo nos filetes de parede para todos os filetes exceto o mais externo, mas só para a primeira camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_x_material_flow description"
 msgid "Flow compensation on wall lines for all wall lines except the outermost one."
 msgstr "Compensação de fluxo em todos os filetes de parede excetuando o mais externo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_material_flow description"
 msgid "Flow compensation on wall lines."
 msgstr "Compensação de fluxo em filetes das paredes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_flow_connection description"
 msgid "Flow compensation when going up or down. Only applies to Wire Printing."
 msgstr "Compensação de Fluxo quanto subindo ou descendo. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_flow_flat description"
 msgid "Flow compensation when printing flat lines. Only applies to Wire Printing."
 msgstr "Compensação de fluxo ao imprimir filetes planos. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flow description"
 msgid "Flow compensation: the amount of material extruded is multiplied by this value."
 msgstr "Compensação de fluxo: a quantidade de material extrudado é multiplicado por este valor."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_flow description"
 msgid "Flow compensation: the amount of material extruded is multiplied by this value. Only applies to Wire Printing."
 msgstr "Compensação de fluxo: a quantidade de material extrudado é multiplicado por este valor. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flush_purge_length label"
 msgid "Flush Purge Length"
 msgstr "Comprimento da Descarga de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flush_purge_speed label"
 msgid "Flush Purge Speed"
 msgstr "Velocidade de Descarga de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_wall_line_width description"
 msgid "For thin structures around once or twice the nozzle size, the line widths need to be altered to adhere to the thickness of the model. This setting controls the minimum line width allowed for the walls. The minimum line widths inherently also determine the maximum line widths, since we transition from N to N+1 walls at some geometry thickness where the N walls are wide and the N+1 walls are narrow. The widest possible wall line is twice the Minimum Wall Line Width."
 msgstr "Para estruturas finas por volta de uma ou duas vezes o tamanho do bico, as larguras de linhas precisam ser alteradas para aderir à grossura do modelo. Este ajuste controla a largura mínima de filete permite para as paredes. As larguras mínimas de filete inerentemente também determinam as larguras máximas, já que transicionamos de N pra N+1 parede na grossura de geometria onde paredes N são largas e as paredes N+1 são estreitas. A  maior largura possível de parede é duas vezes a Largura Mínima de Filete de Parede."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position option front"
 msgid "Front"
 msgstr "Frente"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position option frontleft"
 msgid "Front Left"
 msgstr "Frente à Esquerda"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position option frontright"
 msgid "Front Right"
 msgstr "Frente à Direita"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_height_limitation option full"
 msgid "Full"
 msgstr "Completo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_enabled label"
 msgid "Fuzzy Skin"
 msgstr "Contorno Felpudo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_point_density label"
 msgid "Fuzzy Skin Density"
 msgstr "Densidade do Contorno Felpudo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_outside_only label"
 msgid "Fuzzy Skin Outside Only"
 msgstr "Contorno Felpudo Externo Apenas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_point_dist label"
 msgid "Fuzzy Skin Point Distance"
 msgstr "Distância de Pontos do Contorno Felpudo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_thickness label"
 msgid "Fuzzy Skin Thickness"
 msgstr "Espessura do Contorno Felpudo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor label"
 msgid "G-code Flavor"
 msgstr "Sabor de G-Code"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_end_gcode description"
 msgid ""
 "G-code commands to be executed at the very end - separated by \n"
@@ -1469,7 +1474,7 @@ msgstr ""
 "Comandos G-Code a serem executados no final da impressão - separados por \n"
 "."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_start_gcode description"
 msgid ""
 "G-code commands to be executed at the very start - separated by \n"
@@ -1478,3327 +1483,3397 @@ msgstr ""
 "Comandos G-Code a serem executados no início da impressão - separados por \n"
 "."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_guid description"
 msgid "GUID of the material. This is set automatically."
 msgstr "GUID do material. É ajustado automaticamente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gantry_height label"
 msgid "Gantry Height"
 msgstr "Altura do Eixo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+msgctxt "interlocking_enable label"
+msgid "Generate Interlocking Structure"
+msgstr "Gerar Estrutura Interligada"
+
+#: fdmprinter.def.json
 msgctxt "support_enable label"
 msgid "Generate Support"
 msgstr "Gerar Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_brim_enable description"
 msgid "Generate a brim within the support infill regions of the first layer. This brim is printed underneath the support, not around it. Enabling this setting increases the adhesion of support to the build plate."
 msgstr "Gera o brim dentro das regiões de preenchimento de suporte da primeira camada. Este brim é impresso sob o suporte, não em volta dele. Habilitar este ajuste aumenta a aderência de suporte à mesa de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_enable description"
 msgid "Generate a dense interface between the model and the support. This will create a skin at the top of the support on which the model is printed and at the bottom of the support, where it rests on the model."
 msgstr "Gera uma interface densa entre o modelo e o suporte. Isto criará um contorno no topo do suporte em que o modelo é impresso e na base do suporte, onde ele fica sobre o modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_enable description"
 msgid "Generate a dense slab of material between the bottom of the support and the model. This will create a skin between the model and support."
 msgstr "Gera um bloco denso de material entre a base do suporte e o modelo. Isto criará uma divisória entre o modelo e o suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_enable description"
 msgid "Generate a dense slab of material between the top of support and the model. This will create a skin between the model and support."
 msgstr "Gera um bloco denso de material entre o topo do suporte e o modelo. Isto criará uma divisória entre o modelo e o suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_enable description"
 msgid "Generate structures to support parts of the model which have overhangs. Without these structures, such parts would collapse during printing."
 msgstr "Gerar estrutura que suportem partes do modelo que tenham seções pendentes. Sem estas estruturas, tais partes desabariam durante a impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_buildplate_type option glass"
 msgid "Glass"
 msgstr "Vidro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_enabled description"
 msgid "Go over the top surface one additional time, but this time extruding very little material. This is meant to melt the plastic on top further, creating a smoother surface. The pressure in the nozzle chamber is kept high so that the creases in the surface are filled with material."
 msgstr "Passa sobre a superfície superior uma vez a mais, mas extrudando muito pouco material. Isto serve para derreter mais o plástico em cima, criando uma superfície lisa. A pressão na câmara do bico é mantida alta tal que as rugas na superfície são preenchidas com material."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gradual_infill_step_height label"
 msgid "Gradual Infill Step Height"
 msgstr "Altura de Passo do Preenchimento Gradual"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gradual_infill_steps label"
 msgid "Gradual Infill Steps"
 msgstr "Passos Graduais de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gradual_support_infill_step_height label"
 msgid "Gradual Support Infill Step Height"
 msgstr "Altura de Passo do Preenchimento Gradual de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gradual_support_infill_steps label"
 msgid "Gradual Support Infill Steps"
 msgstr "Passos de Preenchimento Gradual de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+msgctxt "cool_min_temperature description"
+msgid "Gradually reduce to this temperature when printing at reduced speeds because of minimum layer time."
+msgstr "Gradualmente reduzir até esta temperatura quanto se estiver imprimindo a velocidades reduzidas devidas ao tempo mínimo de camada."
+
+#: fdmprinter.def.json
 msgctxt "infill_pattern option grid"
 msgid "Grid"
 msgstr "Grade"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_pattern option grid"
 msgid "Grid"
 msgstr "Grade"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_pattern option grid"
 msgid "Grid"
 msgstr "Grade"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern option grid"
 msgid "Grid"
 msgstr "Grade"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_pattern option grid"
 msgid "Grid"
 msgstr "Grade"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option Griffin"
 msgid "Griffin"
 msgstr "Griffin"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option gyroid"
 msgid "Gyroid"
 msgstr "Giróide"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern option gyroid"
 msgid "Gyroid"
 msgstr "Giróide"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_heated_build_volume label"
 msgid "Has Build Volume Temperature Stabilization"
 msgstr "Tem Estabilização de Temperatura do Volume de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_heated_bed label"
 msgid "Has Heated Build Plate"
 msgstr "Tem Mesa Aquecida"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_heat_up_speed label"
 msgid "Heat Up Speed"
 msgstr "Velocidade de Aquecimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_heat_zone_length label"
 msgid "Heat Zone Length"
 msgstr "Comprimento da Zona de Aquecimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_height description"
 msgid "Height limitation of the draft shield. Above this height no draft shield will be printed."
 msgstr "Limitação de altura da cobertura de trabalho. Acima desta altura a cobertura não será impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_corner option z_seam_corner_inner"
 msgid "Hide Seam"
 msgstr "Ocultar Costura"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_corner option z_seam_corner_any"
 msgid "Hide or Expose Seam"
 msgstr "Ocultar ou Expor Costura"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "hole_xy_offset label"
 msgid "Hole Horizontal Expansion"
 msgstr "Expansão Horizontal do Furo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "small_hole_max_size description"
 msgid "Holes and part outlines with a diameter smaller than this will be printed using Small Feature Speed."
 msgstr "Furos e contornos de partes com diâmetro menor que este serão impressos usando a Velocidade de Aspecto Pequeno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "xy_offset label"
 msgid "Horizontal Expansion"
 msgstr "Expansão Horizontal"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_shrinkage_percentage_xy label"
 msgid "Horizontal Scaling Factor Shrinkage Compensation"
 msgstr "Compensação de Fator de Encolhimento Horizontal"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_branch_distance description"
 msgid "How far apart the branches need to be when they touch the model. Making this distance small will cause the tree support to touch the model at more points, causing better overhang but making support harder to remove."
 msgstr "Quão distantes os galhos precisam estar quando tocam o modelo. Tornar esta distância pequena fará com que o suporte em árvore toque o modelo em mais pontos, permitindo maior sustentação mas tornando o suporte mais difícil de remover."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_preparation_retracted_position description"
 msgid "How far the filament can be stretched before it breaks, while heated."
 msgstr "Quanto o filamento pode ser esticado antes que quebre, quando aquecido."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_anti_ooze_retracted_position description"
 msgid "How far the material needs to be retracted before it stops oozing."
 msgstr "De quanto o material precisa ser retraído antes que pare de escorrer."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "flow_rate_extrusion_offset_factor description"
 msgid "How far to move the filament in order to compensate for changes in flow rate, as a percentage of how far the filament would move in one second of extrusion."
 msgstr "Em quanto mover o filamento para compensar mudanças na taxa de fluxo, como uma porcentagem da distância que o filamento seria movido em um segundo de extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_retracted_position description"
 msgid "How far to retract the filament in order to break it cleanly."
 msgstr "De quanto o filamento deve ser retraído para se destacar completamente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_preparation_speed description"
 msgid "How fast the filament needs to be retracted just before breaking it off in a retraction."
 msgstr "Qual a velocidade do material para que seja retraído antes de quebrar em uma retração."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_anti_ooze_retraction_speed description"
 msgid "How fast the material needs to be retracted during a filament switch to prevent oozing."
 msgstr "Qual a velocidade do material para que seja retraído durante a troca de filamento sem escorrimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_end_of_filament_purge_speed description"
 msgid "How fast to prime the material after replacing an empty spool with a fresh spool of the same material."
 msgstr "Quão rápido purgar o material depois de trocar um carretel vazio por um novo carretel do mesmo material."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flush_purge_speed description"
 msgid "How fast to prime the material after switching to a different material."
 msgstr "Quão rápido purgar o material depois de alternar para um material diferente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_maximum_park_duration description"
 msgid "How long the material can be kept out of dry storage safely."
 msgstr "Quanto tempo o material pode ser mantido fora de armazenamento seco com segurança."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_steps_per_mm_x description"
 msgid "How many steps of the stepper motor will result in one millimeter of movement in the X direction."
 msgstr "Quantos passos do motor de passo resultarão em um milímetro de movimento na direção X."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_steps_per_mm_y description"
 msgid "How many steps of the stepper motor will result in one millimeter of movement in the Y direction."
 msgstr "Quantos passos do motor de passo resultarão em um milímetro de movimento na direção Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_steps_per_mm_z description"
 msgid "How many steps of the stepper motor will result in one millimeter of movement in the Z direction."
 msgstr "Quantos passos do motor de passo resultarão em um milímetro de movimento na direção Z."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_steps_per_mm_e description"
 msgid "How many steps of the stepper motors will result in moving the feeder wheel by one millimeter around its circumference."
 msgstr "Quantos passos dos motores resultarão no movimento da engrenagem de alimentação em um milímetro da circunferência."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_end_of_filament_purge_length description"
 msgid "How much material to use to purge the previous material out of the nozzle (in length of filament) when replacing an empty spool with a fresh spool of the same material."
 msgstr "Quanto material usar para purgar o material anterior do bico (em comprimento de filamento) quando um carretel vazio for trocado por um carretel novo do mesmo material."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flush_purge_length description"
 msgid "How much material to use to purge the previous material out of the nozzle (in length of filament) when switching to a different material."
 msgstr "Quanto material usar para purgar o material anterior do bico (em comprimento de filamento) quando alternar para um material diferente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_extruders_shared_nozzle_initial_retraction description"
 msgid "How much the filament of each extruder is assumed to have been retracted from the shared nozzle tip at the completion of the printer-start gcode script; the value should be equal to or greater than the length of the common part of the nozzle's ducts."
 msgstr "Quanto é assumido que o filamento de cada extrusor  tenha retraído da ponta do bico ao completar o script g-code de início da impressora; o valor deve ser igual ou superior ao comprimento da parte comum dos dutos do bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_support_threshold description"
 msgid "If a skin region is supported for less than this percentage of its area, print it using the bridge settings. Otherwise it is printed using the normal skin settings."
 msgstr "Se uma região do contorno for suportada por menos do que esta porcentagem de sua área, imprimi-la com os ajustes de ponte. Senão, imprimir usando os ajustes normais de contorno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_enable_more_layers description"
 msgid "If enabled, the second and third layers above the air are printed using the following settings. Otherwise, those layers are printed using the normal settings."
 msgstr "Se habilitado, a segunda e terceira camadas sobre o ar serão impressas usando os ajustes seguintes. Senão, estas camadas serão impressas com ajustes normais."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_transition_filter_distance description"
 msgid "If it would be transitioning back and forth between different numbers of walls in quick succession, don't transition at all. Remove transitions if they are closer together than this distance."
 msgstr "Se for detectado que a cabeça de impressão estaria alternando em rápida sucessão entre números diferentes de parede, não fazer tal alternação. Remove transições se elas estiverem próximas até essa distância."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_margin description"
 msgid "If the raft is enabled, this is the extra raft area around the model which is also given a raft. Increasing this margin will create a stronger raft while using more material and leaving less area for your print."
 msgstr "Se o Raft estiver habilitado, esta é a área extra do raft em volta do modelo que também faz parte dele. Aumentar esta margem criará um raft mais forte mas também gastará mais material e deixará menos área para sua impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_union_all description"
 msgid "Ignore the internal geometry arising from overlapping volumes within a mesh and print the volumes as one. This may cause unintended internal cavities to disappear."
 msgstr "Ignora a geometria interna de volumes sobrepostos dentro de uma malha e imprime os volumes como um único volume. Isto pode ter o efeito não-intencional de fazer cavidades desaparecerem."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_bed_temp_prepend label"
 msgid "Include Build Plate Temperature"
 msgstr "Incluir Temperatura da Mesa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_print_temp_prepend label"
 msgid "Include Material Temperatures"
 msgstr "Incluir Temperaturas de Material"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "slicing_tolerance option inclusive"
 msgid "Inclusive"
 msgstr "Inclusivo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill description"
 msgid "Infill"
 msgstr "Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill label"
 msgid "Infill"
 msgstr "Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_infill label"
 msgid "Infill Acceleration"
 msgstr "Aceleração do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_before_walls label"
 msgid "Infill Before Walls"
 msgstr "Preenchimento Antes das Paredes"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_sparse_density label"
 msgid "Infill Density"
 msgstr "Densidade do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_extruder_nr label"
 msgid "Infill Extruder"
 msgstr "Extrusor do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_material_flow label"
 msgid "Infill Flow"
 msgstr "Fluxo de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_infill label"
 msgid "Infill Jerk"
 msgstr "Jerk do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_sparse_thickness label"
 msgid "Infill Layer Thickness"
 msgstr "Espessura da Camada de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_angles label"
 msgid "Infill Line Directions"
 msgstr "Direções de Filetes de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_line_distance label"
 msgid "Infill Line Distance"
 msgstr "Distância da Linha de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_multiplier label"
 msgid "Infill Line Multiplier"
 msgstr "Multiplicador de Filete de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_line_width label"
 msgid "Infill Line Width"
 msgstr "Largura de Extrusão do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_mesh label"
 msgid "Infill Mesh"
 msgstr "Malha de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_support_angle label"
 msgid "Infill Overhang Angle"
 msgstr "Ângulo de Seções Pendentes do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_overlap_mm label"
 msgid "Infill Overlap"
 msgstr "Sobreposição de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_overlap label"
 msgid "Infill Overlap Percentage"
 msgstr "Porcentagem de Sobreposição do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern label"
 msgid "Infill Pattern"
 msgstr "Padrão de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_infill label"
 msgid "Infill Speed"
 msgstr "Velocidade de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_support_enabled label"
 msgid "Infill Support"
 msgstr "Suporte do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_enable_travel_optimization label"
 msgid "Infill Travel Optimization"
 msgstr "Otimização de Percurso de Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_wipe_dist label"
 msgid "Infill Wipe Distance"
 msgstr "Distância de Varredura do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_offset_x label"
 msgid "Infill X Offset"
 msgstr "Deslocamento X do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_offset_y label"
 msgid "Infill Y Offset"
 msgstr "Deslocamento do Preenchimento Y"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "initial_bottom_layers label"
 msgid "Initial Bottom Layers"
 msgstr "Camadas Inferiores Iniciais"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_speed_0 label"
 msgid "Initial Fan Speed"
 msgstr "Velocidade Inicial da Ventoinha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_layer_0 label"
 msgid "Initial Layer Acceleration"
 msgstr "Aceleração da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_material_flow_layer_0 label"
 msgid "Initial Layer Bottom Flow"
 msgstr "Fluxo da Base da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_flow_layer_0 label"
 msgid "Initial Layer Flow"
 msgstr "Fluxo Inicial de Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_height_0 label"
 msgid "Initial Layer Height"
 msgstr "Altura da Primeira Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "xy_offset_layer_0 label"
 msgid "Initial Layer Horizontal Expansion"
 msgstr "Expansão Horizontal da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_x_material_flow_layer_0 label"
 msgid "Initial Layer Inner Wall Flow"
 msgstr "Fluxo de Parede Interna da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_layer_0 label"
 msgid "Initial Layer Jerk"
 msgstr "Jerk da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "initial_layer_line_width_factor label"
 msgid "Initial Layer Line Width"
 msgstr "Largura de Extrusão da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_material_flow_layer_0 label"
 msgid "Initial Layer Outer Wall Flow"
 msgstr "Fluxo de Parede Externa da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_print_layer_0 label"
 msgid "Initial Layer Print Acceleration"
 msgstr "Aceleração de Impressão da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_print_layer_0 label"
 msgid "Initial Layer Print Jerk"
 msgstr "Jerk de Impressão da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_print_layer_0 label"
 msgid "Initial Layer Print Speed"
 msgstr "Velocidade de Impressão da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_layer_0 label"
 msgid "Initial Layer Speed"
 msgstr "Velocidade da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_initial_layer_line_distance label"
 msgid "Initial Layer Support Line Distance"
 msgstr "Distância de Filetes da Camada Inicial de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_travel_layer_0 label"
 msgid "Initial Layer Travel Acceleration"
 msgstr "Aceleração de Percurso da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_travel_layer_0 label"
 msgid "Initial Layer Travel Jerk"
 msgstr "Jerk de Percurso da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_travel_layer_0 label"
 msgid "Initial Layer Travel Speed"
 msgstr "Velocidade de Percurso da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_0_z_overlap label"
 msgid "Initial Layer Z Overlap"
 msgstr "Sobreposição em Z das Camadas Iniciais"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_initial_print_temperature label"
 msgid "Initial Printing Temperature"
 msgstr "Temperatura Inicial de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_wall_x label"
 msgid "Inner Wall Acceleration"
 msgstr "Aceleração das Paredes Interiores"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_x_extruder_nr label"
 msgid "Inner Wall Extruder"
 msgstr "Extrusor da Parede Interior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_wall_x label"
 msgid "Inner Wall Jerk"
 msgstr "Jerk das Paredes Internas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_wall_x label"
 msgid "Inner Wall Speed"
 msgstr "Velocidade da Parede Interior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_x_material_flow label"
 msgid "Inner Wall(s) Flow"
 msgstr "Fluxo da(s) Parede(s) Interna(s)"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_line_width_x label"
 msgid "Inner Wall(s) Line Width"
 msgstr "Largura de Extrusão das Paredes Internas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_inset description"
 msgid "Inset applied to the path of the outer wall. If the outer wall is smaller than the nozzle, and printed after the inner walls, use this offset to get the hole in the nozzle to overlap with the inner walls instead of the outside of the model."
 msgstr "Penetração adicional aplicada ao caminho da parede externa. Se a parede externa for menor que o bico, e impressa depois das paredes internas, use este deslocamento para fazer o orifício do bico se sobrepor às paredes internas ao invés de ao lado de fora do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "inset_direction option inside_out"
 msgid "Inside To Outside"
 msgstr "De Dentro Pra Fora"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+msgctxt "interlocking_beam_layer_count label"
+msgid "Interlocking Beam Layer Count"
+msgstr "Contagem de Camadas das Vigas Interligadas"
+
+#: fdmprinter.def.json
+msgctxt "interlocking_beam_width label"
+msgid "Interlocking Beam Width"
+msgstr "Largura da Viga Interligada"
+
+#: fdmprinter.def.json
+msgctxt "interlocking_boundary_avoidance label"
+msgid "Interlocking Boundary Avoidance"
+msgstr "Prevenção de Fronteira de Interligação"
+
+#: fdmprinter.def.json
+msgctxt "interlocking_depth label"
+msgid "Interlocking Depth"
+msgstr "Profundidade de Interligação"
+
+#: fdmprinter.def.json
+msgctxt "interlocking_orientation label"
+msgid "Interlocking Structure Orientation"
+msgstr "Orientação da Estrutura de Interligação"
+
+#: fdmprinter.def.json
 msgctxt "ironing_only_highest_layer label"
 msgid "Iron Only Highest Layer"
 msgstr "Passar a Ferro Somente Camada Mais Alta"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_ironing label"
 msgid "Ironing Acceleration"
 msgstr "Aceleração de Passar a Ferro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_flow label"
 msgid "Ironing Flow"
 msgstr "Fluxo de Passagem a Ferro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_inset label"
 msgid "Ironing Inset"
 msgstr "Penetração da Passagem a Ferro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_ironing label"
 msgid "Ironing Jerk"
 msgstr "Jerk de Passar a Ferro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_line_spacing label"
 msgid "Ironing Line Spacing"
 msgstr "Espaçamento de Passagem a Ferro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_pattern label"
 msgid "Ironing Pattern"
 msgstr "Padrão de Passagem a Ferro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_ironing label"
 msgid "Ironing Speed"
 msgstr "Velocidade de Passar o Ferro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_center_is_zero label"
 msgid "Is Center Origin"
 msgstr "Origem é no Centro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_crystallinity description"
 msgid "Is this material the type that breaks off cleanly when heated (crystalline), or is it the type that produces long intertwined polymer chains (non-crystalline)?"
 msgstr "Este material é do tipo que se destaca completamente quando aquecido (cristalino), ou é o tipo que produz cadeias de polímero entrelaçadas (não-cristalino)?"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_outside_only description"
 msgid "Jitter only the parts' outlines and not the parts' holes."
 msgstr "Flutuar movimento apenas nos contornos e não nos furos das peças."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_keep_open_polygons label"
 msgid "Keep Disconnected Faces"
 msgstr "Manter Faces Desconectadas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_strategy option knot"
 msgid "Knot"
 msgstr "Nó"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_height label"
 msgid "Layer Height"
 msgstr "Altura de Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_start_x label"
 msgid "Layer Start X"
 msgstr "X Inicial da Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_start_y label"
 msgid "Layer Start Y"
 msgstr "Y Inicial da Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_thickness description"
 msgid "Layer thickness of the base raft layer. This should be a thick layer which sticks firmly to the printer build plate."
 msgstr "Espessura de camada da camada de base do raft. Esta camada deve ser grossa para poder aderir firmemente à mesa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_thickness description"
 msgid "Layer thickness of the middle raft layer."
 msgstr "Espessura da camada intermediária do raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_thickness description"
 msgid "Layer thickness of the top raft layers."
 msgstr "Espessura de camada das camadas superiores do raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_skip_zag_per_mm description"
 msgid "Leave out a connection between support lines once every N millimeter to make the support structure easier to break away."
 msgstr "Evita uma conexão entre linhas de suporte uma vez a cada N milímetros para fazer a estrutura de suporte mais fácil de ser removida."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position option left"
 msgid "Left"
 msgstr "Esquerda"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_lift_head label"
 msgid "Lift Head"
 msgstr "Levantar Cabeça"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option lightning"
 msgid "Lightning"
 msgstr "Relâmpago"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "lightning_infill_overhang_angle label"
 msgid "Lightning Infill Overhang Angle"
 msgstr "Ângulo de Seção Pendente do Preenchimento Relâmpago"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "lightning_infill_prune_angle label"
 msgid "Lightning Infill Prune Angle"
 msgstr "Ângulo de Poda do Preenchimento Relâmpago"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "lightning_infill_straightening_angle label"
 msgid "Lightning Infill Straightening Angle"
 msgstr "Ângulo de Retificação do Preenchimento Relâmpago"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "lightning_infill_support_angle label"
 msgid "Lightning Infill Support Angle"
 msgstr "Ângulo de Suporte do Preenchimento Relâmpago"
 
-#: /fdmprinter.def.json
-msgctxt "limit_support_retractions label"
-msgid "Limit Support Retractions"
-msgstr "Limitar Retrações de Suporte"
-
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cutting_mesh description"
 msgid "Limit the volume of this mesh to within other meshes. You can use this to make certain areas of one mesh print with different settings and with a whole different extruder."
 msgstr "Limitar o volume desta malha para dentro de outras malhas. Você pode usar isto para fazer certas áreas de uma malha imprimirem com ajustes diferentes, incluindo extrusor diferente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_height_limitation option limited"
 msgid "Limited"
 msgstr "Limitado"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "line_width label"
 msgid "Line Width"
 msgstr "Largura de Extrusão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option lines"
 msgid "Lines"
 msgstr "Linhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_pattern option lines"
 msgid "Lines"
 msgstr "Linhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_pattern option lines"
 msgid "Lines"
 msgstr "Linhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_pattern option lines"
 msgid "Lines"
 msgstr "Linhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern option lines"
 msgid "Lines"
 msgstr "Linhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_pattern option lines"
 msgid "Lines"
 msgstr "Linhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern option lines"
 msgid "Lines"
 msgstr "Linhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern_0 option lines"
 msgid "Lines"
 msgstr "Linhas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option MACH3"
 msgid "Mach3"
 msgstr "Mach3"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_settings label"
 msgid "Machine"
 msgstr "Máquina"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_depth label"
 msgid "Machine Depth"
 msgstr "Profundidade da Mesa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_head_with_fans_polygon label"
 msgid "Machine Head & Fan Polygon"
 msgstr "Polígono da Cabeça com Ventoinha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_height label"
 msgid "Machine Height"
 msgstr "Altura do Volume"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_name label"
 msgid "Machine Type"
 msgstr "Tipo de Máquina"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_width label"
 msgid "Machine Width"
 msgstr "Largura da Mesa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_settings description"
 msgid "Machine specific settings"
 msgstr "Ajustes específicos da máquina"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "conical_overhang_enabled label"
 msgid "Make Overhang Printable"
 msgstr "Torna Seções Pendentes Imprimíveis"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "multiple_mesh_overlap description"
 msgid "Make meshes which are touching each other overlap a bit. This makes them bond together better."
 msgstr "Faz malhas que tocam uma à outra se sobreporem um pouco. Isto faz com que elas se combinem com mais força."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_conical_enabled description"
 msgid "Make support areas smaller at the bottom than at the overhang."
 msgstr "Faz as áreas de suporte menores na base que na seção pendente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_mesh_drop_down description"
 msgid "Make support everywhere below the support mesh, so that there's no overhang in the support mesh."
 msgstr "Cria suport em todo lugar abaixo da malha de suporte de modo que não haja seções pendentes nela."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruder_prime_pos_abs description"
 msgid "Make the extruder prime position absolute rather than relative to the last-known location of the head."
 msgstr "Faz a posição de purga do extrusor absoluta ao invés de relativa à última posição conhecida da cabeça."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_0_z_overlap description"
 msgid "Make the first and second layer of the model overlap in the Z direction to compensate for the filament lost in the airgap. All models above the first model layer will be shifted down by this amount."
 msgstr "Faz a primeira e segunda camadas do modelo se sobreporem na direção Z para compensar pelo filamento perdido no vão aéreo. Todos os modelos acima da primeira camada de modelo serão deslocados para baixo por essa distância."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix description"
 msgid "Make the meshes more suited for 3D printing."
 msgstr "Faz as malhas mais adequadas para impressão 3D."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option Makerbot"
 msgid "Makerbot"
 msgstr "Makerbot"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option RepRap (Marlin/Sprinter)"
 msgid "Marlin"
 msgstr "Marlin"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option RepRap (Volumetric)"
 msgid "Marlin (Volumetric)"
 msgstr "Marlin (Volumétrico)"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material description"
 msgid "Material"
 msgstr "Material"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material label"
 msgid "Material"
 msgstr "Material"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_guid label"
 msgid "Material GUID"
 msgstr "GUID do Material"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "max_extrusion_before_wipe label"
 msgid "Material Volume Between Wipes"
 msgstr "Volume de Material Entre Limpezas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing_max_distance label"
 msgid "Max Comb Distance With No Retract"
 msgstr "Máxima Distância de Combing Sem Retração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_acceleration_x label"
 msgid "Maximum Acceleration X"
 msgstr "Aceleração Máxima em X"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_acceleration_y label"
 msgid "Maximum Acceleration Y"
 msgstr "Aceleração Máxima em Y"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_acceleration_z label"
 msgid "Maximum Acceleration Z"
 msgstr "Aceleração Máxima em Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_maximum_deviation label"
 msgid "Maximum Deviation"
 msgstr "Desvio Máximo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_maximum_extrusion_area_deviation label"
 msgid "Maximum Extrusion Area Deviation"
 msgstr "Desvio Máximo de Área de Extrusão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_speed_max label"
 msgid "Maximum Fan Speed"
 msgstr "Velocidade Máxima da Ventoinha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_acceleration_e label"
 msgid "Maximum Filament Acceleration"
 msgstr "Aceleração Máxima do Filamento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "conical_overhang_angle label"
 msgid "Maximum Model Angle"
 msgstr "Ângulo Máximo do Modelo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "conical_overhang_hole_size label"
 msgid "Maximum Overhang Hole Area"
 msgstr "Área Máxima de Furo de Seções Pendentes"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_maximum_park_duration label"
 msgid "Maximum Park Duration"
 msgstr "Duração Máxima de Descanso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_maximum_resolution label"
 msgid "Maximum Resolution"
 msgstr "Resolução Máxima"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_count_max label"
 msgid "Maximum Retraction Count"
 msgstr "Contagem de Retrações Máxima"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "max_skin_angle_for_expansion label"
 msgid "Maximum Skin Angle for Expansion"
 msgstr "Ângulo Máximo do Contorno para Expansão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_feedrate_e label"
 msgid "Maximum Speed E"
 msgstr "Velocidade Máxima de Extrusão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_feedrate_x label"
 msgid "Maximum Speed X"
 msgstr "Velocidade Máxima em X"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_feedrate_y label"
 msgid "Maximum Speed Y"
 msgstr "Velocidade Máxima em Y"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_feedrate_z label"
 msgid "Maximum Speed Z"
 msgstr "Velocidade Máxima em Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tower_maximum_supported_diameter label"
 msgid "Maximum Tower-Supported Diameter"
 msgstr "Diâmetro Máximo Suportado por Torres"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_maximum_travel_resolution label"
 msgid "Maximum Travel Resolution"
 msgstr "Máxima Resolução de Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_acceleration_x description"
 msgid "Maximum acceleration for the motor of the X-direction"
 msgstr "A aceleração máxima para o motor da impressora na direção X"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_acceleration_y description"
 msgid "Maximum acceleration for the motor of the Y-direction."
 msgstr "A aceleração máxima para o motor da impressora na direção Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_acceleration_z description"
 msgid "Maximum acceleration for the motor of the Z-direction."
 msgstr "A aceleração máxima para o motor da impressora na direção Z."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_acceleration_e description"
 msgid "Maximum acceleration for the motor of the filament."
 msgstr "Aceleração máxima para a entrada de filamento no hotend."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_sparse_infill_max_density description"
 msgid "Maximum density of infill considered to be sparse. Skin over sparse infill is considered to be unsupported and so may be treated as a bridge skin."
 msgstr "Densidade máxima do preenchimento considerado esparso. Contorno sobre o preenchimento esparso é considerado não-suportado e portanto será tratado como contorno de ponte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tower_maximum_supported_diameter description"
 msgid "Maximum diameter in the X/Y directions of a small area which is to be supported by a specialized support tower."
 msgstr "Diâmetro máximo nas direções X e Y da pequena área que será suportada por uma torre especializada de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "max_extrusion_before_wipe description"
 msgid "Maximum material that can be extruded before another nozzle wipe is initiated. If this value is less than the volume of material required in a layer, the setting has no effect in this layer, i.e. it is limited to one wipe per layer."
 msgstr "Material máximo que pode ser extrudado antes que outra limpeza de bico seja iniciada. Se este valor for menor que o volume de material requerido em uma camada, ele não terá efeito nenhum nesta camada, isto é, está limitado a uma limpeza por camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "multiple_mesh_overlap label"
 msgid "Merged Meshes Overlap"
 msgstr "Sobreposição de Malhas Combinadas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix label"
 msgid "Mesh Fixes"
 msgstr "Correções de Malha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mesh_position_x label"
 msgid "Mesh Position X"
 msgstr "Posição X da Malha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mesh_position_y label"
 msgid "Mesh Position Y"
 msgstr "Posição Y da Malha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mesh_position_z label"
 msgid "Mesh Position Z"
 msgstr "Posição Z da Malha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_mesh_order label"
 msgid "Mesh Processing Rank"
 msgstr "Hierarquia do Processamento de Malha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mesh_rotation_matrix label"
 msgid "Mesh Rotation Matrix"
 msgstr "Matriz de Rotação da Malha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "slicing_tolerance option middle"
 msgid "Middle"
 msgstr "Meio"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mold_width label"
 msgid "Minimal Mold Width"
 msgstr "Largura Mínima do Molde"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_min_cool_heat_time_window label"
 msgid "Minimal Time Standby Temperature"
 msgstr "Tempo Mínima em Temperatura de Espera"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_wall_min_length label"
 msgid "Minimum Bridge Wall Length"
 msgstr "Comprimento de Parede de Ponte Mínimo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_even_wall_line_width label"
 msgid "Minimum Even Wall Line Width"
 msgstr "Largura Mínima de Filete de Parede Par"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_extrusion_window label"
 msgid "Minimum Extrusion Distance Window"
 msgstr "Janela de Distância de Extrusão Mínima"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_feature_size label"
 msgid "Minimum Feature Size"
 msgstr "Mínimo Tamanho de Detalhe"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_minimum_feedrate label"
 msgid "Minimum Feedrate"
 msgstr "Velocidade Mínima de Alimentação"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_infill_area label"
 msgid "Minimum Infill Area"
 msgstr "Área Mínima para Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_min_layer_time label"
 msgid "Minimum Layer Time"
 msgstr "Tempo Mínimo de Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_odd_wall_line_width label"
 msgid "Minimum Odd Wall Line Width"
 msgstr "Largura Mínima de Filete de Parede Ímpar"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_polygon_circumference label"
 msgid "Minimum Polygon Circumference"
 msgstr "Mínima Circunferência do Polígono"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_skin_width_for_expansion label"
 msgid "Minimum Skin Width for Expansion"
 msgstr "Largura Mínima de Contorno para Expansão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_min_speed label"
 msgid "Minimum Speed"
 msgstr "Velocidade Mínima"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_support_area label"
 msgid "Minimum Support Area"
 msgstr "Área Mínima de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_bottom_area label"
 msgid "Minimum Support Floor Area"
 msgstr "Área Mínima de Base de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_interface_area label"
 msgid "Minimum Support Interface Area"
 msgstr "Área Mínima de Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_roof_area label"
 msgid "Minimum Support Roof Area"
 msgstr "Área Mínima de Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_xy_distance_overhang label"
 msgid "Minimum Support X/Y Distance"
 msgstr "Distância Mínima de Suporte X/Y"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_bead_width label"
 msgid "Minimum Thin Wall Line Width"
 msgstr "Largura Mínima de Filete de Parede Fina"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "coasting_min_volume label"
 msgid "Minimum Volume Before Coasting"
 msgstr "Volume Mínimo Antes da Desengrenagem"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_wall_line_width label"
 msgid "Minimum Wall Line Width"
 msgstr "Largura Mínina de Filete de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_interface_area description"
 msgid "Minimum area size for support interface polygons. Polygons which have an area smaller than this value will be printed as normal support."
 msgstr "Área mínima para os polígonos da interface de suporte. Polígonos que têm área menor que este valor serão impressos como suporte normal."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_support_area description"
 msgid "Minimum area size for support polygons. Polygons which have an area smaller than this value will not be generated."
 msgstr "Área mínima para polígonos de suporte. Polígonos que tiverem uma área menor que essa não serão gerados."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_bottom_area description"
 msgid "Minimum area size for the floors of the support. Polygons which have an area smaller than this value will be printed as normal support."
 msgstr "Área mínima para as bases do suport. Polígonos que têm área menor que este valor serão impressos como suporte normal."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_roof_area description"
 msgid "Minimum area size for the roofs of the support. Polygons which have an area smaller than this value will be printed as normal support."
 msgstr "Área mínima para os tetos do suporte. Polígonos que têm área menor que este valor serão impressos como suporte normal."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_feature_size description"
 msgid "Minimum thickness of thin features. Model features that are thinner than this value will not be printed, while features thicker than the Minimum Feature Size will be widened to the Minimum Wall Line Width."
 msgstr "Espessura mínima de detalhes finos. Detalhes de modelo que forem mais finos que este valor não serão impressos, enquanto que detalhes mais espessos que o Tamanho Mínimo de Detalhe serão aumentados para a Largura Mínima de Filete de Parede."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_conical_min_width description"
 msgid "Minimum width to which the base of the conical support area is reduced. Small widths can lead to unstable support structures."
 msgstr "Largura mínima para a qual a base do suporte cônico é reduzida. Pequenas larguras podem levar a estruturas de suporte instáveis."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mold_enabled label"
 msgid "Mold"
 msgstr "Molde"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mold_angle label"
 msgid "Mold Angle"
 msgstr "Ângulo do Molde"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mold_roof_height label"
 msgid "Mold Roof Height"
 msgstr "Altura de Teto do Molde"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_monotonic label"
 msgid "Monotonic Ironing Order"
 msgstr "Ordem de Passagem a Ferro Monotônica"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_monotonic label"
 msgid "Monotonic Top Surface Order"
 msgstr "Ordem da Superfície Monotônica Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_monotonic label"
 msgid "Monotonic Top/Bottom Order"
 msgstr "Ordem Monotônica Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_line_count description"
 msgid "Multiple skirt lines help to prime your extrusion better for small models. Setting this to 0 will disable the skirt."
 msgstr "Múltiplas linhas de skirt te ajudam a fazer purga de sua extrusão melhor para pequenos modelos. Se o valor for zero o skirt é desabilitado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "initial_layer_line_width_factor description"
 msgid "Multiplier of the line width on the first layer. Increasing this could improve bed adhesion."
 msgstr "Multiplicador da largura de extrusão da primeira camada. Aumentar este ajuste pode melhorar a aderência à mesa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_no_load_move_factor label"
 msgid "No Load Move Factor"
 msgstr "Fator de Movimento Sem Carga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_no_small_gaps_heuristic label"
 msgid "No Skin in Z Gaps"
 msgstr "Sem Contorno nas Lacunas Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "blackmagic description"
 msgid "Non-traditional ways to print your models."
 msgstr "Jeitos não-tradicionais de imprimir seus modelos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adhesion_type option none"
 msgid "None"
 msgstr "Nenhuma"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_corner option z_seam_corner_none"
 msgid "None"
 msgstr "Nenhum"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_mesh_surface_mode option normal"
 msgid "Normal"
 msgstr "Normal"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_structure option normal"
 msgid "Normal"
 msgstr "Normal"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_keep_open_polygons description"
 msgid "Normally Cura tries to stitch up small holes in the mesh and remove parts of a layer with big holes. Enabling this option keeps those parts which cannot be stitched. This option should be used as a last resort option when everything else fails to produce proper g-code."
 msgstr "Normalmente o Cura tenta costurar pequenos furos na malha e remover partes de uma camada com grandes buracos. Habilitar esta opção mantém as partes que ele não consegue costurar. Esta opção deve ser usada como última alternativa quando tudo o mais falhar para produzir G-Code apropriado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing option noskin"
 msgid "Not in Skin"
 msgstr "Não no Contorno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing option no_outer_surfaces"
 msgid "Not on Outer Surface"
 msgstr "Não na Superfície Externa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_expansion_angle label"
 msgid "Nozzle Angle"
 msgstr "Ângulo do Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_size label"
 msgid "Nozzle Diameter"
 msgstr "Diâmetro do bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "nozzle_disallowed_areas label"
 msgid "Nozzle Disallowed Areas"
 msgstr "Áreas Proibidas para o Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_id label"
 msgid "Nozzle ID"
 msgstr "ID do Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_head_distance label"
 msgid "Nozzle Length"
 msgstr "Comprimento do Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_extra_prime_amount label"
 msgid "Nozzle Switch Extra Prime Amount"
 msgstr "Quantidade de Avanço Extra da Troca de Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_prime_speed label"
 msgid "Nozzle Switch Prime Speed"
 msgstr "Velocidade de Avanço da Troca de Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_retraction_speed label"
 msgid "Nozzle Switch Retract Speed"
 msgstr "Velocidade de Retração da Troca de Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_retraction_amount label"
 msgid "Nozzle Switch Retraction Distance"
 msgstr "Distância de Retração da Troca de Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_retraction_speeds label"
 msgid "Nozzle Switch Retraction Speed"
 msgstr "Velocidade de Retração da Troca do Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_extruder_count label"
 msgid "Number of Extruders"
 msgstr "Número de extrusores"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruders_enabled_count label"
 msgid "Number of Extruders That Are Enabled"
 msgstr "Número de Extrusores Habilitados"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_slowdown_layers label"
 msgid "Number of Slower Layers"
 msgstr "Número de Camadas Mais Lentas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruders_enabled_count description"
 msgid "Number of extruder trains that are enabled; automatically set in software"
 msgstr "O número de carros extrusores que estão habilitados; automaticamente ajustado em software"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_extruder_count description"
 msgid "Number of extruder trains. An extruder train is the combination of a feeder, bowden tube, and nozzle."
 msgstr "Número de carros extrusores. Um carro extrusor é a combinação de um alimentador/tracionador, opcional tubo de filamento guiado e o hotend."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_repeat_count description"
 msgid "Number of times to move the nozzle across the brush."
 msgstr "Número de vezes com que mover o bico através da varredura."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gradual_infill_steps description"
 msgid "Number of times to reduce the infill density by half when getting further below top surfaces. Areas which are closer to top surfaces get a higher density, up to the Infill Density."
 msgstr "Número de vezes para reduzir a densidade de preenchimento pela metade quando estiver chegando mais além embaixo das superfícies superiores. Áreas que estão mais perto das superfícies superiores ganham uma densidade maior, numa gradação até a densidade configurada de preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gradual_support_infill_steps description"
 msgid "Number of times to reduce the support infill density by half when getting further below top surfaces. Areas which are closer to top surfaces get a higher density, up to the Support Infill Density."
 msgstr "Número de vezes para reduzir a densidade de preenchimento de suporte pela metade quando avançando abaixo das superfícies inferiores. Áreas mais próximas ao topo terão maior densidade, até a Densidade de Preenchimento de Suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option tetrahedral"
 msgid "Octet"
 msgstr "Octeto"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing option off"
 msgid "Off"
 msgstr "Desligado"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mesh_position_x description"
 msgid "Offset applied to the object in the x direction."
 msgstr "Deslocamento aplicado ao objeto na direção X."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mesh_position_y description"
 msgid "Offset applied to the object in the y direction."
 msgstr "Deslocamento aplicado ao objeto na direção Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mesh_position_z description"
 msgid "Offset applied to the object in the z direction. With this you can perform what was used to be called 'Object Sink'."
 msgstr "Deslocamento aplicado ao objeto na direção Z. Com isto você pode fazer afundamento do objeto na plataforma."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_use_extruder_offset_to_offset_coords label"
 msgid "Offset with Extruder"
 msgstr "Deslocamento com o Extrusor"
 
-#: /fdmprinter.def.json
-msgctxt "limit_support_retractions description"
-msgid "Omit retraction when moving from support to support in a straight line. Enabling this setting saves print time, but can lead to excessive stringing within the support structure."
-msgstr "Omitir a retração ao mover de suporte a suporte em linha reta. Habilitar este ajuste economiza tempo de impressão, mas pode levar a fiapos excessivos na estrutura de suporte."
-
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "print_sequence option one_at_a_time"
 msgid "One at a Time"
 msgstr "Um de Cada Vez"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop_only_when_collides description"
 msgid "Only perform a Z Hop when moving over printed parts which cannot be avoided by horizontal motion by Avoid Printed Parts when Traveling."
 msgstr "Somente fazer o Salto Z quando se mover sobre partes impressas que não podem ser evitadas pelo movimento horizontal quando a opção 'Evitar Peças Impressas nas Viagens' estiver ligada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_only_highest_layer description"
 msgid "Only perform ironing on the very last layer of the mesh. This saves time if the lower layers don't need a smooth surface finish."
 msgstr "Somente executar a passagem a ferro na última camada da malha. Isto economiza tempo se as camadas abaixo não precisarem de um acabamento de superfície amaciado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "brim_outside_only description"
 msgid "Only print the brim on the outside of the model. This reduces the amount of brim you need to remove afterwards, while it doesn't reduce the bed adhesion that much."
 msgstr "Imprimir o Brim somente no lado de fora do modelo. Isto reduz a quantidade de brim a ser removida no final, e não reduz tanto a aderência à mesa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ooze_shield_angle label"
 msgid "Ooze Shield Angle"
 msgstr "Ângulo da Cobertura de Escorrimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ooze_shield_dist label"
 msgid "Ooze Shield Distance"
 msgstr "Distância da Cobertura de Escorrimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "optimize_wall_printing_order label"
 msgid "Optimize Wall Printing Order"
 msgstr "Otimizar Ordem de Impressão de Paredes"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "optimize_wall_printing_order description"
 msgid "Optimize the order in which walls are printed so as to reduce the number of retractions and the distance travelled. Most parts will benefit from this being enabled but some may actually take longer so please compare the print time estimates with and without optimization. First layer is not optimized when choosing brim as build plate adhesion type."
 msgstr "Otimiza a ordem em que as paredes são impressas, tais que o número de retrações e a distância percorrida sejam reduzidos. A maioria das peças se beneficiará deste ajuste habilitado mas outras poderão demorar mais, portanto compare as estimativas de tempo de impressão com e sem otimização. A primeira camada não é otimizada quando o brim é selecionado como tipo de aderência da mesa de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_tip_outer_diameter label"
 msgid "Outer Nozzle Diameter"
 msgstr "Diâmetro Externo do Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_wall_0 label"
 msgid "Outer Wall Acceleration"
 msgstr "Aceleração da Parede Exterior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_extruder_nr label"
 msgid "Outer Wall Extruder"
 msgstr "Extrusor da Parede Externa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_material_flow label"
 msgid "Outer Wall Flow"
 msgstr "Fluxo da Parede Externa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_inset label"
 msgid "Outer Wall Inset"
 msgstr "Penetração da Parede Externa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_wall_0 label"
 msgid "Outer Wall Jerk"
 msgstr "Jerk da Parede Exterior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_line_width_0 label"
 msgid "Outer Wall Line Width"
 msgstr "Largura de Extrusão da Parede Externa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_wall_0 label"
 msgid "Outer Wall Speed"
 msgstr "Velocidade da Parede Exterior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_wipe_dist label"
 msgid "Outer Wall Wipe Distance"
 msgstr "Distância de Varredura da Parede Externa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "inset_direction option outside_in"
 msgid "Outside To Inside"
 msgstr "De Fora Pra Dentro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_overhang_angle label"
 msgid "Overhanging Wall Angle"
 msgstr "Ângulo de Parede Pendente"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_overhang_speed_factor label"
 msgid "Overhanging Wall Speed"
 msgstr "Velocidade de Parede Pendente"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_overhang_speed_factor description"
 msgid "Overhanging walls will be printed at this percentage of their normal print speed."
 msgstr "Paredes pendentes serão impressas com esta porcentagem de sua velocidade de impressão normal."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_pause description"
 msgid "Pause after the unretract."
 msgstr "Pausa após desfazimento da retração."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_fan_speed description"
 msgid "Percentage fan speed to use when printing bridge walls and skin."
 msgstr "Porcentagem da velocidade de ventoinha a usar quando imprimir paredes e contornos em pontes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_fan_speed_2 description"
 msgid "Percentage fan speed to use when printing the second bridge skin layer."
 msgstr "Porcentagem da velocidade da ventoinha a usar quando se imprimir a segunda camada de contorno da ponte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_supported_skin_fan_speed description"
 msgid "Percentage fan speed to use when printing the skin regions immediately above the support. Using a high fan speed can make the support easier to remove."
 msgstr "Porcentagem de velocidade da ventoinha a usar ao imprimir as regiões de contorno imediatamente sobre o suporte. Usar uma velocidade de ventoinha alta pode fazer o suporte mais fácil de remover."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_fan_speed_3 description"
 msgid "Percentage fan speed to use when printing the third bridge skin layer."
 msgstr "Porcentagem da velocidade da ventoinha a usar quando se imprimir a terceira camada de contorno da ponte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_straight_before_down description"
 msgid "Percentage of a diagonally downward line which is covered by a horizontal line piece. This can prevent sagging of the top most point of upward lines. Only applies to Wire Printing."
 msgstr "Porcentagem de um filete descendente diagonal que é coberto por uma peça de filete horizontal. Isto pode prevenir enfraquecimento do ponto superior das linhas ascendentes. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "minimum_polygon_circumference description"
 msgid "Polygons in sliced layers that have a circumference smaller than this amount will be filtered out. Lower values lead to higher resolution mesh at the cost of slicing time. It is meant mostly for high resolution SLA printers and very tiny 3D models with a lot of details."
 msgstr "Polígonos em camadas fatiadas que tiverem uma circunferência menor que esta quantia serão excluídos. Menores valores levam a malha de maior resolução ao custo de tempo de fatiamento. Serve melhor para impressoras SLA de alta resolução e pequenos modelos 3D com muitos detalhes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_transition_filter_deviation description"
 msgid "Prevent transitioning back and forth between one extra wall and one less. This margin extends the range of line widths which follow to [Minimum Wall Line Width - Margin, 2 * Minimum Wall Line Width + Margin]. Increasing this margin reduces the number of transitions, which reduces the number of extrusion starts/stops and travel time. However, large line width variation can lead to under- or overextrusion problems."
 msgstr "Impede de alternar entre uma parede a mais e uma a menos. Esta margem estende o alcance dos comprimentos de file a seguir para [Largura Mínima de Filete de Parede - Margem, 2 * Largura Mínima de Filete de Parede + Margem]. Aumentar esta margem reduz o número de transições, que por sua vez reduz o número de paradas e inícios de extrusão e tempo de percurso. No entanto, variação de largura de filete pode levar a problemas de subextrusão ou sobre-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_prime_tower label"
 msgid "Prime Tower Acceleration"
 msgstr "Aceleração da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_brim_enable label"
 msgid "Prime Tower Brim"
 msgstr "Brim da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_flow label"
 msgid "Prime Tower Flow"
 msgstr "Fluxo da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_prime_tower label"
 msgid "Prime Tower Jerk"
 msgstr "Jerk da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_line_width label"
 msgid "Prime Tower Line Width"
 msgstr "Largura de Extrusão da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_min_volume label"
 msgid "Prime Tower Minimum Volume"
 msgstr "Volume Mínimo da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_size label"
 msgid "Prime Tower Size"
 msgstr "Tamanho da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_prime_tower label"
 msgid "Prime Tower Speed"
 msgstr "Velocidade da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_position_x label"
 msgid "Prime Tower X Position"
 msgstr "Posição X da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_position_y label"
 msgid "Prime Tower Y Position"
 msgstr "Posição Y da Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_brim_enable description"
 msgid "Prime-towers might need the extra adhesion afforded by a brim even if the model doesn't. Presently can't be used with the 'Raft' adhesion-type."
 msgstr "Torres de Prime podem precisar de aderência extra dada por um brim mesmo se o modelo não precisar. No momento não pode ser usado com o tipo de aderência 'Raft'."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_print label"
 msgid "Print Acceleration"
 msgstr "Aceleração da Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_print label"
 msgid "Print Jerk"
 msgstr "Jerk da Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "print_sequence label"
 msgid "Print Sequence"
 msgstr "Sequência de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_print label"
 msgid "Print Speed"
 msgstr "Velocidade de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "fill_outline_gaps label"
 msgid "Print Thin Walls"
 msgstr "Imprimir Paredes Finas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_enable description"
 msgid "Print a tower next to the print which serves to prime the material after each nozzle switch."
 msgstr "Imprimir uma torre próxima à impressão que serve para purgar o material a cada troca de bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_support_enabled description"
 msgid "Print infill structures only where tops of the model should be supported. Enabling this reduces print time and material usage, but leads to ununiform object strength."
 msgstr "Imprime estruturas de preenchimento somente onde os tetos do modelo devam ser suportados. Habilitar este ajuste reduz tempo de impressão e uso de material, mas leva a resistências não-uniformes no objeto."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_monotonic description"
 msgid "Print ironing lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent."
 msgstr "Imprime filetes de passagem a ferro em uma ordem que os faz com que sempre se sobreponham a linhas adjacentes em uma única direção. Isso faz levar um pouco mais de tempo na impressão, mas torna as superfícies mais consistentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mold_enabled description"
 msgid "Print models as a mold, which can be cast in order to get a model which resembles the models on the build plate."
 msgstr "Imprimir modelos como moldes com o negativo das peças de modo que se possa encher de resina para as gerar."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_enabled description"
 msgid "Print only the outside surface with a sparse webbed structure, printing 'in thin air'. This is realized by horizontally printing the contours of the model at given Z intervals which are connected via upward and diagonally downward lines."
 msgstr "Imprime somente a superfície exterior usando uma estrutura esparsa em forma de teia sem usar as camadas horizontais de impressão, e imprimindo no ar. Isto é feito imprimindo horizontalmente os contornos do modelo em dados intervalos Z que são conectados por filetes diagonais para cima e para baixo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "fill_outline_gaps description"
 msgid "Print pieces of the model which are horizontally thinner than the nozzle size."
 msgstr "Imprime partes do modelo que são horizontalmente mais finas que o tamanho do bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_speed_2 description"
 msgid "Print speed to use when printing the second bridge skin layer."
 msgstr "Velocidade de impressão a usar quando imprimir a segunda camada de ponte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_speed_3 description"
 msgid "Print speed to use when printing the third bridge skin layer."
 msgstr "Velocidade de impressão a usar quando imprimir a terceira camada de ponte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_before_walls description"
 msgid "Print the infill before printing the walls. Printing the walls first may lead to more accurate walls, but overhangs print worse. Printing the infill first leads to sturdier walls, but the infill pattern might sometimes show through the surface."
 msgstr "Imprime o preenchimento antes de imprimir as paredes. Imprimir as paredes primeiro pode levar a paredes mais precisas, mas seções pendentes são impressas com pior qualidade. Imprimir o preenchimento primeiro leva a paredes mais fortes, mas o padrão de preenchimento pode às vezes aparecer através da superfície."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_monotonic description"
 msgid "Print top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent."
 msgstr "Imprime os filetes da superfície superior em uma ordem que faz com que sempre se sobreponham a linhas adjacentes em uma única direção. Faz levar um pouco mais de tempo na impressão, mas torna as superfícies planas mais consistentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_monotonic description"
 msgid "Print top/bottom lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes flat surfaces look more consistent."
 msgstr "Imprime filetes superiores e inferiores em uma ordem que os faz sempre se sobreporem a filetes adjacentes em uma única direção. Faz levar um pouco mais de tempo na impressão, mas torna superfícies planas mais consistentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_print_temperature label"
 msgid "Printing Temperature"
 msgstr "Temperatura de Impressão"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_print_temperature_layer_0 label"
 msgid "Printing Temperature Initial Layer"
 msgstr "Temperatura de Impressão da Camada Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "alternate_extra_perimeter description"
 msgid "Prints an extra wall at every other layer. This way infill gets caught between these extra walls, resulting in stronger prints."
 msgstr "Imprime uma parede adicional a cada duas camadas. Deste jeito o preenchimento fica aprisionado entre estas paredes extras, resultando em impressões mais fortes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "resolution label"
 msgid "Quality"
 msgstr "Qualidade"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option quarter_cubic"
 msgid "Quarter Cubic"
 msgstr "Quarto Cúbico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adhesion_type option raft"
 msgid "Raft"
 msgstr "Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_airgap label"
 msgid "Raft Air Gap"
 msgstr "Vão Aéreo do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_extruder_nr label"
 msgid "Raft Base Extruder"
 msgstr "Extrusor da Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_fan_speed label"
 msgid "Raft Base Fan Speed"
 msgstr "Velocidade de Ventoinha da Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_line_spacing label"
 msgid "Raft Base Line Spacing"
 msgstr "Espaçamento de Filete de Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_line_width label"
 msgid "Raft Base Line Width"
 msgstr "Largura de Linha da Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_acceleration label"
 msgid "Raft Base Print Acceleration"
 msgstr "Aceleração de Impressão da Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_jerk label"
 msgid "Raft Base Print Jerk"
 msgstr "Jerk de Impressão da Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_speed label"
 msgid "Raft Base Print Speed"
 msgstr "Velocidade de Impressão da Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_thickness label"
 msgid "Raft Base Thickness"
 msgstr "Espessura da Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_wall_count label"
 msgid "Raft Base Wall Count"
 msgstr "Contagem de Paredes da Base do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_margin label"
 msgid "Raft Extra Margin"
 msgstr "Margem Adicional do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_fan_speed label"
 msgid "Raft Fan Speed"
 msgstr "Velocidade de Ventoinha no Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_extruder_nr label"
 msgid "Raft Middle Extruder"
 msgstr "Extrusor do Meio do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_fan_speed label"
 msgid "Raft Middle Fan Speed"
 msgstr "Velocidade de Ventoinha do Meio do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_layers label"
 msgid "Raft Middle Layers"
 msgstr "Camadas Centrais do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_line_width label"
 msgid "Raft Middle Line Width"
 msgstr "Largura da Linha do Meio do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_acceleration label"
 msgid "Raft Middle Print Acceleration"
 msgstr "Aceleração de Impressão do Meio do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_jerk label"
 msgid "Raft Middle Print Jerk"
 msgstr "Jerk de Impressão do Meio do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_speed label"
 msgid "Raft Middle Print Speed"
 msgstr "Velocidade de Impressão do Meio do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_line_spacing label"
 msgid "Raft Middle Spacing"
 msgstr "Espaçamento do Meio do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_thickness label"
 msgid "Raft Middle Thickness"
 msgstr "Espessura do Meio do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_acceleration label"
 msgid "Raft Print Acceleration"
 msgstr "Aceleração de Impressão do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_jerk label"
 msgid "Raft Print Jerk"
 msgstr "Jerk de Impressão do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_speed label"
 msgid "Raft Print Speed"
 msgstr "Velocidade de Impressão do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_smoothing label"
 msgid "Raft Smoothing"
 msgstr "Amaciamento do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_extruder_nr label"
 msgid "Raft Top Extruder"
 msgstr "Extrusor do Topo do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_fan_speed label"
 msgid "Raft Top Fan Speed"
 msgstr "Velocidade da Ventoinha para o Topo do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_thickness label"
 msgid "Raft Top Layer Thickness"
 msgstr "Espessura da Camada Superior do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_layers label"
 msgid "Raft Top Layers"
 msgstr "Camadas Superiores do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_line_width label"
 msgid "Raft Top Line Width"
 msgstr "Largura do Filete Superior do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_acceleration label"
 msgid "Raft Top Print Acceleration"
 msgstr "Aceleração de Impressão do Topo do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_jerk label"
 msgid "Raft Top Print Jerk"
 msgstr "Jerk de Impressão do Topo do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_speed label"
 msgid "Raft Top Print Speed"
 msgstr "Velocidade de Impressão do Topo do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_line_spacing label"
 msgid "Raft Top Spacing"
 msgstr "Espaçamento Superior do Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_type option random"
 msgid "Random"
 msgstr "Aleatório"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_randomize_start_location label"
 msgid "Randomize Infill Start"
 msgstr "Aleatorizar o Começo do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_randomize_start_location description"
 msgid "Randomize which infill line is printed first. This prevents one segment becoming the strongest, but it does so at the cost of an additional travel move."
 msgstr "Aleatoriza qual linha do preenchimento é impressa primeiro. Isto evita que um segmento seja mais forte que os outros, mas ao custo de um percurso adicional."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_enabled description"
 msgid "Randomly jitter while printing the outer wall, so that the surface has a rough and fuzzy look."
 msgstr "Faz flutuações de movimento aleatório enquanto imprime a parede mais externa, de modo que a superfície do objeto ganhe uma aparência felpuda ou acidentada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_shape option rectangular"
 msgid "Rectangular"
 msgstr "Retangular"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_speed_min label"
 msgid "Regular Fan Speed"
 msgstr "Velocidade Regular da Ventoinha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_full_at_height label"
 msgid "Regular Fan Speed at Height"
 msgstr "Velocidade Regular da Ventoinha na Altura"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_full_layer label"
 msgid "Regular Fan Speed at Layer"
 msgstr "Velocidade Regular da Ventoinha na Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_min_layer_time_fan_speed_max label"
 msgid "Regular/Maximum Fan Speed Threshold"
 msgstr "Limite de Tempo para Mudança de Velocidade da Ventoinha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "relative_extrusion label"
 msgid "Relative Extrusion"
 msgstr "Extrusão Relativa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_union_all_remove_holes label"
 msgid "Remove All Holes"
 msgstr "Remover Todos os Furos"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "remove_empty_first_layers label"
 msgid "Remove Empty First Layers"
 msgstr "Remover Camadas Iniciais Vazias"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "carve_multiple_volumes label"
 msgid "Remove Mesh Intersection"
 msgstr "Remover Interseções de Malha"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_remove_inside_corners label"
 msgid "Remove Raft Inside Corners"
 msgstr "Remover Cantos Internos de Raft"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "carve_multiple_volumes description"
 msgid "Remove areas where multiple meshes are overlapping with each other. This may be used if merged dual material objects overlap with each other."
 msgstr "Remove áreas onde várias malhas estão sobrepondo uma à outra. Isto pode ser usado se objetos de material duplo se sobrepõem um ao outro."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "remove_empty_first_layers description"
 msgid "Remove empty layers beneath the first printed layer if they are present. Disabling this setting can cause empty first layers if the Slicing Tolerance setting is set to Exclusive or Middle."
 msgstr "Remove camadas vazias entre a primeira camada impressa se estiverem presentes. Desabilitar este ajuste pode criar camadas iniciais vazias se a Tolerância de Fatiamento estiver configurada para Exclusivo ou Meio."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_remove_inside_corners description"
 msgid "Remove inside corners from the raft, causing the raft to become convex."
 msgstr "Remove os cantos internos do raft, fazendo com que ele se torne convexo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_union_all_remove_holes description"
 msgid "Remove the holes in each layer and keep only the outside shape. This will ignore any invisible internal geometry. However, it also ignores layer holes which can be viewed from above or below."
 msgstr "Remove os furos de cada camada e mantém somente aqueles da forma externa. Isto ignorará qualquer geometria interna invisível. No entanto, também ignorará furos de camada que poderiam ser vistos de cima ou de baixo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option RepRap (RepRap)"
 msgid "RepRap"
 msgstr "RepRap"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option Repetier"
 msgid "Repetier"
 msgstr "Repetier"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_outline_count description"
 msgid "Replaces the outermost part of the top/bottom pattern with a number of concentric lines. Using one or two lines improves roofs that start on infill material."
 msgstr "Substitui a parte externa do padrão superior/inferir com um número de linhas concêntricas. Usar uma ou duas linhas melhora tetos e topos que começam a ser construídos em cima de padrões de preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_collision_resolution description"
 msgid "Resolution to compute collisions with to avoid hitting the model. Setting this lower will produce more accurate trees that fail less often, but increases slicing time dramatically."
 msgstr "Resolução para computar colisões com a qual evitar tocar o modelo. Ajustar valor mais baixos produzirá árvore mais precisas que falharão menos, mas aumentará o tempo de fatiamento dramaticamente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_strategy option retract"
 msgid "Retract"
 msgstr "Retrair"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel_retract_before_outer_wall label"
 msgid "Retract Before Outer Wall"
 msgstr "Retrair Antes da Parede Externa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retract_at_layer_change label"
 msgid "Retract at Layer Change"
 msgstr "Retrai em Mudança de Camada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_enable description"
 msgid "Retract the filament when the nozzle is moving over a non-printed area."
 msgstr "Retrair o filamento quando o bico estiver se movendo sobre uma área não-impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_enable description"
 msgid "Retract the filament when the nozzle is moving over a non-printed area."
 msgstr "Retrair o filamento quando o bico se mover sobre uma área não impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retract_at_layer_change description"
 msgid "Retract the filament when the nozzle is moving to the next layer."
 msgstr "Retrai o filamento quando o bico está se movendo para a próxima camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_amount label"
 msgid "Retraction Distance"
 msgstr "Distância da Retração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_extra_prime_amount label"
 msgid "Retraction Extra Prime Amount"
 msgstr "Quantidade Adicional de Avanço da Retração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_min_travel label"
 msgid "Retraction Minimum Travel"
 msgstr "Percurso Mínimo para Retração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_prime_speed label"
 msgid "Retraction Prime Speed"
 msgstr "Velocidade de Avanço da Retração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_retract_speed label"
 msgid "Retraction Retract Speed"
 msgstr "Velocidade de Recolhimento de Retração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_speed label"
 msgid "Retraction Speed"
 msgstr "Velocidade de Retração"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position option right"
 msgid "Right"
 msgstr "Direita"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_scale_fan_speed_zero_to_one label"
 msgid "Scale Fan Speed To 0-1"
 msgstr "Velocidade de Escala da Ventoinha A 0-1"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_scale_fan_speed_zero_to_one description"
 msgid "Scale the fan speed to be between 0 and 1 instead of between 0 and 256."
 msgstr "Usa a escala da velocidade da ventoinha como um número entre 0 e 1 ao invés de 0 a 256."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_shrinkage_percentage label"
 msgid "Scaling Factor Shrinkage Compensation"
 msgstr "Compensação de Fator de Encolhimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_meshes_present label"
 msgid "Scene Has Support Meshes"
 msgstr "A Cena Tem Malhas de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_corner label"
 msgid "Seam Corner Preference"
 msgstr "Preferência do Canto da Costura"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_height_limitation description"
 msgid "Set the height of the draft shield. Choose to print the draft shield at the full height of the model or at a limited height."
 msgstr "Estabelece a altura da cobertura de trabalho. Escolha imprimir a cobertura na altura total dos modelos ou até uma altura limitada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "dual description"
 msgid "Settings used for printing with multiple extruders."
 msgstr "Ajustes usados para imprimir com vários extrusores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "command_line_settings description"
 msgid "Settings which are only used if CuraEngine isn't called from the Cura frontend."
 msgstr "Ajustes que sào usados somentes se o CuraEngine não for chamado da interface do Cura."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_extruders_shared_nozzle_initial_retraction label"
 msgid "Shared Nozzle Initial Retraction"
 msgstr "Retração Inicial do Bico Compartilhado"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_type option sharpest_corner"
 msgid "Sharpest Corner"
 msgstr "Canto Mais Agudo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "shell description"
 msgid "Shell"
 msgstr "Perímetro"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_type option shortest"
 msgid "Shortest"
 msgstr "Mais Curto"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_show_variants label"
 msgid "Show Machine Variants"
 msgstr "Exibir Variantes de Máquina"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_edge_support_layers label"
 msgid "Skin Edge Support Layers"
 msgstr "Camadas do Suporte da Aresta de Contorno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_edge_support_thickness label"
 msgid "Skin Edge Support Thickness"
 msgstr "Espessura do Suporte da Aresta de Contorno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "expand_skins_expand_distance label"
 msgid "Skin Expand Distance"
 msgstr "Distância de Expansão do Contorno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_overlap_mm label"
 msgid "Skin Overlap"
 msgstr "Sobreposição do Contorno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_overlap label"
 msgid "Skin Overlap Percentage"
 msgstr "Porcentagem de Sobreposição do Contorno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_preshrink label"
 msgid "Skin Removal Width"
 msgstr "Largura de Remoção de Contorno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_skin_width_for_expansion description"
 msgid "Skin areas narrower than this are not expanded. This avoids expanding the narrow skin areas that are created when the model surface has a slope close to the vertical."
 msgstr "Áreas de contorno mais estreitas que esta não são expandidas. Isto evita expandir as áreas estreitas que são criadas quando a superfície do modelo tem inclinações quase verticais."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_zag_skip_count description"
 msgid "Skip one in every N connection lines to make the support structure easier to break away."
 msgstr "Evitar uma em cada N linhas de conexão para fazer a estrutura de suporte mais fácil de ser removida."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_skip_some_zags description"
 msgid "Skip some support line connections to make the support structure easier to break away. This setting is applicable to the Zig Zag support infill pattern."
 msgstr "Evitar algumas conexões de linha de suporte para fazer a estrutura de suporte mais fácil de ser removida. Este ajuste é aplicável ao padrão de preenchimento de suporte de ziguezague."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adhesion_type option skirt"
 msgid "Skirt"
 msgstr "Skirt"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_gap label"
 msgid "Skirt Distance"
 msgstr "Distância do Skirt"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_line_count label"
 msgid "Skirt Line Count"
 msgstr "Contagem de linhas de Skirt"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_skirt_brim label"
 msgid "Skirt/Brim Acceleration"
 msgstr "Aceleração para Skirt e Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_extruder_nr label"
 msgid "Skirt/Brim Extruder"
 msgstr "Extrusor do Skirt/Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_material_flow label"
 msgid "Skirt/Brim Flow"
 msgstr "Fluxo de Skirt/Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_skirt_brim label"
 msgid "Skirt/Brim Jerk"
 msgstr "Jerk de Skirt e Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_line_width label"
 msgid "Skirt/Brim Line Width"
 msgstr "Largura de Extrusão do Brim e Skirt"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_minimal_length label"
 msgid "Skirt/Brim Minimum Length"
 msgstr "Mínimo Comprimento do Skirt e Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_speed label"
 msgid "Skirt/Brim Speed"
 msgstr "Velocidade do Skirt e Brim"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "slicing_tolerance label"
 msgid "Slicing Tolerance"
 msgstr "Tolerância de Fatiamento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "small_feature_speed_factor_0 label"
 msgid "Small Feature Initial Layer Speed"
 msgstr "Velocidade de Camada Inicial de Aspecto Pequeno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "small_feature_max_length label"
 msgid "Small Feature Max Length"
 msgstr "Comprimento Máximo do Aspecto Pequeno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "small_feature_speed_factor label"
 msgid "Small Feature Speed"
 msgstr "Velocidade de Aspecto Pequeno"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "small_hole_max_size label"
 msgid "Small Hole Max Size"
 msgstr "Tamanho Máximo de Furos Pequenos"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "cool_min_temperature label"
+msgid "Small Layer Printing Temperature"
+msgstr "Temperatura de Impressão Final"
+
+#: fdmprinter.def.json
 msgctxt "small_feature_speed_factor_0 description"
 msgid "Small features on the first layer will be printed at this percentage of their normal print speed. Slower printing can help with adhesion and accuracy."
 msgstr "Aspectos pequenos na primeira camada serão impressos nesta porcentagem de sua velocidade de impressão normal. Impressão mais lenta pode ajudar com aderência e precisão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "small_feature_speed_factor description"
 msgid "Small features will be printed at this percentage of their normal print speed. Slower printing can help with adhesion and accuracy."
 msgstr "Aspectos pequenos serão impressos nessa porcentagem da velocidade normal. Impressão mais lenta pode ajudar com aderência e precisão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_corner option z_seam_corner_weighted"
 msgid "Smart Hiding"
 msgstr "Ocultação Inteligente"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "smooth_spiralized_contours label"
 msgid "Smooth Spiralized Contours"
 msgstr "Suavizar Contornos Espiralizados"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "smooth_spiralized_contours description"
 msgid "Smooth the spiralized contours to reduce the visibility of the Z seam (the Z seam should be barely visible on the print but will still be visible in the layer view). Note that smoothing will tend to blur fine surface details."
 msgstr "Suavizar os contornos espiralizados para reduzir a visibilidade da costura Z (a costura Z deve ser quase invisível na impressão mas ainda será visível na visão de camadas). Note que a suavização tenderá a embaçar detalhes finos de superfície."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_extra_prime_amount description"
 msgid "Some material can ooze away during a travel move, which can be compensated for here."
 msgstr "Alguns materiais podem escorrer um pouco durante o percurso, o que pode ser compensando neste ajuste."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_extra_prime_amount description"
 msgid "Some material can ooze away during a wipe travel moves, which can be compensated for here."
 msgstr "Um pouco de material pode escorrer durante os movimentos do percurso de limpeza e isso pode ser compensado neste ajuste."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "blackmagic label"
 msgid "Special Modes"
 msgstr "Modos Especiais"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed description"
 msgid "Speed"
 msgstr "Velocidade"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed label"
 msgid "Speed"
 msgstr "Velocidade"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed description"
 msgid "Speed at which the nozzle moves when extruding material. Only applies to Wire Printing."
 msgstr "Velocidade com que a cabeça de impressão se move ao extrudar material. Somente se aplica a Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed_down description"
 msgid "Speed of printing a line diagonally downward. Only applies to Wire Printing."
 msgstr "Velocidade de impressão dos filetes descendentes feitas 'no ar'. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed_up description"
 msgid "Speed of printing a line upward 'in thin air'. Only applies to Wire Printing."
 msgstr "Velocidade de impressão dos filetes ascendentes feitas 'no ar'. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed_bottom description"
 msgid "Speed of printing the first layer, which is the only layer touching the build platform. Only applies to Wire Printing."
 msgstr "Velocidade de Impressão da primeira camada, que é a única camada que toca a mesa. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed_flat description"
 msgid "Speed of printing the horizontal contours of the model. Only applies to Wire Printing."
 msgstr "Velocidade de impressão dos contornos horizontais do modelo. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_hop_speed description"
 msgid "Speed to move the z-axis during the hop."
 msgstr "Velocidade com que mover o eixo Z durante o salto."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_spiralize label"
 msgid "Spiralize Outer Contour"
 msgstr "Espiralizar o Contorno Externo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_spiralize description"
 msgid "Spiralize smooths out the Z move of the outer edge. This will create a steady Z increase over the whole print. This feature turns a solid model into a single walled print with a solid bottom. This feature should only be enabled when each layer only contains a single part."
 msgstr "'Espiralizar' faz com que o movimento vertical (em Z) seja contínuo e gradual seguindo o contorno da peça. Este recurso transforma um modelo sólido em uma simples linha contínua em espiral partindo de uma base sólida. O recurso só deve ser habilitado quando cada camada horizontal contiver somente um contorno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_standby_temperature label"
 msgid "Standby Temperature"
 msgstr "Temperatura de Espera"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_start_gcode label"
 msgid "Start G-code"
 msgstr "G-Code Inicial"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_type description"
 msgid "Starting point of each path in a layer. When paths in consecutive layers start at the same point a vertical seam may show on the print. When aligning these near a user specified location, the seam is easiest to remove. When placed randomly the inaccuracies at the paths' start will be less noticeable. When taking the shortest path the print will be quicker."
 msgstr "Ponto de partida de cada caminho em uma camada. Quando caminhos em camadas consecutivas iniciam no mesmo ponto (X,Y), uma 'costura' vertical pode ser vista na impressão. Quando se alinha esta costura a uma coordenada especificada pelo usuário, a costura é mais fácil de remover pós-impressão. Quando colocada aleatoriamente as bolhinhas do início dos caminhos será menos perceptível. Quando se toma o menor caminho, a impressão será mais rápida."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_steps_per_mm_e label"
 msgid "Steps per Millimeter (E)"
 msgstr "Passos por Milímetro (E)"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_steps_per_mm_x label"
 msgid "Steps per Millimeter (X)"
 msgstr "Passos por Milímetro (X)"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_steps_per_mm_y label"
 msgid "Steps per Millimeter (Y)"
 msgstr "Passos por Milímetro (Y)"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_steps_per_mm_z label"
 msgid "Steps per Millimeter (Z)"
 msgstr "Passos por Milímetro (Z)"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_strategy description"
 msgid "Strategy for making sure two consecutive layers connect at each connection point. Retraction lets the upward lines harden in the right position, but may cause filament grinding. A knot can be made at the end of an upward line to heighten the chance of connecting to it and to let the line cool; however, it may require slow printing speeds. Another strategy is to compensate for the sagging of the top of an upward line; however, the lines won't always fall down as predicted."
 msgstr "Estratégia para se assegurar que duas camadas consecutivas se conectam a cada ponto de conexão. Retração faz com que os filetes ascendentes se solidifiquem na posição correta, mas pode causar desgaste de filamento. Um nó pode ser feito no fim de um filete ascendentes para aumentar a chance de se conectar a ele e deixar o filete esfriar; no entanto, pode exigir velocidades de impressão lentas. Outra estratégia é compensar pelo enfraquecimento do topo de uma linha ascendente; no entanto, as linhas nem sempre cairão como preditas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support description"
 msgid "Support"
 msgstr "Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support label"
 msgid "Support"
 msgstr "Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support label"
 msgid "Support Acceleration"
 msgstr "Aceleração do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_distance label"
 msgid "Support Bottom Distance"
 msgstr "Distância Inferior do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "support_bottom_wall_count label"
+msgid "Support Bottom Wall Line Count"
+msgstr "Contagem de Linhas de Parede de Suporte"
+
+#: fdmprinter.def.json
 msgctxt "support_brim_line_count label"
 msgid "Support Brim Line Count"
 msgstr "Número de Filetes do Brim de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_brim_width label"
 msgid "Support Brim Width"
 msgstr "Largura do Brim de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_zag_skip_count label"
 msgid "Support Chunk Line Count"
 msgstr "Contagem de Linhas de Pedaço de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_skip_zag_per_mm label"
 msgid "Support Chunk Size"
 msgstr "Tamanho do Pedaço de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_infill_rate label"
 msgid "Support Density"
 msgstr "Densidade do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_xy_overrides_z label"
 msgid "Support Distance Priority"
 msgstr "Prioridade das Distâncias de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_extruder_nr label"
 msgid "Support Extruder"
 msgstr "Extrusor do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support_bottom label"
 msgid "Support Floor Acceleration"
 msgstr "Aceleração da Base do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_density label"
 msgid "Support Floor Density"
 msgstr "Densidade da Base do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_extruder_nr label"
 msgid "Support Floor Extruder"
 msgstr "Extrusor da Base do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_material_flow label"
 msgid "Support Floor Flow"
 msgstr "Fluxo da Base de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_offset label"
 msgid "Support Floor Horizontal Expansion"
 msgstr "Expansão Horizontal da Base do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support_bottom label"
 msgid "Support Floor Jerk"
 msgstr "Jerk da Base do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_angles label"
 msgid "Support Floor Line Directions"
 msgstr "Direções de Filete da Base do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_line_distance label"
 msgid "Support Floor Line Distance"
 msgstr "Distância de Filetes da Base de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_line_width label"
 msgid "Support Floor Line Width"
 msgstr "Largura de Extrusão da Base do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_pattern label"
 msgid "Support Floor Pattern"
 msgstr "Padrão de Base de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support_bottom label"
 msgid "Support Floor Speed"
 msgstr "Velocidade de Base do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_height label"
 msgid "Support Floor Thickness"
 msgstr "Espessura da Base de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_material_flow label"
 msgid "Support Flow"
 msgstr "Fluxo de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_offset label"
 msgid "Support Horizontal Expansion"
 msgstr "Expansão Horizontal do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support_infill label"
 msgid "Support Infill Acceleration"
 msgstr "Aceleração do Preenchimento do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_infill_extruder_nr label"
 msgid "Support Infill Extruder"
 msgstr "Extrusor do Preenchimento do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support_infill label"
 msgid "Support Infill Jerk"
 msgstr "Jerk de Preenchimento de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_infill_sparse_thickness label"
 msgid "Support Infill Layer Thickness"
 msgstr "Espessura de Camada do Preenchimento de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_infill_angles label"
 msgid "Support Infill Line Directions"
 msgstr "Direção de Filete do Preenchimento de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support_infill label"
 msgid "Support Infill Speed"
 msgstr "Velocidade do Preenchimento do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support_interface label"
 msgid "Support Interface Acceleration"
 msgstr "Aceleração da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_density label"
 msgid "Support Interface Density"
 msgstr "Densidade da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_extruder_nr label"
 msgid "Support Interface Extruder"
 msgstr "Extrusor da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_material_flow label"
 msgid "Support Interface Flow"
 msgstr "Fluxo de Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_offset label"
 msgid "Support Interface Horizontal Expansion"
 msgstr "Expansão Horizontal da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support_interface label"
 msgid "Support Interface Jerk"
 msgstr "Jerk da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_angles label"
 msgid "Support Interface Line Directions"
 msgstr "Direções do Filete de Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_line_width label"
 msgid "Support Interface Line Width"
 msgstr "Largura de Extrusão da Interface do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_pattern label"
 msgid "Support Interface Pattern"
 msgstr "Padrão da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_skip_height label"
 msgid "Support Interface Resolution"
 msgstr "Resolução da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support_interface label"
 msgid "Support Interface Speed"
 msgstr "Velocidade da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_height label"
 msgid "Support Interface Thickness"
 msgstr "Espessura da Interface de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "support_interface_wall_count label"
+msgid "Support Interface Wall Line Count"
+msgstr "Contagem de Linhas de Parede de Suporte"
+
+#: fdmprinter.def.json
 msgctxt "jerk_support label"
 msgid "Support Jerk"
 msgstr "Jerk do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_join_distance label"
 msgid "Support Join Distance"
 msgstr "Distância de União do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_line_distance label"
 msgid "Support Line Distance"
 msgstr "Distância das Linhas do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_line_width label"
 msgid "Support Line Width"
 msgstr "Largura de Extrusão do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_mesh label"
 msgid "Support Mesh"
 msgstr "Malha de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_angle label"
 msgid "Support Overhang Angle"
 msgstr "Ângulo para Caracterizar Seções Pendentes"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern label"
 msgid "Support Pattern"
 msgstr "Padrão do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_type label"
 msgid "Support Placement"
 msgstr "Colocação dos Suportes"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support_roof label"
 msgid "Support Roof Acceleration"
 msgstr "Aceleração do Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_density label"
 msgid "Support Roof Density"
 msgstr "Densidade do Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_extruder_nr label"
 msgid "Support Roof Extruder"
 msgstr "Extrusor do Teto do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_material_flow label"
 msgid "Support Roof Flow"
 msgstr "Fluxo do Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_offset label"
 msgid "Support Roof Horizontal Expansion"
 msgstr "Expansão Horizontal do Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support_roof label"
 msgid "Support Roof Jerk"
 msgstr "Jerk do Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_angles label"
 msgid "Support Roof Line Directions"
 msgstr "Direções de Filete do Teto do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_line_distance label"
 msgid "Support Roof Line Distance"
 msgstr "Distância de Filetes do Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_line_width label"
 msgid "Support Roof Line Width"
 msgstr "Largura de Extrusão do Teto do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_pattern label"
 msgid "Support Roof Pattern"
 msgstr "Padrão de Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support_roof label"
 msgid "Support Roof Speed"
 msgstr "Velocidade do Teto de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_height label"
 msgid "Support Roof Thickness"
 msgstr "Espessura do Topo do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "support_roof_wall_count label"
+msgid "Support Roof Wall Line Count"
+msgstr "Contagem de Linhas de Parede de Suporte"
+
+#: fdmprinter.def.json
 msgctxt "speed_support label"
 msgid "Support Speed"
 msgstr "Velocidade do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_stair_step_height label"
 msgid "Support Stair Step Height"
 msgstr "Altura do Passo de Suporte em Escada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_stair_step_width label"
 msgid "Support Stair Step Maximum Width"
 msgstr "Largura Máxima do Passo de Suporte em Escada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_stair_step_min_slope label"
 msgid "Support Stair Step Minimum Slope Angle"
 msgstr "Ângulo Mínimo de Inclinação do Passo de Suporte em Escada"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_structure label"
 msgid "Support Structure"
 msgstr "Estrutura de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_top_distance label"
 msgid "Support Top Distance"
 msgstr "Distância Superior do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_wall_count label"
 msgid "Support Wall Line Count"
 msgstr "Contagem de Linhas de Parede de Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_xy_distance label"
 msgid "Support X/Y Distance"
 msgstr "Distância X/Y do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_z_distance label"
 msgid "Support Z Distance"
 msgstr "Distância em Z do Suporte"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_supported_skin_fan_speed label"
 msgid "Supported Skin Fan Speed"
 msgstr "Velocidade de Ventoinha do Contorno Suportado"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_mesh_surface_mode option surface"
 msgid "Surface"
 msgstr "Superfície"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_surface_energy label"
 msgid "Surface Energy"
 msgstr "Energia de Superfície"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_mesh_surface_mode label"
 msgid "Surface Mode"
 msgstr "Modo de Superficie"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_adhesion_tendency description"
 msgid "Surface adhesion tendency."
 msgstr "Tendência de aderência da superfície."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_surface_energy description"
 msgid "Surface energy."
 msgstr "Energia de superfície."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "alternate_carve_order description"
 msgid "Switch to which mesh intersecting volumes will belong with every layer, so that the overlapping meshes become interwoven. Turning this setting off will cause one of the meshes to obtain all of the volume in the overlap, while it is removed from the other meshes."
 msgstr "Troca quais volumes sobrepondo malhas vão pertencer a cada camada, de modo que as malhas sobrepostas se tornem entrelaçadas. Desligar esta opção vai fazer com que uma das malhas obtenha todo o volume da sobreposiçào, removendo este volume das outras malhas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adaptive_layer_height_threshold description"
 msgid "Target horizontal distance between two adjacent layers. Reducing this setting causes thinner layers to be used to bring the edges of the layers closer together."
 msgstr "Trata da distância horizontal entre duas camadas adjacentes. Reduzir este ajuste faz com que camadas mais finas sejam usadas para reunir as bordas das camadas mais perto uma da outra."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_start_x description"
 msgid "The X coordinate of the position near where to find the part to start printing each layer."
 msgstr "A coordenada X da posição próxima de onde achar a parte com que começar a imprimir cada camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_x description"
 msgid "The X coordinate of the position near where to start printing each part in a layer."
 msgstr "A coordenada X da posição onde iniciar a impressão de cada parte em uma camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruder_prime_pos_x description"
 msgid "The X coordinate of the position where the nozzle primes at the start of printing."
 msgstr "A coordenada X da posição onde o bico faz a purga no início da impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_start_y description"
 msgid "The Y coordinate of the position near where to find the part to start printing each layer."
 msgstr "A coordenada Y da posição próxima de onde achar a parte com que começar a imprimir cada camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_y description"
 msgid "The Y coordinate of the position near where to start printing each part in a layer."
 msgstr "A coordenada Y da posição onde iniciar a impressão de cada parte em uma camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruder_prime_pos_y description"
 msgid "The Y coordinate of the position where the nozzle primes at the start of printing."
 msgstr "A coordenada Y da posição onde o bico faz a purga no início da impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "extruder_prime_pos_z description"
 msgid "The Z coordinate of the position where the nozzle primes at the start of printing."
 msgstr "Coordenada Z da posição onde o bico faz a purga no início da impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_print_layer_0 description"
 msgid "The acceleration during the printing of the initial layer."
 msgstr "Aceleração durante a impressão da camada inicial."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_layer_0 description"
 msgid "The acceleration for the initial layer."
 msgstr "Aceleração para a camada inicial."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_travel_layer_0 description"
 msgid "The acceleration for travel moves in the initial layer."
 msgstr "Aceleração para percursos na camada inicial."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_travel_layer_0 description"
 msgid "The acceleration for travel moves in the initial layer."
 msgstr "A mudança instantânea máxima de velocidade em uma direção nos percursos da camada inicial."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_wall_x description"
 msgid "The acceleration with which all inner walls are printed."
 msgstr "Aceleração com que se imprimem as paredes interiores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_infill description"
 msgid "The acceleration with which infill is printed."
 msgstr "A aceleração com que o preenchimento é impresso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_ironing description"
 msgid "The acceleration with which ironing is performed."
 msgstr "A aceleração com que o recurso de passar a ferro é feito."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_print description"
 msgid "The acceleration with which printing happens."
 msgstr "Aceleração com que se realiza a impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_acceleration description"
 msgid "The acceleration with which the base raft layer is printed."
 msgstr "A aceleração com que as camadas de base do raft são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support_bottom description"
 msgid "The acceleration with which the floors of support are printed. Printing them at lower acceleration can improve adhesion of support on top of your model."
 msgstr "A aceleração com que as bases do suporte são impressas. Imprimi-las em aceleração menor pode melhorar aderência dos suportes no topo da superfície."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support_infill description"
 msgid "The acceleration with which the infill of support is printed."
 msgstr "Aceleração com que se imprime o preenchimento dos suportes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_acceleration description"
 msgid "The acceleration with which the middle raft layer is printed."
 msgstr "A aceleração com que a camada intermediária do raft é impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_wall_0 description"
 msgid "The acceleration with which the outermost walls are printed."
 msgstr "Aceleração com que se imprime a parede exterior."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_prime_tower description"
 msgid "The acceleration with which the prime tower is printed."
 msgstr "Aceleração com que a torre de purga é impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_acceleration description"
 msgid "The acceleration with which the raft is printed."
 msgstr "A aceleração com que o raft é impresso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support_interface description"
 msgid "The acceleration with which the roofs and floors of support are printed. Printing them at lower acceleration can improve overhang quality."
 msgstr "A aceleração com que os tetos e bases de suporte são impressos. Imprimi-los em aceleração menor pode melhorar a qualidade das seções pendentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support_roof description"
 msgid "The acceleration with which the roofs of support are printed. Printing them at lower acceleration can improve overhang quality."
 msgstr "A aceleração com que os tetos de suporte são impressos. Imprimi-los em aceleração menor pode melhorar a qualidade das seções pendentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_skirt_brim description"
 msgid "The acceleration with which the skirt and brim are printed. Normally this is done with the initial layer acceleration, but sometimes you might want to print the skirt or brim at a different acceleration."
 msgstr "Aceleração com a qual o skirt e o brim são impressos. Normalmente isto é feito com a aceleração de camada inicial, mas às vezes você pode querer imprimir o skirt ou brim em uma aceleração diferente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_support description"
 msgid "The acceleration with which the support structure is printed."
 msgstr "Aceleração com que as estruturas de suporte são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_acceleration description"
 msgid "The acceleration with which the top raft layers are printed."
 msgstr "A aceleração com que as camadas superiores do raft são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_wall description"
 msgid "The acceleration with which the walls are printed."
 msgstr "Aceleração com que se imprimem as paredes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_roofing description"
 msgid "The acceleration with which top surface skin layers are printed."
 msgstr "A aceleração com a qual as camadas da superfície superior são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_topbottom description"
 msgid "The acceleration with which top/bottom layers are printed."
 msgstr "Aceleração com que as camadas superiores e inferiores são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_travel description"
 msgid "The acceleration with which travel moves are made."
 msgstr "Aceleração com que se realizam os percursos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_flow description"
 msgid "The amount of material, relative to a normal skin line, to extrude during ironing. Keeping the nozzle filled helps filling some of the crevices of the top surface, but too much results in overextrusion and blips on the side of the surface."
 msgstr "A quantidade de material, relativa ao filete normal de extrusão, para extrudar durante a passagem a ferro. Manter o bico com algum material ajuda a preencher algumas das lacunas e fendas da superfície superior, mas material demais resulta em superextrusão e verrugas nas laterais da superfície."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_overlap description"
 msgid "The amount of overlap between the infill and the walls as a percentage of the infill line width. A slight overlap allows the walls to connect firmly to the infill."
 msgstr "A quantidade de sobreposição entre o preenchimento e as paredes como uma porcentagem da largura de extrusão de preenchimento. Uma leve sobreposição permite que as paredes se conectem firmemente ao preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_overlap_mm description"
 msgid "The amount of overlap between the infill and the walls. A slight overlap allows the walls to connect firmly to the infill."
 msgstr "A quantidade de sobreposição entre o preenchimento e as paredes. Uma leve sobreposição permite que as paredes se conectem firmemente ao preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_retraction_amount description"
 msgid "The amount of retraction when switching extruders. Set to 0 for no retraction at all. This should generally be the same as the length of the heat zone."
 msgstr "A quantidade de retração ao mudar extrusores. Coloque em 0 para não haver retração. Isto deve geralmente ser o mesmo que o comprimento da zona de aquecimento do hotend."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_expansion_angle description"
 msgid "The angle between the horizontal plane and the conical part right above the tip of the nozzle."
 msgstr "Ângulo entre o plano horizontal e a parte cônica logo acima da ponta do bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tower_roof_angle description"
 msgid "The angle of a rooftop of a tower. A higher value results in pointed tower roofs, a lower value results in flattened tower roofs."
 msgstr "Ângulo do Teto (parte superior) de uma torre. Um valor maior resulta em tetos pontiagudos, um valor menor resulta em tetos achatados."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mold_angle description"
 msgid "The angle of overhang of the outer walls created for the mold. 0° will make the outer shell of the mold vertical, while 90° will make the outside of the model follow the contour of the model."
 msgstr "O ângulo de seção pendente das paredes externas criadas para o molde. 0° fará a superfície externa do molde vertical, enquanto 90° fará a superfície externa do molde seguir o contorno do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_branch_diameter_angle description"
 msgid "The angle of the branches' diameter as they gradually become thicker towards the bottom. An angle of 0 will cause the branches to have uniform thickness over their length. A bit of an angle can increase stability of the tree support."
 msgstr "O ângulo do diâmetro dos galhos enquanto se tornam gradualmente mais grossos na direção da base. Um ângulo de 0 fará com que os galhos tenham grossura uniforme no seu comrpimento. Um ângulo levemente maior que zero pode aumentar a estabilidade do suporte em árvore."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_angle description"
 msgid "The angle of the branches. Use a lower angle to make them more vertical and more stable. Use a higher angle to be able to have more reach."
 msgstr "Ô angulo dos galhos. Use um ângulo menor para torná-los mais verticais e mais estáveis. Use um ângulo maior para aumentar o alcance."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_conical_angle description"
 msgid "The angle of the tilt of conical support. With 0 degrees being vertical, and 90 degrees being horizontal. Smaller angles cause the support to be more sturdy, but consist of more material. Negative angles cause the base of the support to be wider than the top."
 msgstr "O ângulo da inclinação do suporte cônico. Como 0 graus sendo vertical e 90 graus sendo horizontal. Ângulos menores farão o suporte ser mais firme, mas gastarão mais material. Ângulos negativos farão a base do suporte mais larga que o topo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_point_density description"
 msgid "The average density of points introduced on each polygon in a layer. Note that the original points of the polygon are discarded, so a low density results in a reduction of the resolution."
 msgstr "A densidade média dos pontos introduzidos em cada polígono de uma camada. Note que os pontos originais do polígono são descartados, portanto uma densidade baixa resulta da redução de resolução."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_point_dist description"
 msgid "The average distance between the random points introduced on each line segment. Note that the original points of the polygon are discarded, so a high smoothness results in a reduction of the resolution. This value must be higher than half the Fuzzy Skin Thickness."
 msgstr "A distância média entre os pontos aleatórios introduzidos em cada segmento de linha. Note que os pontos originais do polígono são descartados, portanto umo alto alisamento resulta em redução da resolução. Este valor deve ser maior que a metade da Espessura do Contorno Felpudo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_acceleration description"
 msgid "The default acceleration of print head movement."
 msgstr "A aceleração default a ser usada nos eixos para o movimento da cabeça de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "default_material_print_temperature description"
 msgid "The default temperature used for printing. This should be the \"base\" temperature of a material. All other print temperatures should use offsets based on this value"
 msgstr "A temperatura default usada para a impressão. Esta deve ser a temperatura \"base\" de um material. Todas as outras temperaturas de impressão devem usar diferenças baseadas neste valor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "default_material_bed_temperature description"
 msgid "The default temperature used for the heated build plate. This should be the \"base\" temperature of a build plate. All other print temperatures should use offsets based on this value"
 msgstr "A temperatura default usada para a plataforma aquecida de impressão. Este valor deve ser a temperatura \"base\" da plataforma. Todas as outras temperaturas de impressão devem usar diferenças baseadas neste valor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_density description"
 msgid "The density of the bridge skin layer. Values less than 100 will increase the gaps between the skin lines."
 msgstr "A densidade da camada de contorno de ponte. Valores menores que 100 aumentarão a lacuna entre as linhas de contorno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_density description"
 msgid "The density of the floors of the support structure. A higher value results in better adhesion of the support on top of the model."
 msgstr "A densidade das bases da estrutura de suporte. Um valor maior resulta em melhor aderência do suporte no topo da superfície."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_density description"
 msgid "The density of the roofs of the support structure. A higher value results in better overhangs, but the supports are harder to remove."
 msgstr "A densidade dos tetos da estrutura de suporte. Um valor maior resulta em seções pendentes melhores, mas os suportes são mais difíceis de remover."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_density_2 description"
 msgid "The density of the second bridge skin layer. Values less than 100 will increase the gaps between the skin lines."
 msgstr "A densidade da segunda camada de contorno da ponte. Valores menores que 100 aumentarão a lacuna entre as linhas de contorno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_density_3 description"
 msgid "The density of the third bridge skin layer. Values less than 100 will increase the gaps between the skin lines."
 msgstr "A densidade da terceira camada de contorno da ponte. Valores menores que 100 aumentarão a lacuna entre as linhas de contorno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_depth description"
 msgid "The depth (Y-direction) of the printable area."
 msgstr "A profundidade (direção Y) da área imprimível."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tower_diameter description"
 msgid "The diameter of a special tower."
 msgstr "O diâmetro da torre especial."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_branch_diameter description"
 msgid "The diameter of the thinnest branches of tree support. Thicker branches are more sturdy. Branches towards the base will be thicker than this."
 msgstr "O diâmetro dos galhos mais finos do suporte em árvore. Galhos mais grossos são mais resistentes. Galhos na direção da base serão mais grossos que essa medida."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_feeder_wheel_diameter description"
 msgid "The diameter of the wheel that drives the material in the feeder."
 msgstr "O diâmetro da engrenagem que traciona o material no alimentador."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_max_diameter description"
 msgid "The diameter of the widest branches of tree support. A thicker trunk is more sturdy; a thinner trunk takes up less space on the build plate."
 msgstr "O diâmetro dos galhos mais espessos do suporte em árvore. Um tronco mais espesso é mais robusto; um tronco mais fino ocupa menos espaço na plataforma de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adaptive_layer_height_variation_step description"
 msgid "The difference in height of the next layer height compared to the previous one."
 msgstr "A diferença em tamanho da próxima camada comparada à anterior."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_line_spacing description"
 msgid "The distance between the lines of ironing."
 msgstr "A distância entre as trajetórias de passagem a ferro."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel_avoid_distance description"
 msgid "The distance between the nozzle and already printed parts when avoiding during travel moves."
 msgstr "A distância entre o bico e as partes já impressas quando evitadas durante o percurso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_line_spacing description"
 msgid "The distance between the raft lines for the base raft layer. Wide spacing makes for easy removal of the raft from the build plate."
 msgstr "A distância entre as linhas do raft para a camada de base do raft. Um espaçamento esparso permite a remoção fácil do raft da mesa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_line_spacing description"
 msgid "The distance between the raft lines for the middle raft layer. The spacing of the middle should be quite wide, while being dense enough to support the top raft layers."
 msgstr "A distância entre as linhas do raft para a camada intermediária. O espaçamento do meio deve ser grande, ao mesmo tempo que deve ser denso o suficiente para suportar as camadas superiores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_line_spacing description"
 msgid "The distance between the raft lines for the top raft layers. The spacing should be equal to the line width, so that the surface is solid."
 msgstr "Distância entre as linhas do raft para as camadas superiores. O espaçamento deve ser igual à largura de linha, de modo que a superfície seja sólida."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_roof_inset description"
 msgid "The distance covered when making a connection from a roof outline inward. Only applies to Wire Printing."
 msgstr "A distância coberta quando é feita uma conexão do contorno do teto para dentro. Somente se aplica a Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+msgctxt "interlocking_depth description"
+msgid "The distance from the boundary between models to generate interlocking structure measured in cells. Too few cells will result in poor adhesion."
+msgstr "A distância da fronteira entre os modelos para gerar a estrutura de interligação, medida em células. Poucas células resultam em baixa aderência."
+
+#: fdmprinter.def.json
 msgctxt "brim_width description"
 msgid "The distance from the model to the outermost brim line. A larger brim enhances adhesion to the build plate, but also reduces the effective print area."
 msgstr "A distância do modelo à linha mais externa do brim. Um brim mais largo aumenta a aderência à mesa, mas também reduz a área efetiva de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "interlocking_boundary_avoidance description"
+msgid "The distance from the outside of a model where interlocking structures will not be generated, measured in cells."
+msgstr "Distância da ponta do bico onde 'estacionar' o filamento quando seu extrusor não estiver sendo usado."
+
+#: fdmprinter.def.json
 msgctxt "machine_heat_zone_length description"
 msgid "The distance from the tip of the nozzle in which heat from the nozzle is transferred to the filament."
 msgstr "Distância da ponta do bico, em que calor do bico é transferido para o filamento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_roof_drag_along description"
 msgid "The distance of the end piece of an inward line which gets dragged along when going back to the outer outline of the roof. This distance is compensated for. Only applies to Wire Printing."
 msgstr "A distância da parte final de um filete para dentro que é arrastada quando o extrusor começa a voltar para o contorno externo do topo. Esta distância é compensada. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bottom_skin_expand_distance description"
 msgid "The distance the bottom skins are expanded into the infill. Higher values makes the skin attach better to the infill pattern and makes the skin adhere better to the walls on the layer below. Lower values save amount of material used."
 msgstr "A distância com que os contornos inferiores são expandidos para dentro do preenchimento. Valores mais altos fazem o contorno se anexar melhor ao padrão de preenchimento e fazem as paredes da camada abaixo aderirem melhor ao contorno. Valores mais baixos economizam a quantidade de material usado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "expand_skins_expand_distance description"
 msgid "The distance the skins are expanded into the infill. Higher values makes the skin attach better to the infill pattern and makes the walls on neighboring layers adhere better to the skin. Lower values save amount of material used."
 msgstr "A distância em que os contornos são expandidos pra dentro do preenchimento. Valores mais altos fazem o contorno aderir melhor ao padrão de preenchimento e faz as paredes de camadas vizinhas aderirem melhor ao contorno. Valores menores diminuem a quantidade de material usado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_skin_expand_distance description"
 msgid "The distance the top skins are expanded into the infill. Higher values makes the skin attach better to the infill pattern and makes the walls on the layer above adhere better to the skin. Lower values save amount of material used."
 msgstr "A distância com que os contornos superiores são expandidos para dentro do preenchimento. Valores mais altos fazem o contorno se anexar melhor ao padrão de preenchimento e fazem as paredes da camada acima aderirem melhor ao contorno. Valores mais baixos economizam a quantidade de material usado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_move_distance description"
 msgid "The distance to move the head back and forth across the brush."
 msgstr "A distância com que mover a cabeça pra frente e pra trás durante a varredura."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_roof_fall_down description"
 msgid "The distance which horizontal roof lines printed 'in thin air' fall down when being printed. This distance is compensated for. Only applies to Wire Printing."
 msgstr "A distância em que filetes horizontais do topo impressos no ar caem quando sendo impressos. Esta distância é compensada. Somente se aplica à Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "lightning_infill_prune_angle description"
 msgid "The endpoints of infill lines are shortened to save on material. This setting is the angle of overhang of the endpoints of these lines."
 msgstr "As pontas dos filetes de preenchimento são encurtadas para poupar material. Este ajuste é o ângulo da seção pendente das pontas desses filetes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_extrusion_cool_down_speed description"
 msgid "The extra speed by which the nozzle cools while extruding. The same value is used to signify the heat up speed lost when heating up while extruding."
 msgstr "Velocidade adicional pela qual o bico resfria enquanto extruda. O mesmo valor é uso para denotar a velocidade de aquecimento quando se esquenta ao extrudar."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_extruder_nr_layer_0 description"
 msgid "The extruder train to use for printing the first layer of support infill. This is used in multi-extrusion."
 msgstr "O extrusor a usar para imprimir a primeira camada de preenchimento de suporte. Isto é utilizado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_extruder_nr description"
 msgid "The extruder train to use for printing the first layer of the raft. This is used in multi-extrusion."
 msgstr "O carro extrusor a ser usado para imprimir a primeira camada do Raft. Isto é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_extruder_nr description"
 msgid "The extruder train to use for printing the floors of the support. This is used in multi-extrusion."
 msgstr "O extrusor a usar para imprimir as bases dos suportes. Isto é utilizado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_infill_extruder_nr description"
 msgid "The extruder train to use for printing the infill of the support. This is used in multi-extrusion."
 msgstr "O extrusor a usar para imprimir o preenchimento do suporte. Isto é utilizado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_extruder_nr description"
 msgid "The extruder train to use for printing the middle layer of the raft. This is used in multi-extrusion."
 msgstr "O carro extrusor a ser usado para imprimir a camada central do raft. Isto é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_extruder_nr description"
 msgid "The extruder train to use for printing the roofs and floors of the support. This is used in multi-extrusion."
 msgstr "O extrusor a usar para imprimir os tetos e bases dos suportes. Isto é utilizado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_extruder_nr description"
 msgid "The extruder train to use for printing the roofs of the support. This is used in multi-extrusion."
 msgstr "O extrusor a usar para imprimir o teto do suporte. Isto é utilizado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_extruder_nr description"
 msgid "The extruder train to use for printing the skirt or brim. This is used in multi-extrusion."
 msgstr "O carro extrusor a ser usado para imprimir o skirt ou brim. Isto é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adhesion_extruder_nr description"
 msgid "The extruder train to use for printing the skirt/brim/raft. This is used in multi-extrusion."
 msgstr "O extrusor usado ara imprimir skirt, brim ou raft. Usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_extruder_nr description"
 msgid "The extruder train to use for printing the support. This is used in multi-extrusion."
 msgstr "O extrusor a usar para imprimir os suportes. Isto é utilizado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_extruder_nr description"
 msgid "The extruder train to use for printing the top layer(s) of the raft. This is used in multi-extrusion."
 msgstr "O carro extrusor a ser usado para imprimir a(s) camada(s) central(is) do raft. Isto é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_extruder_nr description"
 msgid "The extruder train used for printing infill. This is used in multi-extrusion."
 msgstr "O carro extrusor usado para imprimir preenchimento. Este ajuste é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_x_extruder_nr description"
 msgid "The extruder train used for printing the inner walls. This is used in multi-extrusion."
 msgstr "O carro extrusor usado para imprimir as paredes internas. Este ajuste é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_0_extruder_nr description"
 msgid "The extruder train used for printing the outer wall. This is used in multi-extrusion."
 msgstr "O carro extrusor usado para imprimir a parede externa. Este ajuste é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_extruder_nr description"
 msgid "The extruder train used for printing the top and bottom skin. This is used in multi-extrusion."
 msgstr "O carro extrusor usado para imprimir as paredes superiores e inferiores. Este ajuste é usado na multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_extruder_nr description"
 msgid "The extruder train used for printing the top most skin. This is used in multi-extrusion."
 msgstr "O carro extrusor usado para imprimir a parte superior da peça. Este ajuste é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_extruder_nr description"
 msgid "The extruder train used for printing the walls. This is used in multi-extrusion."
 msgstr "O carro extrusor usado para imprimir paredes. Este ajuste é usado em multi-extrusão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_fan_speed description"
 msgid "The fan speed for the base raft layer."
 msgstr "A velocidade de ventoinha para a camada base do raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_fan_speed description"
 msgid "The fan speed for the middle raft layer."
 msgstr "A velocidade de ventoina para a camada intermediária do raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_fan_speed description"
 msgid "The fan speed for the raft."
 msgstr "A velocidade da ventoinha para a impressão do raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_fan_speed description"
 msgid "The fan speed for the top raft layers."
 msgstr "A velocidade da ventoinha para as camadas superiores do raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cross_infill_density_image description"
 msgid "The file location of an image of which the brightness values determine the minimal density at the corresponding location in the infill of the print."
 msgstr "A localização do arquivo de imagem onde os valores de brilho determinam a densidade mínima no local correspondente do preenchimento da impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cross_support_density_image description"
 msgid "The file location of an image of which the brightness values determine the minimal density at the corresponding location in the support."
 msgstr "A localização do arquivo de imagem onde os valores de brilho determinam a densidade mínima no local correspondente do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_slowdown_layers description"
 msgid "The first few layers are printed slower than the rest of the model, to get better adhesion to the build plate and improve the overall success rate of prints. The speed is gradually increased over these layers."
 msgstr "As poucas primeiras camadas são impressas mais devagar que o resto do modelo, para conseguir melhor aderência à mesa e melhorar a taxa de sucesso geral das impressão. A velocidade é gradualmente aumentada entre estas camadas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_airgap description"
 msgid "The gap between the final raft layer and the first layer of the model. Only the first layer is raised by this amount to lower the bonding between the raft layer and the model. Makes it easier to peel off the raft."
 msgstr "O vão entre a camada final do raft e a primeira camada do modelo. Somente a primeira camada é elevada por esta distância para enfraquecer a conexão entre o raft e o modelo, tornando mais fácil a remoção do raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_height description"
 msgid "The height (Z-direction) of the printable area."
 msgstr "A altura (direção Z) do volume imprimível."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mold_roof_height description"
 msgid "The height above horizontal parts in your model which to print mold."
 msgstr "A altura acima das partes horizontais do modelo onde criar o molde."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_full_at_height description"
 msgid "The height at which the fans spin on regular fan speed. At the layers below the fan speed gradually increases from Initial Fan Speed to Regular Fan Speed."
 msgstr "A altura em que as ventoinhas girarão na velocidade regular. Nas camadas abaixo a velocidade da ventoinha gradualmente aumenta da velocidade inicial para a velocidade regular."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gantry_height description"
 msgid "The height difference between the tip of the nozzle and the gantry system (X and Y axes)."
 msgstr "Diferença de altura entre a ponta do bico e o sistema de eixos X ou X e Y (onde o extrusor desliza)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_head_distance description"
 msgid "The height difference between the tip of the nozzle and the lowest part of the print head."
 msgstr "Diferença de altura entre a ponta do bico e a parte mais baixa da cabeça de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop_after_extruder_switch_height description"
 msgid "The height difference when performing a Z Hop after extruder switch."
 msgstr "A diferença de altura ao executar um Salto Z após trocar extrusores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop description"
 msgid "The height difference when performing a Z Hop."
 msgstr "Diferença de altura ao realizar um Salto Z."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_hop_amount description"
 msgid "The height difference when performing a Z Hop."
 msgstr "A diferença de altura ao executar um Salto Z."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "layer_height description"
 msgid "The height of each layer in mm. Higher values produce faster prints in lower resolution, lower values produce slower prints in higher resolution."
 msgstr "A altura das camadas em mm. Valores mais altos produzem impressões mais rápidas em resoluções baixas, valores mais baixos produzem impressão mais lentas em resolução mais alta. Recomenda-se não deixar a altura de camada maior que 80% do diâmetro do bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gradual_infill_step_height description"
 msgid "The height of infill of a given density before switching to half the density."
 msgstr "A altura do preenchimento de uma dada densidade antes de trocar para a metade desta densidade."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "gradual_support_infill_step_height description"
 msgid "The height of support infill of a given density before switching to half the density."
 msgstr "A altura do preenchimento de suporte de dada densidade antes de trocar para metade desta densidade."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+msgctxt "interlocking_beam_layer_count description"
+msgid "The height of the beams of the interlocking structure, measured in number of layers. Less layers is stronger, but more prone to defects."
+msgstr "A altura das vigas da estrutura de interligação, medida em número de camadas. Menos camadas são mais fortes, mas mais susceptíveis a defeitos."
+
+#: fdmprinter.def.json
+msgctxt "interlocking_orientation description"
+msgid "The height of the beams of the interlocking structure, measured in number of layers. Less layers is stronger, but more prone to defects."
+msgstr "A altura das vigas da estrutura de interligação, medidas em número de camadas. Menos camadas são mais fortes, mas mais susceptíveis a defeitos."
+
+#: fdmprinter.def.json
 msgctxt "layer_height_0 description"
 msgid "The height of the initial layer in mm. A thicker initial layer makes adhesion to the build plate easier."
 msgstr "A altura da camada inicial em mm. Uma camada inicial mais espessa faz a aderência à mesa de impressão ser maior."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_stair_step_height description"
 msgid "The height of the steps of the stair-like bottom of support resting on the model. A low value makes the support harder to remove, but too high values can lead to unstable support structures. Set to zero to turn off the stair-like behaviour."
 msgstr "A altura dos degraus da base estilo escada do suporte em cima do modelo. Um valor baixo faz o suporte mais difícil de remover, mas valores muito altos podem levar a estruturas de suporte instáveis. Deixe em zero para desligar o comportamento de escada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_height description"
 msgid "The height of the upward and diagonally downward lines between two horizontal parts. This determines the overall density of the net structure. Only applies to Wire Printing."
 msgstr "A altura dos filetes diagonais para cima e para baixo entre duas partes horizontais. Isto determina a densidade geral da estrutura em rede. Somente se aplica a Impressão em Arame."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "brim_gap description"
 msgid "The horizontal distance between the first brim line and the outline of the first layer of the print. A small gap can make the brim easier to remove while still providing the thermal benefits."
 msgstr "A distância horizontal entre o primeiro filete de brim e o contorno da primeira camada da impressão. Um pequeno vão pode fazer o brim mais fácil de remover sem deixar de prover os benefícios térmicos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_gap description"
 msgid ""
 "The horizontal distance between the skirt and the first layer of the print.\n"
@@ -4807,1877 +4882,1901 @@ msgstr ""
 "A distância horizontal entre o skirt a primeira camada da impressão.\n"
 "Esta é a distância mínima. Linhas múltiplas de skirt estenderão além desta distância."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "lightning_infill_straightening_angle description"
 msgid "The infill lines are straightened out to save on printing time. This is the maximum angle of overhang allowed across the length of the infill line."
 msgstr "Os filetes de preenchimentos são retificados para poupar tempo de impressão. Este é o ângulo máximo de seção pendente permito através do comprimento do filete de preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_offset_x description"
 msgid "The infill pattern is moved this distance along the X axis."
 msgstr "O padrão de preenchimento é movido por esta distância no eixo X."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_offset_y description"
 msgid "The infill pattern is moved this distance along the Y axis."
 msgstr "O padrão de preenchimento é movido por esta distância no eixo Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_size description"
 msgid "The inner diameter of the nozzle. Change this setting when using a non-standard nozzle size."
 msgstr "O diâmetro interior do bico (o orifício). Altere este ajuste quanto estiver usando um tamanho de bico fora do padrão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_jerk description"
 msgid "The jerk with which the base raft layer is printed."
 msgstr "O jerk com o qual a camada de base do raft é impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_jerk description"
 msgid "The jerk with which the middle raft layer is printed."
 msgstr "O jerk com o qual a camada intermediária do raft é impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_jerk description"
 msgid "The jerk with which the raft is printed."
 msgstr "O jerk com o qual o raft é impresso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_jerk description"
 msgid "The jerk with which the top raft layers are printed."
 msgstr "O jerk com o qual as camadas superiores do raft são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bottom_skin_preshrink description"
 msgid "The largest width of bottom skin areas which are to be removed. Every skin area smaller than this value will disappear. This can help in limiting the amount of time and material spent on printing bottom skin at slanted surfaces in the model."
 msgstr "A maior largura das áreas de contorno inferiores que serão removidas. Cada área de contorno menor que este valor desaparecerá. Isto pode ajudar em limitar a quantidade de tempo e material gastos em impressão de contornos inferiores em superfícies inclinadas do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_preshrink description"
 msgid "The largest width of skin areas which are to be removed. Every skin area smaller than this value will disappear. This can help in limiting the amount of time and material spent on printing top/bottom skin at slanted surfaces in the model."
 msgstr "A maior largura das áreas de contorno que serão removidas. Cada área de contorno menor que este valor desaparecerá. Isto pode ajudar em limitar a quantidade de tempo e material gastos em impressão de contornos inferiores e superiores em superfícies inclinadas do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_skin_preshrink description"
 msgid "The largest width of top skin areas which are to be removed. Every skin area smaller than this value will disappear. This can help in limiting the amount of time and material spent on printing top skin at slanted surfaces in the model."
 msgstr "A maior largura das áreas de contorno superiores que serão removidas. Cada área de contorno menor que este valor desaparecerá. Isto pode ajudar em limitar a quantidade de tempo e material gastos em impressão de contornos superiores em superfícies inclinadas do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_full_layer description"
 msgid "The layer at which the fans spin on regular fan speed. If regular fan speed at height is set, this value is calculated and rounded to a whole number."
 msgstr "A camada em que as ventoinhas girarão na velocidade regular. Se a 'velocidade regular na altura' estiver ajustada, este valor é calculado e arredondado para um número inteiro."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_min_layer_time_fan_speed_max description"
 msgid "The layer time which sets the threshold between regular fan speed and maximum fan speed. Layers that print slower than this time use regular fan speed. For faster layers the fan speed gradually increases towards the maximum fan speed."
 msgstr "O tempo de camada que define o limite entre a velocidade regular da ventoinha e a máxima. Camadas cuja impressão é mais lenta que este tempo usarão a velocidade regular. Camadas mais rápidas gradualmente aumentarão até a velocidade máxima de ventoinha."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_amount description"
 msgid "The length of material retracted during a retraction move."
 msgstr "O comprimento de filamento retornado durante uma retração."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_buildplate_type description"
 msgid "The material of the build plate installed on the printer."
 msgstr "O material da plataforma de impressão presente na impressora."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adaptive_layer_height_variation description"
 msgid "The maximum allowed height different from the base layer height."
 msgstr "A variação de altura máxima permitida para a camada de base."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ooze_shield_angle description"
 msgid "The maximum angle a part in the ooze shield will have. With 0 degrees being vertical, and 90 degrees being horizontal. A smaller angle leads to less failed ooze shields, but more material."
 msgstr "O ângulo de separação máximo que partes da cobertura de escorrimento terão. Com 0 graus sendo na vertical e 90 graus sendo horizontal. Um ângulo menor leva a coberturas de escorrimento falhando menos, mas mais gasto de material."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "conical_overhang_angle description"
 msgid "The maximum angle of overhangs after the they have been made printable. At a value of 0° all overhangs are replaced by a piece of model connected to the build plate, 90° will not change the model in any way."
 msgstr "O ângulo máximo de seçọes pendentes depois de se tornarem imprimíveis. Com o valor de 0° todas as seções pendentes serão trocadas por uma parte do modelo conectada à mesa e 90° não mudará o modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "conical_overhang_hole_size description"
 msgid "The maximum area of a hole in the base of the model before it's removed by Make Overhang Printable.  Holes smaller than this will be retained.  A value of 0 mm² will fill all holes in the models base."
 msgstr "A área máxima de um furo na base do modelo antes que seja removido por \"Torna Seções Pendentes Imprimíveis\". Furos com área menor que esta serão retidos. O valor de 0 mm² preenche todos os furos na base do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_maximum_deviation description"
 msgid "The maximum deviation allowed when reducing the resolution for the Maximum Resolution setting. If you increase this, the print will be less accurate, but the g-code will be smaller. Maximum Deviation is a limit for Maximum Resolution, so if the two conflict the Maximum Deviation will always be held true."
 msgstr "O desvio máximo permitido ao reduzir a resolução para o ajuste de Máxima Resolução. Se você aumentar isto, a impressão será menos precisa, mas o G-Code será menor. O Desvio Máximo é um limite para Resolução Máxima, portanto se os dois conflitarem o Desvio Máximo sempre será o valor dominante."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_join_distance description"
 msgid "The maximum distance between support structures in the X/Y directions. When separate structures are closer together than this value, the structures merge into one."
 msgstr "A distância máxima entre as estruturas de suporte nas direções X/Y. Quando estruturas separadas estão mais próximas que este valor, elas são fundidas em uma só."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "flow_rate_max_extrusion_offset description"
 msgid "The maximum distance in mm to move the filament to compensate for changes in flow rate."
 msgstr "A distância máxima em mm para mover o filamento para compensar mudanças na taxa de fluxo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_maximum_extrusion_area_deviation description"
 msgid "The maximum extrusion area deviation allowed when removing intermediate points from a straight line. An intermediate point may serve as width-changing point in a long straight line. Therefore, if it is removed, it will cause the line to have a uniform width and, as a result, lose (or gain) a bit of extrusion area. If you increase this you may notice slight under- (or over-) extrusion in between straight parallel walls, as more intermediate width-changing points will be allowed to be removed. Your print will be less accurate, but the g-code will be smaller."
 msgstr "O desvio máximo da área de extrusão permitido ao remover pontos intermediários de uma linha reta. Um ponto intermediário pode servir como ponto de mudança de largura em uma longa linha reta. Portanto, se ele for removido, fará com que a linha tenha uma largura uniforme e, como resultado, perderá (ou ganhará) um pouco de área de extrusão. Se você aumentar o valor, você poderá perceber uma sutil sobre-extrusão ou sub-extrusão no meio de paredes retas paralelas, já que mais pontos intermediários com espessura variante poderão ser removidos. Sua impressão será menos acurada, mas o G-Code será menor."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_print_layer_0 description"
 msgid "The maximum instantaneous velocity change during the printing of the initial layer."
 msgstr "A mudança instantânea máxima de velocidade em uma direção durante a impressão da camada inicial."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_print description"
 msgid "The maximum instantaneous velocity change of the print head."
 msgstr "A mudança instantânea máxima de velocidade em uma direção da cabeça de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_ironing description"
 msgid "The maximum instantaneous velocity change while performing ironing."
 msgstr "A máxima mudança de velocidade instantânea em uma direção com que o recurso de passar a ferro é feito."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_wall_x description"
 msgid "The maximum instantaneous velocity change with which all inner walls are printed."
 msgstr "A máxima mudança de velocidade instantânea em uma direção com que as paredes internas são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_infill description"
 msgid "The maximum instantaneous velocity change with which infill is printed."
 msgstr "A mudança instantânea máxima de velocidade em uma direção com que o preenchimento é impresso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support_bottom description"
 msgid "The maximum instantaneous velocity change with which the floors of support are printed."
 msgstr "A máxima mudança de velocidade instantânea com que as bases dos suportes são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support_infill description"
 msgid "The maximum instantaneous velocity change with which the infill of support is printed."
 msgstr "A máxima mudança de velocidade instantânea em uma direção com que o preenchimento do suporte é impresso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_wall_0 description"
 msgid "The maximum instantaneous velocity change with which the outermost walls are printed."
 msgstr "A máxima mudança de velocidade instantânea em uma direção com que a parede externa é impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_prime_tower description"
 msgid "The maximum instantaneous velocity change with which the prime tower is printed."
 msgstr "A mudança instantânea máxima de velocidade em uma direção com que a torre de purga é impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support_interface description"
 msgid "The maximum instantaneous velocity change with which the roofs and floors of support are printed."
 msgstr "A máxima mudança de velocidade instantânea com a qual os tetos e bases dos suportes são impressos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support_roof description"
 msgid "The maximum instantaneous velocity change with which the roofs of support are printed."
 msgstr "A máxima mudança de velocidade instantânea com que os tetos dos suportes são impressos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_skirt_brim description"
 msgid "The maximum instantaneous velocity change with which the skirt and brim are printed."
 msgstr "A mudança instantânea máxima de velocidade em uma direção com que o skirt (saia) e brim (bainha) são impressos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_support description"
 msgid "The maximum instantaneous velocity change with which the support structure is printed."
 msgstr "A máxima mudança de velocidade instantânea em uma direção com que as estruturas de suporte são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_wall description"
 msgid "The maximum instantaneous velocity change with which the walls are printed."
 msgstr "A máxima mudança de velocidade instantânea em uma direção com que as paredes são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_roofing description"
 msgid "The maximum instantaneous velocity change with which top surface skin layers are printed."
 msgstr "A máxima mudança de velocidade instantânea em uma direção com que as camadas da superfície superior são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_topbottom description"
 msgid "The maximum instantaneous velocity change with which top/bottom layers are printed."
 msgstr "A máxima mudança de velocidade instantânea em uma direção com que as camadas superiores e inferiores são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_travel description"
 msgid "The maximum instantaneous velocity change with which travel moves are made."
 msgstr "A mudança instantânea máxima de velocidade em uma direção com que os percursos são feitos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_feedrate_x description"
 msgid "The maximum speed for the motor of the X-direction."
 msgstr "A velocidade máxima para o motor da impressora na direção X."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_feedrate_y description"
 msgid "The maximum speed for the motor of the Y-direction."
 msgstr "A velocidade máxima para o motor da impressora na direção Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_feedrate_z description"
 msgid "The maximum speed for the motor of the Z-direction."
 msgstr "A velocidade máxima para o motor da impressora na direção Z."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_max_feedrate_e description"
 msgid "The maximum speed of the filament."
 msgstr "A velocidade máxima de entrada de filamento no hotend."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_stair_step_width description"
 msgid "The maximum width of the steps of the stair-like bottom of support resting on the model. A low value makes the support harder to remove, but too high values can lead to unstable support structures."
 msgstr "A largura máxima dos passos da base estilo escada do suporte em cima do modelo. Um valor baixo faz o suporte mais difícil de remover, mas valores muito altos podem levar a estruturas de suporte instáveis."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mold_width description"
 msgid "The minimal distance between the outside of the mold and the outside of the model."
 msgstr "A distância mínima entre o exterior do molde e o exterior do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_minimum_feedrate description"
 msgid "The minimal movement speed of the print head."
 msgstr "Velocidade mínima de entrada de filamento no hotend."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_initial_print_temperature description"
 msgid "The minimal temperature while heating up to the Printing Temperature at which printing can already start."
 msgstr "A temperatura mínima enquanto se esquenta até a Temperatura de Impressão na qual a impressão pode já ser iniciada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_min_cool_heat_time_window description"
 msgid "The minimal time an extruder has to be inactive before the nozzle is cooled. Only when an extruder is not used for longer than this time will it be allowed to cool down to the standby temperature."
 msgstr "Tempo mínimo em que um extrusor precisará estar inativo antes que o bico seja resfriado. Somente quando o extrusor não for usado por um tempo maior que esse, lhe será permitido resfriar até a temperatura de espera."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_support_angle description"
 msgid "The minimum angle of internal overhangs for which infill is added. At a value of 0° objects are totally filled with infill, 90° will not provide any infill."
 msgstr "O ângulo mínimo de seções pendentes internas para as quais o preenchimento é adicionado. Em um valor de 0°, objetos são completamente preenchidos no padrão escolhido, e 90° torna o volume oco, sem preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_angle description"
 msgid "The minimum angle of overhangs for which support is added. At a value of 0° all overhangs are supported, 90° will not provide any support."
 msgstr "O ângulo mínimo de seções pendentes para os quais o suporte é criado. Com o valor de 0° todas as seções pendentes serão suportadas, e 90° não criará nenhum suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_min_travel description"
 msgid "The minimum distance of travel needed for a retraction to happen at all. This helps to get fewer retractions in a small area."
 msgstr "A distância mínima de percurso necessária para que uma retração aconteça. Isto ajuda a ter menos retrações em uma área pequena."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_minimal_length description"
 msgid "The minimum length of the skirt or brim. If this length is not reached by all skirt or brim lines together, more skirt or brim lines will be added until the minimum length is reached. Note: If the line count is set to 0 this is ignored."
 msgstr "O comprimento mínimo do skirt ou brim. Se este comprimento não for cumprido por todas as linhas do skirt ou brim juntas, mais linhas serão adicionadas até que o mínimo comprimento seja alcançado. Se a contagem de linhas estiver em 0, isto é ignorado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_odd_wall_line_width description"
 msgid "The minimum line width for middle line gap filler polyline walls. This setting determines at which model thickness we switch from printing two wall lines, to printing two outer walls and a single central wall in the middle. A higher Minimum Odd Wall Line Width leads to a higher maximum even wall line width. The maximum odd wall line width is calculated as 2 * Minimum Even Wall Line Width."
 msgstr "A mínima largura de extrusão para paredes multifiletes de preenchimento de vão de filete central. Este ajuste determina em que espessura de modelo nós alternamos de imprimir dois filetes de parede para imprimir duas paredes externas e uma parede central no meio. Uma Largura de Extrusão de Parede Ímpar Mínima mais alta leva a uma largura máxima de extrusão de parede par mais alta. A largura máxima de extrusão de parede ímpar é calculada como 2 * Largura Mínima de Extrusão de Parede Par."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_even_wall_line_width description"
 msgid "The minimum line width for normal polygonal walls. This setting determines at which model thickness we switch from printing a single thin wall line, to printing two wall lines. A higher Minimum Even Wall Line Width leads to a higher maximum odd wall line width. The maximum even wall line width is calculated as Outer Wall Line Width + 0.5 * Minimum Odd Wall Line Width."
 msgstr "A mínima largura de filete para paredes poligonais normais. Este ajuste determina em que espessura do modelo nós alternamos da impressão de um file de parede fina único para a impressão de dois filetes de parede. Uma Largura Mínima de Filete de Parede Par mais alta leva a uma largura máxima de filete de parede ímpar também mais alta. A largura máxima de filete de parede par é calculada como a Largura de Filete da Parede Externa + 0.5 * Largura Mínima de Filete de Parede Ímpar."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_min_speed description"
 msgid "The minimum print speed, despite slowing down due to the minimum layer time. When the printer would slow down too much, the pressure in the nozzle would be too low and result in bad print quality."
 msgstr "A velocidade mínima de impressão, mesmo que se tente desacelerar para obedecer ao tempo mínimo de camada. Quando a impressora desacelera demais, a pressão no bico pode ficar muito baixa, o que resulta em baixa qualidade de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_maximum_resolution description"
 msgid "The minimum size of a line segment after slicing. If you increase this, the mesh will have a lower resolution. This may allow the printer to keep up with the speed it has to process g-code and will increase slice speed by removing details of the mesh that it can't process anyway."
 msgstr "O tamanho mínimo de um segmento de linha após o fatiamento. Se você aumentar este valor, a malha terá uma resolução menor. Isto pode permitir que a impressora mantenha a velocidade que precisa para processar o G-Code e aumentará a velocidade de fatiamento ao remover detalhes da malha que não poderia processar de qualquer jeito."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_maximum_travel_resolution description"
 msgid "The minimum size of a travel line segment after slicing. If you increase this, the travel moves will have less smooth corners. This may allow the printer to keep up with the speed it has to process g-code, but it may cause model avoidance to become less accurate."
 msgstr "O tamanho mínimo de um segmento de linha de percurso após o fatiamento. Se o valor aumenta, os movimentos de percurso terão cantos menos suaves. Isto pode permitir que a impressora mantenha a velocidade necessária para processar o G-Code, mas pode fazer com que evitar topar no modelo fique menos preciso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_stair_step_min_slope description"
 msgid "The minimum slope of the area for stair-stepping to take effect. Low values should make support easier to remove on shallower slopes, but really low values may result in some very counter-intuitive results on other parts of the model."
 msgstr "A mínima inclinação da área para que o suporte em escada tenha efeito. Valores baixos devem tornar o suporte mais fácil de remover em inclinações rasas, mas muitos baixos resultarão em resultados bastante contra-intuitivos em outras partes do modelo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_min_layer_time description"
 msgid "The minimum time spent in a layer. This forces the printer to slow down, to at least spend the time set here in one layer. This allows the printed material to cool down properly before printing the next layer. Layers may still take shorter than the minimal layer time if Lift Head is disabled and if the Minimum Speed would otherwise be violated."
 msgstr "O tempo mínimo empregado em uma camada. Isto força a impressora a desacelerar para no mínimo usar o tempo ajustado aqui em uma camada. Isto permite que o material impresso resfrie apropriadamente antes de passar para a próxima camada. As camadas podem ainda assim levar menos tempo que o tempo mínimo de camada se Levantar Cabeça estiver desabilitado e se a Velocidade Mínima fosse violada com a lentidão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_min_volume description"
 msgid "The minimum volume for each layer of the prime tower in order to purge enough material."
 msgstr "O volume mínimo para cada camada da torre de purga de forma a purgar material suficiente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_name description"
 msgid "The name of your 3D printer model."
 msgstr "Nome do seu modelo de impressora 3D."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_id description"
 msgid "The nozzle ID for an extruder train, such as \"AA 0.4\" and \"BB 0.8\"."
 msgstr "O identificador do bico para o carro extrusor, tais como \"AA 0.4\" ou \"BB 0.8\"."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel_avoid_other_parts description"
 msgid "The nozzle avoids already printed parts when traveling. This option is only available when combing is enabled."
 msgstr "O bico evita partes já impressas quando está em uma percurso. Esta opção está disponível somente quando combing (penteamento) está habilitado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel_avoid_supports description"
 msgid "The nozzle avoids already printed supports when traveling. This option is only available when combing is enabled."
 msgstr "O bico evita suportes já impressos durante o percurso. Esta opção só está disponível quando combing estiver habilitado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bottom_layers description"
 msgid "The number of bottom layers. When calculated by the bottom thickness, this value is rounded to a whole number."
 msgstr "O número de camadas inferiores. Quando calculado da espessura inferior, este valor é arredondado para um inteiro."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_wall_count description"
 msgid "The number of contours to print around the linear pattern in the base layer of the raft."
 msgstr "O número de contornos a serem impressos em volta do padrão linear na camada base do raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_edge_support_layers description"
 msgid "The number of infill layers that supports skin edges."
 msgstr "O número de camadas de preenchimento que suportam arestas de contorno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "initial_bottom_layers description"
 msgid "The number of initial bottom layers, from the build-plate upwards. When calculated by the bottom thickness, this value is rounded to a whole number."
 msgstr "O número de camadas inferiores iniciais da plataforma de impressão pra cima. Quanto calculado a partir da espessura inferior, esse valor é arrendado para um número inteiro."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_layers description"
 msgid "The number of layers between the base and the surface of the raft. These comprise the main thickness of the raft. Increasing this creates a thicker, sturdier raft."
 msgstr "O número de camadas entre a base e a superfície do raft. Isso corresponde à espessura principal do raft. Aumentar este valor cria um raft mais espesso e resistente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "brim_line_count description"
 msgid "The number of lines used for a brim. More brim lines enhance adhesion to the build plate, but also reduces the effective print area."
 msgstr "O número de linhas usada para o brim. Mais linhas de brim melhoram a aderência à mesa, mas também reduzem a área efetiva de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_brim_line_count description"
 msgid "The number of lines used for the support brim. More brim lines enhance adhesion to the build plate, at the cost of some extra material."
 msgstr "O número de filetes usado para o brim de suporte. Mais filetes melhoram a aderência na mesa de impressão, ao custo de material extra."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_layers description"
 msgid "The number of top layers on top of the 2nd raft layer. These are fully filled layers that the model sits on. 2 layers result in a smoother top surface than 1."
 msgstr "O número de camadas superiores acima da segunda camada do raft. Estas são camadas completamente preenchidas em que o modelo se assenta. 2 camadas resultam em uma superfície superior mais lisa que apenas uma."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_layers description"
 msgid "The number of top layers. When calculated by the top thickness, this value is rounded to a whole number."
 msgstr "O número de camadas superiores. Quando calculado da espessura superior, este valor é arredondado para um inteiro."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_layer_count description"
 msgid "The number of top most skin layers. Usually only one top most layer is sufficient to generate higher quality top surfaces."
 msgstr "O número de camadas da superfície superior. Geralmente somente uma camada é suficiente para gerar superfícies de alta qualidade."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_wall_count description"
 msgid "The number of walls with which to surround support infill. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used."
 msgstr "O número de paredes com as quais contornar o preenchimento de suporte. Adicionar uma parede pode tornar a impressão de suporte mais confiável e apoiar seções pendentes melhor, mas aumenta tempo de impressão e material usado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "support_bottom_wall_count description"
+msgid "The number of walls with which to surround support interface floor. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used."
+msgstr "O número de paredes com as quais contornar o preenchimento de suporte. Adicionar uma parede pode tornar a impressão de suporte mais confiável e apoiar seções pendentes melhor, mas aumenta tempo de impressão e material usado."
+
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "support_roof_wall_count description"
+msgid "The number of walls with which to surround support interface roof. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used."
+msgstr "O número de paredes com as quais contornar o preenchimento de suporte. Adicionar uma parede pode tornar a impressão de suporte mais confiável e apoiar seções pendentes melhor, mas aumenta tempo de impressão e material usado."
+
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "support_interface_wall_count description"
+msgid "The number of walls with which to surround support interface. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used."
+msgstr "O número de paredes com as quais contornar o preenchimento de suporte. Adicionar uma parede pode tornar a impressão de suporte mais confiável e apoiar seções pendentes melhor, mas aumenta tempo de impressão e material usado."
+
+#: fdmprinter.def.json
 msgctxt "wall_distribution_count description"
 msgid "The number of walls, counted from the center, over which the variation needs to be spread. Lower values mean that the outer walls don't change in width."
 msgstr "O número de paredes, contadas a partir do centro, sobre as quais a variação será distribuída. Valores menores significam que as paredes mais externas não mudam de comprimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_line_count description"
 msgid "The number of walls. When calculated by the wall thickness, this value is rounded to a whole number."
 msgstr "Número de filetes da parede. Quando calculado pela espessura de parede, este valor é arredondado para um inteiro."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_tip_outer_diameter description"
 msgid "The outer diameter of the tip of the nozzle."
 msgstr "Diâmetro exterior do bico (a ponta do hotend)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern description"
 msgid "The pattern of the infill material of the print. The line and zig zag infill swap direction on alternate layers, reducing material cost. The grid, triangle, tri-hexagon, cubic, octet, quarter cubic, cross and concentric patterns are fully printed every layer. Gyroid, cubic, quarter cubic and octet infill change with every layer to provide a more equal distribution of strength over each direction. Lightning infill tries to minimize the infill, by only supporting the ceiling of the object."
 msgstr "O padrão do material de preenchimento da impressão. Os preenchimentos de linha e ziguezague trocam de direção em camadas alternadas, reduzindo custo de material. Os padrões de grade, triângulo, tri-hexágono, cúbico, octeto, quarto cúbico, cruzado e concêntrico são completamente impressos a cada camada. Os preenchimentos giroide, cúbico, quarto cúbico e octeto mudam a cada camada para prover uma distribuição de força mais uniforme em cada direção. O preenchimento de relâmpago tenta minimizar material somente suportando o teto do objeto."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern description"
 msgid "The pattern of the support structures of the print. The different options available result in sturdy or easy to remove support."
 msgstr "O padrão (estampa) das estruturas de suporte da impressão. As diferentes opções disponíveis resultam em suportes mais resistentes ou mais fáceis de remover."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_pattern description"
 msgid "The pattern of the top most layers."
 msgstr "O padrão das camadas superiores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern description"
 msgid "The pattern of the top/bottom layers."
 msgstr "Padrão ou Estampa das camadas superiores e inferiores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern_0 description"
 msgid "The pattern on the bottom of the print on the first layer."
 msgstr "O padrão na base da impressão na primeira camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_pattern description"
 msgid "The pattern to use for ironing top surfaces."
 msgstr "O padrão a usar quando se passa a ferro as superfícies superiores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_pattern description"
 msgid "The pattern with which the floors of the support are printed."
 msgstr "O padrão com o qual as bases do suporte são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_pattern description"
 msgid "The pattern with which the interface of the support with the model is printed."
 msgstr "Padrão (estampa) com a qual a interface do suporte para o modelo é impressa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_pattern description"
 msgid "The pattern with which the roofs of the support are printed."
 msgstr "O padrão com o qual o teto do suporte é impresso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position description"
 msgid "The position near where to start printing each part in a layer."
 msgstr "A posição perto da qual se inicia a impressão de cada parte em uma camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_layer_0 description"
 msgid "The print maximum instantaneous velocity change for the initial layer."
 msgstr "A mudança instantânea máxima de velocidade em uma direção para a camada inicial."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_shape description"
 msgid "The shape of the build plate without taking unprintable areas into account."
 msgstr "A forma da mesa de impressão sem levar área não-imprimíveis em consideração."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_head_with_fans_polygon description"
 msgid "The shape of the print head. These are coordinates relative to the position of the print head, which is usually the position of its first extruder. The dimensions left and in front of the print head must be negative coordinates."
 msgstr "A forma da cabeça de impressão. Essas são coordenadas relativas à posição da cabeça de impressão, que é geralmente a posição do seu primeiro extrusor. As dimensões à esquerda e na frente da cabeça devem ser coordenadas negativas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cross_infill_pocket_size description"
 msgid "The size of pockets at four-way crossings in the cross 3D pattern at heights where the pattern is touching itself."
 msgstr "O tamanho dos bolso em cruzamentos quádruplos no padrão cruzado 3D em alturas onde o padrão esteja se tocando."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "coasting_min_volume description"
 msgid "The smallest volume an extrusion path should have before allowing coasting. For smaller extrusion paths, less pressure has been built up in the bowden tube and so the coasted volume is scaled linearly. This value should always be larger than the Coasting Volume."
 msgstr "O menor volume que um caminho de extrusão deve apresentar antes que lhe seja permitido desengrenar. Para caminhos de extrusão menores, menos pressão é criada dentro do hotend e o volume de desengrenagem é redimensionado linearmente. Este valor deve sempre ser maior que o Volume de Desengrenagem."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_cool_down_speed description"
 msgid "The speed (°C/s) by which the nozzle cools down averaged over the window of normal printing temperatures and the standby temperature."
 msgstr "Velocidade (°C/s) pela qual o bico resfria tirada pela média na janela de temperaturas normais de impressão e temperatura de espera."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_heat_up_speed description"
 msgid "The speed (°C/s) by which the nozzle heats up averaged over the window of normal printing temperatures and the standby temperature."
 msgstr "Velocidade (°C/s) pela qual o bico aquece tirada pela média na janela de temperaturas normais de impressão e temperatura de espera."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_wall_x description"
 msgid "The speed at which all inner walls are printed. Printing the inner wall faster than the outer wall will reduce printing time. It works well to set this in between the outer wall speed and the infill speed."
 msgstr "A velocidade em que todas as paredes interiores são impressas. Imprimir a parede interior mais rapidamente que a parede externa reduzirá o tempo de impressão. Funciona bem ajustar este valor a meio caminho entre a velocidade da parede mais externa e a velocidade de preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_speed description"
 msgid "The speed at which bridge skin regions are printed."
 msgstr "A velocidade com a qual regiões de contorno de ponte são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_infill description"
 msgid "The speed at which infill is printed."
 msgstr "Velocidade em que se imprime o preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_print description"
 msgid "The speed at which printing happens."
 msgstr "Velocidade em que se realiza a impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_speed description"
 msgid "The speed at which the base raft layer is printed. This should be printed quite slowly, as the volume of material coming out of the nozzle is quite high."
 msgstr "A velocidade em que a camada de base do raft é impressa. Deve ser impressa lentamente, já que o volume do material saindo do bico será bem alto."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_wall_speed description"
 msgid "The speed at which the bridge walls are printed."
 msgstr "A velocidade com a qual as paredes de ponte são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_speed_0 description"
 msgid "The speed at which the fans spin at the start of the print. In subsequent layers the fan speed is gradually increased up to the layer corresponding to Regular Fan Speed at Height."
 msgstr "A velocidade em que as ventoinhas giram no início da impressão. Em camadas subsequentes a velocidade da ventoinha é gradualmente aumentada até a camada correspondente ao ajuste 'Velocidade Regular da Ventoinha na Altura'."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_speed_min description"
 msgid "The speed at which the fans spin before hitting the threshold. When a layer prints faster than the threshold, the fan speed gradually inclines towards the maximum fan speed."
 msgstr "Velocidade em que as ventoinhas giram antes de dispararem o limite. Quando uma camada imprime mais rapidamente que o limite de tempo, a velocidade de ventoinha aumenta gradualmente até a velocidade máxima."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_speed_max description"
 msgid "The speed at which the fans spin on the minimum layer time. The fan speed gradually increases between the regular fan speed and maximum fan speed when the threshold is hit."
 msgstr "Velocidade em que as ventoinhas giram no tempo mínimo de camada. A velocidade da ventoinha gradualmente aumenta da regular até a máxima quando o limite é atingido."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_prime_speed description"
 msgid "The speed at which the filament is primed during a retraction move."
 msgstr "A velocidade com a qual o filamento é avançado durante o movimento de retração."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_prime_speed description"
 msgid "The speed at which the filament is primed during a wipe retraction move."
 msgstr "A velocidade com que o filamento é purgado durante um movimento de retração de limpeza."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_prime_speed description"
 msgid "The speed at which the filament is pushed back after a nozzle switch retraction."
 msgstr "A velocidade em que o filamento é empurrado para a frente depois de uma retração de troca de bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_speed description"
 msgid "The speed at which the filament is retracted and primed during a retraction move."
 msgstr "A velocidade com a qual o filamento é recolhido e avançado durante o movimento de retração."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_speed description"
 msgid "The speed at which the filament is retracted and primed during a wipe retraction move."
 msgstr "A velocidade com que o filamento é retraído e purgado durante um movimento de retração de limpeza."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_retraction_speed description"
 msgid "The speed at which the filament is retracted during a nozzle switch retract."
 msgstr "A velocidade em que o filamento é retraído durante uma retração de troca de bico."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_retract_speed description"
 msgid "The speed at which the filament is retracted during a retraction move."
 msgstr "A velocidade com a qual o filamento é recolhido durante o movimento de retração."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_retract_speed description"
 msgid "The speed at which the filament is retracted during a wipe retraction move."
 msgstr "A velocidade com que o filamento é retraído durante um movimento de retração de limpeza."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "switch_extruder_retraction_speeds description"
 msgid "The speed at which the filament is retracted. A higher retraction speed works better, but a very high retraction speed can lead to filament grinding."
 msgstr "A velocidade em que o filamento é retraído. Uma velocidade de retração mais alta funciona melhor, mas uma velocidade muito alta pode levar a desgaste do filamento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support_bottom description"
 msgid "The speed at which the floor of support is printed. Printing it at lower speed can improve adhesion of support on top of your model."
 msgstr "A velocidade em que a base do suporte é impressa. Imprimi-la em velocidade mais baixa pode melhorar a aderência do suporte no topo da superfície."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support_infill description"
 msgid "The speed at which the infill of support is printed. Printing the infill at lower speeds improves stability."
 msgstr "A velocidade em que o preenchimento do suporte é impresso. Imprimir o preenchimento em velocidades menores melhora a estabilidade."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_speed description"
 msgid "The speed at which the middle raft layer is printed. This should be printed quite slowly, as the volume of material coming out of the nozzle is quite high."
 msgstr "A velocidade em que a camada intermediária do raft é impressa. Esta deve ser impressa devagar, já que o volume de material saindo do bico é bem alto."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_wall_0 description"
 msgid "The speed at which the outermost walls are printed. Printing the outer wall at a lower speed improves the final skin quality. However, having a large difference between the inner wall speed and the outer wall speed will affect quality in a negative way."
 msgstr "A velocidade em que as paredes mais externas são impressas. Imprimir a parede mais externa a uma velocidade menor melhora a qualidade final do contorno. No entanto, ter uma diferença muito grande entre a velocidade da parede interna e a velocidade da parede externa afetará a qualidade de forma negativa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_prime_tower description"
 msgid "The speed at which the prime tower is printed. Printing the prime tower slower can make it more stable when the adhesion between the different filaments is suboptimal."
 msgstr "A velocidade em que a torre de purga é impressa. Imprimir a torre de purga mais lentamente pode torná-la mais estável quando a aderência entre os diferentes filamentos é subótima."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_fan_speed description"
 msgid "The speed at which the print cooling fans spin."
 msgstr "A velocidade em que as ventoinhas giram."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_speed description"
 msgid "The speed at which the raft is printed."
 msgstr "A velocidade em que o raft é impresso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support_interface description"
 msgid "The speed at which the roofs and floors of support are printed. Printing them at lower speeds can improve overhang quality."
 msgstr "A velocidade com que os tetos e bases do suporte são impressos. Imprimi-los em velocidades mais baixas pode melhorar a qualidade de seções pendentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support_roof description"
 msgid "The speed at which the roofs of support are printed. Printing them at lower speeds can improve overhang quality."
 msgstr "A velocidade em que os tetos dos suportes são impressos. Imprimi-los em velocidade mais baixas pode melhorar a qualidade de seções pendentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_speed description"
 msgid "The speed at which the skirt and brim are printed. Normally this is done at the initial layer speed, but sometimes you might want to print the skirt or brim at a different speed."
 msgstr "Velocidade em que o Brim (Bainha) e Skirt (Saia) são impressos. Normalmente isto é feito na velocidade de camada inicial, mas você pode querer imprimi-los em velocidade diferente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_support description"
 msgid "The speed at which the support structure is printed. Printing support at higher speeds can greatly reduce printing time. The surface quality of the support structure is not important since it is removed after printing."
 msgstr "A velocidade em que a estrutura de suporte é impressa. Imprimir o suporte a velocidades mais altas pode reduzir bastante o tempo de impressão. A qualidade de superfície das estruturas de suporte não é importante já que são removidas após a impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_speed description"
 msgid "The speed at which the top raft layers are printed. These should be printed a bit slower, so that the nozzle can slowly smooth out adjacent surface lines."
 msgstr "A velocidade em que as camadas superiores do raft são impressas. Elas devem ser impressas um pouco mais devagar, de modo que o bico possa lentamente alisar as linhas de superfície adjacentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_z_hop description"
 msgid "The speed at which the vertical Z movement is made for Z Hops. This is typically lower than the print speed since the build plate or machine's gantry is harder to move."
 msgstr "A velocidade em que o movimento Z vertical é feito para os saltos Z. Tipicamente mais baixa que a velocidade de impressão já que mover a mesa de impressão ou eixos da máquina é mais difícil."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_wall description"
 msgid "The speed at which the walls are printed."
 msgstr "Velocidade em que se imprimem as paredes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_ironing description"
 msgid "The speed at which to pass over the top surface."
 msgstr "A velocidade com a qual o ajuste de passar ferro é aplicado sobre a superfície superior."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_speed description"
 msgid "The speed at which to retract the filament in order to break it cleanly."
 msgstr "A velocidade com a qual retrair o filamento para que se destaque completamente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_roofing description"
 msgid "The speed at which top surface skin layers are printed."
 msgstr "A velocidade com que as camadas superiores são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_topbottom description"
 msgid "The speed at which top/bottom layers are printed."
 msgstr "Velocidade em que as camadas superiores e inferiores são impressas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_travel description"
 msgid "The speed at which travel moves are made."
 msgstr "Velocidade em que ocorrem os movimentos de percurso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "coasting_speed description"
 msgid "The speed by which to move during coasting, relative to the speed of the extrusion path. A value slightly under 100% is advised, since during the coasting move the pressure in the bowden tube drops."
 msgstr "A velocidade pela qual se mover durante a desengrenagem, relativa à velocidade do caminho de extrusão. Um valor ligeiramente menor que 100% é sugerido, já que durante a desengrenagem a pressão dentro do hotend cai."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_layer_0 description"
 msgid "The speed for the initial layer. A lower value is advised to improve adhesion to the build plate. Does not affect the build plate adhesion structures themselves, like brim and raft."
 msgstr "A velocidade para a camada inicial. Um valor menor é sugerido para melhorar aderência à mesa de impressão. Não afeta as estruturas de aderência à mesa de impressão como o brim e o raft."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_print_layer_0 description"
 msgid "The speed of printing for the initial layer. A lower value is advised to improve adhesion to the build plate."
 msgstr "A velocidade de impressão para a camada inicial. Um valor menor é aconselhado para aprimorar a aderência à mesa de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_travel_layer_0 description"
 msgid "The speed of travel moves in the initial layer. A lower value is advised to prevent pulling previously printed parts away from the build plate. The value of this setting can automatically be calculated from the ratio between the Travel Speed and the Print Speed."
 msgstr "A velocidade dos percursos da camada inicial. Um valor mais baixo que o normal é aconselhado para prevenir o puxão de partes impressas da mesa de impressão. O valor deste ajuste pode ser automaticamente calculado do raio entre a Velocidade de Percurso e a Velocidade de Impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_temperature description"
 msgid "The temperature at which the filament is broken for a clean break."
 msgstr "A temperatura em que o filamento é destacado completamente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "build_volume_temperature description"
 msgid "The temperature of the environment to print in. If this is 0, the build volume temperature will not be adjusted."
 msgstr "A temperatura do ambiente em que imprimir. Se este valor for 0, a temperatura de volume de impressão não será ajustada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_standby_temperature description"
 msgid "The temperature of the nozzle when another nozzle is currently used for printing."
 msgstr "A temperatura do bico quando outro bico está sendo usado para a impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_final_print_temperature description"
 msgid "The temperature to which to already start cooling down just before the end of printing."
 msgstr "A temperatura para a qual se deve começar a esfriar pouco antes do fim da impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_print_temperature_layer_0 description"
 msgid "The temperature used for printing the first layer. Set at 0 to disable special handling of the initial layer."
 msgstr "A temperatura usada para imprimir a primeira camada. Coloque 0 para desabilitar processamento especial da camada inicial."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_print_temperature description"
 msgid "The temperature used for printing."
 msgstr "A temperatura usada para impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_bed_temperature_layer_0 description"
 msgid "The temperature used for the heated build plate at the first layer. If this is 0, the build plate is left unheated during the first layer."
 msgstr "A temperatura usada para a plataforma aquecida de impressão na primeira camada. Se for 0, a plataforma de impressão não será aquecida durante a primeira camada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_bed_temperature description"
 msgid "The temperature used for the heated build plate. If this is 0, the build plate is left unheated."
 msgstr "A temperatura usada para a plataforma aquecida de impressão. Se for 0, a plataforma de impressão não será aquecida."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_break_preparation_temperature description"
 msgid "The temperature used to purge material, should be roughly equal to the highest possible printing temperature."
 msgstr "A temperatura usada para purgar material, deve ser grosso modo a temperatura de impressão mais alta possível."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bottom_thickness description"
 msgid "The thickness of the bottom layers in the print. This value divided by the layer height defines the number of bottom layers."
 msgstr "A espessura das camadas inferiores da impressão. Este valor dividido pela altura de camada define o número de camadas inferiores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_edge_support_thickness description"
 msgid "The thickness of the extra infill that supports skin edges."
 msgstr "A espessura do preenchimento extra que suporta arestas de contorno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_height description"
 msgid "The thickness of the interface of the support where it touches with the model on the bottom or the top."
 msgstr "A espessura da interface do suporte onde ele toca o modelo na base ou no topo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_height description"
 msgid "The thickness of the support floors. This controls the number of dense layers that are printed on top of places of a model on which support rests."
 msgstr "A espessura das bases de suporte. Isto controla o número de camadas densas que são impressas no topo dos pontos do modelo em que o suporte se assenta."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_height description"
 msgid "The thickness of the support roofs. This controls the amount of dense layers at the top of the support on which the model rests."
 msgstr "A espessura do topo do suporte. Isto controla a quantidade de camadas densas no topo do suporte em que o modelo se assenta."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_thickness description"
 msgid "The thickness of the top layers in the print. This value divided by the layer height defines the number of top layers."
 msgstr "A espessura das camadas superiores da impressão. Este valor dividido pela altura de camada define o número de camadas superiores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_thickness description"
 msgid "The thickness of the top/bottom layers in the print. This value divided by the layer height defines the number of top/bottom layers."
 msgstr "A espessura das camadas superiores e inferiores da impressão. Este valor dividido pela altura de camada define o número de camadas superiores e inferiores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_thickness description"
 msgid "The thickness of the walls in the horizontal direction. This value divided by the wall line width defines the number of walls."
 msgstr "A espessura das paredes na direção horizontal. Este valor dividido pela largura de extrusão da parede define o número de filetes da parede."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_sparse_thickness description"
 msgid "The thickness per layer of infill material. This value should always be a multiple of the layer height and is otherwise rounded."
 msgstr "A espessura por camada de material de preenchimento. Este valor deve sempre ser um múltiplo da altura de camada e se não for, é arredondado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_infill_sparse_thickness description"
 msgid "The thickness per layer of support infill material. This value should always be a multiple of the layer height and is otherwise rounded."
 msgstr "A espessura por camada do material de preenchimento de suporte. Este valor deve sempre ser um múltiplo da altura de camada e é arredondado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor description"
 msgid "The type of g-code to be generated."
 msgstr "O tipo de G-Code a ser gerado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "coasting_volume description"
 msgid "The volume otherwise oozed. This value should generally be close to the nozzle diameter cubed."
 msgstr "Volume que seria escorrido. Este valor deve em geral estar perto do diâmetro do bico ao cubo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_width description"
 msgid "The width (X-direction) of the printable area."
 msgstr "A largura (direção X) da área imprimível."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_brim_width description"
 msgid "The width of the brim to print underneath the support. A larger brim enhances adhesion to the build plate, at the cost of some extra material."
 msgstr "A largura do brim a ser impresso sob o suporte. Um brim mais largo melhora a aderência à mesa de impressão, ao custo de material extra."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
+#, fuzzy
+msgctxt "interlocking_beam_width description"
+msgid "The width of the interlocking structure beams."
+msgstr "A largura da torre de purga."
+
+#: fdmprinter.def.json
 msgctxt "prime_tower_size description"
 msgid "The width of the prime tower."
 msgstr "A largura da torre de purga."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_fuzzy_skin_thickness description"
 msgid "The width within which to jitter. It's advised to keep this below the outer wall width, since the inner walls are unaltered."
 msgstr "A largura dentro da qual flutuar. É sugerido deixar este valor abaixo da largura da parede externa, já que as paredes internas não são alteradas pelo algoritmo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_extrusion_window description"
 msgid "The window in which the maximum retraction count is enforced. This value should be approximately the same as the retraction distance, so that effectively the number of times a retraction passes the same patch of material is limited."
 msgstr "A janela em que a contagem de retrações máxima é válida. Este valor deve ser aproximadamente o mesmo que a distância de retração, de modo que efetivamente o número de vez que a retração passa pelo mesmo segmento de material é limitada."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_position_x description"
 msgid "The x coordinate of the position of the prime tower."
 msgstr "A coordenada X da posição da torre de purga."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_position_y description"
 msgid "The y coordinate of the position of the prime tower."
 msgstr "A coordenada Y da posição da torre de purga."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_meshes_present description"
 msgid "There are support meshes present in the scene. This setting is controlled by Cura."
 msgstr "Há malhas de suporte presentes na cena. Este ajuste é controlado pelo Cura."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_wall_coast description"
 msgid "This controls the distance the extruder should coast immediately before a bridge wall begins. Coasting before the bridge starts can reduce the pressure in the nozzle and may produce a flatter bridge."
 msgstr "Este ajuste controla a distância que o extrusor deve parar de extrudar antes que a parede de ponte comece. Desengrenar antes da ponte iniciar pode reduzir a pressão no bico e produzir em uma ponte mais horizontal."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_smoothing description"
 msgid "This setting controls how much inner corners in the raft outline are rounded. Inward corners are rounded to a semi circle with a radius equal to the value given here. This setting also removes holes in the raft outline which are smaller than such a circle."
 msgstr "Este ajuste controla quanto os cantos internos do contorno do raft são arredondados. Esses cantos internos são convertidos em semicírculos com raio igual ao valor dado aqui. Este ajuste também remove furos no contorno do raft que forem menores que o círculo equivalente."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_count_max description"
 msgid "This setting limits the number of retractions occurring within the minimum extrusion distance window. Further retractions within this window will be ignored. This avoids retracting repeatedly on the same piece of filament, as that can flatten the filament and cause grinding issues."
 msgstr "Este ajuste limita o número de retrações ocorrendo dentro da janela de distância de extrusão mínima. Retrações subsequentes dentro desta janela serão ignoradas. Isto previne repetidas retrações no mesmo pedaço de filamento, já que isso pode acabar ovalando e desgastando o filamento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "draft_shield_enabled description"
 msgid "This will create a wall around the model, which traps (hot) air and shields against exterior airflow. Especially useful for materials which warp easily."
 msgstr "Isto criará uma parede em volta do modelo que aprisiona ar quente da mesa e protege contra fluxo de ar do exterior. Especialmente útil para materiais que sofrem bastante warp e impressoras 3D que não são cobertas."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_roof_outer_delay description"
 msgid "Time spent at the outer perimeters of hole which is to become a roof. Longer times can ensure a better connection. Only applies to Wire Printing."
 msgstr "El tiempo empleado en los perímetros exteriores del agujero que se convertirá en un techo. Cuanto mayor sea el tiempo, mejor será la conexión. Solo se aplica a la impresión de alambre."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_shrinkage_percentage_xy description"
 msgid "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the XY-direction (horizontally)."
 msgstr "Para compensar pelo encolhimento do material enquanto ele esfria, o modelo será ampliado por este fator na direção XY (horizontalmente)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_shrinkage_percentage_z description"
 msgid "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor in the Z-direction (vertically)."
 msgstr "Para compensar pelo encolhimento do material enquanto esfria, o modelo será ampliado por este fator na direção Z (verticalmente)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_shrinkage_percentage description"
 msgid "To compensate for the shrinkage of the material as it cools down, the model will be scaled with this factor."
 msgstr "Para compensar o encolhimento do material enquanto esfria, o modelo será redimensionado por este fator."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_layers label"
 msgid "Top Layers"
 msgstr "Camadas Superiores"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_skin_expand_distance label"
 msgid "Top Skin Expand Distance"
 msgstr "Distância de Expansão do Contorno Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_skin_preshrink label"
 msgid "Top Skin Removal Width"
 msgstr "Largura de Remoção do Contorno Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_roofing label"
 msgid "Top Surface Skin Acceleration"
 msgstr "Aceleração da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_extruder_nr label"
 msgid "Top Surface Skin Extruder"
 msgstr "Extrusor da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_material_flow label"
 msgid "Top Surface Skin Flow"
 msgstr "Fluxo do Contorno da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_roofing label"
 msgid "Top Surface Skin Jerk"
 msgstr "Jerk da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_layer_count label"
 msgid "Top Surface Skin Layers"
 msgstr "Camadas da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_angles label"
 msgid "Top Surface Skin Line Directions"
 msgstr "Direções dos Filetes da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_line_width label"
 msgid "Top Surface Skin Line Width"
 msgstr "Largura de extrusão da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_pattern label"
 msgid "Top Surface Skin Pattern"
 msgstr "Padrão da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_roofing label"
 msgid "Top Surface Skin Speed"
 msgstr "Velocidade da Superfície Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_thickness label"
 msgid "Top Thickness"
 msgstr "Espessura Superior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "max_skin_angle_for_expansion description"
 msgid "Top and/or bottom surfaces of your object with an angle larger than this setting, won't have their top/bottom skin expanded. This avoids expanding the narrow skin areas that are created when the model surface has a near vertical slope. An angle of 0° is horizontal and will cause no skin to be expanded, while an angle of 90° is vertical and will cause all skin to be expanded."
 msgstr "Superfícies superiores e/ou inferiores de seu objeto com um ângulo maior que este ajuste não terão seu contorno expandido. Isto permite evitar a expansão de áreas estreitas de contorno que são criadas quando a superfície do modelo tem uma inclinação quase vertical. Um ângulo de 0° é horizontal e não causará expansão no contorno, enquanto que um ângulo de 90° é vertical e causará expansão em todo o contorno."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom description"
 msgid "Top/Bottom"
 msgstr "Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom label"
 msgid "Top/Bottom"
 msgstr "Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_topbottom label"
 msgid "Top/Bottom Acceleration"
 msgstr "Aceleração Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_extruder_nr label"
 msgid "Top/Bottom Extruder"
 msgstr "Extrusor Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_material_flow label"
 msgid "Top/Bottom Flow"
 msgstr "Fluxo de Topo/Base"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_topbottom label"
 msgid "Top/Bottom Jerk"
 msgstr "Jerk Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_angles label"
 msgid "Top/Bottom Line Directions"
 msgstr "Direções de Linha Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_line_width label"
 msgid "Top/Bottom Line Width"
 msgstr "Largura de Extrusão Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern label"
 msgid "Top/Bottom Pattern"
 msgstr "Padrão Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_topbottom label"
 msgid "Top/Bottom Speed"
 msgstr "Velocidade Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_thickness label"
 msgid "Top/Bottom Thickness"
 msgstr "Espessura Superior/Inferior"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_type option buildplate"
 msgid "Touching Buildplate"
 msgstr "Tocando a Mesa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tower_diameter label"
 msgid "Tower Diameter"
 msgstr "Diâmetro da Torre"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tower_roof_angle label"
 msgid "Tower Roof Angle"
 msgstr "Ângulo do Teto da Torre"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "mesh_rotation_matrix description"
 msgid "Transformation matrix to be applied to the model when loading it from file."
 msgstr "Matriz de transformação a ser aplicada ao modelo após o carregamento do arquivo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel label"
 msgid "Travel"
 msgstr "Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_travel label"
 msgid "Travel Acceleration"
 msgstr "Aceleração de Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel_avoid_distance label"
 msgid "Travel Avoid Distance"
 msgstr "Distância de Desvio de Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_travel label"
 msgid "Travel Jerk"
 msgstr "Jerk de Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_travel label"
 msgid "Travel Speed"
 msgstr "Velocidade de Percurso"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "magic_mesh_surface_mode description"
 msgid "Treat the model as a surface only, a volume, or volumes with loose surfaces. The normal print mode only prints enclosed volumes. \"Surface\" prints a single wall tracing the mesh surface with no infill and no top/bottom skin. \"Both\" prints enclosed volumes like normal and any remaining polygons as surfaces."
 msgstr "Tratar o modelo como apenas superfície, um volume ou volumes com superfícies soltas. O modo de impressão normal somente imprime volumes fechados. O modo \"superfície\" imprime uma parede única traçando a superfície da malha sem nenhun preenchimento e sem paredes superiores ou inferiores. O modo \"ambos\" imprime volumes fechados como o modo normal e volumes abertos como superfícies."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_structure option tree"
 msgid "Tree"
 msgstr "Árvore"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_angle label"
 msgid "Tree Support Branch Angle"
 msgstr "Ângulo do Galho do Suporte em Árvore"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_branch_diameter label"
 msgid "Tree Support Branch Diameter"
 msgstr "Diâmetro de Galho do Suporte em Árvore"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_branch_diameter_angle label"
 msgid "Tree Support Branch Diameter Angle"
 msgstr "Ângulo do Diâmetro do Galho do Suporte em Árvore"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_branch_distance label"
 msgid "Tree Support Branch Distance"
 msgstr "Distância dos Galhos do Suporte em Árvore"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_collision_resolution label"
 msgid "Tree Support Collision Resolution"
 msgstr "Resolução de Colisão do Suporte em Árvore"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_tree_max_diameter label"
 msgid "Tree Support Trunk Diameter"
 msgstr "Diâmetro de Tronco do Suporte em Árvore"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option trihexagon"
 msgid "Tri-Hexagon"
 msgstr "Tri-Hexágono"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option triangles"
 msgid "Triangles"
 msgstr "Triângulos"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_pattern option triangles"
 msgid "Triangles"
 msgstr "Triângulo"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_pattern option triangles"
 msgid "Triangles"
 msgstr "Triângulos"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern option triangles"
 msgid "Triangles"
 msgstr "Triângulos"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_pattern option triangles"
 msgid "Triangles"
 msgstr "Triângulos"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_gcode_flavor option UltiGCode"
 msgid "Ultimaker 2"
 msgstr "Ultimaker 2"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "meshfix_union_all label"
 msgid "Union Overlapping Volumes"
 msgstr "Volumes de Sobreposição de Uniões"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_wall_min_length description"
 msgid "Unsupported walls shorter than this will be printed using the normal wall settings. Longer unsupported walls will be printed using the bridge wall settings."
 msgstr "Paredes não-suportadas mais curtas que esta quantia serão impressas usando ajustes normais de paredes. Paredes mais longas serão impressas com os ajustes de parede de ponte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "adaptive_layer_height_enabled label"
 msgid "Use Adaptive Layers"
 msgstr "Usar Camadas Adaptativas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_use_towers label"
 msgid "Use Towers"
 msgstr "Usar Torres"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_travel_enabled description"
 msgid "Use a separate acceleration rate for travel moves. If disabled, travel moves will use the acceleration value of the printed line at their destination."
 msgstr "Usar taxa de aceleração separada para movimentos de percurso. Se desabilitado, os movimentos de percurso usarão o valor de aceleração da linha impressa em seu destino."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_travel_enabled description"
 msgid "Use a separate jerk rate for travel moves. If disabled, travel moves will use the jerk value of the printed line at their destination."
 msgstr "Usar taxa de jerk separada para movimentos de percurso. Se desabilitado, os movimentos de percurso usarão o valor de jerk da linha impressa em seu destino."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "relative_extrusion description"
 msgid "Use relative extrusion rather than absolute extrusion. Using relative E-steps makes for easier post-processing of the g-code. However, it's not supported by all printers and it may produce very slight deviations in the amount of deposited material compared to absolute E-steps. Irrespective of this setting, the extrusion mode will always be set to absolute before any g-code script is output."
 msgstr "Usar extrusão relativa ao invés de extrusão absoluta. Passos de extrusão relativos no G-Code tornam o pós-processamento mais fácil. No entanto, isso não é suportado por todas as impressoras e pode produzir pequenos desvios na quantidade de material depositado comparado a passos de extrusão absolutos. Independente deste ajuste, o modo de extrusão sempre será ajustado para absoluto antes que qualquer script G-Code seja processado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_use_towers description"
 msgid "Use specialized towers to support tiny overhang areas. These towers have a larger diameter than the region they support. Near the overhang the towers' diameter decreases, forming a roof."
 msgstr "Usa torres especializadas como suporte de pequenas seções pendentes. Essas torres têm um diâmetro mais largo que a região que elas suportam. Perto da seção pendente, o diâmetro das torres aumenta, formando um 'teto'."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_mesh description"
 msgid "Use this mesh to modify the infill of other meshes with which it overlaps. Replaces infill regions of other meshes with regions for this mesh. It's suggested to only print one Wall and no Top/Bottom Skin for this mesh."
 msgstr "Utilize esta malha para modificar o preenchimento de outras malhas com as quais ela se sobrepõe. Substitui regiões de preenchimento de outras malhas com regiões desta malha. É sugerido que se imprima com somente uma parede e sem paredes superiores e inferiores para esta malha."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_mesh description"
 msgid "Use this mesh to specify support areas. This can be used to generate support structure."
 msgstr "Use esta malha para especificar áreas obrigatoriamente suportadas. Isto será usado para gerar estruturas de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "anti_overhang_mesh description"
 msgid "Use this mesh to specify where no part of the model should be detected as overhang. This can be used to remove unwanted support structure."
 msgstr "Use esta malha para especificar onde nenhuma parte do modelo deverá ser detectada como seção Pendente e por conseguinte não elegível a receber suporte. Com esta malha sobreposta a um modelo, você poderá marcar onde ele não deverá receber suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_type option back"
 msgid "User Specified"
 msgstr "Especificado pelo Usuário"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_shrinkage_percentage_z label"
 msgid "Vertical Scaling Factor Shrinkage Compensation"
 msgstr "Compensação de Fator de Encolhimento Vertical"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "slicing_tolerance description"
 msgid "Vertical tolerance in the sliced layers. The contours of a layer are normally generated by taking cross sections through the middle of each layer's thickness (Middle). Alternatively each layer can have the areas which fall inside of the volume throughout the entire thickness of the layer (Exclusive) or a layer has the areas which fall inside anywhere within the layer (Inclusive). Inclusive retains the most details, Exclusive makes for the best fit and Middle stays closest to the original surface."
 msgstr "Tolerância vertical das camadas fatiadas. Os contornos de uma camada são normalmente gerados se tomando seções cruzadas pelo meio de cada espessura de camada (Meio). Alternativamente, cada camada pode ter as áreas que caem fora do volume por toda a espessura da camada (Exclusivo) ou a camada pode ter as áreas que caem dentro de qualquer lugar dentro da camada (Inclusivo). Inclusivo retém mais detalhes, Exclusivo proporciona o melhor encaixe e Meio permanece mais próximo da superfície original."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_bottom_delay label"
 msgid "WP Bottom Delay"
 msgstr "Espera da Base de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed_bottom label"
 msgid "WP Bottom Printing Speed"
 msgstr "Velocidade de Impressão da Base da IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_flow_connection label"
 msgid "WP Connection Flow"
 msgstr "Fluxo de Conexão da IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_height label"
 msgid "WP Connection Height"
 msgstr "Altura da Conexão IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed_down label"
 msgid "WP Downward Printing Speed"
 msgstr "Velocidade de Impressão Descendente de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_drag_along label"
 msgid "WP Drag Along"
 msgstr "Arrasto de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_up_half_speed label"
 msgid "WP Ease Upward"
 msgstr "Facilitador Ascendente da IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_fall_down label"
 msgid "WP Fall Down"
 msgstr "Queda de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_flat_delay label"
 msgid "WP Flat Delay"
 msgstr "Espera Plana de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_flow_flat label"
 msgid "WP Flat Flow"
 msgstr "Fluxo Plano de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_flow label"
 msgid "WP Flow"
 msgstr "Fluxo da IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed_flat label"
 msgid "WP Horizontal Printing Speed"
 msgstr "Velocidade de Impressão Horizontal de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_top_jump label"
 msgid "WP Knot Size"
 msgstr "Tamanho do Nó de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_nozzle_clearance label"
 msgid "WP Nozzle Clearance"
 msgstr "Espaço Livre para o Bico em IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_roof_drag_along label"
 msgid "WP Roof Drag Along"
 msgstr "Arrasto do Topo de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_roof_fall_down label"
 msgid "WP Roof Fall Down"
 msgstr "Queda do Topo de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_roof_inset label"
 msgid "WP Roof Inset Distance"
 msgstr "Distância de Penetração do Teto da IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_roof_outer_delay label"
 msgid "WP Roof Outer Delay"
 msgstr "Retardo exterior del techo en IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed label"
 msgid "WP Speed"
 msgstr "Velocidade da IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_straight_before_down label"
 msgid "WP Straighten Downward Lines"
 msgstr "Endireitar Filetes Descendentes de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_strategy label"
 msgid "WP Strategy"
 msgstr "Estratégia de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_top_delay label"
 msgid "WP Top Delay"
 msgstr "Espera do Topo de IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_printspeed_up label"
 msgid "WP Upward Printing Speed"
 msgstr "Velocidade de Impressão Ascendente da IA"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_bed_temp_wait label"
 msgid "Wait for Build Plate Heatup"
 msgstr "Aguardar o Aquecimento da Mesa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_print_temp_wait label"
 msgid "Wait for Nozzle Heatup"
 msgstr "Aguardar Aquecimento do Bico"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "acceleration_wall label"
 msgid "Wall Acceleration"
 msgstr "Aceleração da Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_distribution_count label"
 msgid "Wall Distribution Count"
 msgstr "Contagem de Distribuição de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_extruder_nr label"
 msgid "Wall Extruder"
 msgstr "Extrusor das Paredes"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_material_flow label"
 msgid "Wall Flow"
 msgstr "Fluxo de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "jerk_wall label"
 msgid "Wall Jerk"
 msgstr "Jerk da Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_line_count label"
 msgid "Wall Line Count"
 msgstr "Número de Filetes da Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_line_width label"
 msgid "Wall Line Width"
 msgstr "Largura de Extrusão da Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "inset_direction label"
 msgid "Wall Ordering"
 msgstr "Ordem de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_wall label"
 msgid "Wall Speed"
 msgstr "Velocidade da Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_thickness label"
 msgid "Wall Thickness"
 msgstr "Espessura de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_transition_length label"
 msgid "Wall Transition Length"
 msgstr "Comprimento de Transição de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_transition_filter_distance label"
 msgid "Wall Transitioning Filter Distance"
 msgstr "Distância de Filtro da Transição de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_transition_filter_deviation label"
 msgid "Wall Transitioning Filter Margin"
 msgstr "Margem de Filtro de Transição de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_transition_angle label"
 msgid "Wall Transitioning Threshold Angle"
 msgstr "Ângulo-Limite de Transição de Parede"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "shell label"
 msgid "Walls"
 msgstr "Paredes"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_overhang_angle description"
 msgid "Walls that overhang more than this angle will be printed using overhanging wall settings. When the value is 90, no walls will be treated as overhanging. Overhang that gets supported by support will not be treated as overhang either."
 msgstr "Paredes que pendem por mais do que esse ângulo serão impressas usando ajustes de paredes pendentes. Quando este valor for 90, nenhuma parede será tratada como pendente. Seções pendentes que têm suportes também não serão tratadas como pendentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_skip_height description"
 msgid "When checking where there's model above and below the support, take steps of the given height. Lower values will slice slower, while higher values may cause normal support to be printed in some places where there should have been support interface."
 msgstr "Quando verificar se há partes do modelo abaixo e acima do suporte, usar passos de dada altura. Valores baixos fatiarão mais lentamente, enquanto que valores altos farão com que suporte convencional seja impresso em lugares em que deveria haver interface de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_enable_travel_optimization description"
 msgid "When enabled, the order in which the infill lines are printed is optimized to reduce the distance travelled. The reduction in travel time achieved very much depends on the model being sliced, infill pattern, density, etc. Note that, for some models that have many small areas of infill, the time to slice the model may be greatly increased."
 msgstr "Quando habilitado, a ordem em que os filetes de preenchimento são impressos é otimizada para reduzir a distância percorrida. A redução em tempo de percurso conseguida depende bastante do modelo sendo fatiado, do padrão de preenchimento, da densidade, etc. Note que, para alguns modelos que têm áreas bem pequenas de preenchimento, o tempo de fatiamento pode ser aumentado bastante."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_fan_enable description"
 msgid "When enabled, the print cooling fan speed is altered for the skin regions immediately above the support."
 msgstr "Quando habilitado, a velocidade da ventoinha de resfriamento é alterada para as regiões de contorno imediatamente acima do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_relative description"
 msgid "When enabled, the z seam coordinates are relative to each part's centre. When disabled, the coordinates define an absolute position on the build plate."
 msgstr "Quando habilitado, as coordenadas da costura Z são relativas ao centro de cada parte. Quando desabilitado, as coordenadas definem uma posição absoluta na plataforma de impressão."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing_max_distance description"
 msgid "When greater than zero, combing travel moves that are longer than this distance will use retraction. If set to zero, there is no maximum and combing moves will not use retraction."
 msgstr "Quando maior que zero, os movimentos de percurso de combing que forem maiores que essa distância usarão retração. Se deixado em zero, não haverá máximo e os movimentos de combing não usarão retração."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_material_flow description"
 msgid "When printing bridge skin regions, the amount of material extruded is multiplied by this value."
 msgstr "Ao imprimir regiões de contorno de ponte, a quantidade de material extrudado é multiplicada por este valor."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_wall_material_flow description"
 msgid "When printing bridge walls, the amount of material extruded is multiplied by this value."
 msgstr "Ao se imprimir paredes de ponte, a quantidade de material extrudado é multiplicada por este valor."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_material_flow_2 description"
 msgid "When printing the second bridge skin layer, the amount of material extruded is multiplied by this value."
 msgstr "Ao imprimir a segunda camada de contorno de ponte, a quantidade de material é multiplicada por este valor."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "bridge_skin_material_flow_3 description"
 msgid "When printing the third bridge skin layer, the amount of material extruded is multiplied by this value."
 msgstr "Ao imprimir a terceira de contorno da ponte, a quantidade de material é multiplicada por este valor."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "cool_lift_head description"
 msgid "When the minimum speed is hit because of minimum layer time, lift the head away from the print and wait the extra time until the minimum layer time is reached."
 msgstr "Quando a velocidade mínima acaba sendo usada por causa do tempo mínimo de camada, levanta a cabeça para longe da impressão e espera tempo extra até que o tempo mínimo de camada seja alcançado."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_no_small_gaps_heuristic description"
 msgid "When the model has small vertical gaps of only a few layers, there should normally be skin around those layers in the narrow space. Enable this setting to not generate skin if the vertical gap is very small. This improves printing time and slicing time, but technically leaves infill exposed to the air."
 msgstr "Quando o modelo tem pequenas lacunas verticais de apenas umas poucas camadas, normalmente há contorno em volta dessas camadas no espaço estreito. Habilite este ajuste para não gerar o contorno se a lacuna vertical for bem pequena. Isso melhora o tempo de impressão e fatiamento, mas tecnicamente deixa preenchimento exposto ao ar."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_transition_angle description"
 msgid "When to create transitions between even and odd numbers of walls. A wedge shape with an angle greater than this setting will not have transitions and no walls will be printed in the center to fill the remaining space. Reducing this setting reduces the number and length of these center walls, but may leave gaps or overextrude."
 msgstr "Quanto criar transições entre números de paredes pares e ímpares. A forma de cunha em ângulo maior que este ajuste não terá transições e nenhuma parede será impressa no centro para preencher o espaço remanescente. Reduzir este ajuste faz reduzir o número e comprimento das paredes centrais, mas pode deixar vãos ou sobre-extrudar."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_transition_length description"
 msgid "When transitioning between different numbers of walls as the part becomes thinner, a certain amount of space is allotted to split or join the wall lines."
 msgstr "Ao transicionar entre diferentes números de paredes à medida que a peça fica mais fina, uma certa quantidade de espaço é alocada para partir ou juntar os filetes de parede."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_hop_enable description"
 msgid "When wiping, the build plate is lowered to create clearance between the nozzle and the print. It prevents the nozzle from hitting the print during travel moves, reducing the chance to knock the print from the build plate."
 msgstr "Quando limpando, a plataforma de impressão é abaixada para criar uma folga entre o bico e a impressão. Isso previne que o bico bata na impressão durante movimentos de percurso, reduzindo a chance de descolar o objeto da plataforma."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop_enabled description"
 msgid "Whenever a retraction is done, the build plate is lowered to create clearance between the nozzle and the print. It prevents the nozzle from hitting the print during travel moves, reducing the chance to knock the print from the build plate."
 msgstr "Sempre que uma retração é feita, sobe-se um pouco em Z para criar um espaço entre o bico e a impressão. Isso evita que o bico fique batendo nas impressões durante o percurso, reduzindo a chance de chutar a peça para fora da mesa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_xy_overrides_z description"
 msgid "Whether the Support X/Y Distance overrides the Support Z Distance or vice versa. When X/Y overrides Z the X/Y distance can push away the support from the model, influencing the actual Z distance to the overhang. We can disable this by not applying the X/Y distance around overhangs."
 msgstr "Decide se a distância XY substitui a distância Z de suporte ou vice-versa. Quando XY substitui Z a distância XY pode afastar o suporte do modelo, influenciando a distância Z real até a seção pendente. Podemos desabilitar isso não aplicando a distância XY em volta das seções pendentes."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_center_is_zero description"
 msgid "Whether the X/Y coordinates of the zero position of the printer is at the center of the printable area."
 msgstr "Decide se as coordenadas X/Y da posição zero da impressão estão no centro da área imprimível (senão, estarão no canto inferior esquerdo)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_endstop_positive_direction_x description"
 msgid "Whether the endstop of the X axis is in the positive direction (high X coordinate) or negative (low X coordinate)."
 msgstr "Decide se o endstop do eixo X está na direção positiva (coordenada X alta) ou negativa (coordenada X baixa)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_endstop_positive_direction_y description"
 msgid "Whether the endstop of the Y axis is in the positive direction (high Y coordinate) or negative (low Y coordinate)."
 msgstr "Decide se o endstop do eixo Y está na direção positiva (coordenada Y alta) ou negativa (coordenada Y baixa)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_endstop_positive_direction_z description"
 msgid "Whether the endstop of the Z axis is in the positive direction (high Z coordinate) or negative (low Z coordinate)."
 msgstr "Decide se o endstop do eixo Z está na direção positiva (coordenada Z alta) ou negativa (coordenada Z baixa)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_extruders_share_heater description"
 msgid "Whether the extruders share a single heater rather than each extruder having its own heater."
 msgstr "Decide se os extrusores usam um único aquecedor combinado ou cada um tem o seu respectivo aquecedor."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_extruders_share_nozzle description"
 msgid "Whether the extruders share a single nozzle rather than each extruder having its own nozzle. When set to true, it is expected that the printer-start gcode script properly sets up all extruders in an initial retraction state that is known and mutually compatible (either zero or one filament not retracted); in that case the initial retraction status is described, per extruder, by the 'machine_extruders_shared_nozzle_initial_retraction' parameter."
 msgstr "Decide se os extrusores compartilham um único bico ao invés de cada extrusor ter seu próprio. Quando colocado em verdadeiro, é esperado que o script g-code de início da impressora configure todos os extrusores em um estado inicial de retração que seja conhecido e mutuamente compatível (ou zero ou filamento não retraído); neste caso, o status de retração inicial é descrito, por extrusor, pelo parâmetro 'machine_extruders_shared_nozzle_initial_retraction'."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_heated_bed description"
 msgid "Whether the machine has a heated build plate present."
 msgstr "Decide se a plataforma de impressão pode ser aquecida."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_heated_build_volume description"
 msgid "Whether the machine is able to stabilize the build volume temperature."
 msgstr "Decide se a máquina consegue estabilizar a temperatura do volume de construção."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "center_object description"
 msgid "Whether to center the object on the middle of the build platform (0,0), instead of using the coordinate system in which the object was saved."
 msgstr "Decide se o objeto deve ser centralizado no meio da plataforma de impressão, ao invés de usar o sistema de coordenadas em que o objeto foi salvo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_nozzle_temp_enabled description"
 msgid "Whether to control temperature from Cura. Turn this off to control nozzle temperature from outside of Cura."
 msgstr "Decide se a temperatura deve ser controlada pelo Cura. Desligue para controlar a temperatura do bico fora do Cura."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_bed_temp_prepend description"
 msgid "Whether to include build plate temperature commands at the start of the gcode. When the start_gcode already contains build plate temperature commands Cura frontend will automatically disable this setting."
 msgstr "Decide se haverá a inclusão de comandos de temperatura da mesa de impressão no início do G-Code. Quando o G-Code Inicial já contiver comandos de temperatura da mesa, a interface do Cura automaticamente desabilitará este ajuste."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_print_temp_prepend description"
 msgid "Whether to include nozzle temperature commands at the start of the gcode. When the start_gcode already contains nozzle temperature commands Cura frontend will automatically disable this setting."
 msgstr "Decide se haverá a inclusão de comandos de temperatura do bico no início do G-Code. Quando o G-Code Inicial já contiver comandos de temperatura do bico, a interface do Cura automaticamente desabilitará este ajuste."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "clean_between_layers description"
 msgid "Whether to include nozzle wipe G-Code between layers (maximum 1 per layer). Enabling this setting could influence behavior of retract at layer change. Please use Wipe Retraction settings to control retraction at layers where the wipe script will be working."
 msgstr "Decide se haverá inclusão de G-Code de limpeza de bico entre camadas (no máximo 1 por camada). Habilitar este ajuste pode influenciar o comportamento de retração na mudança de camada. Por favor use ajustes de Retração de Limpeza para controlar retração nas camadas onde o script de limpeza estará atuando."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_bed_temp_wait description"
 msgid "Whether to insert a command to wait until the build plate temperature is reached at the start."
 msgstr "Decide se haverá inserção do comando para aguardar que a temperatura-alvo da mesa de impressão estabilize no início."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_blob_enable description"
 msgid "Whether to prime the filament with a blob before printing. Turning this setting on will ensure that the extruder will have material ready at the nozzle before printing. Printing Brim or Skirt can act like priming too, in which case turning this setting off saves some time."
 msgstr "Decide se é preciso descarregar o filamento com uma massa de purga antes de imprimir. Ligar este ajuste assegurará que o extrusor tenha material pronto no bico antes de imprimir. Imprimir um Brim ou Skirt pode funcionar como purga também, em cujo caso desligar esse ajuste faz ganhar algum tempo."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "print_sequence description"
 msgid "Whether to print all models one layer at a time or to wait for one model to finish, before moving on to the next. One at a time mode is possible if a) only one extruder is enabled and b) all models are separated in such a way that the whole print head can move in between and all models are lower than the distance between the nozzle and the X/Y axes."
 msgstr "Decide se os modelos devem ser impressos todos de uma vez só, uma camada por vez, ou se se deve esperar a cada modelo terminar antes de prosseguir para o próximo. O modo um de cada vez só é possível se a) somente um extrusor estiver habilitado e b) todos os modelos estiverem separados de modo que a cabeça de impressão pode se mover entre todos e todos os modelos estiverem em altura mais baixa que a distância entre o bico e os eixos X e Y."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_show_variants description"
 msgid "Whether to show the different variants of this machine, which are described in separate json files."
 msgstr "Decide se deseja exibir as variantes desta máquina, que são descrita em arquivos .json separados."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_firmware_retract description"
 msgid "Whether to use firmware retract commands (G10/G11) instead of using the E property in G1 commands to retract the material."
 msgstr "Decide se serão usados comandos de retração de firmware (G10/G11) ao invés da propriedade E dos comandos G1 para retrair o material."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "material_print_temp_wait description"
 msgid "Whether to wait until the nozzle temperature is reached at the start."
 msgstr "Decide se haverá a inserção do comando para aguardar que a temperatura-alvo do bico estabilize no início."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_line_width description"
 msgid "Width of a single infill line."
 msgstr "Largura de um filete de preenchimento."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_line_width description"
 msgid "Width of a single line of support roof or floor."
 msgstr "Largura de um filete usado no teto ou base do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_line_width description"
 msgid "Width of a single line of the areas at the top of the print."
 msgstr "Largura de extrusão de um filete das áreas no topo da peça."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "line_width description"
 msgid "Width of a single line. Generally, the width of each line should correspond to the width of the nozzle. However, slightly reducing this value could produce better prints."
 msgstr "Largura de uma única linha de filete extrudado. Geralmente, a largura da linha corresponde ao diâmetro do bico. No entanto, reduzir ligeiramente este valor pode produzir impressões melhores."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_line_width description"
 msgid "Width of a single prime tower line."
 msgstr "Largura de um filete usado na torre de purga."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skirt_brim_line_width description"
 msgid "Width of a single skirt or brim line."
 msgstr "Largura de um filete do brim (bainha) ou skirt (saia)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_line_width description"
 msgid "Width of a single support floor line."
 msgstr "Largura de um filete usado na base do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_line_width description"
 msgid "Width of a single support roof line."
 msgstr "Largura de um filete usado no teto do suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_line_width description"
 msgid "Width of a single support structure line."
 msgstr "Largura de um filete usado nas estruturas de suporte."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "skin_line_width description"
 msgid "Width of a single top/bottom line."
 msgstr "Largura de extrusão dos filetes das paredes do topo e base dos modelos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_line_width_x description"
 msgid "Width of a single wall line for all wall lines except the outermost one."
 msgstr "Largura de extrusão das paredes internas (todas menos a mais externa)."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_line_width description"
 msgid "Width of a single wall line."
 msgstr "Largura de um filete que faz parte de uma parede."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_base_line_width description"
 msgid "Width of the lines in the base raft layer. These should be thick lines to assist in build plate adhesion."
 msgstr "Largura das linhas na camada de base do raft. Devem ser grossas para auxiliar na aderência à mesa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_interface_line_width description"
 msgid "Width of the lines in the middle raft layer. Making the second layer extrude more causes the lines to stick to the build plate."
 msgstr "Largura das linhas na camada intermediária do raft. Fazer a segunda camada extrudar mais faz as linhas grudarem melhor na mesa."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "raft_surface_line_width description"
 msgid "Width of the lines in the top surface of the raft. These can be thin lines so that the top of the raft becomes smooth."
 msgstr "Largura das linhas na superfície superior do raft. Estas podem ser linhas finas de modo que o topo do raft fique liso."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wall_line_width_0 description"
 msgid "Width of the outermost wall line. By lowering this value, higher levels of detail can be printed."
 msgstr "Largura de Extrusão somente da parede mais externa do modelo. Diminuindo este valor, níveis de detalhes mais altos podem ser impressos."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "min_bead_width description"
 msgid "Width of the wall that will replace thin features (according to the Minimum Feature Size) of the model. If the Minimum Wall Line Width is thinner than the thickness of the feature, the wall will become as thick as the feature itself."
 msgstr "Largura da parede que substituirá detalhes finos (de acordo com o Tamanho Mínimo de Detalhe) do modelo. Se a Largura Mínima de Filete de Parede for mais fina que a espessura do detalhe, a parede se tornará tão espessa quanto o próprio detalhe."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_brush_pos_x label"
 msgid "Wipe Brush X Position"
 msgstr "Posição X da Varredura de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_hop_speed label"
 msgid "Wipe Hop Speed"
 msgstr "Velocidade do Salto de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "prime_tower_wipe_enabled label"
 msgid "Wipe Inactive Nozzle on Prime Tower"
 msgstr "Limpar Bico Inativo na Torre de Purga"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_move_distance label"
 msgid "Wipe Move Distance"
 msgstr "Distância de Movimentação da Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "clean_between_layers label"
 msgid "Wipe Nozzle Between Layers"
 msgstr "Limpar o Bico Entre Camadas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_pause label"
 msgid "Wipe Pause"
 msgstr "Pausa de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_repeat_count label"
 msgid "Wipe Repeat Count"
 msgstr "Contagem de Repetições de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_amount label"
 msgid "Wipe Retraction Distance"
 msgstr "Distância de Retração da Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_enable label"
 msgid "Wipe Retraction Enable"
 msgstr "Habilitar Retração de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_extra_prime_amount label"
 msgid "Wipe Retraction Extra Prime Amount"
 msgstr "Quantidade Extra de Purga da Retração de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_prime_speed label"
 msgid "Wipe Retraction Prime Speed"
 msgstr "Velocidade de Purga da Retração de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_retract_speed label"
 msgid "Wipe Retraction Retract Speed"
 msgstr "Velocidade da Retração da Retração de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_retraction_speed label"
 msgid "Wipe Retraction Speed"
 msgstr "Velocidade da Retração de Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_hop_enable label"
 msgid "Wipe Z Hop"
 msgstr "Salto Z da Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_hop_amount label"
 msgid "Wipe Z Hop Height"
 msgstr "Altura do Salto Z da Limpeza"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wireframe_enabled label"
 msgid "Wire Printing"
 msgstr "Impressão em Arame"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_combing option infill"
 msgid "Within Infill"
 msgstr "Dentro do Preenchimento"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_always_write_active_tool description"
 msgid "Write active tool after sending temp commands to inactive tool. Required for Dual Extruder printing with Smoothie or other firmware with modal tool commands."
 msgstr "Escreve a ferramenta ativa depois de enviar comandos de temperatura para a ferramenta inativa. Requerido para impressão de Extrusor Duplo com Smoothie ou outros firmwares com comandos modais de ferramenta."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_endstop_positive_direction_x label"
 msgid "X Endstop in Positive Direction"
 msgstr "Endstop X na Direção Positiva"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "wipe_brush_pos_x description"
 msgid "X location where wipe script will start."
 msgstr "Localização X onde o script de limpeza iniciará."
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_xy_overrides_z option xy_overrides_z"
 msgid "X/Y overrides Z"
 msgstr "X/Y substitui Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_endstop_positive_direction_y label"
 msgid "Y Endstop in Positive Direction"
 msgstr "Endstop Y na Direção Positiva"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "machine_endstop_positive_direction_z label"
 msgid "Z Endstop in Positive Direction"
 msgstr "Endstop Z na Direção Positiva"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop_after_extruder_switch label"
 msgid "Z Hop After Extruder Switch"
 msgstr "Salto Z Após Troca de Extrusor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop_after_extruder_switch_height label"
 msgid "Z Hop After Extruder Switch Height"
 msgstr "Salto Z Após Troca de Altura do Extrusor"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop label"
 msgid "Z Hop Height"
 msgstr "Altura do Salto Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop_only_when_collides label"
 msgid "Z Hop Only Over Printed Parts"
 msgstr "Salto Z Somente Sobre Partes Impressas"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "speed_z_hop label"
 msgid "Z Hop Speed"
 msgstr "Velocidade do Salto Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "retraction_hop_enabled label"
 msgid "Z Hop When Retracted"
 msgstr "Salto Z Ao Retrair"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_type label"
 msgid "Z Seam Alignment"
 msgstr "Alinhamento da Costura em Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_position label"
 msgid "Z Seam Position"
 msgstr "Posição da Costura Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_relative label"
 msgid "Z Seam Relative"
 msgstr "Costura Z Relativa"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_x label"
 msgid "Z Seam X"
 msgstr "Coordenada X da Costura Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "z_seam_y label"
 msgid "Z Seam Y"
 msgstr "Coordenada Y da Costura Z"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_xy_overrides_z option z_overrides_xy"
 msgid "Z overrides X/Y"
 msgstr "Z substitui X/Y"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "infill_pattern option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "ironing_pattern option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "roofing_pattern option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_bottom_pattern option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_interface_pattern option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_pattern option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "support_roof_pattern option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "top_bottom_pattern_0 option zigzag"
 msgid "Zig Zag"
 msgstr "Ziguezague"
 
-#: /fdmprinter.def.json
+#: fdmprinter.def.json
 msgctxt "travel description"
 msgid "travel"
 msgstr "percurso"
@@ -6754,6 +6853,10 @@ msgstr "percurso"
 #~ msgid "Apply the extruder offset to the coordinate system."
 #~ msgstr "Aplicar o deslocamento do extrusor ao sistema de coordenadas."
 
+#~ msgctxt "material_flow_dependent_temperature label"
+#~ msgid "Auto Temperature"
+#~ msgstr "Temperatura Automática"
+
 #~ msgctxt "z_seam_type option back"
 #~ msgid "Back"
 #~ msgstr "Costas"
@@ -6769,6 +6872,10 @@ msgstr "percurso"
 #~ msgctxt "center_object label"
 #~ msgid "Center object"
 #~ msgstr "Centralizar Objeto"
+
+#~ msgctxt "material_flow_dependent_temperature description"
+#~ msgid "Change the temperature for each layer automatically with the average flow speed of that layer."
+#~ msgstr "Troca a temperatura para cada camada automaticamente de acordo com a velocidade média de fluxo desta camada."
 
 #~ msgctxt "prime_tower_circular label"
 #~ msgid "Circular Prime Tower"
@@ -7094,6 +7201,10 @@ msgstr "percurso"
 #~ msgid "Is center origin"
 #~ msgstr "A origem está no centro"
 
+#~ msgctxt "limit_support_retractions label"
+#~ msgid "Limit Support Retractions"
+#~ msgstr "Limitar Retrações de Suporte"
+
 #~ msgctxt "machine_head_polygon label"
 #~ msgid "Machine Head Polygon"
 #~ msgstr "Polígono Da Cabeça da Máquina"
@@ -7237,6 +7348,10 @@ msgstr "percurso"
 #~ msgctxt "limit_support_retractions description"
 #~ msgid "Omit retraction when moving from support to support in a straight line. Enabling this setting saves print time, but can lead to excesive stringing within the support structure."
 #~ msgstr "Omitir retrações quando mudar de suporte a suporte em linha reta. Habilitar este ajuste economiza tempo de impressão, mas pode levar a fiapos entremeados à estrutura de suporte."
+
+#~ msgctxt "limit_support_retractions description"
+#~ msgid "Omit retraction when moving from support to support in a straight line. Enabling this setting saves print time, but can lead to excessive stringing within the support structure."
+#~ msgstr "Omitir a retração ao mover de suporte a suporte em linha reta. Habilitar este ajuste economiza tempo de impressão, mas pode levar a fiapos excessivos na estrutura de suporte."
 
 #~ msgctxt "cross_infill_apply_pockets_alternatingly description"
 #~ msgid "Only apply pockets at half of the four-way crossings in the cross 3D pattern and alternate the location of the pockets between heights where the pattern is touching itself."
@@ -7437,10 +7552,6 @@ msgstr "percurso"
 #~ msgctxt "lightning_infill_straightening_angle description"
 #~ msgid "The difference a lightning infill layer can have with the one immediately above w.r.t the smoothing of trees. Measured in the angle given the thickness."
 #~ msgstr "A diferença que uma camada de preenchimento relâmpago pode ter em relação à camada imediatamente superior de acordo com a suavização de árvores. Medido em ângulo de acordo com a espessura."
-
-#~ msgctxt "machine_filament_park_distance description"
-#~ msgid "The distance from the tip of the nozzle where to park the filament when an extruder is no longer used."
-#~ msgstr "Distância da ponta do bico onde 'estacionar' o filamento quando seu extrusor não estiver sendo usado."
 
 #~ msgctxt "expand_skins_expand_distance description"
 #~ msgid "The distance the skins are expanded into the infill. The default distance is enough to bridge the gap between the infill lines and will stop holes appearing in the skin where it meets the wall when the infill density is low. A smaller distance will often be sufficient."


### PR DESCRIPTION
# Description

This updates the strings for Brazilian Portuguese internationalization.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [X] Translations

# How Has This Been Tested?

Replaced the strings file locally with my installation of cura

**Test Configuration**:
* Operating System: Linux

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change