### PR TITLE
Pro430 extra generic profiles

### DIFF
--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.05.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.05
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.05.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.05
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = 1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.1.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.1
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = 1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.1.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.1
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.15.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Medium-Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.15
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = 1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.2_pla_h0.15.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.15
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.1.inst.cfg
@@ -1,0 +1,31 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.1
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = 1
+
+[values]
+acceleration_infill = 2500
+acceleration_roofing = 1200
+acceleration_topbottom = 1200
+acceleration_wall_0 = 650.0
+acceleration_wall_x = 1200
+material_print_temperature = =default_material_print_temperature + 30
+retraction_amount = 3.0
+retraction_speed = 40
+speed_print = 50.0
+speed_roofing = 45.0
+speed_topbottom = 45.0
+speed_wall_0 = 35.0
+speed_wall_x = 45.0
+support_interface_enable = False
+support_top_distance = 0.2
+support_z_distance = 0.2
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.1.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.1
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.2.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.2
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = 0
+
+[values]
+acceleration_infill = 3000
+acceleration_roofing = 1600
+acceleration_topbottom = 1500
+acceleration_wall_0 = 850
+acceleration_wall_x = 1600
+material_print_temperature = =default_material_print_temperature + 33
+retraction_amount = 5.0
+retraction_speed = 40.0
+speed_print = 70
+speed_wall_0 = 50
+speed_wall_x = 60
+support_top_distance = 0.1
+support_z_distance = 0.1
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.2.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.2
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = 0
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.3.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.3.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.3
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.3.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.4_pla_h0.3.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.3
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.6_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.6_pla_h0.2.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.2
+setting_version = 22
+type = quality
+variant = Generic 0.6mm
+weight = -1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.6_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.6_pla_h0.2.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.2
 setting_version = 22
 type = quality
-variant = Generic 0.6mm
+variant = Serie 0.6mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.6_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.6_pla_h0.4.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 0.6mm
+weight = -1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.6_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.6_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 0.6mm
+variant = Serie 0.6mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.8_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.8_pla_h0.4.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 0.8mm
+weight = -1
+
+[values]
+gradual_infill_step_height = 2
+gradual_infill_steps = 2
+infill_sparse_density = 20
+material_print_temperature = =default_material_print_temperature + 10
+retraction_amount = 3.5
+retraction_speed = 45
+top_layers = 4
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.8_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.8_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 0.8mm
+variant = Serie 0.8mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.8_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.8_pla_h0.6.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 0.8mm
+weight = 1
+
+[values]
+bottom_layers = 2
+infill_overlap = 5
+infill_sparse_density = 7
+material_flow = 100
+material_flow_layer_0 = 120
+material_print_temperature = =default_material_print_temperature + 60
+skin_overlap = 10
+speed_wall_x = 25
+top_layers = 3
+wall_line_count = 2
+z_seam_corner = z_seam_corner_none
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.8_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_0.8_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 0.8mm
+variant = Serie 0.8mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.4.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = -1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.6.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.8.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.8
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.0_pla_h0.8.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Coarse
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.8
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.2_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.2_pla_h0.6.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 1.2mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.2_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.2_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 1.2mm
+variant = Serie 1.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.2_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.2_pla_h0.8.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Coarse
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.8
+setting_version = 22
+type = quality
+variant = Generic 1.2mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.2_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_generic_1.2_pla_h0.8.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.8
 setting_version = 22
 type = quality
-variant = Generic 1.2mm
+variant = Serie 1.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_global_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_global_h0.05.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Extra Fine
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.05
+setting_version = 22
+type = quality
+weight = 1
+
+[values]
+layer_height = 0.05
+

--- a/resources/quality/dagoma/dagoma_pro_430_bowden_global_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_bowden_global_h0.15.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Medium-Fine
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.15
+setting_version = 22
+type = quality
+weight = 1
+
+[values]
+layer_height = 0.15
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.05.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.05
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.05.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.05
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.1.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.1
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.1.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.1
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.15.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Medium-Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.15
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.2_pla_h0.15.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.15
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.1.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.1
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.1.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.1
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.2.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.2
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = 0
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.2.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.2
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = 0
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.3.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.3.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.3
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.3.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.4_pla_h0.3.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.3
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.6_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.6_pla_h0.2.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.2
+setting_version = 22
+type = quality
+variant = Generic 0.6mm
+weight = 1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.6_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.6_pla_h0.2.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.2
 setting_version = 22
 type = quality
-variant = Generic 0.6mm
+variant = Serie 0.6mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.6_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.6_pla_h0.4.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 0.6mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.6_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.6_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 0.6mm
+variant = Serie 0.6mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.8_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.8_pla_h0.4.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 0.8mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.8_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.8_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 0.8mm
+variant = Serie 0.8mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.8_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.8_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 0.8mm
+variant = Serie 0.8mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.8_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_0.8_pla_h0.6.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 0.8mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.4.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.6.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.8.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Coarse
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.8
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = 0
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.0_pla_h0.8.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.8
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = 0
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.2_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.2_pla_h0.6.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 1.2mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.2_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.2_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 1.2mm
+variant = Serie 1.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.2_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.2_pla_h0.8.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.8
 setting_version = 22
 type = quality
-variant = Generic 1.2mm
+variant = Serie 1.2mm
 weight = 0
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.2_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_generic_1.2_pla_h0.8.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Coarse
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.8
+setting_version = 22
+type = quality
+variant = Generic 1.2mm
+weight = 0
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_global_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_global_h0.05.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Extra Fine
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.05
+setting_version = 22
+type = quality
+weight = 1
+
+[values]
+layer_height = 0.05
+

--- a/resources/quality/dagoma/dagoma_pro_430_directdrive_global_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_directdrive_global_h0.15.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Medium-Fine
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.15
+setting_version = 22
+type = quality
+weight = 1
+
+[values]
+layer_height = 0.15
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.05.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.05
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.05.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.05
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = 1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.1.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.1
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = 1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.1.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.1
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.15.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Medium-Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.15
+setting_version = 22
+type = quality
+variant = Generic 0.2mm
+weight = 1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.2_pla_h0.15.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.15
 setting_version = 22
 type = quality
-variant = Generic 0.2mm
+variant = Serie 0.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.1.inst.cfg
@@ -1,0 +1,31 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.1
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = 1
+
+[values]
+acceleration_infill = 2500
+acceleration_roofing = 1200
+acceleration_topbottom = 1200
+acceleration_wall_0 = 650.0
+acceleration_wall_x = 1200
+material_print_temperature = =default_material_print_temperature + 30
+retraction_amount = 3.0
+retraction_speed = 40
+speed_print = 50.0
+speed_roofing = 45.0
+speed_topbottom = 45.0
+speed_wall_0 = 35.0
+speed_wall_x = 45.0
+support_interface_enable = False
+support_top_distance = 0.2
+support_z_distance = 0.2
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.1.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.1
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.2.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.2
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = 0
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.2.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.2
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = 0
+
+[values]
+acceleration_infill = 3000
+acceleration_roofing = 1600
+acceleration_topbottom = 1500
+acceleration_wall_0 = 850
+acceleration_wall_x = 1600
+material_print_temperature = =default_material_print_temperature + 33
+retraction_amount = 5.0
+retraction_speed = 40.0
+speed_print = 70
+speed_wall_0 = 50
+speed_wall_x = 60
+support_top_distance = 0.1
+support_z_distance = 0.1
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.3.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.3.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.3
+setting_version = 22
+type = quality
+variant = Generic 0.4mm
+weight = -1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.3.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.4_pla_h0.3.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.3
 setting_version = 22
 type = quality
-variant = Generic 0.4mm
+variant = Serie 0.4mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.6_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.6_pla_h0.2.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.2
 setting_version = 22
 type = quality
-variant = Generic 0.6mm
+variant = Serie 0.6mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.6_pla_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.6_pla_h0.2.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.2
+setting_version = 22
+type = quality
+variant = Generic 0.6mm
+weight = -1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.6_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.6_pla_h0.4.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 0.6mm
+weight = -1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.6_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.6_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 0.6mm
+variant = Serie 0.6mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.8_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.8_pla_h0.4.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 0.8mm
+weight = -1
+
+[values]
+gradual_infill_step_height = 2
+gradual_infill_steps = 2
+infill_sparse_density = 20
+material_print_temperature = =default_material_print_temperature + 10
+retraction_amount = 3.5
+retraction_speed = 45
+top_layers = 4
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.8_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.8_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 0.8mm
+variant = Serie 0.8mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.8_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.8_pla_h0.6.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 0.8mm
+weight = 1
+
+[values]
+bottom_layers = 2
+infill_overlap = 5
+infill_sparse_density = 7
+material_flow = 100
+material_flow_layer_0 = 120
+material_print_temperature = =default_material_print_temperature + 60
+skin_overlap = 10
+speed_wall_x = 25
+top_layers = 3
+wall_line_count = 2
+z_seam_corner = z_seam_corner_none
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.8_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_0.8_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 0.8mm
+variant = Serie 0.8mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.4.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.4
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = -1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.4.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Very Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = -1
+
+[values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.6.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.8.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.8
 setting_version = 22
 type = quality
-variant = Generic 1.0mm
+variant = Serie 1.0mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.0_pla_h0.8.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Coarse
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.8
+setting_version = 22
+type = quality
+variant = Generic 1.0mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.2_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.2_pla_h0.6.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Draft
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+variant = Generic 1.2mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.2_pla_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.2_pla_h0.6.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.6
 setting_version = 22
 type = quality
-variant = Generic 1.2mm
+variant = Serie 1.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.2_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.2_pla_h0.8.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Coarse
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = h0.8
+setting_version = 22
+type = quality
+variant = Generic 1.2mm
+weight = 1
+
+[values]
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.2_pla_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_generic_1.2_pla_h0.8.inst.cfg
@@ -8,7 +8,7 @@ material = generic_pla
 quality_type = h0.8
 setting_version = 22
 type = quality
-variant = Generic 1.2mm
+variant = Serie 1.2mm
 weight = 1
 
 [values]

--- a/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.05.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.05.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Extra Fine
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.05
+setting_version = 22
+type = quality
+weight = 1
+
+[values]
+layer_height = 0.05
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.1.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.1.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Fine
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.1
+setting_version = 22
+type = quality
+weight = 1
+
+[values]
+layer_height = 0.1
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.15.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.15.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Medium-Fine
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.15
+setting_version = 22
+type = quality
+weight = 1
+
+[values]
+layer_height = 0.15
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.2.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.2.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Normal
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.2
+setting_version = 22
+type = quality
+weight = 0
+
+[values]
+layer_height = 0.2
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.3.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.3.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Fast
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.3
+setting_version = 22
+type = quality
+weight = -1
+
+[values]
+layer_height = 0.3
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.4.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.4.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Very Fast
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.4
+setting_version = 22
+type = quality
+weight = -2
+
+[values]
+layer_height = 0.4
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.6.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.6.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Draft
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.6
+setting_version = 22
+type = quality
+weight = -3
+
+[values]
+layer_height = 0.6
+

--- a/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.8.inst.cfg
+++ b/resources/quality/dagoma/dagoma_pro_430_dual_global_h0.8.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Coarse
+version = 4
+
+[metadata]
+global_quality = True
+material = generic_pla
+quality_type = h0.8
+setting_version = 22
+type = quality
+weight = -4
+
+[values]
+layer_height = 0.8
+

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.2.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Generic 0.2mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.2mm
+machine_nozzle_size = 0.2

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.2.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_bowden
-name = Generic 0.2mm
+name = Serie 0.2mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.2mm
+machine_nozzle_id = Serie 0.2mm
 machine_nozzle_size = 0.2

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.4.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.4.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_bowden
-name = Generic 0.4mm
+name = Serie 0.4mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.4mm
+machine_nozzle_id = Serie 0.4mm
 machine_nozzle_size = 0.4

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.4.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.4.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Generic 0.4mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.4mm
+machine_nozzle_size = 0.4

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.6.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.6.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Generic 0.6mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.6mm
+machine_nozzle_size = 0.6

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.6.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.6.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_bowden
-name = Generic 0.6mm
+name = Serie 0.6mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.6mm
+machine_nozzle_id = Serie 0.6mm
 machine_nozzle_size = 0.6

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.8.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.8.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Generic 0.8mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.8mm
+machine_nozzle_size = 0.8

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.8.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_bowden
-name = Generic 0.8mm
+name = Serie 0.8mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.8mm
+machine_nozzle_id = Serie 0.8mm
 machine_nozzle_size = 0.8

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_1.0.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_1.0.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Generic 1.0mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 1.0mm
+machine_nozzle_size = 1.0

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_1.0.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_1.0.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_bowden
-name = Generic 1.0mm
+name = Serie 1.0mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 1.0mm
+machine_nozzle_id = Serie 1.0mm
 machine_nozzle_size = 1.0

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_1.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_1.2.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_bowden
+name = Generic 1.2mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 1.2mm
+machine_nozzle_size = 1.2

--- a/resources/variants/dagoma/dagoma_pro_430_bowden_generic_1.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_bowden_generic_1.2.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_bowden
-name = Generic 1.2mm
+name = Serie 1.2mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 1.2mm
+machine_nozzle_id = Serie 1.2mm
 machine_nozzle_size = 1.2

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.2.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_directdrive
-name = Generic 0.2mm
+name = Serie 0.2mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.2mm
+machine_nozzle_id = Serie 0.2mm
 machine_nozzle_size = 0.2

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.2.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Generic 0.2mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.2mm
+machine_nozzle_size = 0.2

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.4.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.4.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Generic 0.4mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.4mm
+machine_nozzle_size = 0.4

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.4.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.4.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_directdrive
-name = Generic 0.4mm
+name = Serie 0.4mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.4mm
+machine_nozzle_id = Serie 0.4mm
 machine_nozzle_size = 0.4

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.6.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.6.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_directdrive
-name = Generic 0.6mm
+name = Serie 0.6mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.6mm
+machine_nozzle_id = Serie 0.6mm
 machine_nozzle_size = 0.6

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.6.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.6.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Generic 0.6mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.6mm
+machine_nozzle_size = 0.6

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.8.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.8.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Generic 0.8mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.8mm
+machine_nozzle_size = 0.8

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.8.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_directdrive
-name = Generic 0.8mm
+name = Serie 0.8mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.8mm
+machine_nozzle_id = Serie 0.8mm
 machine_nozzle_size = 0.8

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_1.0.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_1.0.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Generic 1.0mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 1.0mm
+machine_nozzle_size = 1.0

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_1.0.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_1.0.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_directdrive
-name = Generic 1.0mm
+name = Serie 1.0mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 1.0mm
+machine_nozzle_id = Serie 1.0mm
 machine_nozzle_size = 1.0

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_1.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_1.2.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_directdrive
+name = Generic 1.2mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 1.2mm
+machine_nozzle_size = 1.2

--- a/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_1.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_directdrive_generic_1.2.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_directdrive
-name = Generic 1.2mm
+name = Serie 1.2mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 1.2mm
+machine_nozzle_id = Serie 1.2mm
 machine_nozzle_size = 1.2

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.2.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Generic 0.2mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.2mm
+machine_nozzle_size = 0.2

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.2.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_dual
-name = Generic 0.2mm
+name = Serie 0.2mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.2mm
+machine_nozzle_id = Serie 0.2mm
 machine_nozzle_size = 0.2

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.4.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.4.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_dual
-name = Generic 0.4mm
+name = Serie 0.4mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.4mm
+machine_nozzle_id = Serie 0.4mm
 machine_nozzle_size = 0.4

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.4.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.4.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Generic 0.4mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.4mm
+machine_nozzle_size = 0.4

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.6.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.6.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Generic 0.6mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.6mm
+machine_nozzle_size = 0.6

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.6.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.6.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_dual
-name = Generic 0.6mm
+name = Serie 0.6mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.6mm
+machine_nozzle_id = Serie 0.6mm
 machine_nozzle_size = 0.6

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.8.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.8.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Generic 0.8mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 0.8mm
+machine_nozzle_size = 0.8

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.8.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_0.8.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_dual
-name = Generic 0.8mm
+name = Serie 0.8mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 0.8mm
+machine_nozzle_id = Serie 0.8mm
 machine_nozzle_size = 0.8

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_1.0.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_1.0.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Generic 1.0mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 1.0mm
+machine_nozzle_size = 1.0

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_1.0.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_1.0.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_dual
-name = Generic 1.0mm
+name = Serie 1.0mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 1.0mm
+machine_nozzle_id = Serie 1.0mm
 machine_nozzle_size = 1.0

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_1.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_1.2.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = dagoma_pro_430_dual
-name = Generic 1.2mm
+name = Serie 1.2mm
 version = 4
 
 [metadata]
@@ -9,5 +9,5 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Generic 1.2mm
+machine_nozzle_id = Serie 1.2mm
 machine_nozzle_size = 1.2

--- a/resources/variants/dagoma/dagoma_pro_430_dual_generic_1.2.inst.cfg
+++ b/resources/variants/dagoma/dagoma_pro_430_dual_generic_1.2.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = dagoma_pro_430_dual
+name = Generic 1.2mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_id = Generic 1.2mm
+machine_nozzle_size = 1.2


### PR DESCRIPTION
# Description

This PR just adds some generic profiles for various nozzle types for Dagoma Pro430 printer.
They will be used as a base in particular printer configurations.

## Type of change

- [x] Printer/profile definition file(s)

# How Has This Been Tested?

It has been tested internally by collaborators.

**Test Configuration**:
* Operating Systems: Windows 11, MacOS 13, Xubuntu 22.04