### PR TITLE
Proper print head & gantry dimensions for Ender 3 V3 SE

### DIFF
--- a/resources/definitions/creality_ender3v3se.def.json
+++ b/resources/definitions/creality_ender3v3se.def.json
@@ -20,15 +20,17 @@
     },
     "overrides":
     {
-        "gantry_height": { "value": 25 },
+        "gantry_height": { "value": 47 },
         "machine_depth": { "default_value": 220 },
         "machine_head_with_fans_polygon":
         {
             "default_value": [
-                [-20, 10],
-                [10, 10],
-                [10, -10],
-                [-20, -10]
+                [-36, -14],
+                [-20, -44],
+                [5, -44],
+                [30, -14],
+                [30, 78],
+                [-36, 78]
             ]
         },
         "machine_heated_bed": { "default_value": true },


### PR DESCRIPTION
# Description

This updates the dimensions of the gantry & print head (used for one-at-a-time mode) according to their actual size on an Ender 3 V3 SE

## Type of change

- [x] Printer definition file(s)

# How Has This Been Tested?

- [x] Measured & tested on an Ender 3 V3 SE machine with the stock extruder
- [x] Printed a test consisting of 5 tall objects in a cross pattern spaced accordingy to the configuration file

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
