### PR TITLE
Fix sending over .makerbot files to digital factory for s-line and legacy um printers

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -213,7 +213,12 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
             return
 
         # Export the scene to the correct file type.
-        job = ExportFileJob(file_handler=file_handler, nodes=nodes, firmware_version=self.firmwareVersion)
+        job = ExportFileJob(
+            file_handler=file_handler,
+            nodes=nodes,
+            firmware_version=self.firmwareVersion,
+            print_type=self.printerType,
+        )
         job.finished.connect(self._onPrintJobCreated)
         job.start()
 

--- a/plugins/UM3NetworkPrinting/src/ExportFileJob.py
+++ b/plugins/UM3NetworkPrinting/src/ExportFileJob.py
@@ -16,9 +16,9 @@ from .MeshFormatHandler import MeshFormatHandler
 class ExportFileJob(WriteFileJob):
     """Job that exports the build plate to the correct file format for the target cluster."""
 
-    def __init__(self, file_handler: Optional[FileHandler], nodes: List[SceneNode], firmware_version: str) -> None:
-
-        self._mesh_format_handler = MeshFormatHandler(file_handler, firmware_version)
+    def __init__(self, file_handler: Optional[FileHandler], nodes: List[SceneNode], firmware_version: str,
+                 print_type: str) -> None:
+        self._mesh_format_handler = MeshFormatHandler(file_handler, firmware_version, print_type)
         if not self._mesh_format_handler.is_valid:
             Logger.log("e", "Missing file or mesh writer!")
             return

--- a/plugins/UM3NetworkPrinting/src/MeshFormatHandler.py
+++ b/plugins/UM3NetworkPrinting/src/MeshFormatHandler.py
@@ -19,10 +19,9 @@ I18N_CATALOG = i18nCatalog("cura")
 class MeshFormatHandler:
     """This class is responsible for choosing the formats used by the connected clusters."""
 
-
-    def __init__(self, file_handler: Optional[FileHandler], firmware_version: str) -> None:
+    def __init__(self, file_handler: Optional[FileHandler], firmware_version: str, printer_type: str) -> None:
         self._file_handler = file_handler or CuraApplication.getInstance().getMeshFileHandler()
-        self._preferred_format = self._getPreferredFormat(firmware_version)
+        self._preferred_format = self._getPreferredFormat(firmware_version, printer_type)
         self._writer = self._getWriter(self.mime_type) if self._preferred_format else None
 
     @property
@@ -82,7 +81,7 @@ class MeshFormatHandler:
             value = value.encode()
         return value
 
-    def _getPreferredFormat(self, firmware_version: str) -> Dict[str, Union[str, int, bool]]:
+    def _getPreferredFormat(self, firmware_version: str, printer_type: str) -> Dict[str, Union[str, int, bool]]:
         """Chooses the preferred file format for the given file handler.
 
         :param firmware_version: The version of the firmware.
@@ -103,12 +102,10 @@ class MeshFormatHandler:
         machine_file_formats = [file_type.strip() for file_type in machine_file_formats]
 
         # Exception for UM3 firmware version >=4.4: UFP is now supported and should be the preferred file format.
-        if "application/x-ufp" not in machine_file_formats and Version(firmware_version) >= Version("4.4"):
+        if printer_type in (
+        "ultimaker3", "ultimaker3_extended") and "application/x-ufp" not in machine_file_formats and Version(
+                firmware_version) >= Version("4.4"):
             machine_file_formats = ["application/x-ufp"] + machine_file_formats
-
-        # Exception for makerbot firmware version >=2.700: makerbot is supported
-        elif "application/x-makerbot" not in machine_file_formats and Version(firmware_version >= Version("2.700")):
-            machine_file_formats = ["application/x-makerbot"] + machine_file_formats
 
         # Take the intersection between file_formats and machine_file_formats.
         format_by_mimetype = {f["mime_type"]: f for f in file_formats}

--- a/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Network/LocalClusterOutputDevice.py
@@ -146,7 +146,12 @@ class LocalClusterOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         self.writeStarted.emit(self)
 
         # Export the scene to the correct file type.
-        job = ExportFileJob(file_handler=file_handler, nodes=nodes, firmware_version=self.firmwareVersion)
+        job = ExportFileJob(
+            file_handler=file_handler,
+            nodes=nodes,
+            firmware_version=self.firmwareVersion,
+            print_type=self.printerType,
+        )
         job.finished.connect(self._onPrintJobCreated)
         job.start()
 


### PR DESCRIPTION
# Description

We were uploading `.makerbot` files to the digital factory for s-line and legacy um printers. 
<img width="1138" alt="Screenshot 2023-11-24 at 15 41 54" src="https://github.com/Ultimaker/Cura/assets/6638028/0f83f859-9e9c-46a4-9ef0-99950b2939f1">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

yes

**Test Configuration**:
* Operating System: macOS 13.3

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
