### PR TITLE
Elegoo Neptune 4 / Pro / Plus / Max Definition Updates

### DIFF
--- a/resources/definitions/elegoo_neptune_4.def.json
+++ b/resources/definitions/elegoo_neptune_4.def.json
@@ -9,16 +9,21 @@
     },
     "overrides":
     {
-        "acceleration_layer_0": { "value": 3000 },
-        "acceleration_print": { "value": 3000 },
-        "acceleration_travel": { "value": 5000 },
+        "acceleration_print":
+        {
+            "default_value": 10000,
+            "maximum_value_warning": "20000",
+            "value": 10000
+        },
+        "acceleration_wall": { "value": "acceleration_print/2" },
         "cool_fan_full_layer": { "value": 2 },
         "infill_line_width": { "value": "line_width + 0.05" },
         "infill_overlap": { "value": "0 if infill_sparse_density < 40.01 and infill_pattern != 'concentric' else -5" },
+        "infill_pattern": { "value": "'lines' if infill_sparse_density > 35 else 'grid'" },
         "initial_layer_line_width_factor": { "value": "100.0 if resolveOrValue('adhesion_type') == 'raft' else 125 if line_width < 0.5 else 110" },
-        "machine_acceleration": { "value": 3000 },
+        "machine_acceleration": { "value": 5000 },
         "machine_depth": { "default_value": 230 },
-        "machine_end_gcode": { "default_value": "G91 ;Relative positionning\nG1 E-2 F2700 ;Retract a bit\nG1 E-2 Z0.2 F2400 ;Retract and raise Z\nG1 X5 Y5 F3000 ;Wipe out\nG1 Z2 ;Raise Z more\nG90 ;Absolute positionning\nG1 X0 Y{machine_depth} ;Present print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\nM84 X Y E ;Disable all steppers but Z" },
+        "machine_end_gcode": { "default_value": "G91 ;Relative positionning\nG1 E-2 F2700 ;Retract a bit\nG1 E-2 Z0.2 F2400 ;Retract and raise Z\nG1 X5 Y5 F3000 ;Wipe out\nG1 Z2 ;Raise Z more\nG90 ;Absolute positionning\nG1 X0 Y{machine_depth - 5} ;Present print\nM106 S0 ;Turn-off fan\nM104 S0 ;Turn-off hotend\nM140 S0 ;Turn-off bed\nM84 X Y E ;Disable all steppers but Z" },
         "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
         "machine_head_with_fans_polygon":
         {
@@ -32,12 +37,12 @@
         "machine_heated_bed": { "default_value": true },
         "machine_height": { "default_value": 270 },
         "machine_max_acceleration_e": { "value": 5000 },
-        "machine_max_acceleration_x": { "value": 5000 },
-        "machine_max_acceleration_y": { "value": 5000 },
+        "machine_max_acceleration_x": { "value": 20000 },
+        "machine_max_acceleration_y": { "value": 20000 },
         "machine_name": { "default_value": "ELEGOO NEPTUNE 4" },
         "machine_nozzle_cool_down_speed": { "value": 0.75 },
         "machine_nozzle_heat_up_speed": { "value": 1.6 },
-        "machine_start_gcode": { "default_value": "G28 ;home\nG92 E0 ;Reset Extruder\nG1 Z4.0 F3000 ;Move Z Axis up\nG92 E0 ;Reset Extruder\nG1 X1.1 Y20 Z0.28 F5000.0 ;Move to start position\nG1 X1.1 Y80.0 Z0.28 F1500.0 E10 ;Draw the first line\nG1 X1.4 Y80.0 Z0.28 F5000.0 ;Move to side a little\nG1 X1.4 Y20 Z0.28 F1500.0 E20 ;Draw the second line\nG92 E0 ;Reset Extruder\nG1 Z2.0 F3000 ;Move Z Axis up" },
+        "machine_start_gcode": { "default_value": ";ELEGOO NEPTUNE 4 / 4 PRO\nM220 S100 ;Set the feed speed to 100%\nM221 S100 ;Set the flow rate to 100%\nM104 S140 ;Start heating extruder\nM190 S{material_bed_temperature_layer_0} ;Wait for the bed to reach print temp\nG90\nG28 ;home\nG1 Z10 F300\nG1 X67.5 Y0 F6000\nG1 Z0 F300\nM109 S{material_print_temperature_layer_0} ;Wait for extruder to reach print temp\nG92 E0 ;Reset Extruder\nG1 X67.5 Y0 Z0.4 F300 ;Move to start position\nG1 X167.5 E30 F400 ;Draw the first line\nG1 Z0.6 F120.0 ;Move to side a little\nG1 X162.5 F3000\nG92 E0 ;Reset Extruder" },
         "machine_width": { "default_value": 235 },
         "retraction_amount": { "default_value": 0.5 },
         "retraction_count_max": { "value": 80 },

--- a/resources/definitions/elegoo_neptune_4max.def.json
+++ b/resources/definitions/elegoo_neptune_4max.def.json
@@ -1,0 +1,57 @@
+{
+    "version": 2,
+    "name": "ELEGOO NEPTUNE 4 Max",
+    "inherits": "elegoo_neptune_4",
+    "metadata":
+    {
+        "visible": true,
+        "author": "mastercaution",
+        "quality_definition": "elegoo_neptune_4"
+    },
+    "overrides":
+    {
+        "acceleration_print":
+        {
+            "default_value": 2500,
+            "maximum_value_warning": "15000",
+            "value": 2500
+        },
+        "machine_depth": { "default_value": 430 },
+        "machine_height": { "default_value": 482 },
+        "machine_max_acceleration_e": { "value": 5000 },
+        "machine_max_acceleration_x": { "value": 15000 },
+        "machine_max_acceleration_y": { "value": 15000 },
+        "machine_name": { "default_value": "ELEGOO NEPTUNE 4 Max" },
+        "machine_start_gcode": { "default_value": ";ELEGOO NEPTUNE 4 MAX\nM220 S100 ;Set the feed speed to 100%\nM221 S100 ;Set the flow rate to 100%\nM104 S140 ;Start heating extruder\nM190 S{material_bed_temperature_layer_0} ;Wait for the bed to reach print temp\nG90\nG28 ;home\nG1 Z10 F300\nG1 X165 Y0 F6000\nG1 Z0 F300\nM109 S{material_print_temperature_layer_0} ;Wait for extruder to reach print temp\nG92 E0 ;Reset Extruder\nG1 X165 Y0 Z0.4 F300 ;Move to start position\nG1 X265 E30 F400 ;Draw the first line\nG1 Z0.6 F120.0 ;Move to side a little\nG1 X260 F3000\nG92 E0 ;Reset Extruder" },
+        "machine_width": { "default_value": 430 },
+        "nozzle_disallowed_areas":
+        {
+            "default_value": [
+                [
+                    [-165, -165],
+                    [-165, 165],
+                    [-161, 165],
+                    [-161, -165]
+                ],
+                [
+                    [165, 165],
+                    [165, -165],
+                    [161, -165],
+                    [161, 165]
+                ],
+                [
+                    [-165, -165],
+                    [165, -165],
+                    [-165, -161],
+                    [165, -161]
+                ],
+                [
+                    [-165, 165],
+                    [165, 165],
+                    [-165, 161],
+                    [165, 161]
+                ]
+            ]
+        }
+    }
+}

--- a/resources/definitions/elegoo_neptune_4plus.def.json
+++ b/resources/definitions/elegoo_neptune_4plus.def.json
@@ -1,0 +1,57 @@
+{
+    "version": 2,
+    "name": "ELEGOO NEPTUNE 4 Plus",
+    "inherits": "elegoo_neptune_4",
+    "metadata":
+    {
+        "visible": true,
+        "author": "mastercaution",
+        "quality_definition": "elegoo_neptune_4"
+    },
+    "overrides":
+    {
+        "acceleration_print":
+        {
+            "default_value": 4000,
+            "value": 4000
+        },
+        "machine_acceleration": { "value": 4000 },
+        "machine_depth": { "default_value": 330 },
+        "machine_height": { "default_value": 387 },
+        "machine_max_acceleration_e": { "value": 5000 },
+        "machine_max_acceleration_x": { "value": 20000 },
+        "machine_max_acceleration_y": { "value": 20000 },
+        "machine_name": { "default_value": "ELEGOO NEPTUNE 4 Plus" },
+        "machine_start_gcode": { "default_value": ";ELEGOO NEPTUNE 4 PLUS\nM220 S100 ;Set the feed speed to 100%\nM221 S100 ;Set the flow rate to 100%\nM104 S140 ;Start heating extruder\nM190 S{material_bed_temperature_layer_0} ;Wait for the bed to reach print temp\nG90\nG28 ;home\nG1 Z10 F300\nG1 X115 Y0 F6000\nG1 Z0 F300\nM109 S{material_print_temperature_layer_0} ;Wait for extruder to reach print temp\nG92 E0 ;Reset Extruder\nG1 X115 Y0 Z0.4 F300 ;Move to start position\nG1 X215 E30 F400 ;Draw the first line\nG1 Z0.6 F120.0 ;Move to side a little\nG1 X210 F3000\nG92 E0 ;Reset Extruder" },
+        "machine_width": { "default_value": 330 },
+        "nozzle_disallowed_areas":
+        {
+            "default_value": [
+                [
+                    [-165, -165],
+                    [-165, 165],
+                    [-161, 165],
+                    [-161, -165]
+                ],
+                [
+                    [165, 165],
+                    [165, -165],
+                    [161, -165],
+                    [161, 165]
+                ],
+                [
+                    [-165, -165],
+                    [165, -165],
+                    [-165, -161],
+                    [165, -161]
+                ],
+                [
+                    [-165, 165],
+                    [165, 165],
+                    [-165, 161],
+                    [165, 161]
+                ]
+            ]
+        }
+    }
+}

--- a/resources/variants/elegoo/elegoo_neptune_4max/elegoo_neptune_4max_0.20.inst.cfg
+++ b/resources/variants/elegoo/elegoo_neptune_4max/elegoo_neptune_4max_0.20.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = elegoo_neptune_4max
+name = 0.20mm_Elegoo_Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.2
+

--- a/resources/variants/elegoo/elegoo_neptune_4max/elegoo_neptune_4max_0.40.inst.cfg
+++ b/resources/variants/elegoo/elegoo_neptune_4max/elegoo_neptune_4max_0.40.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = elegoo_neptune_4max
+name = 0.40mm_Elegoo_Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+

--- a/resources/variants/elegoo/elegoo_neptune_4max/elegoo_neptune_4max_0.60.inst.cfg
+++ b/resources/variants/elegoo/elegoo_neptune_4max/elegoo_neptune_4max_0.60.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = elegoo_neptune_4max
+name = 0.60mm_Elegoo_Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/elegoo/elegoo_neptune_4max/elegoo_neptune_4max_0.80.inst.cfg
+++ b/resources/variants/elegoo/elegoo_neptune_4max/elegoo_neptune_4max_0.80.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = elegoo_neptune_4max
+name = 0.80mm_Elegoo_Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+

--- a/resources/variants/elegoo/elegoo_neptune_4plus/elegoo_neptune_4plus_0.20.inst.cfg
+++ b/resources/variants/elegoo/elegoo_neptune_4plus/elegoo_neptune_4plus_0.20.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = elegoo_neptune_4plus
+name = 0.20mm_Elegoo_Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.2
+

--- a/resources/variants/elegoo/elegoo_neptune_4plus/elegoo_neptune_4plus_0.40.inst.cfg
+++ b/resources/variants/elegoo/elegoo_neptune_4plus/elegoo_neptune_4plus_0.40.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = elegoo_neptune_4plus
+name = 0.40mm_Elegoo_Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+

--- a/resources/variants/elegoo/elegoo_neptune_4plus/elegoo_neptune_4plus_0.60.inst.cfg
+++ b/resources/variants/elegoo/elegoo_neptune_4plus/elegoo_neptune_4plus_0.60.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = elegoo_neptune_4plus
+name = 0.60mm_Elegoo_Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/elegoo/elegoo_neptune_4plus/elegoo_neptune_4plus_0.80.inst.cfg
+++ b/resources/variants/elegoo/elegoo_neptune_4plus/elegoo_neptune_4plus_0.80.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = elegoo_neptune_4plus
+name = 0.80mm_Elegoo_Nozzle
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 22
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+


### PR DESCRIPTION
# Description
- Add Definitions for Neptune 4 Plus and Max :partying_face:
- Updated acceleration configuration
- Change default infill to prefer "Grid" when infill density is low
- Updated N4 / 4 Pro start G-code. Basically, the nozzle touches the print bed during heating, so nothing comes out. Then it prints only _one_ line but twice the length compared to the old code. This should minimize the possibility that the nozzle produces and picks up filament chunks during the start procedure (which happened a lot with the old start procedure).

> N4 Plus / Max definitions and the new start G-Code are based on Elegoo Cura profiles (v4.8.0_20231208)

## :test_tube: How to _quickly_ test these profiles?
If you don't want to build Cura yourself, download the new profiles from my [release page](https://github.com/mastercaution/Cura/releases/tag/v2.0). Simply extract the `.zip` and follow the `Readme.txt`. It's basically copying the new profiles into Curas configuration folder.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Printer definition file(s)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Printed models on Neptune 4
- [ ] Printed models on Neptune 4 Pro
- [ ] Printed models on Neptune 4 Plus
- [ ] Printed models on Neptune 4 Max

:exclamation: If you have a N4 Pro, Plus or Max, I would love to hear feedback on how the profiles work for you :)

**Test Configuration**:
* Operating System: Arch Linux (Linux 6.6.4)
* Operating System: Windows 10

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
