### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,6 @@ This fixes... OR This improves... -->
 <!-- Check if relevant -->
 
 - [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
-- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
+- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have uploaded any files required to test this change


### PR DESCRIPTION
# Description

When clicked from PR, the link is broken (Chrome, Windows 11). It appears that GitHub might be case-sensitive w.r.t URLs.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by comparing capitalization differences in Chrome and Windows 11, used URL that worked.

**Test Configuration**:
* Operating System: Windows 11

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/contributing.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change