### PR TITLE
Fixed possibly wrong error message

### DIFF
--- a/plugins/3MFWriter/ThreeMFWorkspaceWriter.py
+++ b/plugins/3MFWriter/ThreeMFWorkspaceWriter.py
@@ -98,7 +98,7 @@ class ThreeMFWorkspaceWriter(WorkspaceWriter):
             Logger.error("No permission to write workspace to this stream.")
             return False
         except EnvironmentError as e:
-            self.setInformation(catalog.i18nc("@error:zip", "The operating system does not allow saving a project file to this location or with this file name."))
+            self.setInformation(catalog.i18nc("@error:zip", str(e)))
             Logger.error("EnvironmentError when writing workspace to this stream: {err}".format(err = str(e)))
             return False
         mesh_writer.setStoreArchive(False)


### PR DESCRIPTION
When unable to save a project file because of full disk, the error message is wrong. I have used the same behavior as for the removable drive, which is to display the system error. It it possibly not displayed in user language, but at least it is accurate.