### PR TITLE
Fix bug loading intents

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -1700,6 +1700,16 @@ class MachineManager(QObject):
             else:  # No intent had the correct category.
                 extruder.intent = empty_intent_container
 
+    @pyqtSlot()
+    def resetIntents(self) -> None:
+        """Reset the intent category of the current printer.
+        """
+        global_stack = self._application.getGlobalContainerStack()
+        if global_stack is None:
+            return
+        for extruder in global_stack.extruderList:
+            extruder.intent = empty_intent_container
+
     def activeQualityGroup(self) -> Optional["QualityGroup"]:
         """Get the currently activated quality group.
 

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -1259,7 +1259,9 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
                 available_intent_category_list = IntentManager.getInstance().currentAvailableIntentCategories()
                 if self._intent_category_to_apply is not None and self._intent_category_to_apply in available_intent_category_list:
                     machine_manager.setIntentByCategory(self._intent_category_to_apply)
-
+                else:
+                    # if no intent is provided, reset to the default (balanced) intent
+                    machine_manager.resetIntents()
         # Notify everything/one that is to notify about changes.
         global_stack.containersChanged.emit(global_stack.getTop())
 

--- a/plugins/3MFReader/WorkspaceDialog.py
+++ b/plugins/3MFReader/WorkspaceDialog.py
@@ -35,10 +35,12 @@ class WorkspaceDialog(QObject):
         self._qml_url = "WorkspaceDialog.qml"
         self._lock = threading.Lock()
         self._default_strategy = None
-        self._result = {"machine": self._default_strategy,
-                        "quality_changes": self._default_strategy,
-                        "definition_changes": self._default_strategy,
-                        "material": self._default_strategy}
+        self._result = {
+            "machine": self._default_strategy,
+            "quality_changes": self._default_strategy,
+            "definition_changes": self._default_strategy,
+            "material": self._default_strategy,
+        }
         self._override_machine = None
         self._visible = False
         self.showDialogSignal.connect(self.__show)
@@ -347,10 +349,12 @@ class WorkspaceDialog(QObject):
         if threading.current_thread() != threading.main_thread():
             self._lock.acquire()
         # Reset the result
-        self._result = {"machine": self._default_strategy,
-                        "quality_changes": self._default_strategy,
-                        "definition_changes": self._default_strategy,
-                        "material": self._default_strategy}
+        self._result = {
+            "machine": self._default_strategy,
+            "quality_changes": self._default_strategy,
+            "definition_changes": self._default_strategy,
+            "material": self._default_strategy,
+        }
         self._visible = True
         self.showDialogSignal.emit()
 


### PR DESCRIPTION
# Description

This PR solves the bug where the intent does not correctly change when loading a project file that was saved using the "default" ("balanced") profile.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Yes

**Test Configuration**:
* Operating System:

mac os arm64

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
