### PR TITLE
Documentation: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@
 [Badge License]: https://img.shields.io/badge/License-LGPL3-336887.svg?style=for-the-badge&labelColor=458cb5&logoColor=white&logo=GNU
 [Badge Closed]: https://img.shields.io/github/issues-closed/ultimaker/cura?style=for-the-badge&logoColor=white&labelColor=629944&color=446a30&logo=AddThis
 [Badge Issues]: https://img.shields.io/github/issues/ultimaker/cura?style=for-the-badge&logoColor=white&labelColor=c34360&color=933349&logo=AdBlock
-[Badge Conan]: https://img.shields.io/github/workflow/status/Ultimaker/Cura/conan-package?style=for-the-badge&logoColor=white&labelColor=6185aa&color=4c6987&logo=Conan&label=Conan%20Package
-[Badge Test]: https://img.shields.io/github/workflow/status/Ultimaker/Cura/unit-test?style=for-the-badge&logoColor=white&labelColor=4a999d&color=346c6e&logo=Codacy&label=Unit%20Test
+[Badge Conan]: https://img.shields.io/github/actions/workflow/status/Ultimaker/Cura/conan-package.yml?branch=main&style=for-the-badge&logoColor=white&labelColor=6185aa&color=4c6987&logo=Conan&label=Conan%20Package
+[Badge Test]: https://img.shields.io/github/actions/workflow/status/Ultimaker/Cura/unit-test.yml?branch=main&style=for-the-badge&logoColor=white&labelColor=4a999d&color=346c6e&logo=Codacy&label=Unit%20Test
 [Badge Size]: https://img.shields.io/github/repo-size/ultimaker/cura?style=for-the-badge&logoColor=white&labelColor=715a97&color=584674&logo=GoogleAnalytics
 [Badge Downloads]: https://img.shields.io/github/downloads-pre/Ultimaker/Cura/latest/total?style=for-the-badge
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![Badge Test]][Test]   
 [![Badge Conan]][Conan]   
-![Badge Downloads]
+[![Badge Downloads]][Downloads]
 <br>
 <br>
 
@@ -67,6 +67,7 @@
 [Issues]: https://github.com/Ultimaker/Cura/issues
 [Conan]: https://github.com/Ultimaker/Cura/actions/workflows/conan-package.yml
 [Test]: https://github.com/Ultimaker/Cura/actions/workflows/unit-test.yml
+[Downloads]: https://github.com/Ultimaker/Cura/releases/latest
 
 [License]: LICENSE
 [Report]: docs/Report.md


### PR DESCRIPTION
# Description

Fixed **Test** and **Conan** badges because they become broken after [Change to GitHub workflow badge routes](https://github.com/badges/shields/issues/8671) . Changes have been made according to the guide from the ticket.

Updated the **Downloads** badge to lead to the *latest release page*.  Because when I clicked on it, the link went to the picture. It's a bad UX that I decided to fix it.

Before
<img width="901" alt="image" src="https://github.com/Ultimaker/Cura/assets/9591166/1a3b804b-ac34-4504-8fa7-dcf695ff7d6c">

After
<img width="899" alt="image" src="https://github.com/Ultimaker/Cura/assets/9591166/24f826f4-63cb-4f5d-a20a-018d8908f6f7">

</br>

## Type of change

Documentation: ReadMe update

# How Has This Been Tested?

#### Downloads badge update
* Click to the  **Downloads** badge
* Assert that user redirected to the latest published release

#### Test and Conan badges fix
* Open ReadMe file in Preview mode or Navigate to the repository main link
* Assert that **Test** and **Conan** badges now shows correct statuses

**Test Configuration**:
* Not needed

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
