### PR TITLE
Fix missing asc file in Linux build artifacts

### DIFF
--- a/.github/workflows/installers.yml
+++ b/.github/workflows/installers.yml
@@ -168,14 +168,22 @@ jobs:
         with:
           name: ${{ steps.filename.outputs.LINUX }}-AppImage
           path: installers
+          
+      - name: Download linux installer jobs asc artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ steps.filename.outputs.LINUX }}-asc
+          path: installers
 
       - name: Rename Linux installer to nightlies
         run: |
           mv installers/${{ steps.filename.outputs.LINUX }}.AppImage installers/${{ steps.filename.outputs.NIGHTLY_NAME }}-linux-X64.AppImage
+          mv installers/${{ steps.filename.outputs.LINUX }}.AppImage.asc installers/${{ steps.filename.outputs.NIGHTLY_NAME }}-linux-X64.AppImage.asc
 
       - name: Update nightly release for Linux
         run: |
           gh release upload nightly installers/${{ steps.filename.outputs.NIGHTLY_NAME }}-linux-X64.AppImage --clobber
+          gh release upload nightly installers/${{ steps.filename.outputs.NIGHTLY_NAME }}-linux-X64.AppImage.asc  --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -257,6 +257,14 @@ jobs:
             dist/${{ steps.filename.outputs.INSTALLER_FILENAME }}.AppImage
           retention-days: 5
 
+      - name: Upload the asc
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.filename.outputs.INSTALLER_FILENAME }}-asc
+          path: |
+            dist/${{ steps.filename.outputs.INSTALLER_FILENAME }}.AppImage.asc
+          retention-days: 5
+
       - name: Write the run info
         shell: python
         run: |

--- a/packaging/AppImage-builder/create_appimage.py
+++ b/packaging/AppImage-builder/create_appimage.py
@@ -38,7 +38,7 @@ def build_appimage(dist_path, version, appimage_filename):
     """
     generate_appimage_builder_config(dist_path, version, appimage_filename)
     create_appimage()
-    sign_appimage(dist_path, appimage_filename)
+    sign_appimage(appimage_filename)
 
 
 def generate_appimage_builder_config(dist_path, version, appimage_filename):
@@ -85,7 +85,7 @@ def create_appimage():
         raise RuntimeError(f"The AppImageTool command returned non-zero: {result}")
 
 
-def sign_appimage(dist_path, appimage_filename):
+def sign_appimage(appimage_filename):
     command = ["gpg", "--yes", "--armor", "--detach-sig", appimage_filename]
     result = subprocess.call(command)
     if result != 0:


### PR DESCRIPTION
# Description

The asc was created for the AppImage, but never uploaded as an artifact. **Merge to `5.5` and then merge `5.5` to `main`**. Since we will use the GH action from main to build the 5.5.0-beta.1 release

Fixes CURA-11087

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] NOT
- [ ] Test B

**Test Configuration**:
* Operating System: Linux

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
