### PR TITLE
Cura 11347

### DIFF
--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -6,7 +6,7 @@ import numpy
 from string import Formatter
 from enum import IntEnum
 import time
-from typing import Any, cast, Dict, List, Optional, Set
+from typing import Any, cast, Dict, List, Optional, Set, Tuple
 import re
 import pyArcus as Arcus  # For typing.
 from PyQt6.QtCore import QCoreApplication
@@ -67,6 +67,14 @@ class GcodeStartEndFormatter(Formatter):
         super().__init__()
         self._default_extruder_nr: int = default_extruder_nr
         self._additional_per_extruder_settings: Optional[Dict[str, Dict[str, any]]] = additional_per_extruder_settings
+
+    def get_field(self, field_name, args: [str], kwargs: dict) -> Tuple[str, str]:
+        # get_field method parses all fields in the format-string and parses them individually to the get_value method.
+        # e.g. for a string "Hello {foo.bar}" would the complete field "foo.bar" would be passed to get_field, and then
+        # the individual parts "foo" and "bar" would be passed to get_value. This poses a problem for us, because  want
+        # to parse the entire field as a single expression. To solve this, we override the get_field method and return
+        # the entire field as the expression.
+        return self.get_value(field_name, args, kwargs), field_name
 
     def get_value(self, expression: str, args: [str], kwargs: dict) -> str:
 

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -118,8 +118,6 @@ class GcodeStartEndFormatter(Formatter):
         setting_function = SettingFunction(expression)
         value = setting_function(container_stack, additional_variables=additional_variables)
 
-        print("value", value)
-        print("expression", expression)
 
         return value
 

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -69,6 +69,14 @@ class GcodeStartEndFormatter(Formatter):
         self._additional_per_extruder_settings: Optional[Dict[str, Dict[str, any]]] = additional_per_extruder_settings
 
     def get_value(self, expression: str, args: [str], kwargs: dict) -> str:
+
+        # The following variables are not settings, but only become available after slicing.
+        # when these variables are encountered, we return them as-is. They are replaced later
+        # when the actual values are known.
+        post_slice_data_variables = ["filament_cost", "print_time", "filament_amount", "filament_weight", "jobname"]
+        if expression in post_slice_data_variables:
+            return f"{{{expression}}}"
+
         extruder_nr = self._default_extruder_nr
 
         # The settings may specify a specific extruder to use. This is done by
@@ -101,6 +109,9 @@ class GcodeStartEndFormatter(Formatter):
 
         setting_function = SettingFunction(expression)
         value = setting_function(container_stack, additional_variables=additional_variables)
+
+        print("value", value)
+        print("expression", expression)
 
         return value
 


### PR DESCRIPTION
# Description

With the previous implementation of the formula's in start/end gcode templates we made some oversights. With that implementation the following template (valid) would _not_ be accepted
```
; {filament_cost}, {print_time}, {filament_amount}, {filament_weight}, {jobname} <- post slice variables are not availabe in templates
; {3.14} decimal would be interpreted as object attribute retrieval, `14` is not an attribute of the number `3`
; {any([True])}  function calls would be parsed, and each function-part would be retrieved and resolved individually, instead we would like to interpret them as a whole
```
There is one asterix attached to the current implementation; that is that post slice variables won't work with formula's. This is because the templates are resolved in a two step process. First all template strings are resolved execpt for a string that exactly matches a variable name from the post slice variables (`filament_cost`, `print_time`, `filament_amount`, `filament_weight`, `jobname`). Then after slicing is complete these post slice variables are substituted.

We cannot substitute formula's post slicing since we have lost information about start/end code. We loose information regarding
- the type of gcode (machine or extruder)
- the extruder nr the start/end code belongs to
And vice versa we cannot use the post slice variables before slicing since these variables are generated during the slicing (as the name suggests)

Don't think this is an issue since we only re-introduced this feature in order to not regress compared to previous cura versions. Entering formula's in this version

CURA-11347

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Yess

**Test Configuration**:
* Operating System: MacOS

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change