### PR TITLE
Grey out menu if no items are present

### DIFF
--- a/resources/qml/Menus/MaterialMenu.qml
+++ b/resources/qml/Menus/MaterialMenu.qml
@@ -76,6 +76,7 @@ Cura.Menu
     {
         id: genericMenu
         title: catalog.i18nc("@label:category menu label", "Generic")
+        enabled: genericMaterialsModel.items.length > 0
 
         Instantiator
         {


### PR DESCRIPTION
# Description

Grey-out generic menu if no options are available

<img width="1280" alt="Screenshot 2023-11-02 at 17 15 50" src="https://github.com/Ultimaker/Cura/assets/6638028/cfee7198-e567-4504-bf4c-ad633b032047">
  
CURA-11266

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

yes

**Test Configuration**:
* Operating System: macOS

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
