### PR TITLE
Profile updates Cura 5.5 beta 

### DIFF
--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.06mm_visual.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = high
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 0.5
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm_visual.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s3
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = normal
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 0.5
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.06mm_visual.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = high
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 0.5
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm_visual.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s5
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = normal
+setting_version = 22
+type = intent
+variant = AA 0.4
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 0.5
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 20
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
@@ -24,9 +24,11 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 100
 bridge_skin_speed = =bridge_wall_speed
 bridge_sparse_infill_max_density = 50
-bridge_wall_speed = 30
+bridge_wall_material_flow = 100
+bridge_wall_speed = 20
 cool_min_layer_time = 4
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 infill_sparse_density = 15
@@ -47,7 +49,7 @@ meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = True
 retraction_amount = 3.5
-retraction_prime_speed = 22
+retraction_prime_speed = 15
 retraction_speed = 45
 skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
@@ -24,9 +24,11 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 100
 bridge_skin_speed = =bridge_wall_speed
 bridge_sparse_infill_max_density = 50
-bridge_wall_speed = 30
+bridge_wall_material_flow = 100
+bridge_wall_speed = 20
 cool_min_layer_time = 4
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 infill_sparse_density = 15
@@ -46,7 +48,7 @@ material_print_temperature = =default_material_print_temperature - 5
 optimize_wall_printing_order = False
 prime_tower_enable = True
 retraction_amount = 3.5
-retraction_prime_speed = 22
+retraction_prime_speed = 15
 retraction_speed = 45
 skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
@@ -24,9 +24,11 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 100
 bridge_skin_speed = =bridge_wall_speed
 bridge_sparse_infill_max_density = 50
-bridge_wall_speed = 30
+bridge_wall_material_flow = 100
+bridge_wall_speed = 20
 cool_min_layer_time = 4
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 infill_sparse_density = 15
@@ -46,7 +48,7 @@ material_print_temperature = =default_material_print_temperature - 5
 optimize_wall_printing_order = False
 prime_tower_enable = True
 retraction_amount = 3.5
-retraction_prime_speed = 22
+retraction_prime_speed = 15
 retraction_speed = 45
 skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
@@ -24,9 +24,11 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 100
 bridge_skin_speed = =bridge_wall_speed
 bridge_sparse_infill_max_density = 50
-bridge_wall_speed = 30
+bridge_wall_material_flow = 100
+bridge_wall_speed = 20
 cool_min_layer_time = 4
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 infill_sparse_density = 15
@@ -47,7 +49,7 @@ meshfix_maximum_resolution = 0.7
 optimize_wall_printing_order = False
 prime_tower_enable = True
 retraction_amount = 3.5
-retraction_prime_speed = 22
+retraction_prime_speed = 15
 retraction_speed = 45
 skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
@@ -24,9 +24,11 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 100
 bridge_skin_speed = =bridge_wall_speed
 bridge_sparse_infill_max_density = 50
-bridge_wall_speed = 30
+bridge_wall_material_flow = 100
+bridge_wall_speed = 20
 cool_min_layer_time = 4
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 infill_sparse_density = 15
@@ -46,7 +48,7 @@ material_print_temperature = =default_material_print_temperature - 5
 optimize_wall_printing_order = False
 prime_tower_enable = True
 retraction_amount = 3.5
-retraction_prime_speed = 22
+retraction_prime_speed = 15
 retraction_speed = 45
 skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
@@ -24,9 +24,11 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 100
 bridge_skin_speed = =bridge_wall_speed
 bridge_sparse_infill_max_density = 50
-bridge_wall_speed = 30
+bridge_wall_material_flow = 100
+bridge_wall_speed = 20
 cool_min_layer_time = 4
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
 infill_sparse_density = 15
@@ -46,7 +48,7 @@ material_print_temperature = =default_material_print_temperature - 5
 optimize_wall_printing_order = False
 prime_tower_enable = True
 retraction_amount = 3.5
-retraction_prime_speed = 22
+retraction_prime_speed = 15
 retraction_speed = 45
 skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False


### PR DESCRIPTION
- Added PETG visual mode for 0.1mm and 0.06mm
- Improved bridging settings for PETG AA0.8
- Improved unretract settings for PETG and ABS AA0.8