### PR TITLE
Cura 11482 sentry

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,7 +1,7 @@
 version: "5.7.0-alpha.0"
 requirements:
   - "uranium/(latest)@ultimaker/testing"
-  - "curaengine/(latest)@ultimaker/testing"
+  - "curaengine/(latest)@ultimaker/cura_11482"
   - "cura_binary_data/(latest)@ultimaker/testing"
   - "fdm_materials/(latest)@ultimaker/testing"
   - "curaengine_plugin_gradual_flow/(latest)@ultimaker/stable"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,12 +1,11 @@
 version: "5.7.0-alpha.0"
 requirements:
   - "uranium/(latest)@ultimaker/testing"
-  - "curaengine/(latest)@ultimaker/cura_11482"
+  - "curaengine/(latest)@ultimaker/testing"
   - "cura_binary_data/(latest)@ultimaker/testing"
   - "fdm_materials/(latest)@ultimaker/testing"
   - "curaengine_plugin_gradual_flow/(latest)@ultimaker/stable"
   - "dulcificum/latest@ultimaker/testing"
-  - "arcus/(latest)@ultimaker/cura_11482"
   - "pysavitar/5.3.0"
   - "pynest2d/5.3.0"
   - "curaengine_grpc_definitions/(latest)@ultimaker/testing"

--- a/conandata.yml
+++ b/conandata.yml
@@ -6,7 +6,7 @@ requirements:
   - "fdm_materials/(latest)@ultimaker/testing"
   - "curaengine_plugin_gradual_flow/(latest)@ultimaker/stable"
   - "dulcificum/latest@ultimaker/testing"
-  - "pyarcus/5.3.0"
+  - "arcus/(latest)@ultimaker/cura_11482"
   - "pysavitar/5.3.0"
   - "pynest2d/5.3.0"
   - "curaengine_grpc_definitions/(latest)@ultimaker/testing"

--- a/conanfile.py
+++ b/conanfile.py
@@ -321,6 +321,7 @@ class CuraConan(ConanFile):
         if self.conf.get("user.curaengine:sentry_url", "", check_type=str) != "":
             self.options["curaengine"].enable_sentry = True
             self.options["arcus"].enable_sentry = True
+            self.options["clipper"].enable_sentry = True
 
     def validate(self):
         version = self.conf.get("user.cura:version", default = self.version, check_type = str)

--- a/conanfile.py
+++ b/conanfile.py
@@ -336,6 +336,7 @@ class CuraConan(ConanFile):
             for req in self.conan_data["requirements_internal"]:
                 self.requires(req)
         self.requires("cpython/3.10.4@ultimaker/stable")
+        self.requires("clipper/6.4.2@ultimaker/cura_11482")  # TODO: change channel to `testing` once merged
         self.requires("openssl/3.2.0")
         self.requires("boost/1.82.0")
         self.requires("spdlog/1.12.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -337,7 +337,7 @@ class CuraConan(ConanFile):
             for req in self.conan_data["requirements_internal"]:
                 self.requires(req)
         self.requires("cpython/3.10.4@ultimaker/stable")
-        self.requires("clipper/6.4.2@ultimaker/cura_11482")  # TODO: change channel to `testing` once merged
+        self.requires("clipper/6.4.2@ultimaker/stable")
         self.requires("openssl/3.2.0")
         self.requires("boost/1.82.0")
         self.requires("spdlog/1.12.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -320,6 +320,7 @@ class CuraConan(ConanFile):
             self.options["openssl"].shared = True
         if self.conf.get("user.curaengine:sentry_url", "", check_type=str) != "":
             self.options["curaengine"].enable_sentry = True
+            self.options["arcus"].enable_sentry = True
 
     def validate(self):
         version = self.conf.get("user.cura:version", default = self.version, check_type = str)

--- a/conanfile.py
+++ b/conanfile.py
@@ -242,7 +242,7 @@ class CuraConan(ConanFile):
                 self.output.warning(f"Source path for binary {binary['binary']} does not exist")
                 continue
 
-            for bin in Path(src_path).glob(binary["binary"] + "*[.exe|.dll|.so|.dylib|.so.|.pdb]*"):
+            for bin in Path(src_path).glob(binary["binary"] + "*[.exe|.dll|.so|.dylib|.so.]*"):
                 binaries.append((str(bin), binary["dst"]))
             for bin in Path(src_path).glob(binary["binary"]):
                 binaries.append((str(bin), binary["dst"]))

--- a/plugins/CuraEngineBackend/Cura.proto
+++ b/plugins/CuraEngineBackend/Cura.proto
@@ -36,6 +36,7 @@ message Slice
     string sentry_id = 6; // The anonymized Sentry user id that requested the slice
     string cura_version = 7; // The version of Cura that requested the slice
     optional string project_name = 8; // The name of the project that requested the slice
+    optional string user_name = 9; // The Digital Factory account name of the user that requested the slice
 }
 
 message Extruder

--- a/plugins/CuraEngineBackend/Cura.proto
+++ b/plugins/CuraEngineBackend/Cura.proto
@@ -35,6 +35,7 @@ message Slice
     repeated EnginePlugin engine_plugins = 5;
     string sentry_id = 6; // The anonymized Sentry user id that requested the slice
     string cura_version = 7; // The version of Cura that requested the slice
+    optional string project_name = 8; // The name of the project that requested the slice
 }
 
 message Extruder

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -199,7 +199,6 @@ class CuraEngineBackend(QObject, Backend):
 
         # Ensure that the initial value for send_engine_crash is handled correctly.
         application.callLater(self._onPreferencesChanged, "info/send_engine_crash")
-        application.callLater(self._onPreferencesChanged, "info/anonymous_engine_crash_report")
 
     def startPlugins(self) -> None:
         """
@@ -1104,11 +1103,6 @@ class CuraEngineBackend(QObject, Backend):
                 self._change_timer.start()
         elif preference == "info/send_engine_crash":
             os.environ["USE_SENTRY"] = "1" if CuraApplication.getInstance().getPreferences().getValue("info/send_engine_crash") else "0"
-        elif preference == "info/anonymous_engine_crash_report":
-            if not CuraApplication.getInstance().getPreferences().getValue("info/anonymous_engine_crash_report"):
-                account = CuraApplication.getInstance().getCuraAPI().account
-                if account and account.isLoggedIn:
-                    os.environ["CURAENGINE_SENTRY_USER"] = account.userName
 
     def tickle(self) -> None:
         """Tickle the backend so in case of auto slicing, it starts the timer."""

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -1105,9 +1105,10 @@ class CuraEngineBackend(QObject, Backend):
         elif preference == "info/send_engine_crash":
             os.environ["USE_SENTRY"] = "1" if CuraApplication.getInstance().getPreferences().getValue("info/send_engine_crash") else "0"
         elif preference == "info/anonymous_engine_crash_report":
-            account = CuraApplication.getInstance().getCuraAPI().account
-            if account and account.isLoggedIn and not CuraApplication.getInstance().getPreferences().getValue("info/anonymous_engine_crash_report"):
-               os.environ["CURAENGINE_SENTRY_USER"] = account.userName
+            if not CuraApplication.getInstance().getPreferences().getValue("info/anonymous_engine_crash_report"):
+                account = CuraApplication.getInstance().getCuraAPI().account
+                if account and account.isLoggedIn:
+                    os.environ["CURAENGINE_SENTRY_USER"] = account.userName
 
     def tickle(self) -> None:
         """Tickle the backend so in case of auto slicing, it starts the timer."""

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -344,6 +344,7 @@ class StartSliceJob(Job):
         account = CuraApplication.getInstance().getCuraAPI().account
         if account and account.isLoggedIn and not CuraApplication.getInstance().getPreferences().getValue("info/anonymous_engine_crash_report"):
             self._slice_message.project_name = CuraApplication.getInstance().getPrintInformation().baseName
+            self._slice_message.user_name = account.userName
 
         # Build messages for extruder stacks
         for extruder_stack in global_stack.extruderList:

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -340,6 +340,11 @@ class StartSliceJob(Job):
         self._slice_message.sentry_id = f"{user_id}"
         self._slice_message.cura_version = CuraVersion
 
+        # Add the project name to the message if the user allows for non-anonymous crash data collection.
+        account = CuraApplication.getInstance().getCuraAPI().account
+        if account and account.isLoggedIn and not CuraApplication.getInstance().getPreferences().getValue("info/anonymous_engine_crash_report"):
+            self._slice_message.project_name = CuraApplication.getInstance().getPrintInformation().baseName
+
         # Build messages for extruder stacks
         for extruder_stack in global_stack.extruderList:
             self._buildExtruderMessage(extruder_stack)

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -906,13 +906,13 @@ UM.PreferencesPage
                 width: childrenRect.width
                 height: visible ? childrenRect.height : 0
                 visible: Cura.API.account.isLoggedIn
-                text: catalog.i18nc("@info:tooltip", "Send crash reports with your registered UltiMaker account email adress to UltiMaker. No model data is being send.")
+                text: catalog.i18nc("@info:tooltip", "Send crash reports with your registered UltiMaker account name and the project name to UltiMaker Sentry. No actual model data is being send.")
                 anchors.left: parent.left
                 anchors.leftMargin: UM.Theme.getSize("default_margin").width
                 Cura.RadioButton
                 {
                     id: sendEngineCrashCheckboxUser
-                    text: catalog.i18nc("@option:radio", "Crash reports with email adress")
+                    text: catalog.i18nc("@option:radio", "Send crash reports with UltiMaker account name")
                     enabled: sendEngineCrashCheckbox.checked
                     checked: !boolCheck(UM.Preferences.getValue("info/anonymous_engine_crash_report")) && Cura.API.account.isLoggedIn
                     onClicked: UM.Preferences.setValue("info/anonymous_engine_crash_report", false)

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -872,7 +872,7 @@ UM.PreferencesPage
                 UM.CheckBox
                 {
                     id: sendEngineCrashCheckbox
-                    text: catalog.i18nc("@option:check","Send (anonymous) engine crash reports")
+                    text: catalog.i18nc("@option:check","Send engine crash reports")
                     checked: boolCheck(UM.Preferences.getValue("info/send_engine_crash"))
                     onCheckedChanged: UM.Preferences.setValue("info/send_engine_crash", checked)
                 }
@@ -888,7 +888,6 @@ UM.PreferencesPage
             {
                 width: childrenRect.width
                 height: visible ? childrenRect.height : 0
-                visible: Cura.API.account.isLoggedIn
                 text: catalog.i18nc("@info:tooltip", "Send crash reports without any personally identifiable information or models data to UltiMaker.")
                 anchors.left: parent.left
                 anchors.leftMargin: UM.Theme.getSize("default_margin").width
@@ -896,7 +895,7 @@ UM.PreferencesPage
                 {
                     id: sendEngineCrashCheckboxAnonymous
                     text: catalog.i18nc("@option:radio", "Anonymous crash reports")
-                    enabled: sendEngineCrashCheckbox.checked
+                    enabled: sendEngineCrashCheckbox.checked && Cura.API.account.isLoggedIn
                     checked: boolCheck(UM.Preferences.getValue("info/anonymous_engine_crash_report"))
                     onClicked: UM.Preferences.setValue("info/anonymous_engine_crash_report", true)
                 }
@@ -905,15 +904,16 @@ UM.PreferencesPage
             {
                 width: childrenRect.width
                 height: visible ? childrenRect.height : 0
-                visible: Cura.API.account.isLoggedIn
-                text: catalog.i18nc("@info:tooltip", "Send crash reports with your registered UltiMaker account name and the project name to UltiMaker Sentry. No actual model data is being send.")
+                text: Cura.API.account.isLoggedIn ?
+                      catalog.i18nc("@info:tooltip", "Send crash reports with your registered UltiMaker account name and the project name to UltiMaker Sentry. No actual model data is being send.") :
+                      catalog.i18nc("@info:tooltip", "Please sign in to your UltiMaker account to allow sending non-anonymous data.")
                 anchors.left: parent.left
                 anchors.leftMargin: UM.Theme.getSize("default_margin").width
                 Cura.RadioButton
                 {
                     id: sendEngineCrashCheckboxUser
-                    text: catalog.i18nc("@option:radio", "Send crash reports with UltiMaker account name")
-                    enabled: sendEngineCrashCheckbox.checked
+                    text: catalog.i18nc("@option:radio", "Include UltiMaker account name")
+                    enabled: sendEngineCrashCheckbox.checked && Cura.API.account.isLoggedIn
                     checked: !boolCheck(UM.Preferences.getValue("info/anonymous_engine_crash_report")) && Cura.API.account.isLoggedIn
                     onClicked: UM.Preferences.setValue("info/anonymous_engine_crash_report", false)
                 }

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -124,6 +124,9 @@ UM.PreferencesPage
         UM.Preferences.resetPreference("info/send_engine_crash")
         sendEngineCrashCheckbox.checked = boolCheck(UM.Preferences.getValue("info/send_engine_crash"))
 
+        UM.Preferences.resetPreference("info/anonymous_engine_crash_report")
+        sendEngineCrashCheckboxAnonymous.checked = boolCheck(UM.Preferences.getValue("info/anonymous_engine_crash_report"))
+
         UM.Preferences.resetPreference("info/automatic_update_check")
         checkUpdatesCheckbox.checked = boolCheck(UM.Preferences.getValue("info/automatic_update_check"))
 
@@ -859,11 +862,12 @@ UM.PreferencesPage
                 font: UM.Theme.getFont("medium_bold")
                 text: catalog.i18nc("@label", "Privacy")
             }
+
             UM.TooltipArea
             {
                 width: childrenRect.width
                 height: visible ? childrenRect.height : 0
-                text: catalog.i18nc("@info:tooltip", "Should slicing crashes be automatically reported to Ultimaker? Note, no models, IP addresses or other personally identifiable information is sent or stored.")
+                text: catalog.i18nc("@info:tooltip", "Should slicing crashes be automatically reported to Ultimaker? Note, no models, IP addresses or other personally identifiable information is sent or stored, unless you give explicit permission.")
 
                 UM.CheckBox
                 {
@@ -871,6 +875,47 @@ UM.PreferencesPage
                     text: catalog.i18nc("@option:check","Send (anonymous) engine crash reports")
                     checked: boolCheck(UM.Preferences.getValue("info/send_engine_crash"))
                     onCheckedChanged: UM.Preferences.setValue("info/send_engine_crash", checked)
+                }
+            }
+
+            ButtonGroup
+            {
+                id: curaCrashGroup
+                buttons: [sendEngineCrashCheckboxAnonymous, sendEngineCrashCheckboxUser]
+            }
+
+            UM.TooltipArea
+            {
+                width: childrenRect.width
+                height: visible ? childrenRect.height : 0
+                visible: Cura.API.account.isLoggedIn
+                text: catalog.i18nc("@info:tooltip", "Send crash reports without any personally identifiable information or models data to UltiMaker.")
+                anchors.left: parent.left
+                anchors.leftMargin: UM.Theme.getSize("default_margin").width
+                Cura.RadioButton
+                {
+                    id: sendEngineCrashCheckboxAnonymous
+                    text: catalog.i18nc("@option:radio", "Anonymous crash reports")
+                    enabled: sendEngineCrashCheckbox.checked
+                    checked: boolCheck(UM.Preferences.getValue("info/anonymous_engine_crash_report"))
+                    onClicked: UM.Preferences.setValue("info/anonymous_engine_crash_report", true)
+                }
+            }
+            UM.TooltipArea
+            {
+                width: childrenRect.width
+                height: visible ? childrenRect.height : 0
+                visible: Cura.API.account.isLoggedIn
+                text: catalog.i18nc("@info:tooltip", "Send crash reports with your registered UltiMaker account email adress to UltiMaker. No model data is being send.")
+                anchors.left: parent.left
+                anchors.leftMargin: UM.Theme.getSize("default_margin").width
+                Cura.RadioButton
+                {
+                    id: sendEngineCrashCheckboxUser
+                    text: catalog.i18nc("@option:radio", "Crash reports with email adress")
+                    enabled: sendEngineCrashCheckbox.checked
+                    checked: !boolCheck(UM.Preferences.getValue("info/anonymous_engine_crash_report")) && Cura.API.account.isLoggedIn
+                    onClicked: UM.Preferences.setValue("info/anonymous_engine_crash_report", false)
                 }
             }
 


### PR DESCRIPTION
# Description

Allow logged in DF user to **opt-in** for Sentry crash reporting. This should help with triaging GH crashes, to quickly identify your own crash, or to help out customers in the future. 

I have gone over a couple of GitHub issues to test the build, any issue which resulted in a crash and Sentry event I have labeled and linked See: https://github.com/Ultimaker/Cura/issues?q=is%3Aissue+is%3Aopen+label%3A%22Sentry+%3Aeuropean_castle%3A%22 Issues were it sliced without trouble have been closed.

> [!NOTE]
> I also send the project base_name over as an optional (opt-in) this will allow us to write a nightly cron-job, downloading the slicing error :boom: issues and testing them nightly. If the crash is resolved in the latest build we can close the issue, if not we can get the GH issue number in Sentry and couple the information between the Sentry event and the nightly run. Discussed this with @MariMakes and I will create a Jira ticket for next sprint for this automation. 

| not logged in| logged in as DF user |
|-------------------------------------------------------------------------------------------------------| -------------------------------------------------------------------------------------------------------|
| ![image](https://github.com/Ultimaker/Cura/assets/8535734/56911f22-2a48-47d0-b476-14d637f2904c) |![image](https://github.com/Ultimaker/Cura/assets/8535734/c6c9450d-87f0-4358-a6de-38e6c3b6546f) |

> [!IMPORTANT]
> When merging the different branches don't forget to change the `channels` for the conan packages

See also the following PR's:
- CuraEngine: https://github.com/Ultimaker/CuraEngine/pull/2014
- libArcus: https://github.com/Ultimaker/libArcus/pull/154
- conan-ultimaker-index: https://github.com/Ultimaker/conan-ultimaker-index/pull/10

And the following commits:
- cura-workflows: https://github.com/ultimaker/cura-workflows/compare/9ff5a4be3f0ecd14b45e6c271127136c94c5ce4b...bc4a5fa0c31c07f6f191889a76f1235fc3a5b729
- conan-config:
  - https://github.com/ultimaker/conan-config/compare/cf88e3393f19796edba1b06a0309581cd9db8c40...f8670f76e7ac8903be35f2fd8cd7a73c7928ff4c
  - https://github.com/ultimaker/conan-config/compare/b178ef41a280da306129e6bdbe1bb7135e3476d9...b37dc1dc95317c27350fce2641ad555ed2aa28f1
  - etc for all runners on the different branches

> [!TIP]
> Use the build Artifacts of this run: https://github.com/Ultimaker/Cura/actions/runs/7512777745
> Which is this Sentry release: https://ultimaker-o7.sentry.io/releases/5.7.0-alpha.0%2Ba92357/?project=4506257745510401

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Locally
- [ ] Test B

**Test Configuration**:
* Operating System: Linux, Windows

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change