### PR TITLE
[CURA-11157] Remove 'support_interface_skip_height' setting

### DIFF
--- a/plugins/VersionUpgrade/VersionUpgrade56to57/VersionUpgrade56to57.py
+++ b/plugins/VersionUpgrade/VersionUpgrade56to57/VersionUpgrade56to57.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2024 UltiMaker
+# Cura is released under the terms of the LGPLv3 or higher.
+
+import configparser
+from typing import Tuple, List
+import io
+from UM.VersionUpgrade import VersionUpgrade
+
+_REMOVED_SETTINGS = {
+    "support_interface_skip_height",
+}
+_NEW_SETTING_VERSION = "23"
+
+
+class VersionUpgrade56to57(VersionUpgrade):
+    def upgradePreferences(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades preferences to remove from the visibility list the settings that were removed in this version.
+        It also changes the preferences to have the new version number.
+
+        This removes any settings that were removed in the new Cura version.
+        :param serialized: The original contents of the preferences file.
+        :param filename: The file name of the preferences file.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialized)
+
+        # Update version number.
+        parser["metadata"]["setting_version"] = _NEW_SETTING_VERSION
+
+        # Remove deleted settings from the visible settings list.
+        if "general" in parser and "visible_settings" in parser["general"]:
+            visible_settings = set(parser["general"]["visible_settings"].split(";"))
+            for removed in _REMOVED_SETTINGS:
+                if removed in visible_settings:
+                    visible_settings.remove(removed)
+
+            parser["general"]["visible_settings"] = ";".join(visible_settings)
+
+        result = io.StringIO()
+        parser.write(result)
+        return [filename], [result.getvalue()]
+
+    def upgradeInstanceContainer(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades instance containers to remove the settings that were removed in this version.
+        It also changes the instance containers to have the new version number.
+
+        This removes any settings that were removed in the new Cura version and updates settings that need to be updated
+        with a new value.
+
+        :param serialized: The original contents of the instance container.
+        :param filename: The original file name of the instance container.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
+        parser = configparser.ConfigParser(interpolation = None, comment_prefixes = ())
+        parser.read_string(serialized)
+
+        # Update version number.
+        parser["metadata"]["setting_version"] = _NEW_SETTING_VERSION
+
+        if "values" in parser:
+            # Remove deleted settings from the instance containers.
+            for removed in _REMOVED_SETTINGS:
+                if removed in parser["values"]:
+                    del parser["values"][removed]
+
+        result = io.StringIO()
+        parser.write(result)
+        return [filename], [result.getvalue()]
+
+    def upgradeStack(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
+        """
+        Upgrades stacks to have the new version number.
+
+        :param serialized: The original contents of the stack.
+        :param filename: The original file name of the stack.
+        :return: A list of new file names, and a list of the new contents for
+        those files.
+        """
+        parser = configparser.ConfigParser(interpolation = None)
+        parser.read_string(serialized)
+
+        # Update version number.
+        if "metadata" not in parser:
+            parser["metadata"] = {}
+
+        parser["metadata"]["setting_version"] = _NEW_SETTING_VERSION
+
+        result = io.StringIO()
+        parser.write(result)
+        return [filename], [result.getvalue()]

--- a/plugins/VersionUpgrade/VersionUpgrade56to57/__init__.py
+++ b/plugins/VersionUpgrade/VersionUpgrade56to57/__init__.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2024 UltiMaker
+# Cura is released under the terms of the LGPLv3 or higher.
+
+from typing import Any, Dict, TYPE_CHECKING
+
+from . import VersionUpgrade56to57
+
+if TYPE_CHECKING:
+    from UM.Application import Application
+
+upgrade = VersionUpgrade56to57.VersionUpgrade56to57()
+
+
+def getMetaData() -> Dict[str, Any]:
+    return {
+        "version_upgrade": {
+            # From                           To                              Upgrade function
+            ("preferences", 7000022):        ("preferences", 7000023,        upgrade.upgradePreferences),
+            ("machine_stack", 6000022):      ("machine_stack", 6000023,      upgrade.upgradeStack),
+            ("extruder_train", 6000022):     ("extruder_train", 6000023,     upgrade.upgradeStack),
+            ("definition_changes", 4000022): ("definition_changes", 4000023, upgrade.upgradeInstanceContainer),
+            ("quality_changes", 4000022):    ("quality_changes", 4000023,    upgrade.upgradeInstanceContainer),
+            ("quality", 4000022):            ("quality", 4000023,            upgrade.upgradeInstanceContainer),
+            ("user", 4000022):               ("user", 4000023,               upgrade.upgradeInstanceContainer),
+            ("intent", 4000022):             ("intent", 4000023,             upgrade.upgradeInstanceContainer),
+        },
+        "sources": {
+            "preferences": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"."}
+            },
+            "machine_stack": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./machine_instances"}
+            },
+            "extruder_train": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./extruders"}
+            },
+            "definition_changes": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./definition_changes"}
+            },
+            "quality_changes": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./quality_changes"}
+            },
+            "quality": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./quality"}
+            },
+            "user": {
+                "get_version": upgrade.getCfgVersion,
+                "location": {"./user"}
+            }
+        }
+    }
+
+
+def register(app: "Application") -> Dict[str, Any]:
+    return {"version_upgrade": upgrade}

--- a/plugins/VersionUpgrade/VersionUpgrade56to57/plugin.json
+++ b/plugins/VersionUpgrade/VersionUpgrade56to57/plugin.json
@@ -1,0 +1,8 @@
+{
+    "name": "Version Upgrade 5.6 to 5.7",
+    "author": "UltiMaker",
+    "version": "1.0.0",
+    "description": "Upgrades configurations from Cura 5.6 to Cura 5.7.",
+    "api": 8,
+    "i18n-catalog": "cura"
+}

--- a/resources/definitions/ankermake_m5.def.json
+++ b/resources/definitions/ankermake_m5.def.json
@@ -112,7 +112,6 @@
         "support_interface_density": { "value": 33.333 },
         "support_interface_enable": { "value": true },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_roof_enable": { "value": true },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },
         "support_xy_distance_overhang": { "value": "wall_line_width_0" },

--- a/resources/definitions/artillery_base.def.json
+++ b/resources/definitions/artillery_base.def.json
@@ -114,7 +114,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },
         "support_xy_distance_overhang": { "value": "wall_line_width_0" },
         "support_xy_overrides_z": { "value": "'xy_overrides_z'" },

--- a/resources/definitions/atmat_signal_pro_base.def.json
+++ b/resources/definitions/atmat_signal_pro_base.def.json
@@ -154,7 +154,6 @@
         "support_infill_rate": { "value": "20" },
         "support_interface_enable": { "value": "True" },
         "support_interface_height": { "value": "1" },
-        "support_interface_skip_height": { "value": "layer_height" },
         "support_join_distance": { "value": "1" },
         "support_offset": { "value": "1.5" },
         "support_pattern": { "default_value": "zigzag" },

--- a/resources/definitions/biqu_base.def.json
+++ b/resources/definitions/biqu_base.def.json
@@ -108,7 +108,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/blocks_base.def.json
+++ b/resources/definitions/blocks_base.def.json
@@ -97,7 +97,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },
         "support_xy_distance_overhang": { "value": "wall_line_width_0" },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5423,20 +5423,6 @@
                         }
                     }
                 },
-                "support_interface_skip_height":
-                {
-                    "label": "Support Interface Resolution",
-                    "description": "When checking where there's model above and below the support, take steps of the given height. Lower values will slice slower, while higher values may cause normal support to be printed in some places where there should have been support interface.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 0.2,
-                    "value": "layer_height",
-                    "minimum_value": "0",
-                    "maximum_value_warning": "support_interface_height",
-                    "limit_to_extruder": "support_interface_extruder_nr",
-                    "enabled": "support_interface_enable and (support_enable or support_meshes_present)",
-                    "settable_per_mesh": true
-                },
                 "support_interface_density":
                 {
                     "label": "Support Interface Density",

--- a/resources/definitions/flyingbear_base.def.json
+++ b/resources/definitions/flyingbear_base.def.json
@@ -92,7 +92,6 @@
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_line_width": { "value": "line_width - 0.1" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/fusion3_f410.def.json
+++ b/resources/definitions/fusion3_f410.def.json
@@ -112,7 +112,6 @@
         "support_interface_density": { "value": 33.333 },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 0 },
         "support_xy_distance": { "value": "wall_line_width_0 * 3" },

--- a/resources/definitions/kingroon_base.def.json
+++ b/resources/definitions/kingroon_base.def.json
@@ -133,7 +133,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/koonovo_base.def.json
+++ b/resources/definitions/koonovo_base.def.json
@@ -70,7 +70,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/koonovo_kn3.def.json
+++ b/resources/definitions/koonovo_kn3.def.json
@@ -88,7 +88,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/koonovo_kn5.def.json
+++ b/resources/definitions/koonovo_kn5.def.json
@@ -88,7 +88,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/longer_base.def.json
+++ b/resources/definitions/longer_base.def.json
@@ -109,7 +109,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/mingda_base.def.json
+++ b/resources/definitions/mingda_base.def.json
@@ -119,7 +119,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/tank_m_base.def.json
+++ b/resources/definitions/tank_m_base.def.json
@@ -70,7 +70,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/tronxy_x.def.json
+++ b/resources/definitions/tronxy_x.def.json
@@ -111,7 +111,6 @@
         "support_interface_density": { "value": 33.333 },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": "1 if (support_structure == 'tree') else 0" },
         "support_xy_distance": { "value": "wall_line_width_0 * 3" },

--- a/resources/definitions/two_trees_base.def.json
+++ b/resources/definitions/two_trees_base.def.json
@@ -68,7 +68,6 @@
         "support_interface_density": { "value": 33.333 },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": "1 if (support_structure == 'tree') else 0" },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/definitions/vivedino_base.def.json
+++ b/resources/definitions/vivedino_base.def.json
@@ -99,7 +99,6 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "layer_height * 4" },
         "support_interface_pattern": { "value": "'grid'" },
-        "support_interface_skip_height": { "value": 0.2 },
         "support_pattern": { "value": "'zigzag'" },
         "support_wall_count": { "value": 1 },
         "support_xy_distance": { "value": "wall_line_width_0 * 2" },

--- a/resources/i18n/fdmprinter.def.json.pot
+++ b/resources/i18n/fdmprinter.def.json.pot
@@ -3548,14 +3548,6 @@ msgctxt "support_bottom_height description"
 msgid "The thickness of the support floors. This controls the number of dense layers that are printed on top of places of a model on which support rests."
 msgstr ""
 
-msgctxt "support_interface_skip_height label"
-msgid "Support Interface Resolution"
-msgstr ""
-
-msgctxt "support_interface_skip_height description"
-msgid "When checking where there's model above and below the support, take steps of the given height. Lower values will slice slower, while higher values may cause normal support to be printed in some places where there should have been support interface."
-msgstr ""
-
 msgctxt "support_interface_density label"
 msgid "Support Interface Density"
 msgstr ""

--- a/resources/quality/beamup_l/beamup_l_coarse.inst.cfg
+++ b/resources/quality/beamup_l/beamup_l_coarse.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.60
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.30
 support_offset = 0.8
 support_z_distance = 0.4
 wall_thickness = 1.6

--- a/resources/quality/beamup_l/beamup_l_draft.inst.cfg
+++ b/resources/quality/beamup_l/beamup_l_draft.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.60
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.20
 support_offset = 0.8
 support_z_distance = 0.3
 wall_thickness = 1.6

--- a/resources/quality/beamup_l/beamup_l_extra_fine.inst.cfg
+++ b/resources/quality/beamup_l/beamup_l_extra_fine.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.30
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.06
 support_offset = 0.8
 support_z_distance = 0.12
 wall_thickness = 1.6

--- a/resources/quality/beamup_l/beamup_l_fine.inst.cfg
+++ b/resources/quality/beamup_l/beamup_l_fine.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.30
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.10
 support_offset = 0.8
 support_z_distance = 0.2
 wall_thickness = 1.6

--- a/resources/quality/beamup_l/beamup_l_normal.inst.cfg
+++ b/resources/quality/beamup_l/beamup_l_normal.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.45
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.15
 support_offset = 0.8
 support_z_distance = 0.25
 wall_thickness = 1.6

--- a/resources/quality/beamup_s/beamup_s_coarse.inst.cfg
+++ b/resources/quality/beamup_s/beamup_s_coarse.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.60
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.30
 support_offset = 0.8
 support_z_distance = 0.2
 wall_thickness = 0.8

--- a/resources/quality/beamup_s/beamup_s_draft.inst.cfg
+++ b/resources/quality/beamup_s/beamup_s_draft.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.40
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.20
 support_offset = 0.8
 support_z_distance = 0.2
 wall_thickness = 0.8

--- a/resources/quality/beamup_s/beamup_s_extra_fine.inst.cfg
+++ b/resources/quality/beamup_s/beamup_s_extra_fine.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.30
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.06
 support_offset = 0.8
 support_z_distance = 0.2
 wall_thickness = 0.8

--- a/resources/quality/beamup_s/beamup_s_fine.inst.cfg
+++ b/resources/quality/beamup_s/beamup_s_fine.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.30
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.10
 support_offset = 0.8
 support_z_distance = 0.2
 wall_thickness = 0.8

--- a/resources/quality/beamup_s/beamup_s_normal.inst.cfg
+++ b/resources/quality/beamup_s/beamup_s_normal.inst.cfg
@@ -33,7 +33,6 @@ support_infill_rate = 20
 support_interface_enable = True
 support_interface_height = 0.45
 support_interface_pattern = zigzag
-support_interface_skip_height = 0.15
 support_offset = 0.8
 support_z_distance = 0.2
 wall_thickness = 0.8

--- a/resources/quality/flsun_sr/flsun_sr_fine.inst.cfg
+++ b/resources/quality/flsun_sr/flsun_sr_fine.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 60
 support_interface_enable = True
 support_interface_height = 0.96
 support_interface_pattern = grid
-support_interface_skip_height = 0.12
 support_roof_density = 60
 support_type = everywhere
 support_wall_count = 1

--- a/resources/quality/flsun_sr/flsun_sr_normal.inst.cfg
+++ b/resources/quality/flsun_sr/flsun_sr_normal.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 60
 support_interface_enable = True
 support_interface_height = 0.6
 support_interface_pattern = grid
-support_interface_skip_height = 0.2
 support_roof_density = 60
 support_type = everywhere
 support_wall_count = 1

--- a/resources/quality/flsun_v400/flsun_v400_normal.inst.cfg
+++ b/resources/quality/flsun_v400/flsun_v400_normal.inst.cfg
@@ -100,7 +100,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 0.6
 support_interface_pattern = lines
-support_interface_skip_height = 0.2
 support_pattern = zigzag
 support_roof_density = 70
 support_type = everywhere

--- a/resources/quality/imade3d_jellybox/imade3d_jellybox_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox/imade3d_jellybox_coarse.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 2
 support_interface_pattern = concentric
-support_interface_skip_height = 0.1
 support_type = everywhere
 support_use_towers = False
 support_xy_distance = 0.8

--- a/resources/quality/imade3d_jellybox/imade3d_jellybox_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/imade3d_jellybox_fine.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 2
 support_interface_pattern = concentric
-support_interface_skip_height = 0.1
 support_type = everywhere
 support_use_towers = False
 support_xy_distance = 0.8

--- a/resources/quality/imade3d_jellybox/imade3d_jellybox_normal.inst.cfg
+++ b/resources/quality/imade3d_jellybox/imade3d_jellybox_normal.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 2
 support_interface_pattern = concentric
-support_interface_skip_height = 0.1
 support_type = everywhere
 support_use_towers = False
 support_xy_distance = 0.8

--- a/resources/quality/imade3d_jellybox/imade3d_jellybox_ultrafine.inst.cfg
+++ b/resources/quality/imade3d_jellybox/imade3d_jellybox_ultrafine.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 2
 support_interface_pattern = concentric
-support_interface_skip_height = 0.1
 support_type = everywhere
 support_use_towers = False
 support_xy_distance = 0.8

--- a/resources/quality/imade3d_jellybox_2/jb2_global_coarse.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/jb2_global_coarse.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 2
 support_interface_pattern = concentric
-support_interface_skip_height = 0.1
 support_type = everywhere
 support_use_towers = False
 support_xy_distance = 0.8

--- a/resources/quality/imade3d_jellybox_2/jb2_global_fine.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/jb2_global_fine.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 2
 support_interface_pattern = concentric
-support_interface_skip_height = 0.1
 support_type = everywhere
 support_use_towers = False
 support_xy_distance = 0.8

--- a/resources/quality/imade3d_jellybox_2/jb2_global_normal.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/jb2_global_normal.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 2
 support_interface_pattern = concentric
-support_interface_skip_height = 0.1
 support_type = everywhere
 support_use_towers = False
 support_xy_distance = 0.8

--- a/resources/quality/imade3d_jellybox_2/jb2_global_ultrafine.inst.cfg
+++ b/resources/quality/imade3d_jellybox_2/jb2_global_ultrafine.inst.cfg
@@ -65,7 +65,6 @@ support_interface_density = 70
 support_interface_enable = True
 support_interface_height = 2
 support_interface_pattern = concentric
-support_interface_skip_height = 0.1
 support_type = everywhere
 support_use_towers = False
 support_xy_distance = 0.8

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -293,7 +293,6 @@ support_bottom_wall_count
 support_interface_height
 support_roof_height
 support_bottom_height
-support_interface_skip_height
 support_interface_density
 support_roof_density
 support_bottom_density

--- a/resources/variants/arjun/arjun300_pva_0.2.inst.cfg
+++ b/resources/variants/arjun/arjun300_pva_0.2.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjun300_pva_0.3.inst.cfg
+++ b/resources/variants/arjun/arjun300_pva_0.3.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjun300_pva_0.4.inst.cfg
+++ b/resources/variants/arjun/arjun300_pva_0.4.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjun300_pva_0.5.inst.cfg
+++ b/resources/variants/arjun/arjun300_pva_0.5.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjun300_pva_0.6.inst.cfg
+++ b/resources/variants/arjun/arjun300_pva_0.6.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjun300_pva_0.8.inst.cfg
+++ b/resources/variants/arjun/arjun300_pva_0.8.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjunpro300_pva_0.2.inst.cfg
+++ b/resources/variants/arjun/arjunpro300_pva_0.2.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjunpro300_pva_0.3.inst.cfg
+++ b/resources/variants/arjun/arjunpro300_pva_0.3.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjunpro300_pva_0.4.inst.cfg
+++ b/resources/variants/arjun/arjunpro300_pva_0.4.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjunpro300_pva_0.5.inst.cfg
+++ b/resources/variants/arjun/arjunpro300_pva_0.5.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjunpro300_pva_0.6.inst.cfg
+++ b/resources/variants/arjun/arjunpro300_pva_0.6.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/arjun/arjunpro300_pva_0.8.inst.cfg
+++ b/resources/variants/arjun/arjunpro300_pva_0.8.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/kosher/kosher220_pva_0.2.inst.cfg
+++ b/resources/variants/kosher/kosher220_pva_0.2.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/kosher/kosher220_pva_0.3.inst.cfg
+++ b/resources/variants/kosher/kosher220_pva_0.3.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/kosher/kosher220_pva_0.4.inst.cfg
+++ b/resources/variants/kosher/kosher220_pva_0.4.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/kosher/kosher220_pva_0.5.inst.cfg
+++ b/resources/variants/kosher/kosher220_pva_0.5.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/kosher/kosher220_pva_0.6.inst.cfg
+++ b/resources/variants/kosher/kosher220_pva_0.6.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles

--- a/resources/variants/kosher/kosher220_pva_0.8.inst.cfg
+++ b/resources/variants/kosher/kosher220_pva_0.8.inst.cfg
@@ -21,7 +21,6 @@ support_interface_density = 100
 support_interface_enable = True
 support_interface_height = =layer_height * 5
 support_interface_pattern = concentric
-support_interface_skip_height = =layer_height
 support_join_distance = 3
 support_offset = 3
 support_pattern = triangles


### PR DESCRIPTION
Was used for run-time efficiency, but it wasn't really ever set beyond one layer-height, which made it rather useless.

This needed a version-upgrader, since it's the first change that needed it since 5.6

See backend PR: https://github.com/Ultimaker/CuraEngine/pull/2009
