### PR TITLE
[5.3] Fix VzBot Base definition file

### DIFF
--- a/resources/definitions/vzbot_base.def.json
+++ b/resources/definitions/vzbot_base.def.json
@@ -196,7 +196,7 @@
         "wall_line_width": { "value": "machine_nozzle_size" },
         "wall_overhang_angle": { "default_value": 75 },
         "wall_overhang_speed_factor": { "default_value": 50 },
-        "xy_offset_layer_0": { "value": 0.3 },
+        "xy_offset_layer_0": { "value": -0.3 },
         "z_seam_type": { "value": "'back'" },
         "zig_zaggify_infill": { "value": true }
     }


### PR DESCRIPTION

# Description

The correct value should be -03 not 0.3 Should actually still in the 5.3. Maybe it works out.

## Type of change
Fix
