### PR TITLE
Simply support 3MF Production Extension.

### DIFF
--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -207,6 +207,11 @@ class ThreeMFReader(MeshReader):
             archive = zipfile.ZipFile(file_name, "r")
             self._base_name = os.path.basename(file_name)
             parser = Savitar.ThreeMFParser()
+            for name in archive.namelist():
+                if (name.startswith("3D/") and name.endswith(".model") and name != "3D/3dmodel.model"):
+                    Logger.log("i", "Parse 3mf sub model " + name)
+                    substr = archive.open(name).read()
+                    parser.parse(b"/" + bytes(name, "utf-8") + b":" + substr)
             scene_3mf = parser.parse(archive.open("3D/3dmodel.model").read())
             self._unit = scene_3mf.getUnit()
 


### PR DESCRIPTION
# Description

This patch adds simple support for [3MF Production Extension]https://github.com/3MFConsortium/spec_production/blob/master/3MF%20Production%20Extension.md).
This patch needs another patch in [libSavitar](https://github.com/Ultimaker/libSavitar/pull/48). 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Test A
Load old normal 3mf model.
- Test B
Load 3mf model with 'Production Extension'.
https://github.com/3MFConsortium/test_suites/tree/master/suite5_core_prod/positive_test_cases.

# Checklist:
- My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- I have commented my code, particularly in hard-to-understand areas
- I have uploaded any files required to test this change