### PR TITLE
[CURA-10472] Disable horizontal expansion when using tree-support.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5167,11 +5167,11 @@
                     "unit": "mm",
                     "type": "float",
                     "default_value": 0.8,
-                    "value": "support_line_width + 0.4 if support_type == 'normal' else 0.0",
+                    "value": "support_line_width + 0.4 if support_structure == 'normal' else 0.0",
                     "limit_to_extruder": "support_infill_extruder_nr",
                     "minimum_value_warning": "-1 * machine_nozzle_size",
                     "maximum_value_warning": "10 * machine_nozzle_size",
-                    "enabled": "(support_enable or support_meshes_present) and support_type == 'normal'",
+                    "enabled": "(support_enable or support_meshes_present) and support_structure == 'normal'",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5167,11 +5167,11 @@
                     "unit": "mm",
                     "type": "float",
                     "default_value": 0.8,
-                    "value": "support_line_width + 0.4",
+                    "value": "support_line_width + 0.4 if support_type == 'normal' else 0.0",
                     "limit_to_extruder": "support_infill_extruder_nr",
                     "minimum_value_warning": "-1 * machine_nozzle_size",
                     "maximum_value_warning": "10 * machine_nozzle_size",
-                    "enabled": "support_enable or support_meshes_present",
+                    "enabled": "(support_enable or support_meshes_present) and support_type == 'normal'",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },


### PR DESCRIPTION
Done because there where situations (when support interface was set to 'off' and there is a small spike hanging downwards for example), that the support could go around the model rather than actually supporting it. -- The old (now '1.0'/'classic') tree support had horizontal expansion disabled as well. Since you can set both the tip-diameter, the expansion-rate and several other related settings for tree support 2.0, its disablement shouldn't be a great loss even so.