### PR TITLE
Print head & gantry dimensions for Ender 3 V3 SE

### DIFF
--- a/resources/definitions/creality_ender3v3se.def.json
+++ b/resources/definitions/creality_ender3v3se.def.json
@@ -20,15 +20,18 @@
     },
     "overrides":
     {
-        "gantry_height": { "value": 25 },
+        "gantry_height": { "value": 38 },
         "machine_depth": { "default_value": 220 },
         "machine_head_with_fans_polygon":
         {
             "default_value": [
-                [-20, 10],
-                [10, 10],
-                [10, -10],
-                [-20, -10]
+                [-36, -18],
+                [-20, -42],
+                [6, -42],
+                [30, -18],
+                [30, 52],
+                [-3, 56],
+                [-36, 52]
             ]
         },
         "machine_heated_bed": { "default_value": true },


### PR DESCRIPTION
# Description

This updates the dimensions of the gantry & print head (used for one-at-a-time mode) from default values to their actual size on an Ender 3 V3 SE

## Type of change

- [x] Printer definition file(s)

# How Has This Been Tested?

- [x] Measured & tested on an Ender 3 V3 SE machine with the stock extruder
- [x] Printed a test consisting of 5 towers in a cross pattern spaced accordingy to the configuration file

![2023-10-24 13_40_38-CE3V3SE_test - UltiMaker Cura](https://github.com/Ultimaker/Cura/assets/22035925/342ddbcd-3481-4022-9df8-1670d0aadae9)


![photo_2023-10-24_15-34-56](https://github.com/Ultimaker/Cura/assets/22035925/6606d052-fa28-4bc0-942f-63914f1a3171)
