### PR TITLE
Printer name changed to printer type

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -331,7 +331,7 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
             return False
 
         [printer, *_] = self._printers
-        return printer.name in ("ultimaker_methodx", "ultimaker_methodxl")
+        return printer.type in ("MakerBot Method X", "MakerBot Method XL")
 
     @pyqtProperty(bool, notify=_cloudClusterPrintersChanged)
     def supportsPrintJobActions(self) -> bool:


### PR DESCRIPTION
printer names can be different for same type of printer. Also, printer type is coming from cloud here so the type search is changed accordingly

CURA-11432


