### PR TITLE
PP-377 Improve the time estimates for the Method machines

### DIFF
--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -99,7 +99,7 @@
         "acceleration_print":
         {
             "enabled": false,
-            "value": 300
+            "value": 800
         },
         "acceleration_print_layer_0":
         {
@@ -234,7 +234,7 @@
         "jerk_print":
         {
             "enabled": false,
-            "value": 12.5
+            "value": 6.25
         },
         "jerk_print_layer_0":
         {
@@ -279,7 +279,7 @@
         "jerk_travel":
         {
             "enabled": false,
-            "value": 12.5
+            "value": "jerk_print"
         },
         "jerk_travel_enabled":
         {

--- a/resources/extruders/ultimaker_methodx_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_left.def.json
@@ -16,6 +16,7 @@
         },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S255\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
         "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM109 S{material_final_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed*255/100}" },
+        "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },
         "machine_nozzle_size": { "default_value": 0.4 },

--- a/resources/extruders/ultimaker_methodx_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_right.def.json
@@ -16,6 +16,7 @@
         },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S255\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
         "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM109 S{material_final_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed*255/100}" },
+        "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },
         "machine_nozzle_size": { "default_value": 0.4 },

--- a/resources/extruders/ultimaker_methodxl_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_left.def.json
@@ -16,6 +16,7 @@
         },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S255\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
         "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM109 S{material_final_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed*255/100}" },
+        "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },
         "machine_nozzle_size": { "default_value": 0.4 },

--- a/resources/extruders/ultimaker_methodxl_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_right.def.json
@@ -16,6 +16,7 @@
         },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S255\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
         "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM109 S{material_final_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed*255/100}" },
+        "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },
         "machine_nozzle_size": { "default_value": 0.4 },


### PR DESCRIPTION
Improve the time estimates for the Method machines be increasing the acceleration and reducing the jerk. For dual extrusion a rough switch over time estimate is taken into account.

PP-377
