### PR TITLE
CURA-10307_expand-one-at-a-time-shadow

### DIFF
--- a/cura/Scene/ConvexHullDecorator.py
+++ b/cura/Scene/ConvexHullDecorator.py
@@ -111,11 +111,7 @@ class ConvexHullDecorator(SceneNodeDecorator):
 
         # Parent can be None if node is just loaded.
         if self._isSingularOneAtATimeNode():
-            hull = self.getConvexHullHeadFull()
-            if hull is None:
-                return None
-            hull = self._add2DAdhesionMargin(hull)
-            return hull
+            return self.getConvexHullHeadFull()
 
         return self._compute2DConvexHull()
 
@@ -323,6 +319,7 @@ class ConvexHullDecorator(SceneNodeDecorator):
 
     def _compute2DConvexHeadFull(self) -> Optional[Polygon]:
         convex_hull = self._compute2DConvexHull()
+        convex_hull = self._add2DAdhesionMargin(convex_hull)
         if convex_hull:
             return convex_hull.getMinkowskiHull(self._getHeadAndFans())
         return None

--- a/resources/definitions/tizyx_evy.def.json
+++ b/resources/definitions/tizyx_evy.def.json
@@ -57,7 +57,7 @@
                 [25, 49],
                 [25, -49],
                 [-25, -49],
-                [25, 49]
+                [-25, 49]
             ]
         },
         "machine_heated_bed": { "default_value": true },

--- a/resources/definitions/tizyx_evy_dual.def.json
+++ b/resources/definitions/tizyx_evy_dual.def.json
@@ -54,7 +54,7 @@
                 [25, 49],
                 [25, -49],
                 [-25, -49],
-                [25, 49]
+                [-25, 49]
             ]
         },
         "machine_heated_bed": { "default_value": true },

--- a/resources/definitions/tizyx_k25.def.json
+++ b/resources/definitions/tizyx_k25.def.json
@@ -51,7 +51,7 @@
                 [25, 49],
                 [25, -49],
                 [-25, -49],
-                [25, 49]
+                [-25, 49]
             ]
         },
         "machine_heated_bed": { "default_value": true },


### PR DESCRIPTION
Call to _add2DAdhesionMargin is moved to a lower method so that it is always called when appropriate.
This should not cause side-effects, or at least only for one-at-a-time mode which is tagged as experimental.