### PR TITLE
Add printer definition for Flying Bear Ghost 6

### DIFF
--- a/resources/definitions/flyingbear_ghost_6.def.json
+++ b/resources/definitions/flyingbear_ghost_6.def.json
@@ -1,0 +1,49 @@
+{
+    "version": 2,
+    "name": "Flying Bear Ghost 6",
+    "inherits": "flyingbear_base",
+    "metadata":
+    {
+        "visible": true,
+        "author": "barrnet",
+        "platform": "flyingbear_platform.obj",
+        "platform_texture": "flyingbear_platform.png",
+        "quality_definition": "flyingbear_base"
+    },
+    "overrides":
+    {
+	    "machine_name": { "default_value": "Flying Bear Ghost 6" },
+        "acceleration_enabled": { "value": false },
+        "acceleration_print": { "value": 1500 },
+        "acceleration_roofing": { "enabled": "acceleration_enabled and roofing_layer_count > 0 and top_layers > 0" },
+        "acceleration_travel": { "value": 3000 },
+        "acceleration_travel_layer_0": { "value": "acceleration_travel" },
+        "jerk_enabled": { "value": false },
+        "jerk_print": { "value": 20 },
+        "jerk_travel": { "value": "jerk_print" },
+        "jerk_travel_layer_0": { "value": "jerk_travel" },
+        "machine_acceleration": { "value": 1500 },
+        "machine_depth": { "default_value": 210 },
+        "machine_height": { "default_value": 210 },
+		"machine_width": { "default_value": 255 },
+        "machine_max_acceleration_e": { "value": 80000 },
+        "machine_max_acceleration_x": { "value": 1000 },
+        "machine_max_acceleration_y": { "value": 1000 },
+        "machine_max_acceleration_z": { "value": 200 },
+        "machine_max_feedrate_e": { "value": 70 },
+        "machine_max_feedrate_x": { "value": 200 },
+        "machine_max_feedrate_y": { "value": 200 },
+        "machine_max_feedrate_z": { "value": 20 },
+        "machine_max_jerk_e": { "value": 5.0 },
+        "machine_max_jerk_xy": { "value": 15 },
+        "machine_max_jerk_z": { "value": 0.4 },
+        "machine_name": { "default_value": "Flying Bear Ghost 6" },
+        "machine_steps_per_mm_e": { "default_value": 405 },
+        "machine_steps_per_mm_x": { "default_value": 160 },
+        "machine_steps_per_mm_y": { "default_value": 160 },
+        "machine_steps_per_mm_z": { "default_value": 800 },
+		"retraction_amount": { "value": 0.8 },
+        "retraction_extrusion_window": { "value": 1.5 },
+        "retraction_speed": { "default_value": 35 }
+    }
+}

--- a/resources/variants/flyingbear/flyingbear_ghost_6_0.25.inst.cfg
+++ b/resources/variants/flyingbear/flyingbear_ghost_6_0.25.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+definition = flyingbear_ghost_6
+name = 0.25mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.25

--- a/resources/variants/flyingbear/flyingbear_ghost_6_0.30.inst.cfg
+++ b/resources/variants/flyingbear/flyingbear_ghost_6_0.30.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+definition = flyingbear_ghost_6
+name = 0.3mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/flyingbear/flyingbear_ghost_6_0.40.inst.cfg
+++ b/resources/variants/flyingbear/flyingbear_ghost_6_0.40.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+definition = flyingbear_ghost_6
+name = 0.4mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.4

--- a/resources/variants/flyingbear/flyingbear_ghost_6_0.50.inst.cfg
+++ b/resources/variants/flyingbear/flyingbear_ghost_6_0.50.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+definition = flyingbear_ghost_6
+name = 0.5mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/flyingbear/flyingbear_ghost_6_0.60.inst.cfg
+++ b/resources/variants/flyingbear/flyingbear_ghost_6_0.60.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+definition = flyingbear_ghost_6
+name = 0.6mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/flyingbear/flyingbear_ghost_6_0.80.inst.cfg
+++ b/resources/variants/flyingbear/flyingbear_ghost_6_0.80.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+definition = flyingbear_ghost_6
+name = 0.8mm Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.8


### PR DESCRIPTION
I'm using for a couple of month a Flying Bear Ghost 6 with Ultimaker Cura as Slicer. Sadly, there aren't any profiles ready for this printer. I made a new definition for the printer using as base the definition of the previus printer (Ghost 4S) and I have changed the bed size and the retraction settings (the ghost 6 is a direct drive machine). 

For the "Machine Settings" definitions, I used the value returned by the firmware of the printer. This is my first time contributing to Cura, please tell me if I have did something wrong.