### PR TITLE
Add `node` as an optional argument to `isometricSnapshot`

### DIFF
--- a/cura/PreviewPass.py
+++ b/cura/PreviewPass.py
@@ -45,17 +45,17 @@ class PreviewPass(RenderPass):
     This is useful to get a preview image of a scene taken from a different location as the active camera.
     """
 
-    def __init__(self, width: int, height: int) -> None:
+    def __init__(self, width: int, height: int, *, root: CuraSceneNode = None) -> None:
         super().__init__("preview", width, height, 0)
 
-        self._camera = None  # type: Optional[Camera]
+        self._camera: Optional[Camera] = None
 
         self._renderer = Application.getInstance().getRenderer()
 
-        self._shader = None  # type: Optional[ShaderProgram]
-        self._non_printing_shader = None  # type: Optional[ShaderProgram]
-        self._support_mesh_shader = None  # type: Optional[ShaderProgram]
-        self._scene = Application.getInstance().getController().getScene()
+        self._shader: Optional[ShaderProgram] = None
+        self._non_printing_shader: Optional[ShaderProgram] = None
+        self._support_mesh_shader: Optional[ShaderProgram] = None
+        self._root = Application.getInstance().getController().getScene().getRoot() if root is None else root
 
     #   Set the camera to be used by this render pass
     #   if it's None, the active camera is used
@@ -96,7 +96,7 @@ class PreviewPass(RenderPass):
         batch_support_mesh = RenderBatch(self._support_mesh_shader)
 
         # Fill up the batch with objects that can be sliced.
-        for node in DepthFirstIterator(self._scene.getRoot()):
+        for node in DepthFirstIterator(self._root):
             if hasattr(node, "_outside_buildarea") and not getattr(node, "_outside_buildarea"):
                 if node.callDecoration("isSliceable") and node.getMeshData() and node.isVisible():
                     per_mesh_stack = node.callDecoration("getStack")

--- a/cura/Snapshot.py
+++ b/cura/Snapshot.py
@@ -37,15 +37,24 @@ class Snapshot:
         return min_x, max_x, min_y, max_y
 
     @staticmethod
-    def isometricSnapshot(width: int = 300, height: int = 300) -> Optional[QImage]:
-        """Create an isometric snapshot of the scene."""
+    def isometricSnapshot(width: int = 300, height: int = 300, *, node: Optional[SceneNode] = None) -> Optional[QImage]:
+        """
+        Create an isometric snapshot of the scene.
 
-        root = Application.getInstance().getController().getScene().getRoot()
+        :param width: width of the aspect ratio default 300
+        :param height: height of the aspect ratio default 300
+        :param node: node of the scene default is the root of the scene
+        :return: None when there is no model on the build plate otherwise it will return an image
+
+        """
+
+        if node is None:
+            root = Application.getInstance().getController().getScene().getRoot()
 
         # the direction the camera is looking at to create the isometric view
         iso_view_dir = Vector(-1, -1, -1).normalized()
 
-        bounds = Snapshot.nodeBounds(root)
+        bounds = Snapshot.nodeBounds(node)
         if bounds is None:
             Logger.log("w", "There appears to be nothing to render")
             return None
@@ -93,7 +102,7 @@ class Snapshot:
 
         # Render the scene
         renderer = QtRenderer()
-        render_pass = PreviewPass(width, height)
+        render_pass = PreviewPass(width, height, root=node)
         renderer.setViewportSize(width, height)
         renderer.setWindowSize(width, height)
         render_pass.setCamera(camera)


### PR DESCRIPTION
# Description

This PR makes it possible to take snapshots of single scene nodes.

<img width="1680" alt="Screenshot 2023-11-02 at 17 24 37" src="https://github.com/Ultimaker/Cura/assets/6638028/49b23809-64f6-4ebf-8be6-c3bc25d97ade">

_Written as a non breaking api change, as only a node is added_

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Ran from source

**Test Configuration**:
* Operating System:

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
