### PR TITLE
Remove material_print_temperature from sovol_base_planetary.def.json

### DIFF
--- a/resources/definitions/sovol_base_planetary.def.json
+++ b/resources/definitions/sovol_base_planetary.def.json
@@ -13,7 +13,6 @@
         "machine_acceleration": { "value": 1000 },
         "machine_max_feedrate_e": { "value": 40 },
         "machine_max_jerk_xy": { "value": 5 },
-        "material_print_temperature": { "value": 195 },
         "retraction_speed": { "default_value": 30 },
         "z_seam_corner": { "value": "'z_seam_corner_weighted'" }
     }


### PR DESCRIPTION
# Description

material_print_temperature should not be defined at the printer level as it overrides material default print temperature. Every gcode file comes out at 195* unless this setting is removed here, regardless of your material settings.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Tested by editing this file on the installed version of Cura on my PC. After this setting is removed at the printer definition level, the default temperature setting at the material definition level actually affects the final product, as you would expect.