### PR TITLE
Added Kobra Plus printer profile

### DIFF
--- a/resources/definitions/anycubic_kobra_plus.def.json
+++ b/resources/definitions/anycubic_kobra_plus.def.json
@@ -1,0 +1,30 @@
+{
+    "version": 2,
+    "name": "Anycubic Kobra Plus",
+    "inherits": "fdmprinter",
+    "metadata":
+    {
+        "visible": true,
+        "author": "Jordon Brooks",
+        "manufacturer": "Anycubic",
+        "file_formats": "text/x-gcode",
+        "has_machine_quality": true,
+        "has_materials": true,
+        "machine_extruder_trains": { "0": "anycubic_kobra_plus_extruder_0" },
+        "preferred_material": "generic_pla",
+        "preferred_quality_type": "pla",
+        "quality_definition": "anycubic_kobra_plus"
+    },
+    "overrides":
+    {
+        "machine_depth": { "default_value": 302 },
+        "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
+        "machine_heated_bed": { "default_value": true },
+        "machine_height": { "default_value": 352 },
+        "machine_name": { "default_value": "Anycubic Kobra Plus" },
+        "machine_start_gcode": { "default_value": "G28 ;Home\nG1 Z15.0 F6000 ;Move the platform down 15mm\n;Prime the extruder\nG92 E0\nM355 S1; Turn LED on\n; Add Custom purge lines\nG1 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\nG1 X1.0 Y30 Z0.3 F5000.0 ; Move to start position\nG1 X1.0 Y100.0 Z0.3 F1500.0 E15 ; Draw the first line\nG1 X1.3 Y100.0 Z0.3 F5000.0 ; Move to side a little\nG1 X1.3 Y30 Z0.3 F1500.0 E30 ; Draw the second line\nG92 E0 ; Reset Extruder\nG1 E-2 F500 ; Retract a little \nG1 X50 F500 ; wipe away from the filament line\nG1 X100 F9000 ; Quickly wipe away from the filament line\nG1 Z5.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed\n; End custom purge lines" },
+        "machine_end_gcode": { "default_value": "M104 S0\nM140 S0\n;Retract the filament\nG92 E1\nG1 E-1 F300\nG28 X0 Y0\nM84\nM355 S0; led off" },
+        "machine_width": { "default_value": 302 }
+    }
+}
+

--- a/resources/extruders/anycubic_kobra_plus_extruder_0.def.json
+++ b/resources/extruders/anycubic_kobra_plus_extruder_0.def.json
@@ -1,0 +1,16 @@
+{
+    "version": 2,
+    "name": "Extruder 1",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "anycubic_kobra_plus",
+        "position": "0"
+    },
+    "overrides":
+    {
+        "extruder_nr": { "default_value": 0 },
+        "machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 }
+    }
+}

--- a/resources/quality/anycubic_kobra_plus/anycubic_kobra_plus_pla.inst.cfg
+++ b/resources/quality/anycubic_kobra_plus/anycubic_kobra_plus_pla.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = anycubic_kobra_plus
+name = Normal
+version = 4
+
+[metadata]
+global_quality = True
+quality_type = pla
+setting_version = 21
+type = quality
+weight = 0
+
+[values]
+layer_height = 0.2
+layer_height_0 = 0.2
+infill_pattern = cubic
+retraction_hop = 0.1
+retraction_combing = off
+retraction_hop_enabled = True
+retraction_hop_only_when_collides = True
+speed_print = 80
+speed_infill = 40
+speed_wall_x = 60
+speed_layer_0 = 20
+wall_thickness = 1.2
+material_print_temperature = 195
+material_final_print_temperature = 195


### PR DESCRIPTION
# Description

This pull request adds a profile for the Anycubic Kobra Plus. I used the Anycubic Kobra Max profile as a base and modified the area along with some specific tweaks I found to give me better prints.

The start gcode also Includes a nozzle wipe and turns on the LED and when finished also turns it off. The nozzle wipe is based on the Anycubic Mega S profile but more or less flipped vertically as it got caught on the hotbed clips.

The profile also does NOT include the M420 S1 gcode command as I have found out it's enabled by default and homing doesn't turn it off (tested with octoprint terminal).

# How Has This Been Tested?

I tested this profile with various prints and managed to print 2 benchys at 0.2 and 0.1 along with a Groot model and a bunch of cosplay models all successfully.

Note: This has only been tested on 1 Anycubic Kobra Plus.

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change