### PR TITLE
Auto enable interlocking

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -47,6 +47,7 @@
         "infill_material_flow": { "value": "(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow" },
         "infill_overlap": { "value": "0 if infill_sparse_density > 80 else 10" },
         "inset_direction": { "value": "'outside_in'" },
+        "interlocking_enable": { "resolve": "(extruders_enabled_count > 1) and not any(extruderValues('material_is_support_material')) and extruderValue(0, 'default_material_print_temperature') != extruderValue(1, 'default_material_print_temperature')" },
         "jerk_infill": { "minimum_value_warning": 20 },
         "jerk_prime_tower": { "minimum_value_warning": 20 },
         "jerk_print":


### PR DESCRIPTION
Enable interlocking when more then 1 material is used and that non of the materials is a support material and the two model materials are different. 

PP-395