### PR TITLE
Update FilamentChange.py

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/FilamentChange.py
+++ b/plugins/PostProcessingPlugin/scripts/FilamentChange.py
@@ -199,7 +199,7 @@ class FilamentChange(Script):
         if enable_before_macro:
             color_change = color_change + before_macro + "\n"
 
-        color_change = color_change + "M600\n"
+        color_change = color_change + "M600"
 
         if not firmware_config:
             if initial_retract is not None and initial_retract > 0.:
@@ -220,6 +220,8 @@ class FilamentChange(Script):
             if z_pos is not None and z_pos > 0.:
                 color_change = color_change + (" Z%.2f" % z_pos)
 
+        color_change = color_change + "\n"
+                
         if enable_after_macro:
             color_change = color_change + after_macro + "\n"
 


### PR DESCRIPTION
# Description

A trailing \n behind M500 will put the optional parameters E/U/L/X/Y/Z on a separate new line. That makes them to a new unknown command rather then parameters.

To reproduce, slice with post processing script Filament Change and Use Firmware Configuration deactivated. Then print. 

On my Klipper, when the filament got changed there is warning in the console: Unknown command:"E30.00". And the parameters don't have any effect.

Fix: The newline is now placed behind the optional parameters

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Sliced with the same settings as above and printed again.

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change