### PR TITLE
Default temperature corrections on the any color profiles

### DIFF
--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-abs_0.1mm.inst.cfg
@@ -12,6 +12,7 @@ variant = AA 0.25
 weight = 0
 
 [values]
+material_print_temperature = =default_material_print_temperature - 20
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 support_bottom_distance = =support_z_distance
 support_interface_enable = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-petg_0.1mm.inst.cfg
@@ -12,7 +12,7 @@ variant = AA 0.25
 weight = 0
 
 [values]
-material_print_temperature = =default_material_print_temperature - 5
+material_print_temperature = =default_material_print_temperature - 15
 speed_infill = =math.ceil(speed_print * 40 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 support_bottom_distance = =support_z_distance

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-pla_0.1mm.inst.cfg
@@ -16,7 +16,7 @@ brim_width = 8
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_heat_up_speed = 1.4
-material_print_temperature = 190
+material_print_temperature = =default_material_print_temperature - 10
 retraction_hop = 0.2
 speed_print = 30
 speed_wall = =math.ceil(speed_print * 25 / 30)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-tough-pla_0.1mm.inst.cfg
@@ -16,7 +16,7 @@ brim_width = 8
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_heat_up_speed = 1.4
-material_print_temperature = =default_material_print_temperature - 15
+material_print_temperature = =default_material_print_temperature - 5
 speed_print = 30
 speed_topbottom = =math.ceil(speed_print * 20 / 30)
 speed_wall = =math.ceil(speed_print * 25 / 30)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_abs_0.3mm.inst.cfg
@@ -15,6 +15,7 @@ weight = -3
 [values]
 machine_nozzle_heat_up_speed = 1.5
 material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature + 7
 prime_tower_enable = False
 raft_airgap = 0.15
 support_bottom_distance = =support_z_distance

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_petg_0.3mm.inst.cfg
@@ -14,6 +14,7 @@ weight = -3
 
 [values]
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+material_print_temperature = =default_material_print_temperature + 5
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_top_distance = =support_z_distance

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm.inst.cfg
@@ -15,7 +15,7 @@ weight = 1
 machine_nozzle_cool_down_speed = 0.8
 machine_nozzle_heat_up_speed = 1.5
 material_final_print_temperature = =material_print_temperature - 20
-material_print_temperature = =default_material_print_temperature + 5
+material_print_temperature = =default_material_print_temperature - 10
 prime_tower_enable = False
 raft_airgap = 0.15
 speed_infill = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
@@ -41,7 +41,6 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_max_flowrate = 20
-material_print_temperature = =default_material_print_temperature + 15
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_max_flowrate = 20
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm.inst.cfg
@@ -15,7 +15,7 @@ weight = 0
 machine_nozzle_cool_down_speed = 0.85
 machine_nozzle_heat_up_speed = 1.5
 material_final_print_temperature = =material_print_temperature - 20
-material_print_temperature = =default_material_print_temperature + 10
+material_print_temperature = =default_material_print_temperature - 5
 prime_tower_enable = False
 raft_airgap = 0.15
 speed_infill = =math.ceil(speed_print * 40 / 55)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
@@ -41,7 +41,7 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_max_flowrate = 20
-material_print_temperature = =default_material_print_temperature + 20
+material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_max_flowrate = 20
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
@@ -38,9 +38,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_max_flowrate = 20
 material_print_temperature = =default_material_print_temperature + 7
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_max_flowrate = 20
-material_print_temperature = =default_material_print_temperature + 22
+material_print_temperature = =default_material_print_temperature + 7
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 20
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 20
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
@@ -42,6 +42,7 @@ machine_nozzle_cool_down_speed = 1,4
 machine_nozzle_heat_up_speed = 1,7
 material_extrusion_cool_down_speed = 0,7
 material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature - 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_cool_down_speed = 1,4
 machine_nozzle_heat_up_speed = 1,7
 material_extrusion_cool_down_speed = 0,7
 material_max_flowrate = 20
-material_print_temperature = =default_material_print_temperature - 5
+material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
@@ -38,9 +38,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 20
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 12
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 12
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
@@ -38,9 +38,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 12
 material_print_temperature = =default_material_print_temperature + 10
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.06mm.inst.cfg
@@ -14,7 +14,7 @@ weight = 1
 [values]
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
-material_print_temperature = =default_material_print_temperature - 15
+material_print_temperature = =default_material_print_temperature - 5
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 14
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.1mm.inst.cfg
@@ -14,7 +14,7 @@ weight = 0
 [values]
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
-material_print_temperature = =default_material_print_temperature - 15
+material_print_temperature = =default_material_print_temperature - 5
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_print = 45

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 14
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -41,7 +41,6 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,7
 material_max_flowrate = 14
-material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,7
 material_max_flowrate = 14
-material_print_temperature = =default_material_print_temperature + 10
+material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -38,9 +38,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 14
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_flow = 93
 material_max_flowrate = 22
-material_print_temperature = =default_material_print_temperature + 20
+material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_flow = 93
 material_max_flowrate = 22
 material_print_temperature = =default_material_print_temperature + 5

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_flow = 93
 material_max_flowrate = 22
-material_print_temperature = =default_material_print_temperature + 22
+material_print_temperature = =default_material_print_temperature + 7
 optimize_wall_printing_order = False
 prime_tower_enable = True
 raft_airgap = 0.15

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_flow = 93
 material_max_flowrate = 22
 material_print_temperature = =default_material_print_temperature + 7

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_flow = 93
 material_max_flowrate = 22
 material_print_temperature = =default_material_print_temperature + 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_flow = 93
 material_max_flowrate = 22
-material_print_temperature = =default_material_print_temperature + 25
+material_print_temperature = =default_material_print_temperature + 10
 optimize_wall_printing_order = False
 prime_tower_enable = True
 raft_airgap = 0.15

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 23
 material_print_temperature = =default_material_print_temperature - 5

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 23
 material_print_temperature = =default_material_print_temperature - 5

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 23
 material_print_temperature = =default_material_print_temperature - 5

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 15
 material_print_temperature = =default_material_print_temperature + 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 15
 material_print_temperature = =default_material_print_temperature + 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 15
 material_print_temperature = =default_material_print_temperature + 15

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 17
 material_print_temperature = =default_material_print_temperature + 10

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,7
 material_flow = 93
 material_max_flowrate = 17
-material_print_temperature = =default_material_print_temperature + 10
+material_print_temperature = =default_material_print_temperature + 15
 optimize_wall_printing_order = False
 prime_tower_enable = True
 raft_airgap = 0.25

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 17
 material_print_temperature = =default_material_print_temperature + 15

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 17
 material_print_temperature = =default_material_print_temperature + 15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-abs_0.1mm.inst.cfg
@@ -12,6 +12,7 @@ variant = AA 0.25
 weight = 0
 
 [values]
+material_print_temperature = =default_material_print_temperature - 20
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 support_bottom_distance = =support_z_distance
 support_interface_enable = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-petg_0.1mm.inst.cfg
@@ -12,7 +12,7 @@ variant = AA 0.25
 weight = 0
 
 [values]
-material_print_temperature = =default_material_print_temperature - 5
+material_print_temperature = =default_material_print_temperature - 15
 speed_infill = =math.ceil(speed_print * 40 / 55)
 speed_topbottom = =math.ceil(speed_print * 30 / 55)
 support_bottom_distance = =support_z_distance

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-pla_0.1mm.inst.cfg
@@ -16,7 +16,7 @@ brim_width = 8
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_heat_up_speed = 1.4
-material_print_temperature = 190
+material_print_temperature = =default_material_print_temperature - 10
 retraction_hop = 0.2
 speed_print = 30
 speed_wall = =math.ceil(speed_print * 25 / 30)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-tough-pla_0.1mm.inst.cfg
@@ -16,7 +16,7 @@ brim_width = 8
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_heat_up_speed = 1.4
-material_print_temperature = =default_material_print_temperature - 15
+material_print_temperature = =default_material_print_temperature - 5
 speed_print = 30
 speed_topbottom = =math.ceil(speed_print * 20 / 30)
 speed_wall = =math.ceil(speed_print * 25 / 30)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_abs_0.3mm.inst.cfg
@@ -15,6 +15,7 @@ weight = -3
 [values]
 machine_nozzle_heat_up_speed = 1.5
 material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature + 7
 prime_tower_enable = False
 raft_airgap = 0.15
 support_bottom_distance = =support_z_distance

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_petg_0.3mm.inst.cfg
@@ -14,6 +14,7 @@ weight = -3
 
 [values]
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+material_print_temperature = =default_material_print_temperature + 5
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_top_distance = =support_z_distance

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm.inst.cfg
@@ -15,7 +15,7 @@ weight = 1
 machine_nozzle_cool_down_speed = 0.8
 machine_nozzle_heat_up_speed = 1.5
 material_final_print_temperature = =material_print_temperature - 20
-material_print_temperature = =default_material_print_temperature + 5
+material_print_temperature = =default_material_print_temperature - 10
 prime_tower_enable = False
 raft_airgap = 0.15
 speed_infill = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
@@ -41,7 +41,6 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_max_flowrate = 20
-material_print_temperature = =default_material_print_temperature + 15
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_max_flowrate = 20
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm.inst.cfg
@@ -15,7 +15,7 @@ weight = 0
 machine_nozzle_cool_down_speed = 0.85
 machine_nozzle_heat_up_speed = 1.5
 material_final_print_temperature = =material_print_temperature - 20
-material_print_temperature = =default_material_print_temperature + 10
+material_print_temperature = =default_material_print_temperature - 5
 prime_tower_enable = False
 raft_airgap = 0.15
 speed_infill = =math.ceil(speed_print * 40 / 55)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
@@ -41,7 +41,7 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_max_flowrate = 20
-material_print_temperature = =default_material_print_temperature + 20
+material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_max_flowrate = 20
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
@@ -38,9 +38,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_max_flowrate = 20
 material_print_temperature = =default_material_print_temperature + 7
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_max_flowrate = 20
-material_print_temperature = =default_material_print_temperature + 22
+material_print_temperature = =default_material_print_temperature + 7
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 20
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 20
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
@@ -42,6 +42,7 @@ machine_nozzle_cool_down_speed = 1,4
 machine_nozzle_heat_up_speed = 1,7
 material_extrusion_cool_down_speed = 0,7
 material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature - 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_cool_down_speed = 1,4
 machine_nozzle_heat_up_speed = 1,7
 material_extrusion_cool_down_speed = 0,7
 material_max_flowrate = 20
-material_print_temperature = =default_material_print_temperature - 5
+material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
@@ -38,9 +38,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 20
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 12
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 12
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
@@ -38,9 +38,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 12
 material_print_temperature = =default_material_print_temperature + 10
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.06mm.inst.cfg
@@ -14,7 +14,7 @@ weight = 1
 [values]
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
-material_print_temperature = =default_material_print_temperature - 15
+material_print_temperature = =default_material_print_temperature - 5
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 14
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.1mm.inst.cfg
@@ -14,7 +14,7 @@ weight = 0
 [values]
 machine_nozzle_cool_down_speed = 0.75
 machine_nozzle_heat_up_speed = 1.6
-material_print_temperature = =default_material_print_temperature - 15
+material_print_temperature = =default_material_print_temperature - 5
 prime_tower_enable = False
 retraction_prime_speed = =retraction_speed
 speed_print = 45

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 14
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -41,7 +41,6 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,7
 material_max_flowrate = 14
-material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_cool_down_speed = 1,3
 machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,7
 material_max_flowrate = 14
-material_print_temperature = =default_material_print_temperature + 10
+material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -38,9 +38,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_max_flowrate = 14
 material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_flow = 93
 material_max_flowrate = 22
-material_print_temperature = =default_material_print_temperature + 20
+material_print_temperature = =default_material_print_temperature + 5
 meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_flow = 93
 material_max_flowrate = 22
 material_print_temperature = =default_material_print_temperature + 5

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_flow = 93
 material_max_flowrate = 22
-material_print_temperature = =default_material_print_temperature + 22
+material_print_temperature = =default_material_print_temperature + 7
 optimize_wall_printing_order = False
 prime_tower_enable = True
 raft_airgap = 0.15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_flow = 93
 material_max_flowrate = 22
 material_print_temperature = =default_material_print_temperature + 7

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,8
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
 material_flow = 93
 material_max_flowrate = 22
 material_print_temperature = =default_material_print_temperature + 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,8
 material_flow = 93
 material_max_flowrate = 22
-material_print_temperature = =default_material_print_temperature + 25
+material_print_temperature = =default_material_print_temperature + 10
 optimize_wall_printing_order = False
 prime_tower_enable = True
 raft_airgap = 0.15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 23
 material_print_temperature = =default_material_print_temperature - 5

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 23
 material_print_temperature = =default_material_print_temperature - 5

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,4
-machine_nozzle_heat_up_speed = 1,7
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 23
 material_print_temperature = =default_material_print_temperature - 5

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 15
 material_print_temperature = =default_material_print_temperature + 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 15
 material_print_temperature = =default_material_print_temperature + 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 15
 material_print_temperature = =default_material_print_temperature + 15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 17
 material_print_temperature = =default_material_print_temperature + 10

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -42,7 +42,7 @@ machine_nozzle_heat_up_speed = 1,9
 material_extrusion_cool_down_speed = 0,7
 material_flow = 93
 material_max_flowrate = 17
-material_print_temperature = =default_material_print_temperature + 10
+material_print_temperature = =default_material_print_temperature + 15
 optimize_wall_printing_order = False
 prime_tower_enable = True
 raft_airgap = 0.25

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 17
 material_print_temperature = =default_material_print_temperature + 15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -37,9 +37,9 @@ jerk_roofing = =jerk_wall_0
 jerk_topbottom = =jerk_wall
 jerk_wall = =jerk_infill
 jerk_wall_0 = =max(30, speed_wall_0/2)
-machine_nozzle_cool_down_speed = 1,3
-machine_nozzle_heat_up_speed = 1,9
-material_extrusion_cool_down_speed = 0,7
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
 material_flow = 93
 material_max_flowrate = 17
 material_print_temperature = =default_material_print_temperature + 15


### PR DESCRIPTION
PP-350

# Description

The default print temperature have been normalized to the AA0.4, 0.15mm print modes. The temperature delta's for each print modes thus have changed. The new any color material print profiles were not yet adjusted for these changes, this PR changes that, 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Check temperatures PLA, T-PLA, PETG and ABS. The Generic and Ultimaker values are the same for all print modes.

CURA-11060