### PR TITLE
Update PrintMonitor.qml

### DIFF
--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -129,7 +129,7 @@ ScrollView
         {
             id: bedTemperature
             containerStack: Cura.MachineManager.activeMachine
-            key: "material_bed_temperature"
+            key: "material_bed_temperature_layer_0"
             watchedProperties: ["value", "minimum_value", "maximum_value", "resolve"]
             storeIndex: 0
 

--- a/resources/qml/PrinterOutput/ExtruderBox.qml
+++ b/resources/qml/PrinterOutput/ExtruderBox.qml
@@ -22,7 +22,7 @@ Item
     {
         id: extruderTemperature
         containerStackId: Cura.ExtruderManager.extruderIds[position]
-        key: "material_print_temperature"
+        key: "material_print_temperature_layer_0"
         watchedProperties: ["value", "minimum_value", "maximum_value", "resolve"]
         storeIndex: 0
 


### PR DESCRIPTION
# Description
1.) Change the default temperature in the "Monitor / Build Plate / PreHeat Bed Temperature" box to the value of the "material_bed_temperature_layer_0" setting rather than the "material_bed_temperature" setting.
2.) Change the default temperature in the "Monitor / Build Plate / PreHeat Extruder Temperature" box to the value of the "material_print_temperature_layer_0" setting rather than the "material_print_temperature" setting.

This fixes... OR This improves... -->
#17155 

- [ X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* Operating System: Windows 10 Pro
* Cura Version: 5.5.0

# Checklist:
<!-- Check if relevant -->

- [ X] I have uploaded any files required to test this change
