### PR TITLE
Restored PETG and ABS profiles. 

### DIFF
--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -41,6 +41,7 @@
             0
         ],
         "platform_texture": "UltimakerS3backplate.png",
+        "preferred_material": "ultimaker_pla_blue",
         "preferred_quality_type": "draft",
         "preferred_variant_name": "AA 0.4",
         "supported_actions": [ "DiscoverUM3Action" ],

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -38,6 +38,7 @@
             -10
         ],
         "platform_texture": "UltimakerS5backplate.png",
+        "preferred_material": "ultimaker_pla_blue",
         "preferred_quality_type": "draft",
         "preferred_variant_buildplate_name": "Glass",
         "preferred_variant_name": "AA 0.4",

--- a/resources/definitions/ultimaker_s7.def.json
+++ b/resources/definitions/ultimaker_s7.def.json
@@ -32,6 +32,7 @@
             0
         ],
         "platform_texture": "UltimakerS7backplate.png",
+        "preferred_material": "ultimaker_pla_blue",
         "preferred_variant_name": "AA 0.4",
         "quality_definition": "ultimaker_s5",
         "supported_actions": [ "DiscoverUM3Action" ],

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm_visual.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = high
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s3
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = fast
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = fast
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s3
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = normal
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm_visual.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = normal
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s3
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s3
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = False
+acceleration_wall_0 = 2000
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 30
+jerk_wall_0 = 30
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s3
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = fast
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s3
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = normal
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s3
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s3
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = False
+acceleration_wall_0 = 2000
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 30
+jerk_wall_0 = 30
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s3
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s3
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = False
+acceleration_wall_0 = 2000
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 30
+jerk_wall_0 = 30
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s3
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s3
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = False
+acceleration_wall_0 = 2000
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 30
+jerk_wall_0 = 30
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm_visual.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = high
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s5
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = fast
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = fast
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s5
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = normal
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm_visual.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = normal
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s5
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s5
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = False
+acceleration_wall_0 = 2000
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 30
+jerk_wall_0 = 30
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s5
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = fast
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s5
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = normal
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s5
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s5
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = False
+acceleration_wall_0 = 2000
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 30
+jerk_wall_0 = 30
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s5
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s5
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = False
+acceleration_wall_0 = 2000
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 30
+jerk_wall_0 = 30
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s5
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 30
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s5
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = False
+acceleration_wall_0 = 2000
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 30
+jerk_wall_0 = 30
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm_visual.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = intent
+variant = AA 0.8
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(25/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-abs_0.1mm.inst.cfg
@@ -1,0 +1,21 @@
+[general]
+definition = ultimaker_s3
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = normal
+setting_version = 22
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+material_print_temperature = =default_material_print_temperature - 20
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-petg_0.1mm.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s3
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = normal
+setting_version = 22
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+material_print_temperature = =default_material_print_temperature - 15
+speed_infill = =math.ceil(speed_print * 40 / 55)
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.8
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s3
+name = Extra Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = high
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+machine_nozzle_cool_down_speed = 0.8
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature - 10
+prime_tower_enable = False
+raft_airgap = 0.15
+speed_infill = =math.ceil(speed_print * 40 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 30 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Normal

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Normal
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = fast
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s3
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = normal
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = False
+raft_airgap = 0.15
+speed_infill = =math.ceil(speed_print * 40 / 55)
+speed_print = 55
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+speed_wall = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
@@ -1,0 +1,80 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Fast

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Extra Fast

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
@@ -1,0 +1,81 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = verydraft
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 7
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.06mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s3
+name = Extra Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = high
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 10
+speed_infill = =math.ceil(speed_print * 40 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 30 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Normal

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
@@ -1,0 +1,78 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Normal
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = fast
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s3
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = normal
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 5
+speed_infill = =math.ceil(speed_print * 45 / 55)
+speed_print = 55
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+speed_wall = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Fast

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Extra Fast

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
@@ -1,0 +1,80 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = verydraft
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
@@ -62,6 +62,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -62,6 +62,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -62,6 +62,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Fast

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Extra Fast

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = verydraft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 75
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/75))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Sprint

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Sprint
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = superdraft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 10
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/50))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
@@ -1,0 +1,78 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Fast

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Extra Fast

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
@@ -1,0 +1,78 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = verydraft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 75
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/75))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s3
 name = Sprint

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
@@ -1,0 +1,78 @@
+
+
+
+[general]
+definition = ultimaker_s3
+name = Sprint
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = superdraft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/50))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
@@ -64,6 +64,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/65))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/45))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -64,6 +64,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/65))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/45))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-abs_0.1mm.inst.cfg
@@ -1,0 +1,21 @@
+[general]
+definition = ultimaker_s5
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = normal
+setting_version = 22
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+material_print_temperature = =default_material_print_temperature - 20
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-petg_0.1mm.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s5
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = normal
+setting_version = 22
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+material_print_temperature = =default_material_print_temperature - 15
+speed_infill = =math.ceil(speed_print * 40 / 55)
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.8
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s5
+name = Extra Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = high
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+machine_nozzle_cool_down_speed = 0.8
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature - 10
+prime_tower_enable = False
+raft_airgap = 0.15
+speed_infill = =math.ceil(speed_print * 40 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 30 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Normal

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Normal
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = fast
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s5
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = normal
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = False
+raft_airgap = 0.15
+speed_infill = =math.ceil(speed_print * 40 / 55)
+speed_print = 55
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+speed_wall = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
@@ -1,0 +1,80 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Fast

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Extra Fast

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
@@ -1,0 +1,81 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = verydraft
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 7
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.06mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s5
+name = Extra Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = high
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 10
+speed_infill = =math.ceil(speed_print * 40 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 30 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
@@ -1,0 +1,78 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Normal
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = fast
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Normal

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s5
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = normal
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 5
+speed_infill = =math.ceil(speed_print * 45 / 55)
+speed_print = 55
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+speed_wall = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Fast

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
@@ -1,0 +1,80 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = verydraft
+setting_version = 22
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Extra Fast

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
@@ -62,6 +62,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -62,6 +62,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -62,6 +62,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_bottom_distance = =support_z_distance
 support_interface_enable = True
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = draft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Fast

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Extra Fast

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = verydraft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 75
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/75))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Sprint

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
@@ -1,0 +1,79 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Sprint
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = superdraft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 10
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/50))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
@@ -1,0 +1,78 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = draft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Fast

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Extra Fast

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
@@ -1,0 +1,78 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = verydraft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 75
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/75))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
@@ -1,6 +1,3 @@
-
-
-
 [general]
 definition = ultimaker_s5
 name = Sprint

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
@@ -1,0 +1,78 @@
+
+
+
+[general]
+definition = ultimaker_s5
+name = Sprint
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = superdraft
+setting_version = 22
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.2
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 2
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2)
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2)
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_no_small_gaps_heuristic = True
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = =speed_roofing
+speed_prime_tower = =speed_wall_0
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/50))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+z_seam_relative = True
+z_seam_type = back
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
@@ -64,6 +64,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/65))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/45))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -64,6 +64,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/100))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/65))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -63,6 +63,7 @@ speed_topbottom = =speed_print
 speed_wall = =speed_infill
 speed_wall_0 = =math.ceil(speed_wall*(30/45))
 speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
 support_angle = 70
 support_interface_enable = False
 support_structure = tree


### PR DESCRIPTION
is a copy of https://github.com/Ultimaker/Cura/pull/16896
Restored PETG and ABS profiles.
Lowered outer wall speed to 30mm/s for default mode.
Reduced gradual flow for PETG and ABS to 1.
Reduced inner wall speeds on top surface from 100mm/s to 45mm/s.
Make Ultimaker PLA blue the default material iso Generic PLA
Should be used in combination of PR: https://github.com/Ultimaker/Cura/pull/16892