### PR TITLE
qt6.6 scroll issues

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -71,6 +71,7 @@ class CuraConan(ConanFile):
         self._cura_env = Environment()
         self._cura_env.define("QML2_IMPORT_PATH", str(self._site_packages.joinpath("PyQt6", "Qt6", "qml")))
         self._cura_env.define("QT_PLUGIN_PATH", str(self._site_packages.joinpath("PyQt6", "Qt6", "plugins")))
+        self._cura_env.define("QT_QUICK_FLICKABLE_WHEEL_DECELERATION", "5000")
         if not self.in_local_cache:
             self._cura_env.define("CURA_DATA_ROOT", str(self._share_dir.joinpath("cura")))
 

--- a/cura_app.py
+++ b/cura_app.py
@@ -17,6 +17,7 @@ import faulthandler
 import os
 if sys.platform != "linux":  # Turns out the Linux build _does_ use this, but we're not making an Enterprise release for that system anyway.
     os.environ["QT_PLUGIN_PATH"] = ""  # Security workaround: Don't need it, and introduces an attack vector, so set to nul.
+    os.environ["QT_QUICK_FLICKABLE_WHEEL_DECELERATION"] = ""  # Security workaround: Don't need it, and introduces an attack vector, so set to nul.
     os.environ["QML2_IMPORT_PATH"] = ""  # Security workaround: Don't need it, and introduces an attack vector, so set to nul.
     os.environ["QT_OPENGL_DLL"] = ""  # Security workaround: Don't need it, and introduces an attack vector, so set to nul.
 

--- a/cura_app.py
+++ b/cura_app.py
@@ -17,7 +17,11 @@ import faulthandler
 import os
 if sys.platform != "linux":  # Turns out the Linux build _does_ use this, but we're not making an Enterprise release for that system anyway.
     os.environ["QT_PLUGIN_PATH"] = ""  # Security workaround: Don't need it, and introduces an attack vector, so set to nul.
-    os.environ["QT_QUICK_FLICKABLE_WHEEL_DECELERATION"] = ""  # Security workaround: Don't need it, and introduces an attack vector, so set to nul.
+    try:
+        # try converting to integer
+        os.environ["QT_QUICK_FLICKABLE_WHEEL_DECELERATION"] = str(int(os.environ["QT_QUICK_FLICKABLE_WHEEL_DECELERATION"]))
+    except ValueError:
+        os.environ["QT_QUICK_FLICKABLE_WHEEL_DECELERATION"] = "5000"
     os.environ["QML2_IMPORT_PATH"] = ""  # Security workaround: Don't need it, and introduces an attack vector, so set to nul.
     os.environ["QT_OPENGL_DLL"] = ""  # Security workaround: Don't need it, and introduces an attack vector, so set to nul.
 

--- a/packaging/AppImage-builder/AppImageBuilder.yml.jinja
+++ b/packaging/AppImage-builder/AppImageBuilder.yml.jinja
@@ -45,6 +45,7 @@ AppDir:
       LD_LIBRARY_PATH: "$APPDIR:$APPDIR/runtime/compat/:$APPDIR/usr/lib/x86_64-linux-gnu:$APPDIR/lib/x86_64-linux-gnu:$APPDIR/usr/lib:$APPDIR/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders"
       PYTHONPATH: "$APPDIR"
       QT_PLUGIN_PATH: "$APPDIR/qt/plugins"
+      QT_QUICK_FLICKABLE_WHEEL_DECELERATION: "5000"
       QML2_IMPORT_PATH: "$APPDIR/qt/qml"
       QT_QPA_PLATFORMTHEME: xdgdesktopportal
       GDK_PIXBUF_MODULEDIR: $APPDIR/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/2.10.0/loaders

--- a/packaging/AppImage/AppRun
+++ b/packaging/AppImage/AppRun
@@ -5,6 +5,7 @@ scriptdir=$(dirname $0)
 export PYTHONPATH="$scriptdir/lib/python3.10"
 export LD_LIBRARY_PATH=$scriptdir
 export QT_PLUGIN_PATH="$scriptdir/qt/plugins"
+export QT_QUICK_FLICKABLE_WHEEL_DECELERATION="5000"
 export QML2_IMPORT_PATH="$scriptdir/qt/qml"
 export QT_QPA_FONTDIR=/usr/share/fonts
 export QT_QPA_PLATFORMTHEME=xdgdesktopportal


### PR DESCRIPTION
CURA-11468

# Description

qt6.6 changelog: 06540cdb02 Flickable: Proportional wheel scrolling if deceleration is
large
When using a plain "clicky" mouse wheel, Flickable has historically
applied acceleration: the faster you rotate the wheel, the faster it
flicked. The default value of flickDeceleration was 5000, which felt
hard to control, but changing it in QML affected touch-flicking and
wheel behavior simultaneously. So now we decouple those:
flickDeceleration only affects touchscreen flicking, and Flickable
rather uses a new default value of 15000, which is defined to mean that
scroll distance becomes directly proportional to
QWheelEvent::angleDelta() * QStyleHints::wheelScrollLines() (where a
"line" is 24 logical pixels, because Flickable does not have direct
understanding of its contents). You can set the new environment var
QT_QUICK_FLICKABLE_WHEEL_DECELERATION to a value from 1 to 14999 to
restore wheel acceleration behavior from older versions; 5000 was the
old value.

This made scrolling behave abnormally than the previous behavior. The environment variable is now set so that it follows old behavior. 