### PR TITLE
Increase Boxes for Printjob Information

### DIFF
--- a/resources/qml/ActionPanel/PrintJobInformation.qml
+++ b/resources/qml/ActionPanel/PrintJobInformation.qml
@@ -117,7 +117,7 @@ Column
             property var printMaterialWeights: PrintInformation.materialWeights
             property var printMaterialCosts: PrintInformation.materialCosts
             property var printMaterialNames: PrintInformation.materialNames
-            property var columnWidthMultipliers: [ 0.46, 0.18, 0.18, 0.18 ]
+            property var columnWidthMultipliers: [ 0.26, 0.28, 0.18, 0.28 ]
             property var columnHorizontalAligns: [ Text.AlignLeft, Text.AlignHCenter, Text.AlignHCenter, Text.AlignRight ]
 
             function getMaterialTable()


### PR DESCRIPTION
# Description

@Diegovd addressed in https://github.com/Ultimaker/Cura/issues/12270 that the currency in the Material Estimation Box is too small to reflect all the currencies. This is the proposed improvement. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested a number of currencies to see if they fit
![image](https://github.com/Ultimaker/Cura/assets/40423138/076a675a-45dd-4e29-a584-bd263d203dcc)
![image](https://github.com/Ultimaker/Cura/assets/40423138/11e16267-3be2-4dc5-be36-329d3d8d19e1)
![image](https://github.com/Ultimaker/Cura/assets/40423138/32adfb28-fa3b-4312-af5c-ff23bb46217e)


**Test Configuration**:
Operating System:
Windows 11
Cura 5.4