### PR TITLE
Fix cura recommended mode crashing

### DIFF
--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedPrintSetup.qml
@@ -39,7 +39,7 @@ Flickable
         padding: UM.Theme.getSize("default_margin").width
         spacing: UM.Theme.getSize("default_margin").height
 
-        width: recommendedPrintSetup.width - 2 * padding - (scroll.visible ? scroll.width : 0)
+        width: recommendedPrintSetup.width - 2 * padding - UM.Theme.getSize("thin_margin").width
 
         // TODO
         property real firstColumnWidth: Math.round(width / 3)


### PR DESCRIPTION
CURA-11051

# Description

This is most likely a bug in QT, however since it hard to debug/fix QT I propose this PR as a workaround instead. When changing printer/material/nozzle configuration sometimes the content of the recommended mode would change. As the content height of the recommended mode element would change the scroll bar would sometimes appear/disappear. When a scrollbar is visible the width of the recommended mode would change due to the additional space needed for the scrollbar. Some QT items in this page didn't like this and as a result cura would crash (most likely a crash in QT). As a work-around I propose to always leave space for the scroll bar whether is is visible or not. In my opinion it doesn't look bad, and it doesn't crash cura.

![Screenshot 2023-09-25 at 13 43 32](https://github.com/Ultimaker/Cura/assets/6638028/6c2edff3-8b0d-4aba-9105-da87f3246fb1)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?
Running from source, crash doesn't happen anymore.

**Test Configuration**:
* MacOS

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
