### PR TITLE
Fix crash when adding some printers

### DIFF
--- a/cura/Settings/cura_empty_instance_containers.py
+++ b/cura/Settings/cura_empty_instance_containers.py
@@ -28,6 +28,7 @@ empty_material_container.setMetaDataEntry("type", "material")
 empty_material_container.setMetaDataEntry("base_file", "empty_material")
 empty_material_container.setMetaDataEntry("GUID", "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")
 empty_material_container.setMetaDataEntry("material", "empty")
+empty_material_container.setMetaDataEntry("brand", "empty_brand")
 
 # Empty quality
 EMPTY_QUALITY_CONTAINER_ID = "empty_quality"


### PR DESCRIPTION
CURA-11089

Within some conditions, Cura crashes when adding some specific printers, because they use an "empty" material which has no brand reference, and we try to access it.