### PR TITLE
Cura 11064 plugin specific log files

### DIFF
--- a/cura/BackendPlugin.py
+++ b/cura/BackendPlugin.py
@@ -73,12 +73,17 @@ class BackendPlugin(AdditionalSettingDefinitionsAppender, PluginObject):
         """
         if not self.usePlugin():
             return False
+        Logger.info(f"Starting backend_plugin [{self._plugin_id}] with command: {self._validatePluginCommand()}")
+        plugin_log_path = os.path.join(Resources.getDataStoragePath(), f"{self.getPluginId()}.log")
+        if os.path.exists(plugin_log_path):
+            try:
+                os.remove(plugin_log_path)
+            except:
+                pass  # removing is only done such that it doesn't grow out of proportions, if it fails once or twice that is okay
+        Logger.info(f"Logging plugin output to: {plugin_log_path}")
         try:
             # STDIN needs to be None because we provide no input, but communicate via a local socket instead.
             # The NUL device sometimes doesn't exist on some computers.
-            Logger.info(f"Starting backend_plugin [{self._plugin_id}] with command: {self._validatePluginCommand()}")
-            plugin_log_path = os.path.join(Resources.getDataStoragePath(), f"{self.getPluginId()}.log")
-            Logger.info(f"Logging plugin output to: {plugin_log_path}")
             with open(plugin_log_path, 'a') as f:
                 popen_kwargs = {
                     "stdin": None,


### PR DESCRIPTION
# Description
Add backend specific logging, should help with debugging. It will create a log file for each services started in which it pipes the output to a unique file.
[CuraEngineGradualFlow.log](https://github.com/Ultimaker/Cura/files/12673168/CuraEngineGradualFlow.log)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Locally on Windows

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
