### PR TITLE
Move the required plugins list to before it's actually checked

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -495,6 +495,36 @@ class CuraApplication(QtApplication):
     def startSplashWindowPhase(self) -> None:
         """Runs preparations that needs to be done before the starting process."""
 
+        self.setRequiredPlugins([
+            # Misc.:
+            "ConsoleLogger",  # You want to be able to read the log if something goes wrong.
+            "CuraEngineBackend",  # Cura is useless without this one since you can't slice.
+            "FileLogger",  # You want to be able to read the log if something goes wrong.
+            "XmlMaterialProfile",  # Cura crashes without this one.
+            "Marketplace",
+            # This contains the interface to enable/disable plug-ins, so if you disable it you can't enable it back.
+            "PrepareStage",  # Cura is useless without this one since you can't load models.
+            "PreviewStage",  # This shows the list of the plugin views that are installed in Cura.
+            "MonitorStage",  # Major part of Cura's functionality.
+            "LocalFileOutputDevice",  # Major part of Cura's functionality.
+            "LocalContainerProvider",  # Cura is useless without any profiles or setting definitions.
+
+            # Views:
+            "SimpleView",  # Dependency of SolidView.
+            "SolidView",  # Displays models. Cura is useless without it.
+
+            # Readers & Writers:
+            "GCodeWriter",  # Cura is useless if it can't write its output.
+            "STLReader",  # Most common model format, so disabling this makes Cura 90% useless.
+            "3MFWriter",  # Required for writing project files.
+
+            # Tools:
+            "CameraTool",  # Needed to see the scene. Cura is useless without it.
+            "SelectionTool",  # Dependency of the rest of the tools.
+            "TranslateTool",  # You'll need this for almost every print.
+        ])
+        # Plugins need to be set here, since in the super the check is done if they are actually loaded.
+
         super().startSplashWindowPhase()
 
         if not self.getIsHeadLess():
@@ -503,33 +533,7 @@ class CuraApplication(QtApplication):
             except FileNotFoundError:
                 Logger.log("w", "Unable to find the window icon.")
 
-        self.setRequiredPlugins([
-            # Misc.:
-            "ConsoleLogger", #You want to be able to read the log if something goes wrong.
-            "CuraEngineBackend", #Cura is useless without this one since you can't slice.
-            "FileLogger", #You want to be able to read the log if something goes wrong.
-            "XmlMaterialProfile", #Cura crashes without this one.
-            "Marketplace", #This contains the interface to enable/disable plug-ins, so if you disable it you can't enable it back.
-            "PrepareStage", #Cura is useless without this one since you can't load models.
-            "PreviewStage", #This shows the list of the plugin views that are installed in Cura.
-            "MonitorStage", #Major part of Cura's functionality.
-            "LocalFileOutputDevice", #Major part of Cura's functionality.
-            "LocalContainerProvider", #Cura is useless without any profiles or setting definitions.
 
-            # Views:
-            "SimpleView", #Dependency of SolidView.
-            "SolidView", #Displays models. Cura is useless without it.
-
-            # Readers & Writers:
-            "GCodeWriter", #Cura is useless if it can't write its output.
-            "STLReader", #Most common model format, so disabling this makes Cura 90% useless.
-            "3MFWriter", #Required for writing project files.
-
-            # Tools:
-            "CameraTool", #Needed to see the scene. Cura is useless without it.
-            "SelectionTool", #Dependency of the rest of the tools.
-            "TranslateTool", #You'll need this for almost every print.
-        ])
         self._i18n_catalog = i18nCatalog("cura")
 
         self._update_platform_activity_timer = QTimer()


### PR DESCRIPTION
# Description

Cuz ya know. If you don't set the data before checking, you will have a baaaad time.

See also: https://github.com/Ultimaker/Uranium/pull/891

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Remove a plugin that is marked as required, check the logs. 


**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
