### PR TITLE
Add setting for specific prime tower raft line spacing

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6722,6 +6722,22 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },
+                "prime_tower_raft_base_line_spacing":
+                {
+                    "label": "Prime Tower Raft Line Spacing",
+                    "description": "The distance between the raft lines for the unique prime tower raft layer. Wide spacing makes for easy removal of the raft from the build plate.",
+                    "unit": "mm",
+                    "type": "float",
+                    "default_value": 1.6,
+                    "value": "raft_base_line_spacing",
+                    "minimum_value": "0",
+                    "minimum_value_warning": "raft_base_line_width",
+                    "maximum_value_warning": "100",
+                    "enabled": "resolveOrValue('prime_tower_enable') and resolveOrValue('adhesion_type') == 'raft'",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true,
+                    "limit_to_extruder": "raft_base_extruder_nr"
+                },
                 "ooze_shield_enabled":
                 {
                     "label": "Enable Ooze Shield",

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -360,7 +360,8 @@ prime_tower_wipe_enabled
 prime_tower_brim_enable
 prime_tower_base_size
 prime_tower_base_height
-prime_tower_base_curvature
+prime_tower_base_curve_magnitude
+prime_tower_raft_base_line_spacing
 ooze_shield_enabled
 ooze_shield_angle
 ooze_shield_dist


### PR DESCRIPTION
Simply add a setting to allow for a different line spacing for the raft of the prime tower's first layer, because in some situations we want extra adhesion for it as it has a low footprint but can get very tall.

This goes along with https://github.com/Ultimaker/CuraEngine/pull/1974

CURA-11233