### PR TITLE
This addition allows the value not to reset

### DIFF
--- a/resources/qml/Preferences/SettingVisibilityItem.qml
+++ b/resources/qml/Preferences/SettingVisibilityItem.qml
@@ -96,5 +96,6 @@ Item
         containerStackId: "global"
         watchedProperties: [ "enabled" ]
         key: definition ? definition.key : ""
+        removeUnusedValue: false
     }
 }


### PR DESCRIPTION
CURA-10645

fixes: https://github.com/Ultimaker/Cura/issues/6217

The values for information icon button are now updated correctly. But only for settings that are not settable per mesh or per extruder. For these settings , It doesn't show the icon.