### PR TITLE
Cura 11048 unclear support type

### DIFF
--- a/cura/Settings/CuraFormulaFunctions.py
+++ b/cura/Settings/CuraFormulaFunctions.py
@@ -90,6 +90,9 @@ class CuraFormulaFunctions:
             if isinstance(value, SettingFunction):
                 value = value(extruder, context = context)
 
+            if isinstance(value, str):
+                value = value.lower()
+
             result.append(value)
 
         if not result:

--- a/cura/Settings/CuraFormulaFunctions.py
+++ b/cura/Settings/CuraFormulaFunctions.py
@@ -56,6 +56,9 @@ class CuraFormulaFunctions:
         if isinstance(value, SettingFunction):
             value = value(extruder_stack, context = context)
 
+        if isinstance(value, str):
+            value = value.lower()
+
         return value
 
     def _getActiveExtruders(self, context: Optional["PropertyEvaluationContext"] = None) -> List[str]:
@@ -89,9 +92,6 @@ class CuraFormulaFunctions:
 
             if isinstance(value, SettingFunction):
                 value = value(extruder, context = context)
-
-            if isinstance(value, str):
-                value = value.lower()
 
             result.append(value)
 


### PR DESCRIPTION
CURA-11048
This code is an additional check if the enums are named starting with a Capital alphabet in the intent file.
Only check for support type and adhesion type