### PR TITLE
Fix possible hang at startup/add printer

### DIFF
--- a/plugins/USBPrinting/AutoDetectBaudJob.py
+++ b/plugins/USBPrinting/AutoDetectBaudJob.py
@@ -27,14 +27,7 @@ class AutoDetectBaudJob(Job):
         write_timeout = 3
         read_timeout = 3
         tries = 2
-
-        programmer = Stk500v2()
         serial = None
-        try:
-            programmer.connect(self._serial_port)
-            serial = programmer.leaveISP()
-        except ispBase.IspError:
-            programmer.close()
 
         for retry in range(tries):
             for baud_rate in self._all_baud_rates:


### PR DESCRIPTION
I Removed the ISP leaving part from serial communication, which is **probably** unnecessary 99.99% of the times but may cause a hang when some USB devices are connected.

However, this may have side-effects in situations that I'm not aware of. IMHO, it may be useful after a failed firmware update, so that we can still detect the printer and retry the firmware update. But that may be workarounded by forcing the firmware update ? Maybe these cases would need testing.

Tested with UM S2 and Creality Ender 3 : detection still works as expected.