### PR TITLE
Change minimum support area to be 0 when tree supports are used (Elegoo profile)

### DIFF
--- a/resources/definitions/elegoo_base.def.json
+++ b/resources/definitions/elegoo_base.def.json
@@ -69,7 +69,7 @@
         "material_print_temperature_layer_0": { "value": "210 if material_print_temperature < 210 else material_print_temperature" },
         "min_infill_area": { "value": "5" },
         "minimum_interface_area": { "default_value": 10 },
-        "minimum_support_area": { "default_value": 3 },
+        "minimum_support_area": { "value": "3 if support_structure == 'normal' else 0" },
         "optimize_wall_printing_order": { "default_value": true },
         "prime_tower_brim_enable": { "default_value": true },
         "prime_tower_min_volume": { "value": "(layer_height) * (prime_tower_size / 2)**2 * 3 * 0.5 " },


### PR DESCRIPTION
# Description

Change `minimum support area` to be 0 when tree supports are used. This should prevent confusion like https://www.reddit.com/r/Cura/comments/15ggbuj/cura_54_not_generating_tree_supports/

## Type of change

- Printer definition file(s)
