### PR TITLE
Fix nozzle selection checkmark

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -48,6 +48,8 @@ from UM.i18n import i18nCatalog
 catalog = i18nCatalog("cura")
 from cura.Settings.GlobalStack import GlobalStack
 if TYPE_CHECKING:
+    from PyQt6.QtCore import QVariantList
+
     from cura.CuraApplication import CuraApplication
     from cura.Machines.MaterialNode import MaterialNode
     from cura.Machines.QualityChangesGroup import QualityChangesGroup
@@ -580,6 +582,10 @@ class MachineManager(QObject):
     @pyqtProperty(QObject, notify = globalContainerChanged)
     def activeMachine(self) -> Optional["GlobalStack"]:
         return self._global_container_stack
+
+    @pyqtProperty("QVariantList", notify=activeVariantChanged)
+    def activeMachineExtruders(self) -> Optional["QVariantList"]:
+        return self._global_container_stack.extruderList if self._global_container_stack else None
 
     @pyqtProperty(str, notify = activeStackChanged)
     def activeStackId(self) -> str:

--- a/resources/qml/Menus/NozzleMenu.qml
+++ b/resources/qml/Menus/NozzleMenu.qml
@@ -27,24 +27,17 @@ Cura.Menu
         {
             text: model.hotend_name
             checkable: true
-            property var activeMachine: Cura.MachineManager.activeMachine
             checked:
             {
-                if (activeMachine === null)
-                {
-                    return false
-                }
-                var extruder = activeMachine.extruderList[extruderIndex]
-                return (extruder === undefined) ? false : (extruder.variant.name == model.hotend_name)
+                const extruder = Cura.MachineManager.activeMachineExtruders[extruderIndex];
+                if (!extruder) return false;
+                return extruder.variant.name == model.hotend_name;
             }
             enabled:
             {
-                if (activeMachine === null)
-                {
-                    return false
-                }
-                var extruder = activeMachine.extruderList[extruderIndex]
-                return (extruder === undefined) ? false : extruder.isEnabled
+                const extruder = Cura.MachineManager.activeMachineExtruders[extruderIndex];
+                if (!extruder) return false;
+                return extruder.isEnabled;
             }
             onTriggered: Cura.MachineManager.setVariant(nozzleMenu.extruderIndex, model.container_node)
         }
@@ -52,5 +45,4 @@ Cura.Menu
         onObjectAdded: function(index, object) { nozzleMenu.insertItem(index, object) }
         onObjectRemoved: function(index, object) {nozzleMenu.removeItem(object)}
     }
-
 }


### PR DESCRIPTION
# Description

This PR fixes a bug where the nozzle selection would incorrectly show the nozzle being disabled. This is just an UI issue, internally the the right nozzle is always correctly selected.

Example of the bug
https://github.com/Ultimaker/Cura/assets/6638028/0571ab1a-577b-457a-b4d8-ebc5e78e6349

CURA-11299

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?
yes

**Test Configuration**:
MacOS 13
# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
