### PR TITLE
Rename Method Lab extruder to LABS

### DIFF
--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-abscf-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-abscf-175_0.2mm_solid.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-definition = ultimaker_methodxl
+definition = ultimaker_methodx
 name = Solid
 version = 4
 
@@ -9,7 +9,7 @@ material = ultimaker_abscf_175
 quality_type = draft
 setting_version = 22
 type = intent
-variant = Lab
+variant = LABS
 
 [values]
 infill_sparse_density = 100

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm_solid.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-definition = ultimaker_methodxl
+definition = ultimaker_methodx
 name = Solid
 version = 4
 
@@ -9,7 +9,7 @@ material = ultimaker_absr_175
 quality_type = draft
 setting_version = 22
 type = intent
-variant = Lab
+variant = LABS
 
 [values]
 infill_sparse_density = 100

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-abscf-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-abscf-175_0.2mm_solid.inst.cfg
@@ -1,15 +1,15 @@
 [general]
-definition = ultimaker_methodx
+definition = ultimaker_methodxl
 name = Solid
 version = 4
 
 [metadata]
 intent_category = solid
-material = ultimaker_absr_175
+material = ultimaker_abscf_175
 quality_type = draft
 setting_version = 22
 type = intent
-variant = Lab
+variant = LABS
 
 [values]
 infill_sparse_density = 100

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm_solid.inst.cfg
@@ -1,15 +1,15 @@
 [general]
-definition = ultimaker_methodx
+definition = ultimaker_methodxl
 name = Solid
 version = 4
 
 [metadata]
 intent_category = solid
-material = ultimaker_abscf_175
+material = ultimaker_absr_175
 quality_type = draft
 setting_version = 22
 type = intent
-variant = Lab
+variant = LABS
 
 [values]
 infill_sparse_density = 100

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-abscf-175_0.2mm.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-definition = ultimaker_methodxl
+definition = ultimaker_methodx
 name = Fast
 version = 4
 
@@ -8,13 +8,11 @@ material = ultimaker_abscf_175
 quality_type = draft
 setting_version = 22
 type = quality
-variant = Lab
+variant = LABS
 weight = -2
 
 [values]
-build_volume_temperature = 85
 cool_fan_enabled = False
-default_material_bed_temperature = 95
 raft_airgap = 0.3
 speed_prime_tower = 30.0
 speed_print = 120.0

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-definition = ultimaker_methodxl
+definition = ultimaker_methodx
 name = Fast
 version = 4
 
@@ -8,13 +8,11 @@ material = ultimaker_absr_175
 quality_type = draft
 setting_version = 22
 type = quality
-variant = Lab
+variant = LABS
 weight = -2
 
 [values]
-build_volume_temperature = 85
 cool_fan_enabled = False
-default_material_bed_temperature = 95
 raft_airgap = 0.3
 speed_prime_tower = 30.0
 speed_print = 120.0

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-abscf-175_0.2mm.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-definition = ultimaker_methodx
+definition = ultimaker_methodxl
 name = Fast
 version = 4
 
@@ -8,11 +8,13 @@ material = ultimaker_abscf_175
 quality_type = draft
 setting_version = 22
 type = quality
-variant = Lab
+variant = LABS
 weight = -2
 
 [values]
+build_volume_temperature = 85
 cool_fan_enabled = False
+default_material_bed_temperature = 95
 raft_airgap = 0.3
 speed_prime_tower = 30.0
 speed_print = 120.0

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm.inst.cfg
@@ -1,5 +1,5 @@
 [general]
-definition = ultimaker_methodx
+definition = ultimaker_methodxl
 name = Fast
 version = 4
 
@@ -8,11 +8,13 @@ material = ultimaker_absr_175
 quality_type = draft
 setting_version = 22
 type = quality
-variant = Lab
+variant = LABS
 weight = -2
 
 [values]
+build_volume_temperature = 85
 cool_fan_enabled = False
+default_material_bed_temperature = 95
 raft_airgap = 0.3
 speed_prime_tower = 30.0
 speed_print = 120.0

--- a/resources/variants/ultimaker_methodx_LABS.inst.cfg
+++ b/resources/variants/ultimaker_methodx_LABS.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = ultimaker_methodx
-name = Lab
+name = LABS
 version = 4
 
 [metadata]
@@ -9,6 +9,6 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Lab
+machine_nozzle_id = LABS
 machine_nozzle_size = 0.4
 

--- a/resources/variants/ultimaker_methodxl_LABS.inst.cfg
+++ b/resources/variants/ultimaker_methodxl_LABS.inst.cfg
@@ -1,6 +1,6 @@
 [general]
 definition = ultimaker_methodxl
-name = Lab
+name = LABS
 version = 4
 
 [metadata]
@@ -9,6 +9,6 @@ setting_version = 22
 type = variant
 
 [values]
-machine_nozzle_id = Lab
+machine_nozzle_id = LABS
 machine_nozzle_size = 0.4
 


### PR DESCRIPTION
Simply renaming extruder in config files. This apparently does not require an upgrade script as these files are not publicly released yet.