### PR TITLE
Faster bottom interface speed

### DIFF
--- a/resources/variants/ultimaker3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_bb0.8.inst.cfg
@@ -39,7 +39,6 @@ skin_overlap = 5
 speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 speed_print = 35
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_angle = 60

--- a/resources/variants/ultimaker3_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_bb04.inst.cfg
@@ -19,7 +19,6 @@ machine_nozzle_tip_outer_diameter = 1.0
 retraction_min_travel = =3 * line_width
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2

--- a/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb0.8.inst.cfg
@@ -39,7 +39,6 @@ skin_overlap = 5
 speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 speed_print = 35
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_angle = 60

--- a/resources/variants/ultimaker3_extended_bb04.inst.cfg
+++ b/resources/variants/ultimaker3_extended_bb04.inst.cfg
@@ -19,7 +19,6 @@ machine_nozzle_tip_outer_diameter = 1.0
 retraction_min_travel = =3 * line_width
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2

--- a/resources/variants/ultimaker_s3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb0.8.inst.cfg
@@ -37,7 +37,6 @@ skin_overlap = 5
 speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 speed_print = 35
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_angle = 60

--- a/resources/variants/ultimaker_s3_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb04.inst.cfg
@@ -19,7 +19,6 @@ machine_nozzle_tip_outer_diameter = 1.0
 retraction_min_travel = =3 * line_width
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2

--- a/resources/variants/ultimaker_s5_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb0.8.inst.cfg
@@ -37,7 +37,6 @@ skin_overlap = 5
 speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 speed_print = 35
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_angle = 60

--- a/resources/variants/ultimaker_s5_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb04.inst.cfg
@@ -19,7 +19,6 @@ machine_nozzle_tip_outer_diameter = 1.0
 retraction_min_travel = =3 * line_width
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2

--- a/resources/variants/ultimaker_s7_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s7_bb0.8.inst.cfg
@@ -38,7 +38,6 @@ skin_overlap = 5
 speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 speed_print = 35
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_angle = 60

--- a/resources/variants/ultimaker_s7_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s7_bb04.inst.cfg
@@ -20,7 +20,6 @@ retraction_amount = 4.5
 retraction_min_travel = =3 * line_width
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)
-speed_support_bottom = =math.ceil(speed_support_interface * 10 / 20)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)
 speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
 support_bottom_height = =layer_height * 2


### PR DESCRIPTION
Removed the reduced print speed for the bottom interface layers of the BB cores (effectively for PVA).

Relates to PP-328

# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change