### PR TITLE
Let intent selection use the quality_definition instead of direct def

### DIFF
--- a/cura/Machines/Models/IntentSelectionModel.py
+++ b/cura/Machines/Models/IntentSelectionModel.py
@@ -71,15 +71,15 @@ class IntentSelectionModel(ListModel):
 
     def _update(self) -> None:
         Logger.log("d", "Updating {model_class_name}.".format(model_class_name = self.__class__.__name__))
-
-        global_stack = cura.CuraApplication.CuraApplication.getInstance().getGlobalContainerStack()
+        cura_application = cura.CuraApplication.CuraApplication.getInstance()
+        global_stack = cura_application.getGlobalContainerStack()
         if global_stack is None:
             self.setItems([])
             Logger.log("d", "No active GlobalStack, set quality profile model as empty.")
             return
 
         # Check for material compatibility
-        if not cura.CuraApplication.CuraApplication.getInstance().getMachineManager().activeMaterialsCompatible():
+        if not cura_application.getMachineManager().activeMaterialsCompatible():
             Logger.log("d", "No active material compatibility, set quality profile model as empty.")
             self.setItems([])
             return
@@ -101,17 +101,18 @@ class IntentSelectionModel(ListModel):
             else:
                 # There can be multiple intents with the same category, use one of these
                 # intent-metadata's for the icon/description defintions for the intent
-                intent_metadata = cura.CuraApplication.CuraApplication \
-                    .getInstance() \
-                    .getContainerRegistry() \
-                    .findContainersMetadata(type="intent", definition=global_stack.definition.getId(),
-                                            intent_category=category)[0]
+
+
+
+                intent_metadata = cura_application.getContainerRegistry().findContainersMetadata(type="intent",
+                                                                                                 definition=global_stack.findInstanceContainerDefinitionId(global_stack.definition),
+                                                                                                 intent_category=category)[0]
 
                 intent_name = intent_metadata.get("name", category.title())
                 icon = intent_metadata.get("icon", None)
                 description = intent_metadata.get("description", None)
 
-                if icon is not None:
+                if icon is not None and icon != '':
                     try:
                         icon = QUrl.fromLocalFile(
                             Resources.getPath(cura.CuraApplication.CuraApplication.ResourceTypes.ImageFiles, icon))

--- a/cura/Settings/CuraContainerStack.py
+++ b/cura/Settings/CuraContainerStack.py
@@ -359,7 +359,7 @@ class CuraContainerStack(ContainerStack):
         return self.definition
 
     @classmethod
-    def _findInstanceContainerDefinitionId(cls, machine_definition: DefinitionContainerInterface) -> str:
+    def findInstanceContainerDefinitionId(cls, machine_definition: DefinitionContainerInterface) -> str:
         """Find the ID that should be used when searching for instance containers for a specified definition.
 
         This handles the situation where the definition specifies we should use a different definition when
@@ -379,7 +379,7 @@ class CuraContainerStack(ContainerStack):
             Logger.log("w", "Unable to find parent definition {parent} for machine {machine}", parent = quality_definition, machine = machine_definition.id) #type: ignore
             return machine_definition.id #type: ignore
 
-        return cls._findInstanceContainerDefinitionId(definitions[0])
+        return cls.findInstanceContainerDefinitionId(definitions[0])
 
     def getExtruderPositionValueWithDefault(self, key):
         """getProperty for extruder positions, with translation from -1 to default extruder number"""


### PR DESCRIPTION
The issue was that sometimes intents are also shared. This would only cause issues for material profiles from the marketplace that have intents. 

CURA-10788