### PR TITLE
[CURA-10451] Pause at height was not working for UM printers.

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -67,7 +67,7 @@ class PauseAtHeight(Script):
                     "label": "Keep motors engaged",
                     "description": "Keep the steppers engaged to allow change of filament without moving the head. Applying too much force will move the head/bed anyway",
                     "type": "bool",
-                    "default_value": true,
+                    "default_value": false,
                     "enabled": "pause_method != \\\"griffin\\\""
                 },
                 "disarm_timeout":
@@ -218,7 +218,7 @@ class PauseAtHeight(Script):
                     "label": "Beep at pause",
                     "description": "Make a beep when pausing",
                     "type": "bool",
-                    "default_value": true
+                    "default_value": false
                 },                
                 "beep_length":
                 {


### PR DESCRIPTION
Hold-stepper-motor (and maybe beep) options, newly introduced previously, _and on by default_ (even though it was clear they where not meant for Griffin flavour GCode -- because at least the hold-motor option was not even visible for Griffin) where causing UltiMaker printers with prints that had the pause-at-height script enabled to fail.
