### PR TITLE
Add extruder start/end gcode duration settings

### DIFF
--- a/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml
+++ b/plugins/MachineSettingsAction/MachineSettingsExtruderTab.qml
@@ -139,6 +139,34 @@ Item
                 decimals: 0
                 forceUpdateOnChangeFunction: forceUpdateFunction
             }
+
+            Cura.NumericTextFieldWithUnit
+            {
+                id: extruderStartCodeDurationFieldId
+                containerStackId: base.extruderStackId
+                settingKey: "machine_extruder_start_code_duration"
+                settingStoreIndex: propertyStoreIndex
+                labelText: catalog.i18nc("@label", "Extruder Start G-code duration")
+                labelFont: base.labelFont
+                labelWidth: base.labelWidth
+                controlWidth: base.controlWidth
+                unitText: catalog.i18nc("@label", "s")
+                forceUpdateOnChangeFunction: forceUpdateFunction
+            }
+
+            Cura.NumericTextFieldWithUnit
+            {
+                id: extruderEndCodeDurationFieldId
+                containerStackId: base.extruderStackId
+                settingKey: "machine_extruder_end_code_duration"
+                settingStoreIndex: propertyStoreIndex
+                labelText: catalog.i18nc("@label", "Extruder End G-code duration")
+                labelFont: base.labelFont
+                labelWidth: base.labelWidth
+                controlWidth: base.controlWidth
+                unitText: catalog.i18nc("@label", "s")
+                forceUpdateOnChangeFunction: forceUpdateFunction
+            }
         }
     }
 

--- a/resources/definitions/fdmextruder.def.json
+++ b/resources/definitions/fdmextruder.def.json
@@ -62,6 +62,17 @@
                     "settable_per_meshgroup": false,
                     "type": "str"
                 },
+                "machine_extruder_end_code_duration": {
+                    "default_value": 0,
+                    "description": "Duration it takes to execute the end g-code when switching away from this extruder.",
+                    "label": "Extruder End G-Code Duration",
+                    "minimum_value": "0",
+                    "settable_globally": false,
+                    "settable_per_extruder": true,
+                    "settable_per_mesh": false,
+                    "settable_per_meshgroup": false,
+                    "type": "float"
+                },
                 "machine_extruder_end_pos_abs":
                 {
                     "default_value": false,
@@ -107,6 +118,17 @@
                     "settable_per_mesh": false,
                     "settable_per_meshgroup": false,
                     "type": "str"
+                },
+                "machine_extruder_start_code_duration": {
+                    "default_value": 0,
+                    "description": "Duration it takes to execute the start g-code to when switching away from this extruder.",
+                    "label": "Extruder Start G-Code Duration",
+                    "minimum_value": "0",
+                    "settable_globally": false,
+                    "settable_per_extruder": true,
+                    "settable_per_mesh": false,
+                    "settable_per_meshgroup": false,
+                    "type": "float"
                 },
                 "machine_extruder_start_pos_abs":
                 {

--- a/resources/definitions/fdmextruder.def.json
+++ b/resources/definitions/fdmextruder.def.json
@@ -65,7 +65,7 @@
                 "machine_extruder_end_code_duration":
                 {
                     "default_value": 0,
-                    "description": "Duration it takes to execute the end g-code when switching away from this extruder.",
+                    "description": "The time it takes to execute the end g-code, when switching away from this extruder.",
                     "label": "Extruder End G-Code Duration",
                     "minimum_value": "0",
                     "settable_globally": false,
@@ -123,7 +123,7 @@
                 "machine_extruder_start_code_duration":
                 {
                     "default_value": 0,
-                    "description": "Duration it takes to execute the start g-code to when switching away from this extruder.",
+                    "description": "The time it'll take to execute the start g-code, when switching to this extruder.",
                     "label": "Extruder Start G-Code Duration",
                     "minimum_value": "0",
                     "settable_globally": false,

--- a/resources/definitions/fdmextruder.def.json
+++ b/resources/definitions/fdmextruder.def.json
@@ -62,7 +62,8 @@
                     "settable_per_meshgroup": false,
                     "type": "str"
                 },
-                "machine_extruder_end_code_duration": {
+                "machine_extruder_end_code_duration":
+                {
                     "default_value": 0,
                     "description": "Duration it takes to execute the end g-code when switching away from this extruder.",
                     "label": "Extruder End G-Code Duration",
@@ -119,7 +120,8 @@
                     "settable_per_meshgroup": false,
                     "type": "str"
                 },
-                "machine_extruder_start_code_duration": {
+                "machine_extruder_start_code_duration":
+                {
                     "default_value": 0,
                     "description": "Duration it takes to execute the start g-code to when switching away from this extruder.",
                     "label": "Extruder Start G-Code Duration",


### PR DESCRIPTION
# Description

This PR adds the following settings
- Extruder start gcode duration
- Extruder end gcode duration
By entering a duration (expressed in seconds) for this setting the amount of time is added to the time estimation for a nozzle switch. This makes it possible to more accurately tune print time estimations, especially for printers that have longer nozzle switching sequences. Both these settings default to 0; if no value is entered no amount of time is added to the print time estimations.

![Screenshot 2023-11-13 at 10 49 49](https://github.com/Ultimaker/Cura/assets/6638028/6fe6206a-2573-4edc-add9-87712dc2a105)

Also see CuraEngine PR: https://github.com/Ultimaker/CuraEngine/pull/1981

CURA-11099

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Yas

**Test Configuration**:
* Operating System: MacOS 13

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
