### PR TITLE
Replace altool for notary tool

### DIFF
--- a/packaging/MacOS/build_macos.py
+++ b/packaging/MacOS/build_macos.py
@@ -87,15 +87,16 @@ def notarize_file(dist_path: str, filename: str) -> None:
     """ Notarize a file. This takes 5+ minutes, there is indication that this step is successful."""
     notarize_user = os.environ.get("MAC_NOTARIZE_USER")
     notarize_password = os.environ.get("MAC_NOTARIZE_PASS")
-    altool_executable = os.environ.get("ALTOOL_EXECUTABLE", "altool")
+    notarize_team = os.environ.get("MACOS_CERT_USER")
+    notary_executable = os.environ.get("NOTARY_TOOL_EXECUTABLE", "notarytool")
 
     notarize_arguments = [
-        "xcrun", altool_executable,
-        "--notarize-app",
-        "--primary-bundle-id", ULTIMAKER_CURA_DOMAIN,
-        "--username", notarize_user,
+        "xcrun", notary_executable,
+        "submit",
+        "--apple-id", notarize_user,
         "--password", notarize_password,
-        "--file", Path(dist_path, filename)
+        "--team-id", notarize_team,
+        Path(dist_path, filename)
     ]
 
     subprocess.run(notarize_arguments)


### PR DESCRIPTION
# Description

Mac's `altool` is being deprecated. New signing tool provided by apple is `notarytool`. This PR replaces `altool` for `notarytool`.

see: https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool?changes=_3_3

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?
Ran github action and checked if the builds were correctly signed

**Test Configuration**:
mac os arm

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change

CURA-9929