### PR TITLE
Fix memory leak issues in monitor page

### DIFF
--- a/cura/PrinterOutput/NetworkMJPGImage.py
+++ b/cura/PrinterOutput/NetworkMJPGImage.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2018 Aldo Hoeben / fieldOfView
 # NetworkMJPGImage is released under the terms of the LGPLv3 or higher.
 
+from typing import Optional
+
 from PyQt6.QtCore import QUrl, pyqtProperty, pyqtSignal, pyqtSlot, QRect, QByteArray
 from PyQt6.QtGui import QImage, QPainter
 from PyQt6.QtQuick import QQuickPaintedItem
@@ -19,9 +21,9 @@ class NetworkMJPGImage(QQuickPaintedItem):
 
         self._stream_buffer = QByteArray()
         self._stream_buffer_start_index = -1
-        self._network_manager = None  # type: QNetworkAccessManager
-        self._image_request = None  # type: QNetworkRequest
-        self._image_reply = None  # type: QNetworkReply
+        self._network_manager: Optional[QNetworkAccessManager] = None
+        self._image_request: Optional[QNetworkRequest] = None
+        self._image_reply: Optional[QNetworkReply] = None
         self._image = QImage()
         self._image_rect = QRect()
 

--- a/plugins/UM3NetworkPrinting/resources/qml/PrinterVideoStream.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/PrinterVideoStream.qml
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Ultimaker B.V.
+// Copyright (c) 2023 UltiMaker
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.2
@@ -6,7 +6,7 @@ import UM 1.3 as UM
 import Cura 1.0 as Cura
 
 Item {
-    property var cameraUrl: "";
+    property string cameraUrl: "";
 
     Rectangle {
         anchors.fill:parent;
@@ -34,22 +34,29 @@ Item {
 
     Cura.NetworkMJPGImage {
         id: cameraImage
-        anchors.horizontalCenter: parent.horizontalCenter;
-        anchors.verticalCenter: parent.verticalCenter;
-        height: Math.round((imageHeight === 0 ? 600 * screenScaleFactor : imageHeight) * width / imageWidth);
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+
+        readonly property real img_scale_factor: {
+            if (imageWidth > maximumWidth || imageHeight > maximumHeight) {
+                return Math.min(maximumWidth / imageWidth, maximumHeight / imageHeight);
+            }
+            return 1.0;
+        }
+
+        width: imageWidth === 0 ? 800 * screenScaleFactor : imageWidth * img_scale_factor
+        height: imageHeight === 0 ? 600 * screenScaleFactor : imageHeight * img_scale_factor
+
         onVisibleChanged: {
+            if (cameraUrl === "") return;
+
             if (visible) {
-                if (cameraUrl != "") {
-                    start();
-                }
+                start();
             } else {
-                if (cameraUrl != "") {
-                    stop();
-                }
+                stop();
             }
         }
         source: cameraUrl
-        width: Math.min(imageWidth === 0 ? 800 * screenScaleFactor : imageWidth, maximumWidth);
         z: 1
     }
 


### PR DESCRIPTION
# Description

Fix memory leak issues in monitor page. Issue was that QT (incorrectly?) asserted that there was a binding loop between width and height in the `NetworkMJPGImage` component. This caused the height to evalualte to `infinity`, making QT create a buffer with an infinite amount of memory. Solved by calculating a serpeate `img_scale_factor` which both the width and height uses.

CURA-11180

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Yes
**Test Configuration**:
* Operating System:
* macos arm64

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
