### PR TITLE
Updated Brazilian Portuguese strings for 5.5

### DIFF
--- a/resources/i18n/pt_BR/cura.po
+++ b/resources/i18n/pt_BR/cura.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Cura 5.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-09-20 14:03+0000\n"
-"PO-Revision-Date: 2023-02-17 17:37+0100\n"
+"PO-Revision-Date: 2023-10-23 05:56+0200\n"
 "Last-Translator: Cláudio Sampaio <patola@gmail.com>\n"
 "Language-Team: Cláudio Sampaio <patola@gmail.com>\n"
 "Language: pt_BR\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.2.2\n"
+"X-Generator: Poedit 3.3.2\n"
 
 #, python-format
 msgctxt "@info 'width', 'depth' and 'height' are variable names that must NOT be translated; just translate the format of ##x##x## mm."
@@ -353,7 +353,7 @@ msgstr "Adicionar Impressora"
 
 msgctxt "@button"
 msgid "Add UltiMaker printer via Digital Factory"
-msgstr ""
+msgstr "Adicionar impressora UltiMaker via Digital Factory"
 
 msgctxt "@label"
 msgid "Add a Cloud printer"
@@ -377,7 +377,7 @@ msgstr "Adicionar ícone à bandeja do sistema *"
 
 msgctxt "@button"
 msgid "Add local printer"
-msgstr ""
+msgstr "Adicionar impressora local"
 
 msgctxt "@option:check"
 msgid "Add machine prefix to job name"
@@ -495,7 +495,7 @@ msgstr "Um modelo pode ser carregado diminuto se sua unidade for por exemplo em 
 
 msgctxt "@label"
 msgid "Annealing"
-msgstr ""
+msgstr "Recozimento"
 
 msgctxt "@label"
 msgid "Anonymous"
@@ -561,7 +561,7 @@ msgstr "Posicionar Todos os Modelos"
 
 msgctxt "@action:inmenu menubar:edit"
 msgid "Arrange All Models in a grid"
-msgstr ""
+msgstr "Organizar Todos os Modelos em Grade"
 
 msgctxt "@label:button"
 msgid "Ask a question"
@@ -569,7 +569,7 @@ msgstr "Fazer uma pergunta"
 
 msgctxt "@checkbox:description"
 msgid "Auto Backup"
-msgstr ""
+msgstr "Auto Backup"
 
 msgctxt "@checkbox:description"
 msgid "Automatically create a backup each day that Cura is started."
@@ -601,7 +601,7 @@ msgstr "Voltar"
 
 msgctxt "@info:title"
 msgid "Backup"
-msgstr ""
+msgstr "Backup"
 
 msgctxt "@button"
 msgid "Backup Now"
@@ -625,7 +625,7 @@ msgstr "Fazer backup e sincronizar os ajustes do Cura."
 
 msgctxt "@info:title"
 msgid "Backups"
-msgstr ""
+msgstr "Backups"
 
 msgctxt "@action:label"
 msgid "Base (mm)"
@@ -981,7 +981,7 @@ msgstr "Copiar todos os valores alterados para todos os extrusores"
 
 msgctxt "@action:inmenu menubar:edit"
 msgid "Copy to clipboard"
-msgstr ""
+msgstr "Copiar para a área de transferência"
 
 msgctxt "@action:menu"
 msgid "Copy value to all extruders"
@@ -1048,6 +1048,8 @@ msgid ""
 "Couldn't start EnginePlugin: {self._plugin_id}\n"
 "No permission to execute process."
 msgstr ""
+"Não foi possível iniciar EnginePlugin: {self._plugin_id}\n"
+"Sem permissão para executar processo."
 
 #, python-brace-format
 msgctxt "@info:plugin_failed"
@@ -1055,6 +1057,8 @@ msgid ""
 "Couldn't start EnginePlugin: {self._plugin_id}\n"
 "Operating system is blocking it (antivirus?)"
 msgstr ""
+"Não foi possível iniciar EnginePlugin: {self._plugin_id}\n"
+"O sistema operacional está bloqueando (antivírus?)"
 
 #, python-brace-format
 msgctxt "@info:plugin_failed"
@@ -1062,6 +1066,8 @@ msgid ""
 "Couldn't start EnginePlugin: {self._plugin_id}\n"
 "Resource is temporarily unavailable"
 msgstr ""
+"Não foi possível iniciar EnginePlugin: {self._plugin_id}\n"
+"O recurso está temporariamente indisponível"
 
 msgctxt "@title:window"
 msgid "Crash Report"
@@ -1174,11 +1180,11 @@ msgstr "CuraEngine Backend"
 
 msgctxt "description"
 msgid "CuraEngine plugin for gradually smoothing the flow to limit high-flow jumps"
-msgstr ""
+msgstr "Complemento do CuraEngine para gradualmente suavizar o fluxo para limitar rajadas de fluxo intenso"
 
 msgctxt "name"
 msgid "CuraEngineGradualFlow"
-msgstr ""
+msgstr "CuraEngineGradualFlow"
 
 msgctxt "@label"
 msgid "Currency:"
@@ -1214,7 +1220,7 @@ msgstr "Perfil personalizado"
 
 msgctxt "@info"
 msgid "Custom profile name:"
-msgstr ""
+msgstr "Nome de perfil personalizado:"
 
 msgctxt "@label"
 msgid "Custom profiles"
@@ -1226,7 +1232,7 @@ msgstr "Perfis personalizados"
 
 msgctxt "@action:inmenu menubar:edit"
 msgid "Cut"
-msgstr ""
+msgstr "Cortar"
 
 msgctxt "@item:inlistbox"
 msgid "Cutting mesh"
@@ -1258,11 +1264,11 @@ msgstr "Recusar e remover da conta"
 
 msgctxt "@info:No intent profile selected"
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 msgctxt "@label"
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 msgctxt "@window:text"
 msgid "Default behavior for changed setting values when switching to a different profile: "
@@ -1278,7 +1284,7 @@ msgstr "Comportamento default ao abrir um arquivo de projeto: "
 
 msgctxt "@action:button"
 msgid "Defaults"
-msgstr ""
+msgstr "Defaults"
 
 msgctxt "@label"
 msgid "Defines the thickness of your part side walls, roof and floor."
@@ -1402,7 +1408,7 @@ msgstr "Feito"
 
 msgctxt "@button"
 msgid "Downgrade"
-msgstr ""
+msgstr "Downgrade"
 
 msgctxt "@button"
 msgid "Downgrading..."
@@ -1460,7 +1466,7 @@ msgstr "Habilitar Extrusor"
 
 msgctxt "@label"
 msgid "Enable printing a brim or raft. This will add a flat area around or under your object which is easy to cut off afterwards. Disabling it results in a skirt around object by default."
-msgstr ""
+msgstr "Habilita a impressão de brim ou raft. Adicionará uma área plana em volta do objeto ou abaixo dele que seja fácil de destacar depois. Desabilitar este ajuste resulta em um skirt em volta do objeto por default."
 
 msgctxt "@label"
 msgid "Enabled"
@@ -1480,7 +1486,7 @@ msgstr "Solução completa para impressão 3D com filamento fundido."
 
 msgctxt "@info:title"
 msgid "EnginePlugin"
-msgstr ""
+msgstr "EnginePlugin"
 
 msgctxt "@label"
 msgid "Engineering"
@@ -1516,7 +1522,7 @@ msgstr "Sair da Tela Cheia"
 
 msgctxt "@label"
 msgid "Experimental"
-msgstr ""
+msgstr "Experimental"
 
 msgctxt "@action:button"
 msgid "Export"
@@ -1880,7 +1886,7 @@ msgstr "Interface Gráfica de usuário"
 
 msgctxt "@label"
 msgid "Grid Placement"
-msgstr ""
+msgstr "Posicionamento em Grade"
 
 #, python-brace-format
 msgctxt "@label"
@@ -1989,7 +1995,7 @@ msgstr "Para monitorar sua impressão pelo Cura, por favor conecte a impressora.
 
 msgctxt "@label"
 msgid "In order to start using Cura you will need to configure a printer."
-msgstr ""
+msgstr "Para poder iniciar o uso do Cura você precisará configurar uma impressora:"
 
 msgctxt "@button"
 msgid "In order to use the package you will need to restart Cura"
@@ -2005,11 +2011,11 @@ msgstr "Preenchimento"
 
 msgctxt "infill_sparse_density description"
 msgid "Infill Density"
-msgstr ""
+msgstr "Densidade de Preenchimento"
 
 msgctxt "@action:label"
 msgid "Infill Pattern"
-msgstr ""
+msgstr "Padrão de Preenchimento"
 
 msgctxt "@item:inlistbox"
 msgid "Infill mesh only"
@@ -2069,11 +2075,11 @@ msgstr "Instalar Pacote"
 
 msgctxt "@action:button"
 msgid "Install Packages"
-msgstr ""
+msgstr "Instalar Pacotes"
 
 msgctxt "@header"
 msgid "Install Packages"
-msgstr ""
+msgstr "Instala Pacotes"
 
 msgctxt "@header"
 msgid "Install Plugins"
@@ -2081,15 +2087,15 @@ msgstr "Instalar Complementos"
 
 msgctxt "@action:button"
 msgid "Install missing packages"
-msgstr ""
+msgstr "Instalar pacotes faltantes"
 
 msgctxt "@title"
 msgid "Install missing packages"
-msgstr ""
+msgstr "Instala pacotes faltantes"
 
 msgctxt "@label"
 msgid "Install missing packages from project file."
-msgstr ""
+msgstr "Instala pacotes faltantes do arquivo de projeto."
 
 msgctxt "@button"
 msgid "Install pending updates"
@@ -2113,7 +2119,7 @@ msgstr "Objetivo"
 
 msgctxt "@label"
 msgid "Interface"
-msgstr ""
+msgstr "Interface"
 
 msgctxt "@label Description for application component"
 msgid "Interprocess communication library"
@@ -2229,7 +2235,7 @@ msgstr "Saiba mais sobre adicionar impressoras ao Cura"
 
 msgctxt "@label"
 msgid "Learn more about project packages."
-msgstr ""
+msgstr "Aprenda mais sobre pacotes de projeto"
 
 msgctxt "@action:inmenu menubar:view"
 msgid "Left Side View"
@@ -2401,11 +2407,11 @@ msgstr "Gerencie seu complementos e perfis de materiais do Cura aqui. Se assegur
 
 msgctxt "description"
 msgid "Manages extensions to the application and allows browsing extensions from the UltiMaker website."
-msgstr ""
+msgstr "Gerencia extensões à aplicação e permite navegar extensões do website da UltiMaker."
 
 msgctxt "description"
 msgid "Manages network connections to UltiMaker networked printers."
-msgstr ""
+msgstr "Gerencia conexões de rede com as impressoras de rede da UltiMaker."
 
 msgctxt "@label"
 msgid "Manufacturer"
@@ -2505,7 +2511,7 @@ msgstr "Modificar ajustes para sobreposições"
 
 msgctxt "@item:inmenu"
 msgid "Monitor"
-msgstr ""
+msgstr "Monitor"
 
 msgctxt "name"
 msgid "Monitor Stage"
@@ -2559,7 +2565,7 @@ msgstr[1] "Multiplicar Modelos Selecionados"
 
 msgctxt "@info"
 msgid "Multiply selected item and place them in a grid of build plate."
-msgstr ""
+msgstr "Multiplica o item selecionado e o dispõe em grade na plataforma de impressão."
 
 msgctxt "@info:status"
 msgid "Multiplying and placing objects"
@@ -2592,11 +2598,11 @@ msgstr "Novo firmware estável de %s disponível"
 
 msgctxt "@textfield:placeholder"
 msgid "New Custom Profile"
-msgstr ""
+msgstr "Novo Perfil Personalizado"
 
 msgctxt "@label"
 msgid "New UltiMaker printers can be connected to Digital Factory and monitored remotely."
-msgstr ""
+msgstr "Novas impressoras UltiMaker podem ser conectadas à Digital Factory e monitoradas remotamente."
 
 #, python-brace-format
 msgctxt "@info Don't translate {machine_name}, since it gets replaced by a printer name!"
@@ -2627,7 +2633,7 @@ msgstr "Próximo"
 
 msgctxt "@info:title"
 msgid "Nightly build"
-msgstr ""
+msgstr "Compilação noturna"
 
 msgctxt "@info"
 msgid "No"
@@ -2688,7 +2694,7 @@ msgstr "Sem estimativa de tempo disponível"
 
 msgctxt "@button"
 msgid "Non UltiMaker printer"
-msgstr ""
+msgstr "Impressora Não-UltiMaker"
 
 msgctxt "@info No materials"
 msgid "None"
@@ -2813,7 +2819,7 @@ msgstr "Abrir Arquivo de Projeto"
 
 msgctxt "@action:label"
 msgid "Open With"
-msgstr ""
+msgstr "Abrir Com"
 
 msgctxt "@action:button"
 msgid "Open as project"
@@ -2910,7 +2916,7 @@ msgstr "Interpretando G-Code"
 
 msgctxt "@action:inmenu menubar:edit"
 msgid "Paste from clipboard"
-msgstr ""
+msgstr "Colar da área de transferência"
 
 msgctxt "@label"
 msgid "Pause"
@@ -3205,7 +3211,7 @@ msgstr "Imprimir pela nuvem"
 
 msgctxt "@action:label"
 msgid "Print with"
-msgstr ""
+msgstr "Imprimir com"
 
 msgctxt "@title:tab"
 msgid "Printer"
@@ -3422,7 +3428,7 @@ msgstr "Provê suporta à leitura de arquivos AMF."
 
 msgctxt "description"
 msgid "Provides support for reading Ultimaker Format Packages."
-msgstr ""
+msgstr "Provê suporte à leitura de Formatos de Pacote Ultimaker."
 
 msgctxt "description"
 msgid "Provides support for reading X3D files."
@@ -3438,7 +3444,7 @@ msgstr "Provê suporte à escrita de arquivos 3MF."
 
 msgctxt "description"
 msgid "Provides support for writing Ultimaker Format Packages."
-msgstr ""
+msgstr "Provê suporte à escrita de Formatos de Pacote Ultimaker."
 
 msgctxt "description"
 msgid "Provides the Per Model Settings."
@@ -3507,7 +3513,7 @@ msgstr "Recomendado"
 
 msgctxt "@label"
 msgid "Recommended print settings"
-msgstr ""
+msgstr "Ajustes recomendados de impressão"
 
 msgctxt "@info %1 is the name of a profile"
 msgid "Recommended settings (for <b>%1</b>) were altered."
@@ -3531,7 +3537,7 @@ msgstr "Atualizar Lista"
 
 msgctxt "@button"
 msgid "Refreshing..."
-msgstr ""
+msgstr "Atualizando..."
 
 msgctxt "@label"
 msgid "Release Notes"
@@ -3679,7 +3685,7 @@ msgstr "Salvar o projeto Cura e imprimir o arquivo"
 
 msgctxt "@title:window"
 msgid "Save Custom Profile"
-msgstr ""
+msgstr "Salvar Perfil Personalizado"
 
 msgctxt "@title:window"
 msgid "Save Project"
@@ -3691,15 +3697,15 @@ msgstr "Salvar Projeto..."
 
 msgctxt "@action:button"
 msgid "Save as new custom profile"
-msgstr ""
+msgstr "Salvar como novo perfil personalizado"
 
 msgctxt "@action:button"
 msgid "Save changes"
-msgstr ""
+msgstr "Salvar alterações"
 
 msgctxt "@button"
 msgid "Save new profile"
-msgstr ""
+msgstr "Salvar novo perfil"
 
 msgctxt "@text"
 msgid "Save the .umm file on a USB stick."
@@ -3874,7 +3880,7 @@ msgstr "Perímetro"
 
 msgctxt "@action:label"
 msgid "Shell Thickness"
-msgstr ""
+msgstr "Espessura de Perímetro"
 
 msgctxt "@info:tooltip"
 msgid "Should Cura check for updates when the program is started?"
@@ -3946,7 +3952,7 @@ msgstr "Exibir Pasta de Configuração"
 
 msgctxt "@button"
 msgid "Show Custom"
-msgstr ""
+msgstr "Mostrar Personalizado"
 
 msgctxt "@action:inmenu menubar:help"
 msgid "Show Online &Documentation"
@@ -3986,7 +3992,7 @@ msgstr "Exibir diálogo de resumo ao salvar projeto"
 
 msgctxt "@tooltip:button"
 msgid "Show your support for Cura with a donation."
-msgstr ""
+msgstr "Mostre seu suporte ao Cura com uma doação."
 
 msgctxt "@button"
 msgid "Sign Out"
@@ -4006,11 +4012,11 @@ msgstr "Entrar"
 
 msgctxt "@info"
 msgid "Sign in into UltiMaker Digital Factory"
-msgstr ""
+msgstr "Fazer login na Ultimaker Digital Factory"
 
 msgctxt "@button"
 msgid "Sign in to Digital Factory"
-msgstr ""
+msgstr "Fazer login na Digital Factory"
 
 msgctxt "@label"
 msgid "Sign in to the UltiMaker platform"
@@ -4088,15 +4094,15 @@ msgstr ""
 
 msgctxt "@info:status"
 msgid "Some of the packages used in the project file are currently not installed in Cura, this might produce undesirable print results. We highly recommend installing the all required packages from the Marketplace."
-msgstr ""
+msgstr "Alguns dos pacotes usados no arquivo de projeto não estão atualmente instalados no Cura, isto pode produzir resultados de impressão não desejados. Recomendamos fortemente instalar todos os pacotes requeridos pelo MarketPlace."
 
 msgctxt "@info:title"
 msgid "Some required packages are not installed"
-msgstr ""
+msgstr "Alguns pacotes requeridos não estão instalados"
 
 msgctxt "@info %1 is the name of a profile"
 msgid "Some setting-values defined in <b>%1</b> were overridden."
-msgstr ""
+msgstr "Alguns valores de ajustes definidos em <b>%1</b> foram sobrepostos."
 
 msgctxt "@tooltip"
 msgid ""
@@ -4130,11 +4136,11 @@ msgstr "Velocidade"
 
 msgctxt "@action:inmenu"
 msgid "Sponsor Cura"
-msgstr ""
+msgstr "Patrocinar o Cura"
 
 msgctxt "@label:button"
 msgid "Sponsor Cura"
-msgstr ""
+msgstr "Patrocinar o Cura"
 
 msgctxt "@option:radio"
 msgid "Stable and Beta releases"
@@ -4223,7 +4229,7 @@ msgstr "Interface de Suporte"
 
 msgctxt "@action:label"
 msgid "Support Type"
-msgstr ""
+msgstr "Tipo de Suporte"
 
 msgctxt "@label Description for application dependency"
 msgid "Support library for faster math"
@@ -4307,7 +4313,7 @@ msgstr "A quantidade de suavização para aplicar na imagem."
 
 msgctxt "@text"
 msgid "The annealing profile requires post-processing in an oven after the print is finished. This profile retains the dimensional accuracy of the printed part after annealing and improves strength, stiffness, and thermal resistance."
-msgstr ""
+msgstr "O perfil de recozimento requer pós-processamento em um forno depois da impressão terminar. Este perfil retém a acuidade dimensional da parte impressão depois do recozimento e melhora a força, rigidez e resistência térmica."
 
 msgctxt "@label"
 msgid "The assigned printer, %1, requires the following configuration change:"
@@ -4462,7 +4468,7 @@ msgstr "A porcentagem de luz penetrando uma impressão com espessura de 1 milím
 
 msgctxt "@label:label Ultimaker Marketplace is a brand name, don't translate"
 msgid "The plugin associated with the Cura project could not be found on the Ultimaker Marketplace. As the plugin may be required to slice the project it might not be possible to correctly slice the file."
-msgstr ""
+msgstr "O complemento associado com o projeto Cura não foi encontrado no Ultimaker Marketplace. Como o complemento pode ser necessário para fatiar o projeto, pode não ser possível corretamente fatiar este arquivo."
 
 msgctxt "@info:title"
 msgid "The print job was successfully submitted"
@@ -4617,7 +4623,7 @@ msgstr "Este perfil usa os defaults especificados pela impressora, portanto não
 
 msgctxt "@label"
 msgid "This project contains materials or plugins that are currently not installed in Cura.<br/>Install the missing packages and reopen the project."
-msgstr ""
+msgstr "Este projeto contém materiais ou complementos que não estão atualmente instalados no Cura.<br/>Instale os pacotes faltantes e abra novamente o projeto."
 
 msgctxt "@label"
 msgid ""
@@ -4663,7 +4669,7 @@ msgstr "Este ajuste é resolvido dos valores conflitante específicos de extruso
 
 msgctxt "@info:warning"
 msgid "This version is not intended for production use. If you encounter any issues, please report them on our GitHub page, mentioning the full version {self.getVersion()}"
-msgstr ""
+msgstr "Esta versão não é pretendida para uso em produção. Se você encontrar quaisquer problemas, por favor relate-os na nossa página de GitHub, mencionando a versão completa {self.getVersion()}"
 
 msgctxt "@label"
 msgid "Time estimation"
@@ -4797,7 +4803,7 @@ msgstr "Pacote de Formato da UltiMaker"
 
 msgctxt "name"
 msgid "UltiMaker Network Connection"
-msgstr ""
+msgstr "Conexão de Rede UltiMaker"
 
 msgctxt "@info"
 msgid "UltiMaker Verified Package"
@@ -4809,11 +4815,11 @@ msgstr "Complemento Verificado UltiMaker"
 
 msgctxt "name"
 msgid "UltiMaker machine actions"
-msgstr ""
+msgstr "Ações de máquina UltiMaker"
 
 msgctxt "@button"
 msgid "UltiMaker printer"
-msgstr ""
+msgstr "Impressora UltiMaker"
 
 msgctxt "@label:button"
 msgid "UltiMaker support"
@@ -4838,7 +4844,7 @@ msgstr "Não foi possível achar um lugar dentro do volume de construção para 
 #, python-brace-format
 msgctxt "@info:plugin_failed"
 msgid "Unable to find local EnginePlugin server executable for: {self._plugin_id}"
-msgstr ""
+msgstr "Não foi possível encontrar o executável do servidor local de EnginePlugin para: {self._plugin_id}"
 
 #, python-brace-format
 msgctxt "@info:plugin_failed"
@@ -4846,6 +4852,8 @@ msgid ""
 "Unable to kill running EnginePlugin: {self._plugin_id}\n"
 "Access is denied."
 msgstr ""
+"Não foi possível matar o processo EnginePlugin: {self._plugin_id}\n"
+"Acesso negado."
 
 msgctxt "@info"
 msgid "Unable to reach the UltiMaker account server."
@@ -4888,7 +4896,7 @@ msgstr "Não foi possível fatiar com os ajustes atuais. Os seguintes ajustes t�
 
 msgctxt "@info"
 msgid "Unable to start a new sign in process. Check if another sign in attempt is still active."
-msgstr "Não foi possível iniciar processo de sign-in. Verifique se outra tentativa de sign-in ainda está ativa."
+msgstr "Não foi possível iniciar processo de login. Verifique se outra tentativa de login ainda está ativa."
 
 msgctxt "@label:status"
 msgid "Unavailable"
@@ -5093,11 +5101,11 @@ msgstr "Atualiza configurações do Cura 5.2 para o Cura 5.3."
 
 msgctxt "description"
 msgid "Upgrades configurations from Cura 5.3 to Cura 5.4."
-msgstr ""
+msgstr "Atualiza configurações do Cura 5.3 para o Cura 5.4."
 
 msgctxt "description"
 msgid "Upgrades configurations from Cura 5.4 to Cura 5.5."
-msgstr ""
+msgstr "Atualiza configurações do Cura 5.4 para o Cura 5.5."
 
 msgctxt "@action:button"
 msgid "Upload custom Firmware"
@@ -5229,11 +5237,11 @@ msgstr "Atualização de Versão de 5.2 para 5.3"
 
 msgctxt "name"
 msgid "Version Upgrade 5.3 to 5.4"
-msgstr ""
+msgstr "Atualização de Versão de 5.3 para 5.4"
 
 msgctxt "name"
 msgid "Version Upgrade 5.4 to 5.5"
-msgstr ""
+msgstr "Atualização de Versão de 5.4 para 5.5"
 
 msgctxt "@button"
 msgid "View printers in Digital Factory"
@@ -5265,7 +5273,7 @@ msgstr "Visita o website da UltiMaker."
 
 msgctxt "@label"
 msgid "Visual"
-msgstr ""
+msgstr "Visual"
 
 msgctxt "@label"
 msgid "Waiting for"
@@ -5277,7 +5285,7 @@ msgstr "Aguardando resposta da Nuvem"
 
 msgctxt "@button"
 msgid "Waiting for new printers"
-msgstr ""
+msgstr "Esperando por novas impressoras"
 
 msgctxt "@button"
 msgid "Want more?"
@@ -5429,7 +5437,7 @@ msgstr[1] ""
 
 msgctxt "@info:status"
 msgid "You are attempting to connect to a printer that is not running UltiMaker Connect. Please update the printer to the latest firmware."
-msgstr ""
+msgstr "Você está tentando conectar a uma impressora que não está rodando UltiMaker Connect. Por favor atualize a impressora para o firmware mais recente."
 
 #, python-brace-format
 msgctxt "@info:status"

--- a/resources/i18n/pt_BR/fdmprinter.def.json.po
+++ b/resources/i18n/pt_BR/fdmprinter.def.json.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Cura 5.0\n"
 "Report-Msgid-Bugs-To: plugins@ultimaker.com\n"
 "POT-Creation-Date: 2023-09-12 17:04+0000\n"
-"PO-Revision-Date: 2023-06-25 18:17+0200\n"
+"PO-Revision-Date: 2023-10-23 06:17+0200\n"
 "Last-Translator: Cláudio Sampaio <patola@gmail.com>\n"
 "Language-Team: Cláudio Sampaio <patola@gmail.com>\n"
 "Language: pt_BR\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.3.1\n"
+"X-Generator: Poedit 3.3.2\n"
 
 msgctxt "ironing_inset description"
 msgid "A distance to keep from the edges of the model. Ironing all the way to the edge of the mesh may result in a jagged edge on your print."
@@ -783,11 +783,11 @@ msgstr "Distância da estrutura de suporte até a impressão nas direções X e 
 
 msgctxt "meshfix_fluid_motion_shift_distance description"
 msgid "Distance points are shifted to smooth the path"
-msgstr ""
+msgstr "Pontos de distância são deslocados para suavizar o caminho"
 
 msgctxt "meshfix_fluid_motion_small_distance description"
 msgid "Distance points are shifted to smooth the path"
-msgstr ""
+msgstr "Pontos de distância são deslocados para suavizar o caminho"
 
 msgctxt "min_infill_area description"
 msgid "Don't generate areas of infill smaller than this (use skin instead)."
@@ -839,7 +839,7 @@ msgstr "Habilitar Cobertura de Trabalho"
 
 msgctxt "meshfix_fluid_motion_enabled label"
 msgid "Enable Fluid Motion"
-msgstr ""
+msgstr "Habilitar Movimento Fluido"
 
 msgctxt "ironing_enabled label"
 msgid "Enable Ironing"
@@ -903,7 +903,7 @@ msgstr "Habilita a cobertura exterior de escorrimento. Isso criará uma casca ou
 
 msgctxt "small_skin_on_surface description"
 msgid "Enable small (up to 'Small Top/Bottom Width') regions on the topmost skinned layer (exposed to air) to be filled with walls instead of the default pattern."
-msgstr ""
+msgstr "Habilita pequenas regiões (até a 'Largura de Teto/Base Pequenos') na camada superior com contorno (exposta ao ar) pra serem preenchidas com paredes ao invés do padrão default."
 
 msgctxt "jerk_enabled description"
 msgid "Enables adjusting the jerk of print head when the velocity in the X or Y axis changes. Increasing the jerk can reduce printing time at the cost of print quality."
@@ -1119,15 +1119,15 @@ msgstr "Compensação de fluxo: a quantidade de material extrudado é multiplica
 
 msgctxt "meshfix_fluid_motion_angle label"
 msgid "Fluid Motion Angle"
-msgstr ""
+msgstr "Ângulo de Movimento Fluido"
 
 msgctxt "meshfix_fluid_motion_shift_distance label"
 msgid "Fluid Motion Shift Distance"
-msgstr ""
+msgstr "Distância de Deslocamento do Movimento Fluido"
 
 msgctxt "meshfix_fluid_motion_small_distance label"
 msgid "Fluid Motion Small Distance"
-msgstr ""
+msgstr "Distância Pequena do Movimento Fluido"
 
 msgctxt "material_flush_purge_length label"
 msgid "Flush Purge Length"
@@ -1419,7 +1419,7 @@ msgstr "Se uma região do contorno for suportada por menos do que esta porcentag
 
 msgctxt "meshfix_fluid_motion_angle description"
 msgid "If a toolpath-segment deviates more than this angle from the general motion it is smoothed."
-msgstr ""
+msgstr "Se um segmento do percurso do extrusor se desviar do movimento geral por um ângulo maior que esse, será suavizado."
 
 msgctxt "bridge_enable_more_layers description"
 msgid "If enabled, the second and third layers above the air are printed using the following settings. Otherwise, those layers are printed using the normal settings."
@@ -3053,13 +3053,14 @@ msgctxt "small_hole_max_size label"
 msgid "Small Hole Max Size"
 msgstr "Tamanho Máximo de Furos Pequenos"
 
+#, fuzzy
 msgctxt "cool_min_temperature label"
 msgid "Small Layer Printing Temperature"
 msgstr "Temperatura de Impressão Final"
 
 msgctxt "small_skin_on_surface label"
 msgid "Small Top/Bottom On Surface"
-msgstr ""
+msgstr "Pequena Base/Teto Na Superfície"
 
 msgctxt "small_skin_width label"
 msgid "Small Top/Bottom Width"
@@ -3075,7 +3076,7 @@ msgstr "Aspectos pequenos serão impressos nessa porcentagem da velocidade norma
 
 msgctxt "small_skin_width description"
 msgid "Small top/bottom regions are filled with walls instead of the default top/bottom pattern. This helps to avoids jerky motions. Off for the topmost (air-exposed) layer by default (see 'Small Top/Bottom On Surface')."
-msgstr ""
+msgstr "Regiões pequenas de base/teto são preenchidas com paredes ao invés do padrão default de teto/base. Isto ajuda a prevenir movimentos bruscos. Desligado por default para a camada superior (exposta ao ar) (Veja 'Pequena Base/Teto Na Superfície')"
 
 msgctxt "brim_smart_ordering label"
 msgid "Smart Brim"
@@ -3169,6 +3170,7 @@ msgctxt "support_bottom_distance label"
 msgid "Support Bottom Distance"
 msgstr "Distância Inferior do Suporte"
 
+#, fuzzy
 msgctxt "support_bottom_wall_count label"
 msgid "Support Bottom Wall Line Count"
 msgstr "Contagem de Linhas de Parede de Suporte"
@@ -3333,6 +3335,7 @@ msgctxt "support_interface_height label"
 msgid "Support Interface Thickness"
 msgstr "Espessura da Interface de Suporte"
 
+#, fuzzy
 msgctxt "support_interface_wall_count label"
 msgid "Support Interface Wall Line Count"
 msgstr "Contagem de Linhas de Parede de Suporte"
@@ -3417,6 +3420,7 @@ msgctxt "support_roof_height label"
 msgid "Support Roof Thickness"
 msgstr "Espessura do Topo do Suporte"
 
+#, fuzzy
 msgctxt "support_roof_wall_count label"
 msgid "Support Roof Wall Line Count"
 msgstr "Contagem de Linhas de Parede de Suporte"
@@ -3757,6 +3761,7 @@ msgctxt "brim_width description"
 msgid "The distance from the model to the outermost brim line. A larger brim enhances adhesion to the build plate, but also reduces the effective print area."
 msgstr "A distância do modelo à linha mais externa do brim. Um brim mais largo aumenta a aderência à mesa, mas também reduz a área efetiva de impressão."
 
+#, fuzzy
 msgctxt "interlocking_boundary_avoidance description"
 msgid "The distance from the outside of a model where interlocking structures will not be generated, measured in cells."
 msgstr "Distância da ponta do bico onde 'estacionar' o filamento quando seu extrusor não estiver sendo usado."
@@ -4273,14 +4278,17 @@ msgctxt "support_wall_count description"
 msgid "The number of walls with which to surround support infill. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used."
 msgstr "O número de paredes com as quais contornar o preenchimento de suporte. Adicionar uma parede pode tornar a impressão de suporte mais confiável e apoiar seções pendentes melhor, mas aumenta tempo de impressão e material usado."
 
+#, fuzzy
 msgctxt "support_bottom_wall_count description"
 msgid "The number of walls with which to surround support interface floor. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used."
 msgstr "O número de paredes com as quais contornar o preenchimento de suporte. Adicionar uma parede pode tornar a impressão de suporte mais confiável e apoiar seções pendentes melhor, mas aumenta tempo de impressão e material usado."
 
+#, fuzzy
 msgctxt "support_roof_wall_count description"
 msgid "The number of walls with which to surround support interface roof. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used."
 msgstr "O número de paredes com as quais contornar o preenchimento de suporte. Adicionar uma parede pode tornar a impressão de suporte mais confiável e apoiar seções pendentes melhor, mas aumenta tempo de impressão e material usado."
 
+#, fuzzy
 msgctxt "support_interface_wall_count description"
 msgid "The number of walls with which to surround support interface. Adding a wall can make support print more reliably and can support overhangs better, but increases print time and material used."
 msgstr "O número de paredes com as quais contornar o preenchimento de suporte. Adicionar uma parede pode tornar a impressão de suporte mais confiável e apoiar seções pendentes melhor, mas aumenta tempo de impressão e material usado."
@@ -4629,6 +4637,7 @@ msgctxt "support_brim_width description"
 msgid "The width of the brim to print underneath the support. A larger brim enhances adhesion to the build plate, at the cost of some extra material."
 msgstr "A largura do brim a ser impresso sob o suporte. Um brim mais largo melhora a aderência à mesa de impressão, ao custo de material extra."
 
+#, fuzzy
 msgctxt "interlocking_beam_width description"
 msgid "The width of the interlocking structure beams."
 msgstr "A largura da torre de purga."
@@ -4999,7 +5008,7 @@ msgstr "Quando verificar se há partes do modelo abaixo e acima do suporte, usar
 
 msgctxt "meshfix_fluid_motion_enabled description"
 msgid "When enabled tool paths are corrected for printers with smooth motion planners. Small movements that deviate from the general tool path direction are smoothed to improve fluid motions."
-msgstr ""
+msgstr "Quando habilitado os percursos do extrusor são corrigidos para impressora com planejadores de movimento suavizado. Pequenos movimentos que se desviariam da direção geral do percurso do extrusor são suavizados para melhorar os movimentos fluidos."
 
 msgctxt "infill_enable_travel_optimization description"
 msgid "When enabled, the order in which the infill lines are printed is optimized to reduce the distance travelled. The reduction in travel time achieved very much depends on the model being sliced, infill pattern, density, etc. Note that, for some models that have many small areas of infill, the time to slice the model may be greatly increased."
@@ -5023,7 +5032,7 @@ msgstr "Quando maior que zero, a Expansão Horizontal de Furo é gradualmente ap
 
 msgctxt "hole_xy_offset description"
 msgid "When greater than zero, the Hole Horizontal Expansion is the amount of offset applied to all holes in each layer. Positive values increase the size of the holes, negative values reduce the size of the holes. When this setting is enabled it can be further tuned with Hole Horizontal Expansion Max Diameter."
-msgstr ""
+msgstr "Quando maior que zero, a Expansão Original do Furo designa a distância de compensação aplicada a todos os furos em cada camada. Valores positivos aumentam os tamanhos dos furos, valores negativos reduzem os tamanhos dos furos. Quando este ajuste é habilitado, ele pode ser ainda aprimorado com o ajuste 'Diâmetro Máximo da Expansão Horizontal de Furo':"
 
 msgctxt "bridge_skin_material_flow description"
 msgid "When printing bridge skin regions, the amount of material extruded is multiplied by this value."
@@ -5389,52 +5398,46 @@ msgctxt "travel description"
 msgid "travel"
 msgstr "percurso"
 
-
-
-
-### Settings added by bundled engine backend plugins. Add this manually for now. Should be removed whenever we handle it better.
-
+# ## Settings added by bundled engine backend plugins. Add this manually for now. Should be removed whenever we handle it better.
 msgctxt "gradual_flow_enabled label"
 msgid "Gradual flow enabled"
-msgstr ""
+msgstr "Fluxo gradual habilitado"
 
 msgctxt "gradual_flow_enabled description"
 msgid "Enable gradual flow changes. When enabled, the flow is gradually increased/decreased to the target flow. This is useful for printers with a bowden tube where the flow is not immediately changed when the extruder motor starts/stops."
-msgstr ""
+msgstr "Habilita mudanças graduais de fluxo. Quando habilitado, o fluxo é gradualmente aumentado ou reduzido para o fluxo alvo. Útil para impressoras com tubo bowden onde o fluxo não é imediatamente alterado quando o motor do extrusor inicia ou para."
 
 msgctxt "max_flow_acceleration label"
 msgid "Gradual flow max acceleration"
-msgstr ""
+msgstr "Aceleração máxima do fluxo gradual"
 
 msgctxt "max_flow_acceleration description"
 msgid "Maximum acceleration for gradual flow changes"
-msgstr ""
+msgstr "Aceleração máxima para alterações de fluxo gradual"
 
 msgctxt "layer_0_max_flow_acceleration label"
 msgid "Initial layer max flow acceleration"
-msgstr ""
+msgstr "Aceleração máxima de fluxo da camada inicial"
 
 msgctxt "layer_0_max_flow_acceleration description"
 msgid "Minimum speed for gradual flow changes for the first layer"
-msgstr ""
+msgstr "Velocidade mínima para alterações graduais de fluxo na primeira camada"
 
 msgctxt "gradual_flow_discretisation_step_size label"
 msgid "Gradual flow discretisation step size"
-msgstr ""
+msgstr "Tamanho de passo da discretização de fluxo gradual"
 
 msgctxt "gradual_flow_discretisation_step_size description"
 msgid "Duration of each step in the gradual flow change"
-msgstr ""
+msgstr "Duração de cada passo na alteração de fluxo gradual"
 
 msgctxt "reset_flow_duration label"
 msgid "Reset flow duration"
-msgstr ""
+msgstr "Duração de reset do fluxo"
 
 msgctxt "reset_flow_duration description"
 msgid "For any travel move longer than this value, the material flow is reset to the paths target flow"
-msgstr ""
-
-
+msgstr "Para qualquer movimento mais longo que este valor, o fluxo material é resetado para o fluxo-alvo do percurso."
 
 #~ msgctxt "machine_head_polygon description"
 #~ msgid "A 2D silhouette of the print head (fan caps excluded)."
@@ -6652,6 +6655,7 @@ msgstr ""
 #~ msgid "WP Upward Printing Speed"
 #~ msgstr "Velocidade de Impressão Ascendente da IA"
 
+#, fuzzy
 #~ msgctxt "material_bed_temp_wait label"
 #~ msgid "Wait for build plate heatup"
 #~ msgstr "Aguardar o aquecimento do bico"


### PR DESCRIPTION
# Description

Updated Brazilian Portuguese strings for 5.5

## Type of change

- [X] Translations

# How Has This Been Tested?

- Used in local build of Cura 5.5 beta

**Test Configuration**:
* Operating System: Arch Linux current

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
