### PR TITLE
Add Kingroon KP3S Pro Printer

### DIFF
--- a/resources/definitions/kingroon_kp3s_pro.def.json
+++ b/resources/definitions/kingroon_kp3s_pro.def.json
@@ -1,0 +1,36 @@
+{
+    "version": 2,
+    "name": "Kingroon KP3S",
+    "inherits": "kingroon_base",
+    "metadata":
+    {
+        "visible": true,
+        "platform": "kingroon_kp3s.stl",
+        "quality_definition": "kingroon_base"
+    },
+    "overrides":
+    {
+        "machine_acceleration": { "value": 1000 },
+        "machine_max_acceleration_e": { "value": 1000 },
+        "machine_max_acceleration_x": { "value": 1000 },
+        "machine_max_acceleration_y": { "value": 1000 },
+        "machine_max_acceleration_z": { "value": 100 },
+        "machine_max_feedrate_e": { "value": 100 },
+        "machine_max_feedrate_x": { "value": 200 },
+        "machine_max_feedrate_y": { "value": 200 },
+        "machine_max_feedrate_z": { "value": 4 },
+        "machine_max_jerk_xy": { "value": 15 },
+        "machine_max_jerk_z": { "value": 0.4 },
+        "machine_name": { "default_value": "Kingroon KP3S" },
+        "machine_steps_per_mm_e": { "value": 764 },
+        "machine_steps_per_mm_x": { "value": 160 },
+        "machine_steps_per_mm_y": { "value": 160 },
+        "machine_steps_per_mm_z": { "value": 800 },
+        "retraction_amount": { "value": 1 },
+        "retraction_extrusion_window": { "value": 1 },
+        "retraction_speed": { "value": 40 },
+        "speed_z_hop": { "value": 4 },
+        "machine_width": { "default_value": 200 },
+        "machine_height": { "default_value": 200}
+    }
+}

--- a/resources/definitions/kingroon_kp3s_pro.def.json
+++ b/resources/definitions/kingroon_kp3s_pro.def.json
@@ -1,6 +1,6 @@
 {
     "version": 2,
-    "name": "Kingroon KP3S",
+    "name": "Kingroon KP3S Pro",
     "inherits": "kingroon_base",
     "metadata":
     {


### PR DESCRIPTION
# Description
This adds the KP3S Pro using the KP3S base definition. It is slightly larger than the KP3S, with a 200x200x200 build area.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

- [X] Loaded printer profile

**Test Configuration**:
* Operating System: Windows 10