### PR TITLE
Cura 11438 raft monotonic top surface

### DIFF
--- a/plugins/SimulationView/SimulationView.py
+++ b/plugins/SimulationView/SimulationView.py
@@ -372,7 +372,10 @@ class SimulationView(CuraView):
             self._minimum_path_num = min(self._minimum_path_num, self._current_path_num)
             # update _current time when the path is changed by user
             if self._current_path_num < self._max_paths and round(self._current_path_num)== self._current_path_num:
-                self._current_time = self.cumulativeLineDuration()[int(self._current_path_num)]
+                actual_path_num = int(self._current_path_num)
+                cumulative_line_duration = self.cumulativeLineDuration()
+                if actual_path_num < len(cumulative_line_duration):
+                    self._current_time = cumulative_line_duration[actual_path_num]
 
             self._startUpdateTopLayers()
             self.currentPathNumChanged.emit()

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6459,6 +6459,7 @@
                     "description": "Print raft top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes the surface look more consistent, which is also visible on the model bottom surface.",
                     "type": "bool",
                     "default_value": false,
+                    "value": "skin_monotonic",
                     "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_surface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6453,6 +6453,17 @@
                     "settable_per_extruder": true,
                     "limit_to_extruder": "raft_surface_extruder_nr"
                 },
+                "raft_surface_monotonic":
+                {
+                    "label": "Monotonic Raft Top Surface Order",
+                    "description": "Print raft top surface lines in an ordering that causes them to always overlap with adjacent lines in a single direction. This takes slightly more time to print, but makes the surface look more consistent, which is also visible on the model bottom surface.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_surface_layers > 0",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true,
+                    "limit_to_extruder": "raft_surface_extruder_nr"
+                },
                 "raft_wall_count":
                 {
                     "label": "Raft Wall Count",

--- a/resources/setting_visibility/expert.cfg
+++ b/resources/setting_visibility/expert.cfg
@@ -340,6 +340,7 @@ raft_surface_layers
 raft_surface_thickness
 raft_surface_line_width
 raft_surface_line_spacing
+raft_surface_monotonic
 raft_interface_layers
 raft_interface_thickness
 raft_interface_line_width


### PR DESCRIPTION
Add a new setting to enable a monotonic line ordering of the raft top surface, in order to improve model quality.

I decided to link the value of this setting to `skin_monotonic`, because if this one is active, this means the user really wants a clean top/bottom surface, which is also the purpose of this impovement. We could even discuss of removing the new setting and use the existing one for both cases.

Comes along with https://github.com/Ultimaker/CuraEngine/pull/2018