### PR TITLE
Remove "no skin in z gap" from profiles

### DIFF
--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
@@ -48,7 +48,6 @@ raft_airgap = 0.15
 retraction_amount = 6.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.15
 retraction_amount = 6.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.15
 retraction_amount = 6.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
@@ -47,7 +47,6 @@ prime_tower_enable = False
 retraction_amount = 8
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
@@ -48,7 +48,6 @@ prime_tower_enable = False
 retraction_amount = 8
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
@@ -48,7 +48,6 @@ prime_tower_enable = False
 retraction_amount = 8
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
@@ -48,7 +48,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -48,7 +48,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -48,7 +48,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
@@ -50,7 +50,6 @@ raft_airgap = 0.15
 retraction_amount = 4
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.15
 retraction_amount = 4
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.15
 retraction_amount = 4
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
@@ -51,7 +51,6 @@ prime_tower_enable = True
 retraction_amount = 3.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
@@ -50,7 +50,6 @@ prime_tower_enable = True
 retraction_amount = 3.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
@@ -50,7 +50,6 @@ prime_tower_enable = True
 retraction_amount = 3.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
@@ -50,7 +50,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -50,7 +50,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
@@ -48,7 +48,6 @@ raft_airgap = 0.15
 retraction_amount = 6.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.15
 retraction_amount = 6.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.15
 retraction_amount = 6.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
@@ -47,7 +47,6 @@ prime_tower_enable = False
 retraction_amount = 8
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
@@ -48,7 +48,6 @@ prime_tower_enable = False
 retraction_amount = 8
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
@@ -48,7 +48,6 @@ prime_tower_enable = False
 retraction_amount = 8
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
@@ -48,7 +48,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -48,7 +48,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -48,7 +48,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 6.5
 retraction_prime_speed = =retraction_speed
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
@@ -50,7 +50,6 @@ raft_airgap = 0.15
 retraction_amount = 4
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.15
 retraction_amount = 4
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.15
 retraction_amount = 4
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
@@ -51,7 +51,6 @@ prime_tower_enable = True
 retraction_amount = 3.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
@@ -50,7 +50,6 @@ prime_tower_enable = True
 retraction_amount = 3.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
@@ -50,7 +50,6 @@ prime_tower_enable = True
 retraction_amount = 3.5
 retraction_prime_speed = 15
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
@@ -50,7 +50,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -50,7 +50,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -49,7 +49,6 @@ raft_airgap = 0.25
 retraction_amount = 4
 retraction_prime_speed = 22
 retraction_speed = 45
-skin_no_small_gaps_heuristic = True
 small_skin_on_surface = False
 small_skin_width = 4
 speed_infill = =speed_print


### PR DESCRIPTION
# Description

The "No skin in z gap" was enabled in the profiles and caused issues in some prints on the skin layers of AA0.8 prints.
Disabled the option.

Relates to: CURA-11187