### PR TITLE
Add copy, paste, cut functionality

### DIFF
--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 UltiMaker
+// Copyright (c) 2023 UltiMaker
 // Cura is released under the terms of the LGPLv3 or higher.
 
 pragma Singleton
@@ -70,6 +70,10 @@ Item
     property alias configureSettingVisibility: configureSettingVisibilityAction
 
     property alias browsePackages: browsePackagesAction
+
+    property alias paste: pasteAction
+    property alias copy: copyAction
+    property alias cut: cutAction
 
     UM.I18nCatalog{id: catalog; name: "cura"}
 
@@ -307,6 +311,33 @@ Item
         enabled: UM.Controller.toolsEnabled && UM.Selection.hasSelection
         icon.name: "align-vertical-center"
         onTriggered: CuraActions.centerSelection()
+    }
+
+    Action
+    {
+        id: copyAction
+        text: catalog.i18nc("@action:inmenu menubar:edit", "Copy to clipboard")
+        onTriggered: CuraActions.copy()
+        enabled: UM.Controller.toolsEnabled && UM.Selection.hasSelection
+        shortcut: StandardKey.Copy
+    }
+
+    Action
+    {
+        id: pasteAction
+        text: catalog.i18nc("@action:inmenu menubar:edit", "Paste from clipboard")
+        onTriggered: CuraActions.paste()
+        enabled: UM.Controller.toolsEnabled
+        shortcut: StandardKey.Paste
+    }
+
+    Action
+    {
+        id: cutAction
+        text: catalog.i18nc("@action:inmenu menubar:edit", "Cut")
+        onTriggered: CuraActions.cut()
+        enabled: UM.Controller.toolsEnabled && UM.Selection.hasSelection
+        shortcut: StandardKey.Cut
     }
 
     Action

--- a/resources/qml/Menus/ContextMenu.qml
+++ b/resources/qml/Menus/ContextMenu.qml
@@ -19,6 +19,8 @@ Cura.Menu
     // Selection-related actions.
     Cura.MenuItem { action: Cura.Actions.centerSelection; }
     Cura.MenuItem { action: Cura.Actions.deleteSelection; }
+    Cura.MenuItem { action: Cura.Actions.copy; }
+    Cura.MenuItem { action: Cura.Actions.paste; }
     Cura.MenuItem { action: Cura.Actions.multiplySelection; }
 
     // Extruder selection - only visible if there is more than 1 extruder


### PR DESCRIPTION
This PR adds copy, past and cut of buildplate models to cura.

https://github.com/Ultimaker/Cura/assets/6638028/974e53e7-8f3f-4820-9e7c-125d723c03e7

Copy/paste works even after a model has been deleted for the build plate (no reference is needed to the orginal model). This works by writing the serialized model data to the clipboard. As a consequence a users clipboard might look similar to this after using cura
```
<?xml version="1.0"?>
<model unit="millimeter" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02" xmlns:cura="http://software.ultimaker.com/xml/cura/3mf/2015/10" xml:lang="en-US">
	<resources>
		<object id="1" name="cube.stl" type="model">
			<metadatagroup>
				<metadata name="cura:extruder_nr">0</metadata>
			</metadatagroup>
			<mesh>
				<vertices>
					<vertex x="-5" y="5" z="-5" />
					<vertex x="5" y="5" z="5" />
					<vertex x="5" y="5" z="-5" />
					<vertex x="5" y="5" z="5" />
					<vertex x="-5" y="5" z="-5" />
					<vertex x="-5" y="5" z="5" />
					<vertex x="-5" y="-5" z="5" />
					<vertex x="5" y="-5" z="-5" />
					<vertex x="5" y="-5" z="5" />
					<vertex x="5" y="-5" z="-5" />
					<vertex x="-5" y="-5" z="5" />
					<vertex x="-5" y="-5" z="-5" />
					<vertex x="-5" y="-5" z="5" />
					<vertex x="5" y="5" z="5" />
					<vertex x="-5" y="5" z="5" />
					<vertex x="5" y="5" z="5" />
					<vertex x="-5" y="-5" z="5" />
					<vertex x="5" y="-5" z="5" />
					<vertex x="5" y="5" z="5" />
					<vertex x="5" y="-5" z="-5" />
					<vertex x="5" y="5" z="-5" />
					<vertex x="5" y="-5" z="-5" />
					<vertex x="5" y="5" z="5" />
					<vertex x="5" y="-5" z="5" />
					<vertex x="5" y="-5" z="-5" />
					<vertex x="-5" y="5" z="-5" />
					<vertex x="5" y="5" z="-5" />
					<vertex x="-5" y="5" z="-5" />
					<vertex x="5" y="-5" z="-5" />
					<vertex x="-5" y="-5" z="-5" />
					<vertex x="-5" y="-5" z="5" />
					<vertex x="-5" y="5" z="-5" />
					<vertex x="-5" y="-5" z="-5" />
					<vertex x="-5" y="5" z="-5" />
					<vertex x="-5" y="-5" z="5" />
					<vertex x="-5" y="5" z="5" />
				</vertices>
				<triangles>
					<triangle v1="0" v2="1" v3="2" />
					<triangle v1="3" v2="4" v3="5" />
					<triangle v1="6" v2="7" v3="8" />
					<triangle v1="9" v2="10" v3="11" />
					<triangle v1="12" v2="13" v3="14" />
					<triangle v1="15" v2="16" v3="17" />
					<triangle v1="18" v2="19" v3="20" />
					<triangle v1="21" v2="22" v3="23" />
					<triangle v1="24" v2="25" v3="26" />
					<triangle v1="27" v2="28" v3="29" />
					<triangle v1="30" v2="31" v3="32" />
					<triangle v1="33" v2="34" v3="35" />
				</triangles>
			</mesh>
		</object>
	</resources>
	<build>
		<item objectid="1" transform="1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0 16.52989959716797 5.0 -0.002300000051036477" />
	</build>
</model>
```
After a model has been pasted the newly added objects are automatically selected.

The "cut" functionality is also added which simply works by sequencing the copy and delete selected actions.
https://github.com/Ultimaker/Cura/blob/f07faac4223d3d15d36b486e1fce18a84ea55fb0/cura/CuraActions.py#L191C6-L193

Copy paste cut can be executed by either pressing `ctrl+c`, `ctrl+v`, `ctrl+x` keys or by the right click context menu

![Screenshot 2023-08-04 at 13 32 28](https://github.com/Ultimaker/Cura/assets/6638028/b0d63574-c73f-4b70-92b0-7707ef8c342a)

CURA-7913