### PR TITLE
No support material in raft when self support is used

### DIFF
--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -360,7 +360,7 @@
         "raft_interface_line_width": { "value": 1.2 },
         "raft_interface_thickness": { "value": 0.3 },
         "raft_margin": { "value": 3 },
-        "raft_surface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material'))" },
+        "raft_surface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else raft_base_extruder_nr" },
         "retraction_amount": { "value": 0.75 },
         "retraction_combing": { "value": "'off'" },
         "retraction_combing_max_distance": { "value": "speed_travel / 10" },


### PR DESCRIPTION
When self-support is enabled do not use support material layers in the raft. 
Note: Switching support settings takes longer in the UI due to the recalculations.

PP-402