### PR TITLE
Update Voron base definitions to reflect Voron / Klipper docs

### DIFF
--- a/resources/definitions/voron2_base.def.json
+++ b/resources/definitions/voron2_base.def.json
@@ -55,7 +55,7 @@
         "machine_endstop_positive_direction_y": { "default_value": true },
         "machine_endstop_positive_direction_z": { "default_value": false },
         "machine_feeder_wheel_diameter": { "default_value": 7.5 },
-        "machine_gcode_flavor": { "default_value": "RepRap (RepRap)" },
+        "machine_gcode_flavor": { "default_value": "RepRap (Marlin/Sprinter)" },
         "machine_head_with_fans_polygon":
         {
             "default_value": [

--- a/resources/definitions/voron2_base.def.json
+++ b/resources/definitions/voron2_base.def.json
@@ -76,7 +76,7 @@
         "machine_max_jerk_xy": { "default_value": 20 },
         "machine_max_jerk_z": { "default_value": 1 },
         "machine_name": { "default_value": "VORON2" },
-        "machine_start_gcode": { "default_value": "print_start EXTRUDER={material_print_temperature_layer_0} BED={material_bed_temperature_layer_0} CHAMBER={build_volume_temperature}" },
+        "machine_start_gcode": { "default_value": ";Nozzle diameter = {machine_nozzle_size}\n;Filament type = {material_type}\n;Filament name = {material_name}\n;Filament weight = {filament_weight}\n; M190 S{material_bed_temperature_layer_0}\n; M109 S{material_print_temperature_layer_0}\nprint_start EXTRUDER={material_print_temperature_layer_0} BED={material_bed_temperature_layer_0} CHAMBER={build_volume_temperature}" },
         "machine_steps_per_mm_x": { "default_value": 80 },
         "machine_steps_per_mm_y": { "default_value": 80 },
         "machine_steps_per_mm_z": { "default_value": 400 },

--- a/resources/definitions/voron2_base.def.json
+++ b/resources/definitions/voron2_base.def.json
@@ -76,7 +76,7 @@
         "machine_max_jerk_xy": { "default_value": 20 },
         "machine_max_jerk_z": { "default_value": 1 },
         "machine_name": { "default_value": "VORON2" },
-        "machine_start_gcode": { "default_value": "print_start" },
+        "machine_start_gcode": { "default_value": "print_start EXTRUDER={material_print_temperature_layer_0} BED={material_bed_temperature_layer_0} CHAMBER={build_volume_temperature}" },
         "machine_steps_per_mm_x": { "default_value": 80 },
         "machine_steps_per_mm_y": { "default_value": 80 },
         "machine_steps_per_mm_z": { "default_value": 400 },


### PR DESCRIPTION
# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

This fixes the default gcode flavor set in the Voron printer profiles and improves the default start gcode to reflect the current recommended "print_start" macro for Voron/Klipper

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Printer definition file(s)

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
