### PR TITLE
Use correct value for multiple file open enum

### DIFF
--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -628,7 +628,7 @@ UM.MainWindow
         //: File open dialog title
         title: catalog.i18nc("@title:window","Open file(s)")
         modality: Qt.WindowModal
-        fileMode: FileDialog.FileMode.ExistingFile
+        fileMode: FileDialog.FileMode.OpenFiles
         nameFilters: UM.MeshFileHandler.supportedReadFileTypes;
         currentFolder: CuraApplication.getDefaultPath("dialog_load_path")
         onAccepted:


### PR DESCRIPTION
Previously we used the qdialog enum, which isn't the one you should use for the qml dialog.

CURA-10741