### PR TITLE
Fix mistake in FilamentChange script

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/FilamentChange.py
+++ b/plugins/PostProcessingPlugin/scripts/FilamentChange.py
@@ -199,7 +199,7 @@ class FilamentChange(Script):
         if enable_before_macro:
             color_change = color_change + before_macro + "\n"
 
-        color_change = color_change + "M600\n"
+        color_change = color_change + "M600"
 
         if not firmware_config:
             if initial_retract is not None and initial_retract > 0.:
@@ -220,6 +220,8 @@ class FilamentChange(Script):
             if z_pos is not None and z_pos > 0.:
                 color_change = color_change + (" Z%.2f" % z_pos)
 
+        color_change = color_change + "\n"
+            
         if enable_after_macro:
             color_change = color_change + after_macro + "\n"
 


### PR DESCRIPTION
Mistake behaviour:
With disabled `firmware_config` option this script produces incorrect gcode (after_macro = `M109 R205`):

```
;BEGIN FilamentChange plugin
M600
 E30.00 U300.00 X0.00 Y0.00 M109 R205
;END FilamentChange plugin
```

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change