### PR TITLE
Add Makertech 3D Printer Configurations

### DIFF
--- a/resources/definitions/makertech_axis.def.json
+++ b/resources/definitions/makertech_axis.def.json
@@ -1,0 +1,50 @@
+{
+    "version": 2,
+	"inherits": "makertech_base",
+	"name": "AXIS",
+    "metadata": {
+		"author": "Makertech",
+		"visible": true,
+        "file_formats": "text/x-gcode",
+		"quality_definition": "makertech_base"
+		
+		
+    },
+    "overrides": {
+	    "machine_name": { "default_value": "AXIS" },
+        
+        "machine_heated_bed": { "default_value": false },
+		"machine_extruders_share_heater": { "default_value": true },
+        "gantry_height": { "value": 20 },
+		"machine_head_with_fans_polygon": { "default_value": [ [ -50, 32 ],[ -50, -26 ],[ 47, 32 ],[ 47, -26 ] ] },
+        "machine_height": { "default_value": 200 },
+        "machine_depth": { "default_value": 200 },
+        "machine_width": { "default_value": 300 },
+		
+		"speed_equalize_flow_enabled": { "default_value": true },
+
+		"acceleration_enabled": { "default_value": true },
+		"acceleration_print": { "value": 1500 },
+		"acceleration_wall": { "value": 700 },
+		"acceleration_wall_0": { "value": 600 },
+		"acceleration_wall_x": { "value": 800 },
+		"acceleration_travel": { "value": 1500 },
+		"acceleration_layer_0": { "value": 750 },
+		
+		"jerk_enabled": { "default_value": true },
+		"jerk_print": { "default_value": 5 },
+		"jerk_wall": { "value": 3 },
+		"jerk_wall_0": { "value": 3 },
+		"jerk_wall_x": { "value": 4 },
+		"jerk_travel": { "value": 5 },
+		"jerk_layer_0": { "value": 3 },
+       
+        "machine_start_gcode": {
+		            "default_value": ";----------AXIS Start G-code---------- \nT0 \nM104 S{material_print_temperature_layer_0} ;Set hotend temp. \nM140 S{material_bed_temperature_layer_0} ;Set bed temp. \nM109 S{material_print_temperature_layer_0} ;Wait for hotend \nM190 S{material_bed_temperature_layer_0} ;Wait for heated bed \nG28 ;Home \nM420 S1 Z4 ;Activate auto-level and set Z-fade. \nG1 F8000 X10 Y3 ;Move hotend to bottom left corner \nG1 Z{layer_height_0} ;Set to first layer height \nM82 ;absolute extrusion mode \nG92 E0 ;Zero Extruder \nG1 F1500 X290 E12 ;Prime Hotend \n; ----------AXIS start G-code----------"
+        },
+        "machine_end_gcode": {
+            "default_value": "G91 ;Relative postioning\nG1 Z5 F600 ;Raise Hotend\nG90 ;Absolute postioning\nG28 X Y ;Home and present print\nM104 S0 ;Hotend off\nM140 S0 ;Bed off\nM84 ;Motors off"
+        }
+		
+		}
+}

--- a/resources/definitions/makertech_base.def.json
+++ b/resources/definitions/makertech_base.def.json
@@ -1,0 +1,122 @@
+{
+    "name": "Makertech Base Definition",
+    "version": 2,
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": false,
+        "author": "Makertech",
+        "manufacturer": "Makertech 3D",
+        "file_formats": "text/x-gcode",
+        "first_start_actions": ["MachineSettingsAction"],
+		"supports_usb_connection": false,
+        
+		"machine_extruder_trains": {
+            "0": "makertech_extruder_0",
+			"1": "makertech_extruder_1"
+        },
+
+        "has_materials": true,
+        "has_variants": true,
+        "has_machine_quality": true,
+
+		"variants_name": "Nozzle",
+        "preferred_variant_name": "0.4mm",
+		"preferred_material": "generic_pla",
+        "preferred_quality_type": "normal"
+		
+    },
+    "overrides": {
+        "machine_name": { "default_value": "Makertech Base Printer" },
+        "machine_center_is_zero": { "default_value": false },
+		"machine_extruder_count": { "default_value": 2 },
+		"machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
+		"material_print_temp_wait": { "default_value": false },
+        "material_bed_temp_wait": { "default_value": false },
+
+		"material_print_temperature_layer_0": { "value": "material_print_temperature + 5" },
+		"material_initial_print_temperature": { "value": "material_print_temperature" },
+        "material_final_print_temperature": { "value": "material_print_temperature" },
+        "material_standby_temperature": { "value": "material_print_temperature" },
+		
+		"layer_height_0": { "value": "layer_height * 0.8" },
+		"initial_layer_line_width_factor": { "value": 110 },
+
+        "speed_print": { "value": 60.0 } ,
+        "line_width": { "value": "machine_nozzle_size*1.1" },
+
+		
+		"infill_sparse_density": { "default_value": 20 },
+		"infill_pattern": { "default_value": "zigzag" },
+		
+		"skin_overlap": {"default_value": 10 },
+		
+		"speed_wall": { "value": "speed_print / 2" },
+		"speed_wall_x": { "value": "speed_wall * 1.4" },
+		"speed_travel": { "value": "speed_print if magic_spiralize else 80" },
+		
+		"wall_0_wipe_dist": { "default_value": "machine_nozzle_size * 1.7" },
+		"coasting_enable": { "default_value": true },
+		"coasting_volume": { "default_value": 0.2 },
+
+        "z_seam_corner": { "default_value": "z_seam_corner_weighted" },
+        
+        "infill_before_walls": { "value": false },
+        "infill_overlap": { "value": 50.0 },
+        "skin_overlap": { "value": 10.0 },
+        "infill_wipe_dist": { "value": 0.0 },
+        "wall_0_wipe_dist": { "value": 0.0 },
+
+        "fill_perimeter_gaps": { "value": "'everywhere'" },
+        "fill_outline_gaps": { "value": false },
+        "filter_out_tiny_gaps": { "value": true },
+
+        
+        "retraction_combing_max_distance": { "value": 30 },
+        "travel_avoid_supports": { "value": true },
+        "travel_retract_before_outer_wall": { "value": true },
+        
+
+        "cool_fan_full_layer": { "value": 4 },
+        "cool_min_layer_time": { "value": 8 },
+
+        "adhesion_type": { "value": "'brim'" },
+		"skirt_brim_minimal_length": { "default_value": 150 },
+		"brim_line_count": { "value": 3 },
+		"brim_gap": { "value": "machine_nozzle_size" },
+
+        "adaptive_layer_height_variation": { "value": 0.04 },
+        "adaptive_layer_height_variation_step": { "value": 0.04 },
+		"adaptive_layer_height_threshold": { "default_value": 0.24 },
+
+        "meshfix_maximum_resolution": { "value": "0.1" },
+		"meshfix_maximum_deviation": { "value": "0.1" },
+
+        "support_angle": { "value": "math.floor(math.degrees(math.atan(line_width/2.0/layer_height)))" },
+        "support_pattern": { "value": "'zigzag'" },
+        "support_infill_rate": { "value": "0 if support_enable and support_structure == 'tree' else 20" },
+        "support_use_towers": { "value": false },
+        "support_xy_distance": { "value": "wall_line_width_0 * 2" },
+        "support_xy_distance_overhang": { "value": "wall_line_width_0" },
+        "support_z_distance": { "value": "layer_height if layer_height >= 0.16 else layer_height*2" },
+        "support_xy_overrides_z": { "value": "'xy_overrides_z'" },
+        "support_wall_count": { "value": 1 },
+        "support_brim_enable": { "value": true },
+        "support_brim_width": { "value": 3 },
+
+        "support_interface_enable": { "value": true },
+        "support_interface_height": { "value": "layer_height * 4" },
+        "support_interface_density": { "value": 33.333 },
+        "support_interface_pattern": { "value": "'grid'" },
+        "support_interface_skip_height": { "value": 0.2 },
+        "minimum_support_area": { "value": 2 },
+        "minimum_interface_area": { "value": 10 },
+		
+		"bridge_settings_enabled": { "value": true },
+		"bridge_wall_speed": { "value": 60 },
+		"bridge_skin_speed": { "value": 60 },
+		"bridge_enable_more_layers": { "default_value": false },
+		
+		"print_sequence": { "enabled": true }
+
+    }
+}

--- a/resources/definitions/makertech_proforge_2s.def.json
+++ b/resources/definitions/makertech_proforge_2s.def.json
@@ -1,0 +1,30 @@
+{
+    "version": 2,
+	"inherits": "makertech_base",
+	"name": "Proforge 2S",
+    "metadata": {
+	
+		"author": "Makertech",
+		"visible": true,
+        "file_formats": "text/x-gcode",
+		"quality_definition": "makertech_base"
+		
+    },
+    "overrides": {
+	    "machine_name": { "default_value": "Proforge 2S" },
+		"machine_heated_bed": { "default_value": true },
+        "gantry_height": { "default_value": 40 },
+		"machine_head_with_fans_polygon": { "default_value": [ [ -30, 41 ],[ -30, -41 ],[ 72, 41 ],[ 72, -41 ] ] },
+        "machine_height": { "default_value": 300 },
+        "machine_depth": { "default_value": 200 },
+        "machine_width": { "default_value": 300 },
+
+        "machine_start_gcode": {
+		            "default_value": ";----------Proforge 2S Start G-code---------- \nM201 X900 Y900 Z50 E5000 \nM140 S{material_bed_temperature_layer_0} ;Set Bed Temp \nM104 S{material_print_temperature_layer_0} T0; Heat up Hotend 1 (T0) \nM109 S{material_print_temperature_layer_0} T0; Wait for Hotend 1 (T0) \nG28 ;Home \nG29 ;Autolevel Bed \nG1 F8000 X10 Y3 ;Move hotend to bottom left corner \nG1 Z3 ;Move Hotend to assumed Z Home \n  \n; ---Unique to your setup--- \nG92 Z0.0 ;Set Z-offset in 0.1mm incriments (increase if first layer too high, decrease if too low) \n; -------------------------- \n  \nG1 Z{layer_height_0} ;Set to first layer height \nM82 ;absolute extrusion mode \nG92 E0 ;Zero Extruder \nG1 F1500 X290 E12 ;Prime Hotend \n; ----------Proforge 2S Start G-code----------"
+        },
+        "machine_end_gcode": {
+            "default_value": "G91 ;Relative postioning\nG1 Z5 F600 ;Raise Hotend\nG90 ;Absolute postioning\nG28 X Y ;Home and present print\nM104 S0 ;Hotend off\nM140 S0 ;Bed off\nM84 ;Motors off"
+        }
+		
+		}
+}

--- a/resources/definitions/makertech_proforge_3.def.json
+++ b/resources/definitions/makertech_proforge_3.def.json
@@ -1,0 +1,72 @@
+{
+    "version": 2,
+	"inherits": "makertech_base",
+	"name": "Proforge 3",
+    "metadata": {
+
+		"author": "Makertech",
+		"visible": true,
+        "file_formats": "text/x-gcode",
+		"quality_definition": "makertech_base"
+
+		
+    },
+    "overrides": {
+	    "machine_name": { "default_value": "Proforge 3" },
+		"machine_heated_bed": { "default_value": true },
+        "gantry_height": { "default_value": 80 },
+		"machine_head_with_fans_polygon": { "default_value": [ [ -80, 42 ],[ -80, -28 ],[ 80, 42 ],[ 80, -28 ] ] },
+        "machine_height": { "default_value": 300 },
+        "machine_depth": { "default_value": 300 },
+        "machine_width": { "default_value": 300 },
+		
+		
+		"speed_equalize_flow_enabled": { "default_value": true },
+
+		"acceleration_enabled": { "default_value": true },
+		"acceleration_print": { "value": 2000 },
+		"acceleration_wall": { "value": 700 },
+		"acceleration_wall_0": { "value": 600 },
+		"acceleration_wall_x": { "value": 800 },
+		"acceleration_travel": { "value": 2000 },
+		"acceleration_layer_0": { "value": 750 },
+		
+		"jerk_enabled": { "default_value": true },
+		"jerk_print": { "default_value": 10 },
+		"jerk_wall": { "value": 6 },
+		"jerk_wall_0": { "value": 6 },
+		"jerk_wall_x": { "value": 8 },
+		"jerk_travel": { "value": 10 },
+		"jerk_layer_0": { "value": 6 },
+		
+		"retraction_speed": { "maximum_value_warning": "120" },
+		"retraction_retract_speed": { "maximum_value_warning": "120" },
+		"retraction_prime_speed": { "maximum_value_warning": "120" },
+		
+		"switch_extruder_retraction_amount": { "value": 12 },
+		"switch_extruder_retraction_speeds": 
+				{ 
+					"default_value": 100,
+					"maximum_value_warning": "120"
+				},	
+		"switch_extruder_retraction_speed": { "maximum_value_warning": "120" },
+		"switch_extruder_prime_speed": {"maximum_value_warning": "120" },
+		"retraction_hop_after_extruder_switch_height": { "default_value": 0 },
+
+		"bridge_settings_enabled": { "value": false },
+		"coasting_enable": { "default_value": false },
+		
+		"prime_tower_size": { "default_value": 30 },
+		"prime_tower_brim_enable": { "default_value": true },
+		
+		
+
+        "machine_start_gcode": {
+		            "default_value": ";----------Proforge 3 Start G-code---------- \nM24 ;start SD print \nM190 S{material_bed_temperature_layer_0} ;wait for bed temp \nM420 S1 ;Invoke Bed Mesh \nG28 ;Home \nG29 L0 ;Load Mesh \nG29 J ;Probe tilt \nG1 F8000 X10 Y3 ;Move hotend to bottom left corner \nG1 Z{layer_height_0} ;Set to first layer height \nM82 ;absolute extrusion mode \nG92 E0 ;Zero Extruder \nG1 F1500 X290 E16 ;Prime Hotend \n; ----------Proforge 3 Start G-code----------"
+        },
+        "machine_end_gcode": {
+            "default_value": "G91 ;Relative postioning\nG1 Z5 F600 ;Raise Hotend\nG90 ;Absolute postioning\nG1 X300 Y300 F5000 ;Move tool carriage to top right\nM104 S0 ;Hotend off\nM140 S0 ;Bed off\nM84 ;Motors off"
+        }
+		
+		}
+}

--- a/resources/definitions/makertech_proforge_4.def.json
+++ b/resources/definitions/makertech_proforge_4.def.json
@@ -1,0 +1,87 @@
+{
+    "version": 2,
+	"inherits": "makertech_base",
+	"name": "Proforge 4",
+    "metadata": {
+
+		"author": "Makertech",
+		"visible": true,
+        "file_formats": "text/x-gcode",
+		"quality_definition": "makertech_base",
+
+        "machine_extruder_trains": {
+          "0": "p4_extruder_0",
+		  "1": "p4_extruder_1",
+		  "2": "p4_extruder_2",
+		  "3": "p4_extruder_3"
+        }
+
+		
+    },
+    "overrides": {
+	    "machine_name": { "default_value": "Proforge 4" },
+		"machine_heated_bed": { "default_value": true },
+        "gantry_height": { "default_value": 80 },
+        "machine_height": { "default_value": 400 },
+        "machine_depth": { "default_value": 300 },
+        "machine_width": { "default_value": 400 },
+        "machine_extruder_count": { "default_value": 4 },
+		
+
+
+
+        "speed_print": { "value": 120 },
+        	"speed_infill": { "value": 120 },
+        	"speed_wall": { "value": 80 },
+        		"speed_wall_0": { "value": 70 },
+        		"speed_wall_x": { "value": 120 },
+        	"speed_roofing": { "value": 80 },
+        	"speed_topbottom": { "value": 80 },
+        "speed_support": { "value": 70 },
+        "speed_prime_tower": { "value": 70 },
+        "speed_travel": { "value": 200 },
+
+        "speed_layer_0": { "value": 30 },
+        "speed_print_layer_0": { "value": 30 },
+        "speed_travel_layer_0": { "value": 100 },
+
+        "skirt_brim_speed": { "value": 60 },
+        "speed_slowdown_layers": { "value": 1 },
+
+
+
+
+        "machine_max_acceleration_x": { "default_value": 60000 },
+        "machine_max_acceleration_y": { "default_value": 60000 },
+		"acceleration_enabled": { "default_value": true },
+		"acceleration_print": { "value": 7000 },
+		"acceleration_wall": { "value": 7000 },
+		"acceleration_wall_0": { "value": 3500 },
+		"acceleration_wall_x": { "value": 7000 },
+		"acceleration_travel": { "value": 12000, "maximum_value_warning": "60000" },
+		"acceleration_layer_0": { "value": 4000 },
+		"acceleration_travel_layer_0": { "value": 6000 },
+		
+		
+		"retraction_speed": { "maximum_value_warning": "120" },
+		"retraction_retract_speed": { "maximum_value_warning": "120" },
+		"retraction_prime_speed": { "maximum_value_warning": "120" },
+		"switch_extruder_retraction_amount": { "value": 0 },
+
+		"bridge_settings_enabled": { "value": false },
+		"coasting_enable": { "default_value": false },
+		
+		"prime_tower_size": { "default_value": 30 },
+		"prime_tower_brim_enable": { "default_value": true },
+		
+		"draft_shield_enabled": { "default_value": true },
+
+        "machine_start_gcode": {
+		            "default_value": ";----------Proforge 4 Start G-code----------\nG28 ;Home\n_TOOL_CHECK\nM190 S{material_bed_temperature_layer_0} ;wait for bed temp\nZ_TILT_ADJUST\nG0 X200 F12000\n; ----------Proforge 4 Start G-code----------"
+        },
+        "machine_end_gcode": {
+            "default_value": "END_PRINT"
+        }
+		
+		}
+}

--- a/resources/definitions/makertech_proforge_original.def.json
+++ b/resources/definitions/makertech_proforge_original.def.json
@@ -1,0 +1,29 @@
+{
+    "version": 2,
+	"inherits": "makertech_base",
+    "name": "Proforge Original",
+    "metadata": {
+		"author": "Makertech",
+		"visible": true,
+        "file_formats": "text/x-gcode",
+		"quality_definition": "makertech_base"
+		
+
+    },
+
+    "overrides": {
+        "machine_extruder_count": { "default_value": 2 },
+        "machine_heated_bed": { "default_value": true },
+        "gantry_height": { "default_value": 80	},
+        "machine_height": { "default_value": 240 },
+        "machine_depth": { "default_value": 200 },
+        "machine_width": { "default_value": 165 },
+        
+        "machine_start_gcode": {
+            "default_value": ";----------Proforge Original Dual Start G-code---------- \nM140 S{material_bed_temperature_layer_0} ;Set Bed Temp \nM104 S{material_print_temperature_layer_0} T0; Heat up Hotend 1 (T0) \nM104 S{material_print_temperature_layer_0} T1; Heat up Hotend 2 (T1)\n M109 S{material_print_temperature_layer_0} T0; Wait for Hotend 1 (T0)  \n M109 S{material_print_temperature_layer_0} T1 ;Wait for Hotend 2 (T1) \nG28 ;Home \nG29 ;Autolevel Bed \nM420 Z5 ;Levelling fade off \nG1 F8000 X10 Y5 ;Move hotend to bottom left corner \n\n; ---Unique to your setup---\nG0 Z0.0 ;Set Z-offset in 0.1mm incriments (Increase if first layer too low)\n; --------------------------\n\nG92 Z{layer_height_0} ;Set to first layer height \nM82 ;absolute extrusion mode \nG92 E0 ;Zero Extruder \nG1 F1500 X145 E15 ;Prime Hotend\n; ----------Proforge Original Dual Start G-code----------"
+        },
+        "machine_end_gcode": {
+            "default_value": "G91 ;Relative postioning\nG1 Z5 F600 ;Raise Hotend\nG90 ;Absolute postioning\nG28 X Y ;Home \nM104 S0 T0 ;Hotend 1 off \nM104 S0 T1 ;Hotend 2 off \nM140 S0 ;Bed off\nM84 ;Motors off"
+        }
+    }
+}

--- a/resources/extruders/makertech_extruder_0.def.json
+++ b/resources/extruders/makertech_extruder_0.def.json
@@ -1,0 +1,20 @@
+{
+    "version": 2,
+    "name": "Extruder 1 (T0)",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": [ 
+            "makertech_base"
+			
+		],
+        "position": "0"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 0 },
+		"material_diameter": { "default_value": 1.75 },
+		"machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 },
+		"machine_extruder_end_code": { "default_value": "G0 F20000 X{prime_tower_position_x} Y{prime_tower_position_y}" }
+    }
+}

--- a/resources/extruders/makertech_extruder_1.def.json
+++ b/resources/extruders/makertech_extruder_1.def.json
@@ -1,0 +1,23 @@
+{
+    "version": 2,
+    "name": "Extruder 2 (T1)",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": [ 
+			"makertech_base"
+			
+		],
+        "position": "1"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 1 },
+		"material_diameter": { "default_value": 1.75 },
+		"machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 },
+		"machine_extruder_end_code": { "default_value": "G0 F20000 X{prime_tower_position_x} Y{prime_tower_position_y}" }
+		
+    }
+}
+
+

--- a/resources/extruders/p4_extruder_0.def.json
+++ b/resources/extruders/p4_extruder_0.def.json
@@ -1,0 +1,21 @@
+{
+    "version": 2,
+    "name": "Extruder 1 (T0)",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": [ 
+            "makertech_proforge_4"
+			
+		],
+        "position": "0"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 0 },
+		"material_diameter": { "default_value": 1.75 },
+		"machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_start_code": { "default_value": "SELECT_T0" },
+        "machine_extruder_end_code": { "default_value": "DOCK_T0" }
+    }
+}

--- a/resources/extruders/p4_extruder_1.def.json
+++ b/resources/extruders/p4_extruder_1.def.json
@@ -1,0 +1,24 @@
+{
+    "version": 2,
+    "name": "Extruder 2 (T1)",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": [ 
+			"makertech_proforge_4"
+			
+		],
+        "position": "1"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 1 },
+		"material_diameter": { "default_value": 1.75 },
+		"machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_start_code": { "default_value": "SELECT_T1" },
+        "machine_extruder_end_code": { "default_value": "DOCK_T1" }
+		
+    }
+}
+
+

--- a/resources/extruders/p4_extruder_2.def.json
+++ b/resources/extruders/p4_extruder_2.def.json
@@ -1,0 +1,24 @@
+{
+    "version": 2,
+    "name": "Extruder 3 (T2)",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": [ 
+            "makertech_proforge_4"
+			
+		],
+        "position": "2"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 2 },
+		"material_diameter": { "default_value": 1.75 },
+		"machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_start_code": { "default_value": "SELECT_T2" },
+        "machine_extruder_end_code": { "default_value": "DOCK_T2" }
+		
+    }
+}
+
+

--- a/resources/extruders/p4_extruder_3.def.json
+++ b/resources/extruders/p4_extruder_3.def.json
@@ -1,0 +1,24 @@
+{
+    "version": 2,
+    "name": "Extruder 4 (T3)",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": [ 
+            "makertech_proforge_4"
+			
+		],
+        "position": "3"
+    },
+
+    "overrides": {
+        "extruder_nr": { "default_value": 3 },
+		"material_diameter": { "default_value": 1.75 },
+		"machine_nozzle_size": { "default_value": 0.4 },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_start_code": { "default_value": "SELECT_T3" },
+        "machine_extruder_end_code": { "default_value": "DOCK_T3" }
+		
+    }
+}
+
+

--- a/resources/quality/makertech_3d/1_makertech_global_ultra_detailed.inst.cfg
+++ b/resources/quality/makertech_3d/1_makertech_global_ultra_detailed.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+weight = 0
+global_quality = True
+
+[values]
+infill_sparse_density = 15
+infill_pattern = zigzag
+layer_height = 0.04
+top_bottom_thickness = 0.8

--- a/resources/quality/makertech_3d/2_makertech_global_extra_detailed.inst.cfg
+++ b/resources/quality/makertech_3d/2_makertech_global_extra_detailed.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+weight = -1
+global_quality = True
+
+[values]
+infill_sparse_density = 15
+infill_pattern = zigzag
+layer_height = 0.08
+top_bottom_thickness = 0.8

--- a/resources/quality/makertech_3d/3_makertech_global_detailed.inst.cfg
+++ b/resources/quality/makertech_3d/3_makertech_global_detailed.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+weight = -2
+global_quality = True
+
+[values]
+infill_sparse_density = 15
+infill_pattern = zigzag
+layer_height = 0.12
+top_bottom_thickness = 0.96

--- a/resources/quality/makertech_3d/4_makertech_global_standard.inst.cfg
+++ b/resources/quality/makertech_3d/4_makertech_global_standard.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+weight = -3
+global_quality = True
+
+[values]
+infill_sparse_density = 15
+infill_pattern = zigzag
+layer_height = 0.20
+top_bottom_thickness = 1.0

--- a/resources/quality/makertech_3d/5_makertech_global_quick_print.inst.cfg
+++ b/resources/quality/makertech_3d/5_makertech_global_quick_print.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+weight = -4
+global_quality = True
+
+[values]
+infill_sparse_density = 10
+infill_pattern = zigzag
+layer_height = 0.28
+top_bottom_thickness = 1.12
+

--- a/resources/quality/makertech_3d/6_makertech_global_draft.inst.cfg
+++ b/resources/quality/makertech_3d/6_makertech_global_draft.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+weight = -5
+global_quality = True
+
+[values]
+infill_sparse_density = 10
+infill_pattern = zigzag
+layer_height = 0.36
+top_bottom_thickness = 1.08

--- a/resources/quality/makertech_3d/7_makertech_global_coarse.inst.cfg
+++ b/resources/quality/makertech_3d/7_makertech_global_coarse.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+weight = -6
+global_quality = True
+
+[values]
+infill_sparse_density = 10
+infill_pattern = zigzag
+layer_height = 0.60
+top_bottom_thickness = 1.80
+

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_01_gabs_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_01_gabs_02_UD.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+material = generic_abs_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_02_gabs_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_02_gabs_02_ED.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+material = generic_abs_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_03_gabs_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_03_gabs_02_D.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+material = generic_abs_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_04_gabs_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_04_gabs_03_UD.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+material = generic_abs_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_05_gabs_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_05_gabs_03_ED.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+material = generic_abs_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_06_gabs_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_06_gabs_03_D.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+material = generic_abs_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_07_gabs_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_07_gabs_03_S.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+material = generic_abs_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_08_gabs_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_08_gabs_04_D.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+material = generic_abs_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_09_gabs_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_09_gabs_04_S.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+material = generic_abs_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_10_gabs_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_10_gabs_04_QP.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+material = generic_abs_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_11_gabs_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_11_gabs_06_S.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+material = generic_abs_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_12_gabs_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_12_gabs_06_QP.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+material = generic_abs_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_13_gabs_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_13_gabs_06_Dr.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+material = generic_abs_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_14_gabs_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_14_gabs_08_Dr.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+material = generic_abs_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic ABS/makertech_base_15_gabs_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic ABS/makertech_base_15_gabs_08_C.inst.cfg
@@ -1,0 +1,17 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+material = generic_abs_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_01_gcpe_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_01_gcpe_02_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_cpe_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_02_gcpe_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_02_gcpe_02_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_cpe_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_03_gcpe_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_03_gcpe_02_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_cpe_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_04_gcpe_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_04_gcpe_03_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_cpe_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_05_gcpe_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_05_gcpe_03_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_cpe_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_06_gcpe_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_06_gcpe_03_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_cpe_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_07_gcpe_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_07_gcpe_03_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_cpe_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_08_gcpe_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_08_gcpe_04_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_cpe_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_09_gcpe_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_09_gcpe_04_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_cpe_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_10_gcpe_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_10_gcpe_04_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_cpe_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_11_gcpe_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_11_gcpe_06_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_cpe_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_12_gcpe_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_12_gcpe_06_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_cpe_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_13_gcpe_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_13_gcpe_06_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_cpe_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_14_gcpe_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_14_gcpe_08_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_cpe_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic CPE/makertech_base_15_gcpe_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic CPE/makertech_base_15_gcpe_08_C.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+
+material = generic_cpe_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_01_ghips_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_01_ghips_02_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_hips_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_02_ghips_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_02_ghips_02_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_hips_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_03_ghips_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_03_ghips_02_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_hips_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_04_ghips_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_04_ghips_03_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_hips_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_05_ghips_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_05_ghips_03_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_hips_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_06_ghips_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_06_ghips_03_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_hips_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_07_ghips_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_07_ghips_03_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_hips_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_08_ghips_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_08_ghips_04_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_hips_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_09_ghips_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_09_ghips_04_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_hips_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_10_ghips_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_10_ghips_04_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_hips_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_11_ghips_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_11_ghips_06_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_hips_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_12_ghips_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_12_ghips_06_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_hips_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_13_ghips_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_13_ghips_06_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_hips_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_14_ghips_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_14_ghips_08_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_hips_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic HIPS/makertech_base_15_ghips_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic HIPS/makertech_base_15_ghips_08_C.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+
+material = generic_hips_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_01_gnylon_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_01_gnylon_02_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_nylon_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_02_gnylon_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_02_gnylon_02_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_nylon_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_03_gnylon_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_03_gnylon_02_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_nylon_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_04_gnylon_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_04_gnylon_03_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_nylon_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_05_gnylon_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_05_gnylon_03_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_nylon_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_06_gnylon_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_06_gnylon_03_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_nylon_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_07_gnylon_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_07_gnylon_03_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_nylon_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_08_gnylon_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_08_gnylon_04_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_nylon_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_09_gnylon_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_09_gnylon_04_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_nylon_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_10_gnylon_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_10_gnylon_04_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_nylon_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_11_gnylon_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_11_gnylon_06_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_nylon_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_12_gnylon_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_12_gnylon_06_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_nylon_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_13_gnylon_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_13_gnylon_06_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_nylon_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_14_gnylon_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_14_gnylon_08_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_nylon_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic Nylon/makertech_base_15_gnylon_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic Nylon/makertech_base_15_gnylon_08_C.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+
+material = generic_nylon_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_01_gpc_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_01_gpc_02_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_pc_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_02_gpc_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_02_gpc_02_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_pc_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_03_gpc_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_03_gpc_02_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pc_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_04_gpc_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_04_gpc_03_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_pc_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_05_gpc_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_05_gpc_03_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_pc_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_06_gpc_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_06_gpc_03_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pc_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_07_gpc_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_07_gpc_03_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pc_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_08_gpc_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_08_gpc_04_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pc_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_09_gpc_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_09_gpc_04_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pc_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_10_gpc_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_10_gpc_04_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_pc_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_11_gpc_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_11_gpc_06_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pc_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_12_gpc_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_12_gpc_06_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_pc_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_13_gpc_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_13_gpc_06_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_pc_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_14_gpc_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_14_gpc_08_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_pc_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PC/makertech_base_15_gpc_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PC/makertech_base_15_gpc_08_C.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+
+material = generic_pc_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_01_gpetg_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_01_gpetg_02_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_petg_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_02_gpetg_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_02_gpetg_02_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_petg_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_03_gpetg_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_03_gpetg_02_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_petg_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_04_gpetg_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_04_gpetg_03_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_petg_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_05_gpetg_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_05_gpetg_03_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_petg_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_06_gpetg_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_06_gpetg_03_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_petg_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_07_gpetg_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_07_gpetg_03_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_petg_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_08_gpetg_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_08_gpetg_04_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_petg_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_09_gpetg_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_09_gpetg_04_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_petg_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_10_gpetg_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_10_gpetg_04_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_petg_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_11_gpetg_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_11_gpetg_06_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_petg_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_12_gpetg_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_12_gpetg_06_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_petg_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_13_gpetg_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_13_gpetg_06_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_petg_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_14_gpetg_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_14_gpetg_08_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_petg_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PETG/makertech_base_15_gpetg_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PETG/makertech_base_15_gpetg_08_C.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+
+material = generic_petg_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_01_gpla_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_01_gpla_02_UD.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_pla_175
+variant = 0.2mm, 0.3mm, 0.4mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_02_gpla_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_02_gpla_02_ED.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_pla_175
+variant = 0.2mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_03_gpla_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_03_gpla_02_D.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pla_175
+variant = 0.3mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_04_gpla_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_04_gpla_03_UD.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_pla_175
+variant = 0.3mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_05_gpla_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_05_gpla_03_ED.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_pla_175
+variant = 0.3mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_06_gpla_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_06_gpla_03_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pla_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_07_gpla_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_07_gpla_03_S.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pla_175
+variant = 0.3mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_08_gpla_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_08_gpla_04_D.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pla_175
+variant = 0.4mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_09_gpla_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_09_gpla_04_S.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pla_175
+variant = 0.4mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_10_gpla_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_10_gpla_04_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_pla_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_11_gpla_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_11_gpla_06_S.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pla_175
+variant = 0.6mm
+
+[values]
+
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_12_gpla_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_12_gpla_06_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_pla_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_13_gpla_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_13_gpla_06_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_pla_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_14_gpla_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_14_gpla_08_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_pla_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PLA/makertech_base_15_gpla_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PLA/makertech_base_15_gpla_08_C.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+
+material = generic_pla_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = =material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_01_gpva_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_01_gpva_02_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_pva_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_02_gpva_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_02_gpva_02_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_pva_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_03_gpva_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_03_gpva_02_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pva_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_04_gpva_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_04_gpva_03_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_pva_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_05_gpva_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_05_gpva_03_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_pva_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_06_gpva_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_06_gpva_03_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pva_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_07_gpva_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_07_gpva_03_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pva_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_08_gpva_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_08_gpva_04_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_pva_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_09_gpva_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_09_gpva_04_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pva_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_10_gpva_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_10_gpva_04_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_pva_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_11_gpva_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_11_gpva_06_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_pva_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_12_gpva_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_12_gpva_06_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_pva_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_13_gpva_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_13_gpva_06_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_pva_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_14_gpva_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_14_gpva_08_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_pva_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic PVA/makertech_base_15_gpva_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic PVA/makertech_base_15_gpva_08_C.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+
+material = generic_pva_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_01_gtpu_02_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_01_gtpu_02_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_tpu_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_02_gtpu_02_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_02_gtpu_02_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_tpu_175
+variant = 0.2mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_03_gtpu_02_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_03_gtpu_02_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_tpu_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_04_gtpu_03_UD.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_04_gtpu_03_UD.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Ultra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = ultrahigh
+
+material = generic_tpu_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_05_gtpu_03_ED.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_05_gtpu_03_ED.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Extra Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extrahigh
+
+material = generic_tpu_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_06_gtpu_03_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_06_gtpu_03_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_tpu_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_07_gtpu_03_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_07_gtpu_03_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_tpu_175
+variant = 0.3mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_08_gtpu_04_D.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_08_gtpu_04_D.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Detailed
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = high
+
+material = generic_tpu_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_09_gtpu_04_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_09_gtpu_04_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_tpu_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_10_gtpu_04_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_10_gtpu_04_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_tpu_175
+variant = 0.4mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_11_gtpu_06_S.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_11_gtpu_06_S.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Standard
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = normal
+
+material = generic_tpu_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_12_gtpu_06_QP.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_12_gtpu_06_QP.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Quick Print
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = draft
+
+material = generic_tpu_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_13_gtpu_06_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_13_gtpu_06_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_tpu_175
+variant = 0.6mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_14_gtpu_08_Dr.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_14_gtpu_08_Dr.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Draft
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = coarse
+
+material = generic_tpu_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/quality/makertech_3d/Generic TPU/makertech_base_15_gtpu_08_C.inst.cfg
+++ b/resources/quality/makertech_3d/Generic TPU/makertech_base_15_gtpu_08_C.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+version = 4
+name = Coarse
+definition = makertech_base
+
+[metadata]
+setting_version = 16
+type = quality
+quality_type = extracoarse
+
+material = generic_tpu_175
+variant = 0.8mm
+
+[values]
+
+material_print_temperature_layer_0 = =material_print_temperature + 5
+material_final_print_temperature = =material_print_temperature
+material_standby_temperature = material_print_temperature

--- a/resources/variants/makertech3d/makertech_axis_02.inst.cfg
+++ b/resources/variants/makertech3d/makertech_axis_02.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.2mm
+version = 4
+definition =  makertech_axis
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 5

--- a/resources/variants/makertech3d/makertech_axis_03.inst.cfg
+++ b/resources/variants/makertech3d/makertech_axis_03.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.3mm
+version = 4
+definition =  makertech_axis
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 6

--- a/resources/variants/makertech3d/makertech_axis_04.inst.cfg
+++ b/resources/variants/makertech3d/makertech_axis_04.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.4mm
+version = 4
+definition =  makertech_axis
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.4
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 7

--- a/resources/variants/makertech3d/makertech_axis_06.inst.cfg
+++ b/resources/variants/makertech3d/makertech_axis_06.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.6mm
+version = 4
+definition =  makertech_axis
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 8

--- a/resources/variants/makertech3d/makertech_axis_08.inst.cfg
+++ b/resources/variants/makertech3d/makertech_axis_08.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.8mm
+version = 4
+definition =  makertech_axis
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 8

--- a/resources/variants/makertech3d/makertech_base_02.inst.cfg
+++ b/resources/variants/makertech3d/makertech_base_02.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.2mm
+version = 4
+definition = makertech_base
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2
+wall_thickness = 0.8
+retraction_speed = 70
+retraction_amount = 4

--- a/resources/variants/makertech3d/makertech_base_03.inst.cfg
+++ b/resources/variants/makertech3d/makertech_base_03.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.3mm
+version = 4
+definition = makertech_base
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3
+wall_thickness = 0.9
+retraction_speed = 70
+retraction_amount = 5

--- a/resources/variants/makertech3d/makertech_base_04.inst.cfg
+++ b/resources/variants/makertech3d/makertech_base_04.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.4mm
+version = 4
+definition = makertech_base
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.4
+wall_thickness = 1.2
+retraction_speed = 70
+retraction_amount = 5

--- a/resources/variants/makertech3d/makertech_base_06.inst.cfg
+++ b/resources/variants/makertech3d/makertech_base_06.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.6mm
+version = 4
+definition = makertech_base
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6
+wall_thickness = 1.8
+retraction_speed = 70
+retraction_amount = 6

--- a/resources/variants/makertech3d/makertech_base_08.inst.cfg
+++ b/resources/variants/makertech3d/makertech_base_08.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.8mm
+version = 4
+definition = makertech_base
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8
+wall_thickness = 2.4
+retraction_speed = 70
+retraction_amount = 6

--- a/resources/variants/makertech3d/makertech_proforge_2S_02.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_2S_02.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.2mm
+version = 4
+definition =  makertech_proforge_2s
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 5

--- a/resources/variants/makertech3d/makertech_proforge_2S_03.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_2S_03.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.3mm
+version = 4
+definition =  makertech_proforge_2s
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 6

--- a/resources/variants/makertech3d/makertech_proforge_2S_04.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_2S_04.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.4mm
+version = 4
+definition =  makertech_proforge_2s
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.4
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 7

--- a/resources/variants/makertech3d/makertech_proforge_2S_06.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_2S_06.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.6mm
+version = 4
+definition =  makertech_proforge_2s
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 8

--- a/resources/variants/makertech3d/makertech_proforge_2S_08.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_2S_08.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.8mm
+version = 4
+definition =  makertech_proforge_2s
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 8

--- a/resources/variants/makertech3d/makertech_proforge_3_02.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_3_02.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.2mm
+version = 4
+definition =  makertech_proforge_3
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 1

--- a/resources/variants/makertech3d/makertech_proforge_3_03.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_3_03.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.3mm
+version = 4
+definition =  makertech_proforge_3
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 1

--- a/resources/variants/makertech3d/makertech_proforge_3_04.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_3_04.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.4mm
+version = 4
+definition =  makertech_proforge_3
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.4
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 2

--- a/resources/variants/makertech3d/makertech_proforge_3_06.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_3_06.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.6mm
+version = 4
+definition =  makertech_proforge_3
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 3

--- a/resources/variants/makertech3d/makertech_proforge_3_08.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_3_08.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.8mm
+version = 4
+definition =  makertech_proforge_3
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8
+wall_line_count = 3
+retraction_speed = 30
+retraction_amount = 4

--- a/resources/variants/makertech3d/makertech_proforge_4_02.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_4_02.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.2mm
+version = 4
+definition =  makertech_proforge_4
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2
+wall_line_count = 3
+retraction_speed = 100
+retraction_amount = 1.3

--- a/resources/variants/makertech3d/makertech_proforge_4_03.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_4_03.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.3mm
+version = 4
+definition =  makertech_proforge_4
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3
+wall_line_count = 3
+retraction_speed = 100
+retraction_amount = 1.3

--- a/resources/variants/makertech3d/makertech_proforge_4_04.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_4_04.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.4mm
+version = 4
+definition =  makertech_proforge_4
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.4
+wall_line_count = 3
+retraction_speed = 100
+retraction_amount = 1.3

--- a/resources/variants/makertech3d/makertech_proforge_4_06.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_4_06.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.6mm
+version = 4
+definition =  makertech_proforge_4
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6
+wall_line_count = 3
+retraction_speed = 100
+retraction_amount = 1.5

--- a/resources/variants/makertech3d/makertech_proforge_4_08.inst.cfg
+++ b/resources/variants/makertech3d/makertech_proforge_4_08.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+name = 0.8mm
+version = 4
+definition =  makertech_proforge_4
+
+[metadata]
+author = Makertech
+setting_version = 16
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8
+wall_line_count = 3
+retraction_speed = 100
+retraction_amount = 1.5


### PR DESCRIPTION
# Description

Printer configurations for Makertech 3D printers:

- Axis
- Proforge Original
- Proforge 2S
- Proforge 3
- Proforge 4 Tool Changer

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Printer definition file(s)
