### PR TITLE
name fixed for correct property handling

### DIFF
--- a/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml
+++ b/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml
@@ -40,7 +40,7 @@ UM.Dialog
         }
     }
 
-    onAccepted: loadModelFiles(base.selectedFiles)
+    onAccepted: loadModelFiles(base.fileUrls)
 
     UM.Label
     {


### PR DESCRIPTION
CURA-10906

When opening multiple files [either through drag and drop on 5.0.0 or through the recent fix in 5.5 alpha on the open files], if there is a mix of STL & 3mf files in the selection, the pop up for “Import all as models“ shows but upon clicking, no model is imported. So this issue happens when a project file is involved in the mix, multiple project files also result in the same behavior
