### PR TITLE
Update RetractContinue.py

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/RetractContinue.py
+++ b/plugins/PostProcessingPlugin/scripts/RetractContinue.py
@@ -121,6 +121,4 @@ class RetractContinue(Script):
 
             new_layer = "\n".join(lines)
             data[layer_number] = new_layer
-        # Add post processor name to the gcode---------------------------------------------------------
-        data[0] += ";  Retract Continue (ratio: " + str(extra_retraction_speed) + ")\n"
         return data


### PR DESCRIPTION
# Description
Remove a bug that allowed Zhops to short circuit retract continue. Limited the significant digits so Feedrate is an integer, X is 3 decimal places, Y is 3 and Z is 2 decimal places.
This fixes... OR This improves... -->

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ X] Test A 4.x and 5.x

**Test Configuration**:
* Operating System: Win10 Home and Marlin

# Checklist:
<!-- Check if relevant -->

- [X ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have uploaded any files required to test this change