### PR TITLE
SEM-166 Add extra BOM numbers to UMs3, UMs5 and UMs7

### DIFF
--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -9,7 +9,11 @@
         "manufacturer": "Ultimaker B.V.",
         "file_formats": "application/x-ufp;text/x-gcode",
         "platform": "ultimaker_s3_platform.obj",
-        "bom_numbers": [213482, 213483, 213484],
+        "bom_numbers": [
+            213482,
+            213483,
+            213484
+        ],
         "exclude_materials": [
             "generic_hips",
             "generic_petg",

--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -9,7 +9,7 @@
         "manufacturer": "Ultimaker B.V.",
         "file_formats": "application/x-ufp;text/x-gcode",
         "platform": "ultimaker_s3_platform.obj",
-        "bom_numbers": [213482, 213483],
+        "bom_numbers": [213482, 213483, 213484],
         "exclude_materials": [
             "generic_hips",
             "generic_petg",

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -12,7 +12,8 @@
         "bom_numbers": [
             9051,
             214475,
-            214476
+            214476,
+            214477
         ],
         "firmware_update_info":
         {

--- a/resources/definitions/ultimaker_s7.def.json
+++ b/resources/definitions/ultimaker_s7.def.json
@@ -9,10 +9,7 @@
         "manufacturer": "Ultimaker B.V.",
         "file_formats": "application/x-ufp;text/x-gcode",
         "platform": "ultimaker_s7_platform.obj",
-        "bom_numbers": [
-            5078167,
-            5078168
-        ],
+        "bom_numbers": [5078167, 5078168],
         "firmware_update_info":
         {
             "check_urls": [ "https://software.ultimaker.com/releases/firmware/9051/stable/um-update.swu.version" ],

--- a/resources/definitions/ultimaker_s7.def.json
+++ b/resources/definitions/ultimaker_s7.def.json
@@ -10,7 +10,8 @@
         "file_formats": "application/x-ufp;text/x-gcode",
         "platform": "ultimaker_s7_platform.obj",
         "bom_numbers": [
-            5078167
+            5078167,
+            5078168
         ],
         "firmware_update_info":
         {


### PR DESCRIPTION
# Description
Adds new BoM numbers for the UMs3, UMs5 and UMs7 so that Cura can recognize these via local connection.

## Type of change
- [ ] Printer definition file(s)

# How Has This Been Tested?

- [ ] Not yet tested with Cura

# Checklist:
- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change