### PR TITLE
CURA-11392-including-threshold-settings-for-ppr

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -8305,6 +8305,86 @@
                 }
             }
         },
+        "ppr":
+        {
+            "label": "Print Process Reporting",
+            "type": "category",
+            "icon": "DocumentFilled",
+            "description": "Reporting events that go out of set thresholds",
+            "visible": true,
+            "children":
+            {
+                "ppr_enable":
+                {
+                    "label": "Enable Print Process Reporting",
+                    "description": "Enable print process reporting for setting threshold values for possible fault detection.",
+                    "type": "bool",
+                    "default_value": false,
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
+                },
+                "flow_warn_limit":
+                {
+                    "label": "Flow Warning Detection Limit",
+                    "description": "Limit on the flow warning for detection.",
+                    "default_value": "15.0",
+                    "enabled": "ppr_enable",
+                    "unit": "%",
+                    "type": "float",
+                    "settable_per_extruder": true
+                },
+                "flow_anomaly_limit":
+                {
+                    "label": "Flow Anomaly Detection Limit",
+                    "description": "Limit on flow anomaly for detection.",
+                    "default_value": "25.0",
+                    "enabled": "ppr_enable",
+                    "unit": "%",
+                    "type": "float",
+                    "settable_per_extruder": true
+                },
+                "print_temp_warn_limit":
+                {
+                    "label": "Print temperature Warning Detection Limit",
+                    "description": "Limit on Print temperature warning for detection.",
+                    "unit": "\u00b0C",
+                    "type": "float",
+                    "default_value": "3.0",
+                    "enabled": "ppr_enable",
+                    "settable_per_extruder": true
+                },
+                "print_temp_anomaly_limit":
+                {
+                    "label": "Print temperature Anomaly Detection Limit",
+                    "description": "Limit on Print Temperature anomaly for detection.",
+                    "unit": "\u00b0C",
+                    "type": "float",
+                    "default_value": "7.0",
+                    "enabled": "ppr_enable",
+                    "settable_per_extruder": true
+                },
+                "bv_temp_warn_limit":
+                {
+                    "label": "Build Volume temperature Warning Detection Limit",
+                    "description": "Limit on Build Volume Temperature warning for detection.",
+                    "unit": "\u00b0C",
+                    "type": "float",
+                    "default_value": "7.5",
+                    "enabled": "ppr_enable",
+                    "settable_per_extruder": false
+                },
+                "bv_temp_anomaly_limit":
+                {
+                    "label": "Build Volume temperature Anomaly Detection Limit",
+                    "description": "Limit on Build Volume temperature Anomaly for detection.",
+                    "unit": "\u00b0C",
+                    "type": "float",
+                    "default_value": "10.0",
+                    "enabled": "ppr_enable",
+                    "settable_per_extruder": false
+                }
+            }
+        },
         "command_line_settings":
         {
             "label": "Command Line Settings",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -8311,7 +8311,7 @@
             "type": "category",
             "icon": "DocumentFilled",
             "description": "Reporting events that go out of set thresholds",
-            "visible": true,
+            "enabled": "(machine_name == \"Ultimaker S5\") or  (machine_name == \"Ultimaker S7\") or  (machine_name == \"Ultimaker Colorado\")",
             "children":
             {
                 "ppr_enable":
@@ -8319,7 +8319,9 @@
                     "label": "Enable Print Process Reporting",
                     "description": "Enable print process reporting for setting threshold values for possible fault detection.",
                     "type": "bool",
+                    "enabled": "(machine_name == \"Ultimaker S5\") or  (machine_name == \"Ultimaker S7\") or  (machine_name == \"Ultimaker Colorado\")",
                     "default_value": false,
+                    "value": false,
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },


### PR DESCRIPTION
CURA-11392

for internal printers,
Introduce Threshold settings for Print jobs so it can be taken into account for print progress reporting