### PR TITLE
[CURA-10183] Fix G-Code reader crash

### DIFF
--- a/plugins/GCodeReader/FlavorParser.py
+++ b/plugins/GCodeReader/FlavorParser.py
@@ -328,7 +328,11 @@ class FlavorParser:
         if not global_stack:
             return None
 
-        self._current_filament_diameter = global_stack.extruderList[self._extruder_number].getProperty("material_diameter", "value")
+        try:
+            self._current_filament_diameter = global_stack.extruderList[self._extruder_number].getProperty("material_diameter", "value")
+        except IndexError:
+            # There can be a mismatch between the number of extruders in the G-Code file and the number of extruders in the current machine.
+            self._current_filament_diameter = self.DEFAULT_FILAMENT_DIAMETER
 
         scene_node = CuraSceneNode()
 


### PR DESCRIPTION
# Description

Add a try catch around fetching material diameter. This stops crashes when G-Code with more extruders than the active machine is loaded. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test by loading G-Code sliced with a printer that has many extruders while having an active machine with 1 extruder.

**Test Configuration**:
* Operating System: MacOS

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change