### PR TITLE
CURA 11132 fix missing icon crash

### DIFF
--- a/packaging/AppImage-builder/AppImageBuilder.yml.jinja
+++ b/packaging/AppImage-builder/AppImageBuilder.yml.jinja
@@ -47,17 +47,26 @@ AppDir:
     - sourceline: deb https://packagecloud.io/slacktechnologies/slack/debian/ jessie
         main
     include:
-      - xdg-desktop-portal-kde:amd64
+      - xdg-desktop-portal-kde
+      - libgtk-3-0
+      - librsvg2-2
+      - librsvg2-common
+      - libgdk-pixbuf2.0-0
+      - libgdk-pixbuf2.0-bin
+      - libgdk-pixbuf2.0-common
+      - imagemagick
+      - shared-mime-info
+      - gnome-icon-theme-symbolic
+      - hicolor-icon-theme
     exclude: []
   files:
-    include:
-      - usr/share/icons/hicolor/*
+    include: []
     exclude:
-    - usr/share/man
-    - usr/share/doc/*/README.*
-    - usr/share/doc/*/changelog.*
-    - usr/share/doc/*/NEWS.*
-    - usr/share/doc/*/TODO.*
+      - usr/share/man
+      - usr/share/doc/*/README.*
+      - usr/share/doc/*/changelog.*
+      - usr/share/doc/*/NEWS.*
+      - usr/share/doc/*/TODO.*
   runtime:
     env:
       APPDIR_LIBRARY_PATH: "$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/lib/x86_64-linux-gnu:$APPDIR/usr/lib:$APPDIR/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders"
@@ -65,7 +74,8 @@ AppDir:
       QT_PLUGIN_PATH: "$APPDIR/qt/plugins"
       QML2_IMPORT_PATH: "$APPDIR/qt/qml"
       QT_QPA_PLATFORMTHEME: xdgdesktopportal
-      XDG_DATA_HOME: "$APPDIR/usr/share"
+      GDK_PIXBUF_MODULEDIR: $APPDIR/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders
+      GDK_PIXBUF_MODULE_FILE: $APPDIR/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders.cache
     path_mappings:
       - /usr/share:$APPDIR/usr/share
   test:

--- a/packaging/AppImage-builder/AppImageBuilder.yml.jinja
+++ b/packaging/AppImage-builder/AppImageBuilder.yml.jinja
@@ -48,12 +48,10 @@ AppDir:
         main
     include:
       - xdg-desktop-portal-kde:amd64
-    exclude:
-      - hicolor-icon-theme
-      - adwaita-icon-theme
-      - humanity-icon-theme
+    exclude: []
   files:
-    include: []
+    include:
+      - usr/share/icons/hicolor/*
     exclude:
     - usr/share/man
     - usr/share/doc/*/README.*
@@ -67,6 +65,9 @@ AppDir:
       QT_PLUGIN_PATH: "$APPDIR/qt/plugins"
       QML2_IMPORT_PATH: "$APPDIR/qt/qml"
       QT_QPA_PLATFORMTHEME: xdgdesktopportal
+      XDG_DATA_HOME: "$APPDIR/usr/share"
+    path_mappings:
+      - /usr/share:$APPDIR/usr/share
   test:
     fedora-30:
       image: appimagecrafters/tests-env:fedora-30


### PR DESCRIPTION
# Description

Make sure that all relevant icons and pix-buf libs are packaged. Tested in on Manjaro, Mint 20.4, Debian and  Ubuntu

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?
By running this build on various systems: [UltiMaker-Cura-5.6.0-alpha+cura_11132_dd2a80-linux-X64-AppImage](https://github.com/Ultimaker/Cura/suites/17531272304/artifacts/1001529737)


**Test Configuration**:
* Operating System: Linux see above

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
