### PR TITLE
Fix wrong licenses

### DIFF
--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2018 Jaime van Kessel, Ultimaker B.V.
-# The PostProcessingPlugin is released under the terms of the AGPLv3 or higher.
+# The PostProcessingPlugin is released under the terms of the LGPLv3 or higher.
 
 import configparser  # The script lists are stored in metadata as serialised config files.
 import importlib.util

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -1,5 +1,5 @@
 // Copyright (c) 2022 Jaime van Kessel, Ultimaker B.V.
-// The PostProcessingPlugin is released under the terms of the AGPLv3 or higher.
+// The PostProcessingPlugin is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.2
 import QtQuick.Controls 2.15

--- a/plugins/PostProcessingPlugin/Script.py
+++ b/plugins/PostProcessingPlugin/Script.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2015 Jaime van Kessel
 # Copyright (c) 2018 Ultimaker B.V.
-# The PostProcessingPlugin is released under the terms of the AGPLv3 or higher.
+# The PostProcessingPlugin is released under the terms of the LGPLv3 or higher.
 from typing import Optional, Any, Dict, TYPE_CHECKING, List
 
 from UM.Signal import Signal, signalemitter

--- a/plugins/PostProcessingPlugin/scripts/ChangeAtZ.py
+++ b/plugins/PostProcessingPlugin/scripts/ChangeAtZ.py
@@ -1,7 +1,7 @@
 # ChangeAtZ script - Change printing parameters at a given height
 # This script is the successor of the TweakAtZ plugin for legacy Cura.
 # It contains code from the TweakAtZ plugin V1.0-V4.x and from the ExampleScript by Jaime van Kessel, Ultimaker B.V.
-# It runs with the PostProcessingPlugin which is released under the terms of the AGPLv3 or higher.
+# It runs with the PostProcessingPlugin which is released under the terms of the LGPLv3 or higher.
 # This script is licensed under the Creative Commons - Attribution - Share Alike (CC BY-SA) terms
 
 # Authors of the ChangeAtZ plugin / script:

--- a/plugins/PostProcessingPlugin/scripts/ColorMix.py
+++ b/plugins/PostProcessingPlugin/scripts/ColorMix.py
@@ -1,6 +1,6 @@
 # ColorMix script - 2-1 extruder color mix and blending
 # This script is specific for the Geeetech A10M dual extruder but should work with other Marlin printers. 
-# It runs with the PostProcessingPlugin which is released under the terms of the AGPLv3 or higher.
+# It runs with the PostProcessingPlugin which is released under the terms of the LGPLv3 or higher.
 # This script is licensed under the Creative Commons - Attribution - Share Alike (CC BY-SA) terms
 
 #Authors of the 2-1 ColorMix plug-in / script:

--- a/plugins/PostProcessingPlugin/scripts/FilamentChange.py
+++ b/plugins/PostProcessingPlugin/scripts/FilamentChange.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 Ultimaker B.V.
-# The PostProcessingPlugin is released under the terms of the AGPLv3 or higher.
+# The PostProcessingPlugin is released under the terms of the LGPLv3 or higher.
 
 # Modification 06.09.2020
 # add checkbox, now you can choose and use configuration from the firmware itself.

--- a/plugins/PostProcessingPlugin/scripts/RetractContinue.py
+++ b/plugins/PostProcessingPlugin/scripts/RetractContinue.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2023 UltiMaker B.V.
-# The PostProcessingPlugin is released under the terms of the AGPLv3 or higher.
+# The PostProcessingPlugin is released under the terms of the LGPLv3 or higher.
 
 from ..Script import Script
 

--- a/plugins/PostProcessingPlugin/scripts/SearchAndReplace.py
+++ b/plugins/PostProcessingPlugin/scripts/SearchAndReplace.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 Ghostkeeper
-# The PostProcessingPlugin is released under the terms of the AGPLv3 or higher.
+# The PostProcessingPlugin is released under the terms of the LGPLv3 or higher.
 
 import re #To perform the search and replace.
 

--- a/plugins/PostProcessingPlugin/scripts/Stretch.py
+++ b/plugins/PostProcessingPlugin/scripts/Stretch.py
@@ -1,4 +1,4 @@
-# This PostProcessingPlugin script is released under the terms of the AGPLv3 or higher.
+# This PostProcessingPlugin script is released under the terms of the LGPLv3 or higher.
 """
 Copyright (c) 2017 Christophe Baribaud 2017
 Python implementation of https://github.com/electrocbd/post_stretch


### PR DESCRIPTION
These seem to be wrong by accident. Let's update them to reflect the rest of Cura which falls under the LGPLv3 or higher.
This resolves CURA-10814 and https://github.com/Ultimaker/Cura/issues/15731