### PR TITLE
add tina2 support

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -1,0 +1,3 @@
+Copy contents to:
+- C:\Program Files\UltiMaker Cura 5.3.1\share\cura\resources\definitions
+- C:\Program Files\UltiMaker Cura 5.3.1\share\cura\resources\extruders

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,3 +1,0 @@
-Copy contents to:
-- C:\Program Files\UltiMaker Cura 5.3.1\share\cura\resources\definitions
-- C:\Program Files\UltiMaker Cura 5.3.1\share\cura\resources\extruders

--- a/resources/definitions/entina_tina2.def.json
+++ b/resources/definitions/entina_tina2.def.json
@@ -1,11 +1,11 @@
 {
-    "name": "WEEFUN TINA2",
+    "name": "ENTINA TINA2",
     "version": 2,
     "inherits": "weedo_base",
     "metadata": {
         "visible": true,
-        "author": "WEEFUN",
-        "manufacturer": "WEEFUN",
+        "author": "ENTINA",
+        "manufacturer": "ENTINA",
         "file_formats": "text/x-gcode",
         "platform_offset": [
             0,
@@ -173,7 +173,7 @@
     },
     "overrides": {
         "machine_name": {
-            "default_value": "WEEFUN TINA2"
+            "default_value": "ENTINA TINA2"
         },
         "machine_start_gcode": {
             "default_value": ";MachineType:{machine_name}\n;FilamentType:{material_type}\n;InfillDensity:{infill_sparse_density}\n;Extruder0Temperature:{material_print_temperature}\n\n;(**** start.gcode for tina2****)\nM203 Z15\nM104 S150\nG28 Z\nG28 X Y; Home extruder\nG1 X55 Y55 F1000\nG29\nM107 ; Turn off fan\nG90 ; Absolute positioning\nM82 ; Extruder in absolute mode\nM109 S{material_print_temperature_layer_0}\nG92 E0 ; Reset extruder position\nG1 X90 Y6 Z0.27 F2000\nG1 X20 Y6 Z0.27 E15 F1000\nG92 E0 ; Reset extruder position\nM203 Z5"

--- a/resources/definitions/entina_tina2s.def.json
+++ b/resources/definitions/entina_tina2s.def.json
@@ -1,11 +1,11 @@
 {
-    "name": "WEEFUN TINA2",
+    "name": "ENTINA TINA2S",
     "version": 2,
     "inherits": "weedo_base",
     "metadata": {
         "visible": true,
-        "author": "WEEFUN",
-        "manufacturer": "WEEFUN",
+        "author": "ENTINA",
+        "manufacturer": "ENTINA",
         "file_formats": "text/x-gcode",
         "platform_offset": [
             0,
@@ -23,9 +23,7 @@
             "leapfrog_pva_natural",
             "generic_abs_175",
             "generic_asa_175",
-            "generic_bvoh_175",
             "generic_cpe_175",
-            "generic_hips_175",
             "generic_nylon_175",
             "generic_pc_175",
             "generic_petg_175",
@@ -173,10 +171,10 @@
     },
     "overrides": {
         "machine_name": {
-            "default_value": "WEEFUN TINA2"
+            "default_value": "ENTINA TINA2S"
         },
         "machine_start_gcode": {
-            "default_value": ";MachineType:{machine_name}\n;FilamentType:{material_type}\n;InfillDensity:{infill_sparse_density}\n;Extruder0Temperature:{material_print_temperature}\n\n;(**** start.gcode for tina2****)\nM203 Z15\nM104 S150\nG28 Z\nG28 X Y; Home extruder\nG1 X55 Y55 F1000\nG29\nM107 ; Turn off fan\nG90 ; Absolute positioning\nM82 ; Extruder in absolute mode\nM109 S{material_print_temperature_layer_0}\nG92 E0 ; Reset extruder position\nG1 X90 Y6 Z0.27 F2000\nG1 X20 Y6 Z0.27 E15 F1000\nG92 E0 ; Reset extruder position\nM203 Z5"
+            "default_value": ";MachineType:{machine_name}\n;FilamentType:{material_type}\n;InfillDensity:{infill_sparse_density}\n;Extruder0Temperature:{material_print_temperature}\n;BedTemperature:{material_bed_temperature}\n\n;(**** start.gcode for tina2****)\nM203 Z15\nM104 S150\nG28 Z\nG28 X Y; Home extruder\nG1 X55 Y55 F1000\nG29\nM107 ; Turn off fan\nG90 ; Absolute positioning\nM82 ; Extruder in absolute mode\nM109 S{material_print_temperature_layer_0}\nG92 E0 ; Reset extruder position\nG1 X90 Y6 Z0.27 F2000\nG1 X20 Y6 Z0.27 E15 F1000\nG92 E0 ; Reset extruder position\nM203 Z5"
         },
         "machine_end_gcode": {
             "default_value": ";(**** end.gcode for tina2****)\nM203 Z15\nM104 S0\nM107\nG92 E0 (Reset after prime)\nG0 E-1 F300\nG28 Z F300\nG28 X0 Y0\nG1 Y90 F1000"
@@ -185,16 +183,14 @@
             "default_value": 100
         },
         "machine_depth": {
-            "default_value": 120
+            "default_value": 110
         },
         "machine_height": {
             "default_value": 100
         },
-        "machine_heated_bed": {
-            "default_value": false
-        },
-        "infill_pattern": {
-            "value": "'lines' if infill_sparse_density > 45 else 'grid'"
+        "material_bed_temperature": {
+            "maximum_value_warning": "60",
+            "maximum_value": "65"
         },
         "speed_print": {
             "value": 40.0

--- a/resources/definitions/weedo_base.def.json
+++ b/resources/definitions/weedo_base.def.json
@@ -179,9 +179,6 @@
         "material_diameter": {
             "default_value": 1.75
         },
-        "machine_id": {
-            "default_value": 1
-        },
         "material_bed_temp_wait": {
             "default_value": false
         },
@@ -203,20 +200,16 @@
         "machine_min_cool_heat_time_window": {
             "default_value": 1200.0
         },
-        "machine_steps_per_mm_x":
-        {
+        "machine_steps_per_mm_x": {
             "default_value": 94
         },
-        "machine_steps_per_mm_y":
-        {
+        "machine_steps_per_mm_y": {
             "default_value": 94
         },
-        "machine_steps_per_mm_z":
-        {
+        "machine_steps_per_mm_z": {
             "default_value": 400
         },
-        "machine_steps_per_mm_e":
-        {
+        "machine_steps_per_mm_e": {
             "default_value": 96
         },
         "machine_max_feedrate_x": {

--- a/resources/definitions/weedo_base.def.json
+++ b/resources/definitions/weedo_base.def.json
@@ -2,94 +2,450 @@
     "version": 2,
     "name": "WEEDO Base",
     "inherits": "fdmprinter",
-    "metadata":
-    {
-        "visible": false,
+    "metadata": {
         "author": "WEEDO",
         "manufacturer": "WEEDO",
+        "visible": false,
         "file_formats": "text/x-gcode",
-        "exclude_materials": [
-            "Extrudr_GreenTECPro_Anthracite",
-            "Extrudr_GreenTECPro_Black",
-            "Extrudr_GreenTECPro_Blue",
-            "Extrudr_GreenTECPro_Nature",
-            "Extrudr_GreenTECPro_Red",
-            "Extrudr_GreenTECPro_Silver",
-            "Extrudr_GreenTECPro_White",
-            "verbatim_bvoh",
-            "dsm_arnitel2045",
-            "dsm_novamid1070",
-            "imade3d_petg",
-            "imade3d_pla",
-            "innofill_innoflex60"
-        ],
-        "has_machine_quality": false,
+        "machine_extruder_trains": {
+            "0": "weedo_base_extruder_0"
+        },
         "has_materials": true,
         "has_variants": false,
-        "machine_extruder_trains": { "0": "weedo_base_extruder_0" },
+        "has_machine_quality": false,
+        "preferred_quality_type": "draft",
         "preferred_material": "generic_pla_175",
-        "preferred_quality_type": "draft"
+        "exclude_materials": [
+            "3D-Fuel_PLA_PRO_Black",
+            "3D-Fuel_PLA_SnapSupport",
+            "bestfilament_abs_skyblue",
+            "bestfilament_petg_orange",
+            "bestfilament_pla_green",
+            "leapfrog_abs_natural",
+            "leapfrog_epla_natural",
+            "leapfrog_pva_natural",
+            "generic_pc_175",
+            "goofoo_abs",
+            "goofoo_asa",
+            "goofoo_bronze_pla",
+            "goofoo_emarble_pla",
+            "goofoo_esilk_pla",
+            "goofoo_hips",
+            "goofoo_pa_cf",
+            "goofoo_pa",
+            "goofoo_pc",
+            "goofoo_peek",
+            "goofoo_petg",
+            "goofoo_pla",
+            "goofoo_pva",
+            "goofoo_tpe_83a",
+            "goofoo_tpu_87a",
+            "goofoo_tpu_95a",
+            "goofoo_wood_pla",
+            "emotiontech_abs",
+            "emotiontech_absx",
+            "emotiontech_acetate",
+            "emotiontech_asax",
+            "emotiontech_bvoh",
+            "emotiontech_copa",
+            "emotiontech_hips",
+            "emotiontech_nylon_1030",
+            "emotiontech_nylon_1030cf",
+            "emotiontech_nylon_1070",
+            "emotiontech_pc",
+            "emotiontech_pekk",
+            "emotiontech_petg",
+            "emotiontech_pla",
+            "emotiontech_pla_hr_870",
+            "emotiontech_pva-m",
+            "emotiontech_pva-s",
+            "emotiontech_tpu98a",
+            "eryone_petg",
+            "eryone_pla_glow",
+            "eryone_pla_matte",
+            "eryone_pla_wood",
+            "eryone_pla",
+            "eryone_tpu",
+            "eSUN_PETG_Black",
+            "eSUN_PETG_Grey",
+            "eSUN_PETG_Purple",
+            "eSUN_PLA_PRO_Black",
+            "eSUN_PLA_PRO_Grey",
+            "eSUN_PLA_PRO_Purple",
+            "eSUN_PLA_PRO_White",
+            "Extrudr_GreenTECPro_Anthracite_175",
+            "Extrudr_GreenTECPro_Black_175",
+            "Extrudr_GreenTECPro_Blue_175",
+            "Extrudr_GreenTECPro_Nature_175",
+            "Extrudr_GreenTECPro_Red_175",
+            "Extrudr_GreenTECPro_Silver_175",
+            "Extrudr_GreenTECPro_White_175",
+            "verbatim_bvoh_175",
+            "Vertex_Delta_ABS",
+            "Vertex_Delta_PET",
+            "Vertex_Delta_PLA",
+            "Vertex_Delta_TPU",
+            "chromatik_pla",
+            "dsm_arnitel2045_175",
+            "dsm_novamid1070_175",
+            "fabtotum_abs",
+            "fabtotum_nylon",
+            "fabtotum_pla",
+            "fabtotum_tpu",
+            "fdplast_abs_tomato",
+            "fdplast_petg_gray",
+            "fdplast_pla_olive",
+            "fiberlogy_hd_pla",
+            "filo3d_pla",
+            "filo3d_pla_green",
+            "filo3d_pla_red",
+            "imade3d_petg_green",
+            "imade3d_petg_pink",
+            "imade3d_pla_green",
+            "imade3d_pla_pink",
+            "imade3d_petg_175",
+            "imade3d_pla_175",
+            "innofill_innoflex60_175",
+            "layer_one_black_pla",
+            "layer_one_dark_gray_pla",
+            "layer_one_white_pla",
+            "octofiber_pla",
+            "polyflex_pla",
+            "polymax_pla",
+            "polyplus_pla",
+            "polywood_pla",
+            "redd_abs",
+            "redd_asa",
+            "redd_hips",
+            "redd_nylon",
+            "redd_petg",
+            "redd_pla",
+            "redd_tpe",
+            "tizyx_abs",
+            "tizyx_flex",
+            "tizyx_petg",
+            "tizyx_pla_bois",
+            "tizyx_pla",
+            "tizyx_pva",
+            "Vertex_Delta_ABS",
+            "Vertex_Delta_PET",
+            "Vertex_Delta_PLA_Glitter",
+            "Vertex_Delta_PLA_Mat",
+            "Vertex_Delta_PLA_Satin",
+            "Vertex_Delta_PLA_Wood",
+            "Vertex_Delta_PLA",
+            "Vertex_Delta_TPU",
+            "volumic_abs_ultra",
+            "volumic_arma_ultra",
+            "volumic_asa_ultra",
+            "volumic_br80_ultra",
+            "volumic_bumper_ultra",
+            "volumic_cu80_ultra",
+            "volumic_flex93_ultra",
+            "volumic_medical_ultra",
+            "volumic_nylon_ultra",
+            "volumic_pekk_carbone",
+            "volumic_petg_ultra",
+            "volumic_petgcarbone_ultra",
+            "volumic_pla_ultra",
+            "volumic_pp_ultra",
+            "volumic_strong_ultra",
+            "volumic_support_ultra",
+            "xyzprinting_abs",
+            "xyzprinting_antibact_pla",
+            "xyzprinting_carbon_fiber",
+            "xyzprinting_colorinkjet_pla",
+            "xyzprinting_flexible",
+            "xyzprinting_metallic_pla",
+            "xyzprinting_nylon",
+            "xyzprinting_petg",
+            "xyzprinting_pla",
+            "xyzprinting_tough_pla",
+            "xyzprinting_tpu",
+            "zyyx_pro_flex",
+            "zyyx_pro_pla"
+        ]
     },
-    "overrides":
-    {
-        "adhesion_type": { "default_value": "raft" },
-        "default_material_bed_temperature": { "default_value": 35 },
-        "extruder_prime_pos_x":
-        {
-            "maximum_value": "machine_width",
-            "minimum_value": "0"
+    "overrides": {
+        "machine_name": {
+            "default_value": "WEEDO Base"
         },
-        "extruder_prime_pos_y":
-        {
-            "maximum_value": "machine_depth",
-            "minimum_value": "0"
+        "machine_start_gcode": {
+            "default_value": "G28 ;Home\nG92 E0\nG1 F200 E3\nG92 E0"
         },
-        "infill_sparse_density": { "default_value": 10 },
-        "machine_endstop_positive_direction_x": { "default_value": true },
-        "machine_endstop_positive_direction_y": { "default_value": true },
-        "machine_endstop_positive_direction_z": { "default_value": false },
-        "machine_feeder_wheel_diameter": { "default_value": 10.61 },
-        "machine_max_feedrate_e": { "default_value": 45 },
-        "machine_max_feedrate_x": { "default_value": 250 },
-        "machine_max_feedrate_y": { "default_value": 250 },
-        "machine_max_feedrate_z": { "default_value": 10 },
-        "machine_nozzle_size": { "default_value": 0.4 },
-        "machine_steps_per_mm_e": { "default_value": 96 },
-        "machine_steps_per_mm_x": { "default_value": 94 },
-        "machine_steps_per_mm_y": { "default_value": 94 },
-        "machine_steps_per_mm_z": { "default_value": 400 },
-        "material_bed_temp_wait": { "default_value": false },
-        "material_diameter": { "default_value": 1.75 },
-        "material_flow": { "default_value": 95 },
-        "material_print_temp_prepend": { "default_value": false },
-        "material_print_temp_wait": { "default_value": false },
-        "material_standby_temperature": { "minimum_value": "0" },
-        "prime_tower_min_volume": { "default_value": 10 },
-        "prime_tower_size": { "default_value": 15 },
-        "raft_airgap": { "default_value": 0.22 },
-        "raft_base_speed": { "value": 20 },
-        "raft_interface_speed": { "value": 33 },
-        "raft_margin": { "default_value": 8 },
-        "raft_surface_fan_speed": { "value": 100 },
-        "raft_surface_speed": { "value": 40 },
-        "retraction_amount": { "default_value": 1.5 },
-        "retraction_combing": { "value": "off" },
-        "retraction_speed": { "default_value": 28 },
-        "skirt_brim_speed": { "value": 26.0 },
-        "speed_layer_0": { "value": 26.0 },
-        "speed_prime_tower": { "value": "speed_support" },
-        "speed_print_layer_0": { "value": 26.0 },
-        "speed_support": { "value": "round(speed_print*0.82,1)" },
-        "speed_support_interface": { "value": "round(speed_support*0.689,1)" },
-        "speed_topbottom": { "value": "round(speed_print * 0.65,1)" },
-        "speed_travel": { "value": 105.0 },
-        "speed_travel_layer_0": { "value": 80.0 },
-        "speed_wall": { "value": "max(5,round(speed_print / 2,1))" },
-        "speed_wall_0": { "value": "max(5,speed_wall-5)" },
-        "speed_wall_x": { "value": "speed_wall" },
-        "support_angle": { "default_value": 60 },
-        "support_interface_pattern": { "default_value": "lines" },
-        "switch_extruder_retraction_amount": { "value": 16.5 },
-        "switch_extruder_retraction_speeds": { "default_value": 28 }
+        "machine_end_gcode": {
+            "default_value": "G92 E0\nG1 E-3 F1680 \nG28 Z F400; Get extruder out of way.\nM107 ; Turn off fan\n; Disable all extruder\nM104 T0 S0\nG90 ; Absolute positioning\nG92 E0 ; Reset extruder position\nM84 ; Turn steppers off\n"
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        },
+        "machine_id": {
+            "default_value": 1
+        },
+        "material_bed_temp_wait": {
+            "default_value": false
+        },
+        "material_print_temp_wait": {
+            "default_value": false
+        },
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "machine_nozzle_tip_outer_diameter": {
+            "default_value": 0.8
+        },
+        "machine_nozzle_heat_up_speed": {
+            "default_value": 1.8
+        },
+        "machine_nozzle_cool_down_speed": {
+            "default_value": 0.67
+        },
+        "machine_min_cool_heat_time_window": {
+            "default_value": 1200.0
+        },
+        "machine_steps_per_mm_x":
+        {
+            "default_value": 94
+        },
+        "machine_steps_per_mm_y":
+        {
+            "default_value": 94
+        },
+        "machine_steps_per_mm_z":
+        {
+            "default_value": 400
+        },
+        "machine_steps_per_mm_e":
+        {
+            "default_value": 96
+        },
+        "machine_max_feedrate_x": {
+            "default_value": 200
+        },
+        "machine_max_feedrate_y": {
+            "default_value": 130
+        },
+        "machine_max_feedrate_z": {
+            "default_value": 10
+        },
+        "machine_max_feedrate_e": {
+            "default_value": 50
+        },
+        "machine_max_acceleration_x": {
+            "default_value": 3000
+        },
+        "machine_max_acceleration_y": {
+            "default_value": 3000
+        },
+        "machine_max_acceleration_z": {
+            "default_value": 120
+        },
+        "machine_max_acceleration_e": {
+            "default_value": 1600
+        },
+        "machine_acceleration": {
+            "default_value": 3000
+        },
+        "machine_max_jerk_xy": {
+            "default_value": 10.0
+        },
+        "machine_max_jerk_z": {
+            "default_value": 5
+        },
+        "machine_max_jerk_e": {
+            "default_value": 5.1
+        },
+        "infill_line_width": {
+            "value": "line_width * 1.25"
+        },
+        "initial_layer_line_width_factor": {
+            "default_value": 110.0
+        },
+        "wall_0_wipe_dist": {
+            "value": 0.0
+        },
+        "z_seam_corner": {
+            "default_value": "z_seam_corner_any"
+        },
+        "skin_outline_count": {
+            "value": "0"
+        },
+        "infill_sparse_density": {
+            "default_value": 10.0
+        },
+        "infill_pattern": {
+            "value": "'zigzag'"
+        },
+        "infill_before_walls": {
+            "default_value": false
+        },
+        "material_print_temperature": {
+            "maximum_value": "300"
+        },
+        "material_print_temperature_layer_0": {
+            "value": "min(material_print_temperature + 10, 300)"
+        },
+        "material_initial_print_temperature": {
+            "value": "material_print_temperature"
+        },
+        "material_final_print_temperature": {
+            "value": "material_print_temperature"
+        },
+        "material_bed_temperature": {
+            "maximum_value_warning": "96"
+        },
+        "material_flow": {
+            "default_value": 95.0
+        },
+        "material_flow_layer_0": {
+            "default_value": 95.0
+        },
+        "infill_material_flow": {
+            "value": "max(0, material_flow - 5)"
+        },
+        "support_material_flow": {
+            "value": "max(0, material_flow - 5)"
+        },
+        "speed_print": {
+            "default_value": 70.0
+        },
+        "speed_wall": {
+            "value": "max(5, round(speed_print / 2 - 5, 1))"
+        },
+        "speed_wall_0": {
+            "value": "max(5, speed_wall - 5)"
+        },
+        "speed_wall_x": {
+            "value": "speed_wall"
+        },
+        "speed_topbottom": {
+            "value": "round(speed_print * 0.65, 1)"
+        },
+        "speed_support": {
+            "value": "round(speed_print * 0.82, 1)"
+        },
+        "speed_support_interface": {
+            "value": "round(speed_support * 0.689, 1)"
+        },
+        "speed_prime_tower": {
+            "value": "speed_support"
+        },
+        "speed_travel": {
+            "value": 105.0
+        },
+        "speed_layer_0": {
+            "value": 26.0
+        },
+        "speed_travel_layer_0": {
+            "value": 80.0
+        },
+        "skirt_brim_speed": {
+            "value": 26.0
+        },
+        "retraction_amount": {
+            "default_value": 3
+        },
+        "retraction_speed": {
+            "default_value": 28.0
+        },
+        "retraction_min_travel": {
+            "value": 0.8
+        },
+        "retraction_extrusion_window": {
+            "value": 1.0
+        },
+        "material_standby_temperature": {
+            "default_value": 175.0
+        },
+        "switch_extruder_retraction_amount": {
+            "value": 16.5
+        },
+        "switch_extruder_retraction_speeds": {
+            "default_value": 28.0
+        },
+        "retraction_combing": {
+            "value": "off"
+        },
+        "retraction_hop_after_extruder_switch": {
+            "default_value": false
+        },
+        "support_angle": {
+            "default_value": 60.0
+        },
+        "support_connect_zigzags": {
+            "default_value": false
+        },
+        "support_z_distance": {
+            "default_value": 0.18
+        },
+        "support_interface_enable": {
+            "default_value": true
+        },
+        "support_interface_density": {
+            "default_value": 60.0
+        },
+        "support_interface_height": {
+            "default_value": 0.8
+        },
+        "support_interface_pattern": {
+            "default_value": "lines"
+        },
+        "adhesion_type": {
+            "default_value": "raft"
+        },
+        "skirt_line_count": {
+            "default_value": 2
+        },
+        "raft_margin": {
+            "default_value": 8.0
+        },
+        "raft_airgap": {
+            "default_value": 0.19
+        },
+        "layer_0_z_overlap": {
+            "value": 0.09
+        },
+        "raft_surface_thickness": {
+            "value": 0.25
+        },
+        "raft_interface_thickness": {
+            "value": 0.27
+        },
+        "raft_interface_line_width": {
+            "value": 0.7
+        },
+        "raft_base_thickness": {
+            "value": 0.3
+        },
+        "raft_surface_speed": {
+            "value": 40.0
+        },
+        "raft_interface_speed": {
+            "value": 33.0
+        },
+        "raft_base_speed": {
+            "value": 20.0
+        },
+        "raft_surface_fan_speed": {
+            "value": "100.0 if cool_fan_enabled else 0.0"
+        },
+        "raft_interface_fan_speed": {
+            "value": 0.0
+        },
+        "raft_base_fan_speed": {
+            "value": 0.0
+        },
+        "prime_tower_size": {
+            "default_value": 15.0
+        },
+        "prime_tower_min_volume": {
+            "default_value": 10.0
+        },
+        "draft_shield_dist": {
+            "default_value": 3
+        },
+        "top_skin_preshrink": {
+            "value": 0.0
+        }
     }
 }

--- a/resources/definitions/weedo_base.def.json
+++ b/resources/definitions/weedo_base.def.json
@@ -401,12 +401,6 @@
         "raft_surface_thickness": {
             "value": 0.25
         },
-        "raft_interface_thickness": {
-            "value": 0.27
-        },
-        "raft_interface_line_width": {
-            "value": 0.7
-        },
         "raft_base_thickness": {
             "value": 0.3
         },
@@ -418,12 +412,6 @@
         },
         "raft_base_speed": {
             "value": 20.0
-        },
-        "raft_surface_fan_speed": {
-            "value": "100.0 if cool_fan_enabled else 0.0"
-        },
-        "raft_interface_fan_speed": {
-            "value": 0.0
         },
         "raft_base_fan_speed": {
             "value": 0.0

--- a/resources/definitions/weedo_tina2.def.json
+++ b/resources/definitions/weedo_tina2.def.json
@@ -1,11 +1,11 @@
 {
-    "name": "WEEFUN TINA2",
+    "name": "WEEDO TINA2",
     "version": 2,
     "inherits": "weedo_base",
     "metadata": {
         "visible": true,
-        "author": "WEEFUN",
-        "manufacturer": "WEEFUN",
+        "author": "WEEDO",
+        "manufacturer": "WEEDO",
         "file_formats": "text/x-gcode",
         "platform_offset": [
             0,
@@ -173,7 +173,7 @@
     },
     "overrides": {
         "machine_name": {
-            "default_value": "WEEFUN TINA2"
+            "default_value": "WEEDO TINA2"
         },
         "machine_start_gcode": {
             "default_value": ";MachineType:{machine_name}\n;FilamentType:{material_type}\n;InfillDensity:{infill_sparse_density}\n;Extruder0Temperature:{material_print_temperature}\n\n;(**** start.gcode for tina2****)\nM203 Z15\nM104 S150\nG28 Z\nG28 X Y; Home extruder\nG1 X55 Y55 F1000\nG29\nM107 ; Turn off fan\nG90 ; Absolute positioning\nM82 ; Extruder in absolute mode\nM109 S{material_print_temperature_layer_0}\nG92 E0 ; Reset extruder position\nG1 X90 Y6 Z0.27 F2000\nG1 X20 Y6 Z0.27 E15 F1000\nG92 E0 ; Reset extruder position\nM203 Z5"

--- a/resources/definitions/weedo_tina2s.def.json
+++ b/resources/definitions/weedo_tina2s.def.json
@@ -1,11 +1,11 @@
 {
-    "name": "WEEFUN TINA2",
+    "name": "WEEDO TINA2S",
     "version": 2,
     "inherits": "weedo_base",
     "metadata": {
         "visible": true,
-        "author": "WEEFUN",
-        "manufacturer": "WEEFUN",
+        "author": "WEEDO",
+        "manufacturer": "WEEDO",
         "file_formats": "text/x-gcode",
         "platform_offset": [
             0,
@@ -23,9 +23,7 @@
             "leapfrog_pva_natural",
             "generic_abs_175",
             "generic_asa_175",
-            "generic_bvoh_175",
             "generic_cpe_175",
-            "generic_hips_175",
             "generic_nylon_175",
             "generic_pc_175",
             "generic_petg_175",
@@ -173,10 +171,10 @@
     },
     "overrides": {
         "machine_name": {
-            "default_value": "WEEFUN TINA2"
+            "default_value": "WEEDO TINA2S"
         },
         "machine_start_gcode": {
-            "default_value": ";MachineType:{machine_name}\n;FilamentType:{material_type}\n;InfillDensity:{infill_sparse_density}\n;Extruder0Temperature:{material_print_temperature}\n\n;(**** start.gcode for tina2****)\nM203 Z15\nM104 S150\nG28 Z\nG28 X Y; Home extruder\nG1 X55 Y55 F1000\nG29\nM107 ; Turn off fan\nG90 ; Absolute positioning\nM82 ; Extruder in absolute mode\nM109 S{material_print_temperature_layer_0}\nG92 E0 ; Reset extruder position\nG1 X90 Y6 Z0.27 F2000\nG1 X20 Y6 Z0.27 E15 F1000\nG92 E0 ; Reset extruder position\nM203 Z5"
+            "default_value": ";MachineType:{machine_name}\n;FilamentType:{material_type}\n;InfillDensity:{infill_sparse_density}\n;Extruder0Temperature:{material_print_temperature}\n;BedTemperature:{material_bed_temperature}\n\n;(**** start.gcode for tina2****)\nM203 Z15\nM104 S150\nG28 Z\nG28 X Y; Home extruder\nG1 X55 Y55 F1000\nG29\nM107 ; Turn off fan\nG90 ; Absolute positioning\nM82 ; Extruder in absolute mode\nM109 S{material_print_temperature_layer_0}\nG92 E0 ; Reset extruder position\nG1 X90 Y6 Z0.27 F2000\nG1 X20 Y6 Z0.27 E15 F1000\nG92 E0 ; Reset extruder position\nM203 Z5"
         },
         "machine_end_gcode": {
             "default_value": ";(**** end.gcode for tina2****)\nM203 Z15\nM104 S0\nM107\nG92 E0 (Reset after prime)\nG0 E-1 F300\nG28 Z F300\nG28 X0 Y0\nG1 Y90 F1000"
@@ -185,16 +183,14 @@
             "default_value": 100
         },
         "machine_depth": {
-            "default_value": 120
+            "default_value": 110
         },
         "machine_height": {
             "default_value": 100
         },
-        "machine_heated_bed": {
-            "default_value": false
-        },
-        "infill_pattern": {
-            "value": "'lines' if infill_sparse_density > 45 else 'grid'"
+        "material_bed_temperature": {
+            "maximum_value_warning": "60",
+            "maximum_value": "65"
         },
         "speed_print": {
             "value": 40.0

--- a/resources/definitions/weefun_tina2s.def.json
+++ b/resources/definitions/weefun_tina2s.def.json
@@ -1,9 +1,8 @@
 {
-    "version": 2,
     "name": "WEEFUN TINA2S",
+    "version": 2,
     "inherits": "weedo_base",
-    "metadata":
-    {
+    "metadata": {
         "visible": true,
         "author": "WEEFUN",
         "manufacturer": "WEEFUN",
@@ -12,30 +11,228 @@
             0,
             0,
             0
+        ],
+        "exclude_materials": [
+            "3D-Fuel_PLA_PRO_Black",
+            "3D-Fuel_PLA_SnapSupport",
+            "bestfilament_abs_skyblue",
+            "bestfilament_petg_orange",
+            "bestfilament_pla_green",
+            "leapfrog_abs_natural",
+            "leapfrog_epla_natural",
+            "leapfrog_pva_natural",
+            "generic_abs_175",
+            "generic_asa_175",
+            "generic_cpe_175",
+            "generic_nylon_175",
+            "generic_pc_175",
+            "generic_petg_175",
+            "generic_pva_175",
+            "goofoo_abs",
+            "goofoo_asa",
+            "goofoo_bronze_pla",
+            "goofoo_emarble_pla",
+            "goofoo_esilk_pla",
+            "goofoo_hips",
+            "goofoo_pa_cf",
+            "goofoo_pa",
+            "goofoo_pc",
+            "goofoo_peek",
+            "goofoo_petg",
+            "goofoo_pla",
+            "goofoo_pva",
+            "goofoo_tpe_83a",
+            "goofoo_tpu_87a",
+            "goofoo_tpu_95a",
+            "goofoo_wood_pla",
+            "emotiontech_abs",
+            "emotiontech_absx",
+            "emotiontech_acetate",
+            "emotiontech_asax",
+            "emotiontech_bvoh",
+            "emotiontech_copa",
+            "emotiontech_hips",
+            "emotiontech_nylon_1030",
+            "emotiontech_nylon_1030cf",
+            "emotiontech_nylon_1070",
+            "emotiontech_pc",
+            "emotiontech_pekk",
+            "emotiontech_petg",
+            "emotiontech_pla",
+            "emotiontech_pla_hr_870",
+            "emotiontech_pva-m",
+            "emotiontech_pva-s",
+            "emotiontech_tpu98a",
+            "eryone_petg",
+            "eryone_pla_glow",
+            "eryone_pla_matte",
+            "eryone_pla_wood",
+            "eryone_pla",
+            "eryone_tpu",
+            "eSUN_PETG_Black",
+            "eSUN_PETG_Grey",
+            "eSUN_PETG_Purple",
+            "eSUN_PLA_PRO_Black",
+            "eSUN_PLA_PRO_Grey",
+            "eSUN_PLA_PRO_Purple",
+            "eSUN_PLA_PRO_White",
+            "Extrudr_GreenTECPro_Anthracite_175",
+            "Extrudr_GreenTECPro_Black_175",
+            "Extrudr_GreenTECPro_Blue_175",
+            "Extrudr_GreenTECPro_Nature_175",
+            "Extrudr_GreenTECPro_Red_175",
+            "Extrudr_GreenTECPro_Silver_175",
+            "Extrudr_GreenTECPro_White_175",
+            "verbatim_bvoh_175",
+            "Vertex_Delta_ABS",
+            "Vertex_Delta_PET",
+            "Vertex_Delta_PLA",
+            "Vertex_Delta_TPU",
+            "chromatik_pla",
+            "dsm_arnitel2045_175",
+            "dsm_novamid1070_175",
+            "fabtotum_abs",
+            "fabtotum_nylon",
+            "fabtotum_pla",
+            "fabtotum_tpu",
+            "fdplast_abs_tomato",
+            "fdplast_petg_gray",
+            "fdplast_pla_olive",
+            "fiberlogy_hd_pla",
+            "filo3d_pla",
+            "filo3d_pla_green",
+            "filo3d_pla_red",
+            "imade3d_petg_green",
+            "imade3d_petg_pink",
+            "imade3d_pla_green",
+            "imade3d_pla_pink",
+            "imade3d_petg_175",
+            "imade3d_pla_175",
+            "innofill_innoflex60_175",
+            "layer_one_black_pla",
+            "layer_one_dark_gray_pla",
+            "layer_one_white_pla",
+            "octofiber_pla",
+            "polyflex_pla",
+            "polymax_pla",
+            "polyplus_pla",
+            "polywood_pla",
+            "redd_abs",
+            "redd_asa",
+            "redd_hips",
+            "redd_nylon",
+            "redd_petg",
+            "redd_pla",
+            "redd_tpe",
+            "tizyx_abs",
+            "tizyx_flex",
+            "tizyx_petg",
+            "tizyx_pla_bois",
+            "tizyx_pla",
+            "tizyx_pva",
+            "Vertex_Delta_ABS",
+            "Vertex_Delta_PET",
+            "Vertex_Delta_PLA_Glitter",
+            "Vertex_Delta_PLA_Mat",
+            "Vertex_Delta_PLA_Satin",
+            "Vertex_Delta_PLA_Wood",
+            "Vertex_Delta_PLA",
+            "Vertex_Delta_TPU",
+            "volumic_abs_ultra",
+            "volumic_arma_ultra",
+            "volumic_asa_ultra",
+            "volumic_br80_ultra",
+            "volumic_bumper_ultra",
+            "volumic_cu80_ultra",
+            "volumic_flex93_ultra",
+            "volumic_medical_ultra",
+            "volumic_nylon_ultra",
+            "volumic_pekk_carbone",
+            "volumic_petg_ultra",
+            "volumic_petgcarbone_ultra",
+            "volumic_pla_ultra",
+            "volumic_pp_ultra",
+            "volumic_strong_ultra",
+            "volumic_support_ultra",
+            "xyzprinting_abs",
+            "xyzprinting_antibact_pla",
+            "xyzprinting_carbon_fiber",
+            "xyzprinting_colorinkjet_pla",
+            "xyzprinting_flexible",
+            "xyzprinting_metallic_pla",
+            "xyzprinting_nylon",
+            "xyzprinting_petg",
+            "xyzprinting_pla",
+            "xyzprinting_tough_pla",
+            "xyzprinting_tpu",
+            "zyyx_pro_flex",
+            "zyyx_pro_pla"
         ]
     },
-    "overrides":
-    {
-        "gantry_height": { "value": 20 },
-        "machine_center_is_zero": { "default_value": false },
-        "machine_depth": { "default_value": 120 },
-        "machine_end_gcode": { "default_value": ";(**** end.gcode for tina2s****)\nM203 Z15 ;Move Z axis up 5mm\nM104 S0 ;Turn off extruder heating\nM140 S0 ;Turn off bed heating\nM107 ;Turn Fans off\nG92 E0 ;(Reset after prime)\nG0 E-1 F300 ;Retract Fillament 1mm\nG28 Z F300 ;Park Hotend up\nG28 X0 Y0 ;Park Hotend\nG1 Y90 F1000 ;Present finished model\nG0 E-2 F300 ;Retract Fillament 2mm\nM82 ;absolute extrusion mode\nM104 S0 ;Ensure hotend is off\nM117 Print Complete" },
-        "machine_extruder_count": { "default_value": 1 },
-        "machine_heated_bed": { "default_value": true },
-        "machine_height": { "default_value": 100 },
-        "machine_name": { "default_value": "WEEFUN TINA2S" },
-        "machine_start_gcode": { "default_value": ";MachineType:TINA2S\n;FilamentType:{material_type}\n;Layer height:{layer_height}\n;Extruder0Temperature:{material_print_temperature}\n;BedTemperature:{material_bed_temperature}\n;InfillDensity:{infill_sparse_density}\n;(**** start.gcode for tina2s****)\nM203 Z5 ;Move Z axis up 5mm\nM117 Homing axes\nG28 Z; Home extruder axis Z\nG28 X Y; Home extruder axis X Y\nM117 Start Warm Up\nM140 S{material_bed_temperature} ;start heating the bed to what is set in Cura\nM104 S130 ;start heating E to 130 for preheat\nM190 S{material_bed_temperature} ;Wait for Bed Temperature\nM117 Levling the build plate\nG29\nG1 Z1.0 F3000 ;Move Z Axis up to 1mm\nG1 X0.5 Y1 ;Move hotend to starting position\nM117 Heating Hotend\nM104 S{material_initial_print_temperature} T0 ;start heating T0 to what is set in Cura\nM109 S{material_initial_print_temperature} T0 ;Wait for Hotend Temperature\nG92 E0 ;Reset Extruder\nM117 Purging and cleaning nozzle\nG1 X1.1 Y10 Z0.28 F1000.0 ;Move to start position\nG1 X1.1 Y90.0 Z0.28 F2000.0 E15 ;Draw the first line\nG1 X1.4 Y90.0 Z0.23 F5000.0 ;Move to side a little\nG1 X1.4 Y10 Z0.20 F2000.0 E15 ;Draw the second line\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up\nG1 X1 Y5 Z0.2 F5000.0 ;Move over to prevent blob squish\nM117 Printing..." },
-        "machine_width": { "default_value": 100 },
-        "retraction_amount": { "default_value": 3 },
-        "speed_infill": { "value": 40.0 },
-        "speed_print_layer_0": { "value": 22.0 },
-        "speed_roofing": { "value": 25.0 },
-        "speed_support_bottom": { "dvalue": 30.0 },
-        "speed_support_infill": { "value": 45.0 },
-        "speed_support_roof": { "value": 30.0 },
-        "speed_topbottom": { "value": 30.0 },
-        "speed_travel_layer_0": { "value": 60 },
-        "speed_wall_0": { "value": 20.0 },
-        "speed_wall_x": { "value": 25.0 }
+    "overrides": {
+        "machine_name": {
+            "default_value": "WEEFUN TINA2S"
+        },
+        "machine_start_gcode": {
+            "default_value": ";MachineType:{machine_name}\n;FilamentType:{material_type}\n;InfillDensity:{infill_sparse_density}\n;Extruder0Temperature:{material_print_temperature}\n;BedTemperature:{material_bed_temperature}\n\n;(**** start.gcode for tina2****)\nM203 Z15\nM104 S150\nG28 Z\nG28 X Y; Home extruder\nG1 X55 Y55 F1000\nG29\nM107 ; Turn off fan\nG90 ; Absolute positioning\nM82 ; Extruder in absolute mode\nM109 S{material_print_temperature_layer_0}\nG92 E0 ; Reset extruder position\nG1 X90 Y6 Z0.27 F2000\nG1 X20 Y6 Z0.27 E15 F1000\nG92 E0 ; Reset extruder position\nM203 Z5"
+        },
+        "machine_end_gcode": {
+            "default_value": ";(**** end.gcode for tina2****)\nM203 Z15\nM104 S0\nM107\nG92 E0 (Reset after prime)\nG0 E-1 F300\nG28 Z F300\nG28 X0 Y0\nG1 Y90 F1000"
+        },
+        "machine_width": {
+            "default_value": 100
+        },
+        "machine_depth": {
+            "default_value": 110
+        },
+        "machine_height": {
+            "default_value": 100
+        },
+        "material_bed_temperature": {
+            "maximum_value_warning": "60",
+            "maximum_value": "65"
+        },
+        "speed_print": {
+            "value": 40.0
+        },
+        "speed_infill": {
+            "value": 40.0
+        },
+        "speed_wall": {
+            "value": 25.0
+        },
+        "speed_wall_0": {
+            "value": 20.0
+        },
+        "speed_wall_x": {
+            "value": 25.0
+        },
+        "speed_topbottom": {
+            "value": 30.0
+        },
+        "speed_support_infill": {
+            "value": 45.0
+        },
+        "speed_print_layer_0": {
+            "value": 22.0
+        },
+        "speed_travel_layer_0": {
+            "value": 60
+        },
+        "speed_travel": {
+            "value": 65.0
+        },
+        "speed_support_roof": {
+            "value": 30.0
+        },
+        "speed_support_bottom": {
+            "value": 30.0
+        },
+        "speed_roofing": {
+            "value": 25.0
+        },
+        "raft_base_thickness": {
+            "value": 0.35
+        }
     }
 }

--- a/resources/extruders/weedo_base_extruder_0.def.json
+++ b/resources/extruders/weedo_base_extruder_0.def.json
@@ -2,13 +2,12 @@
     "version": 2,
     "name": "Extruder 1",
     "inherits": "fdmextruder",
-    "metadata":
-    {
+    "metadata": {
         "machine": "weedo_base",
         "position": "0"
     },
-    "overrides":
-    {
+
+    "overrides": {
         "extruder_nr": { "default_value": 0 },
         "machine_nozzle_size": { "default_value": 0.4 },
         "material_diameter": { "default_value": 1.75 }


### PR DESCRIPTION
# Description
This PR adds configs for the following printers.
- Weedo Tina2
- Weedo Tina2s
- Entina Tina2
- Entina Tina2s

The configurations came from Entina's prepackaged Cura installer.

## Type of change
Additional printer support.

# How Has This Been Tested?
This has been tested on version 5.3.1 with benchy using PLA+. I've also been printing custom parts with this config over the past week with no issues related to the config.


**Test Configuration**:
* Operating System: Windows 11 Pro Version 22H2, build 22521.1848

# Checklist:
- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change