### PR TITLE
Fix non-raw RegEx pattern string

### DIFF
--- a/cura/UI/ObjectsModel.py
+++ b/cura/UI/ObjectsModel.py
@@ -69,7 +69,7 @@ class ObjectsModel(ListModel):
         self._group_name_template = catalog.i18nc("@label", "Group #{group_nr}")
         self._group_name_prefix = self._group_name_template.split("#")[0]
 
-        self._naming_regex = re.compile("^(.+)\(([0-9]+)\)$")
+        self._naming_regex = re.compile(r"^(.+)\(([0-9]+)\)$")
 
     def setActiveBuildPlate(self, nr: int) -> None:
         if self._build_plate_number != nr:


### PR DESCRIPTION
# Description

This is a minor change that fixes a `DeprecationWarning: invalid escape sequence '\('` by compiling the regex pattern as a raw `str` (i.e., preceded by an `r`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Extensive testing not performed&mdash;should not be necessary.

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change