### PR TITLE
Despite the name, 'Max' Fan Speed should be able to go below min

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4314,7 +4314,7 @@
                             "description": "The speed at which the fans spin on the minimum layer time. The fan speed gradually increases between the regular fan speed and maximum fan speed when the threshold is hit.",
                             "unit": "%",
                             "type": "float",
-                            "minimum_value": "max(0, cool_fan_speed_min)",
+                            "minimum_value": "0",
                             "maximum_value": "100",
                             "default_value": 100,
                             "enabled": "cool_fan_enabled",


### PR DESCRIPTION
This is because the maximum fan speed is really just the fan speed for layers at or below a certain layer time threshold. Interpolation-logic in the backend (engine) still holds up, even if the values are 'switched' in the sense that the supposed 'max' is lower than the 'min'.

Change was needed since some UM materials had a Maximum Fan Speed set to 15, even though the normal speed and the Minimum Fan Speed are set to 50 in the machine. Despite the confusing naming, from context this seems intentional.

Will hopefully fix #15233