### PR TITLE
CURA-10180-warning_out_of_space

### DIFF
--- a/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py
+++ b/plugins/RemovableDriveOutputDevice/RemovableDriveOutputDevice.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
+import os
 import os.path
 
 from UM.Application import Application
@@ -143,38 +144,44 @@ class RemovableDriveOutputDevice(OutputDevice):
 
     def _onFinished(self, job):
         if self._stream:
-            # Explicitly closing the stream flushes the write-buffer
+            error = job.getError()
             try:
+                # Explicitly closing the stream flushes the write-buffer
                 self._stream.close()
-                self._stream = None
-            except:
-                Logger.logException("w", "An exception occurred while trying to write to removable drive.")
-                message = Message(catalog.i18nc("@info:status", "Could not save to removable drive {0}: {1}").format(self.getName(),str(job.getError())),
-                                  title = catalog.i18nc("@info:title", "Error"),
-                                  message_type = Message.MessageType.ERROR)
+            except Exception as e:
+                if not error:
+                    # Only log new error if there was no previous one
+                    error = e
+
+            self._stream = None
+            self._writing = False
+            self.writeFinished.emit(self)
+
+            if not error:
+                message = Message(
+                    catalog.i18nc("@info:status", "Saved to Removable Drive {0} as {1}").format(self.getName(),
+                                                                                                os.path.basename(
+                                                                                                    job.getFileName())),
+                    title=catalog.i18nc("@info:title", "File Saved"),
+                    message_type=Message.MessageType.POSITIVE)
+                message.addAction("eject", catalog.i18nc("@action:button", "Eject"), "eject",
+                                  catalog.i18nc("@action", "Eject removable device {0}").format(self.getName()))
+                message.actionTriggered.connect(self._onActionTriggered)
+                message.show()
+                self.writeSuccess.emit(self)
+            else:
+                try:
+                    os.remove(job.getFileName())
+                except Exception as e:
+                    Logger.logException("e", "Exception when trying to remove incomplete exported file %s",
+                                        str(job.getFileName()))
+                message = Message(catalog.i18nc("@info:status",
+                                                "Could not save to removable drive {0}: {1}").format(self.getName(),
+                                                                                                     str(job.getError())),
+                                  title=catalog.i18nc("@info:title", "Error"),
+                                  message_type=Message.MessageType.ERROR)
                 message.show()
                 self.writeError.emit(self)
-                return
-
-        self._writing = False
-        self.writeFinished.emit(self)
-        if job.getResult():
-            message = Message(catalog.i18nc("@info:status", "Saved to Removable Drive {0} as {1}").format(self.getName(), os.path.basename(job.getFileName())),
-                              title = catalog.i18nc("@info:title", "File Saved"),
-                              message_type = Message.MessageType.POSITIVE)
-            message.addAction("eject", catalog.i18nc("@action:button", "Eject"), "eject", catalog.i18nc("@action", "Eject removable device {0}").format(self.getName()))
-            message.actionTriggered.connect(self._onActionTriggered)
-            message.show()
-            self.writeSuccess.emit(self)
-        else:
-            message = Message(catalog.i18nc("@info:status",
-                                            "Could not save to removable drive {0}: {1}").format(self.getName(),
-                                                                                                 str(job.getError())),
-                              title = catalog.i18nc("@info:title", "Error"),
-                              message_type = Message.MessageType.ERROR)
-            message.show()
-            self.writeError.emit(self)
-        job.getStream().close()
 
     def _onActionTriggered(self, message, action):
         if action == "eject":


### PR DESCRIPTION
The file exported on USB storage is now removed after the export in case an error occured.
I couldn't resist to clean the _onFinished method because it had a duplicate error handling, including one for which I'm failing to see how it could be reached (and could even possibly lead to a dirty situation). If this was necessary somehow, advise me and I will make the according revert.