### PR TITLE
Fix Python Installs about dialog

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 import os
+from io import StringIO
 from pathlib import Path
 
 from jinja2 import Template
@@ -150,6 +151,7 @@ class CuraConan(ConanFile):
         return "None"
 
     def _conan_installs(self):
+        self.output.info("Collecting conan installs")
         conan_installs = {}
 
         # list of conan installs
@@ -161,13 +163,22 @@ class CuraConan(ConanFile):
         return conan_installs
 
     def _python_installs(self):
+        self.output.info("Collecting python installs")
         python_installs = {}
 
         # list of python installs
-        python_ins_cmd = f"python -c \"import pkg_resources; print(';'.join([(s.key+','+ s.version) for s in pkg_resources.working_set]))\""
-        from six import StringIO
+        run_env = VirtualRunEnv(self)
+        env = run_env.environment()
+        env.prepend_path("PYTHONPATH", str(self._site_packages.as_posix()))
+        venv_vars = env.vars(self, scope = "run")
+
+        outer = '"' if self.settings.os == "Windows" else "'"
+        inner = "'" if self.settings.os == "Windows" else '"'
         buffer = StringIO()
-        self.run(python_ins_cmd, run_environment= True, env = "conanrun",  output=buffer)
+        with venv_vars.apply():
+            self.run(f"""python -c {outer}import pkg_resources;  print({inner};{inner}.join([(s.key+{inner},{inner}+ s.version) for s in pkg_resources.working_set])){outer}""",
+                          env = "conanrun",
+                          output = buffer)
 
         packages = str(buffer.getvalue()).split("-----------------\n")
         packages = packages[1].strip('\r\n').split(";")
@@ -504,10 +515,14 @@ echo "CURA_APP_NAME={{ cura_app_name }}" >> ${{ env_prefix }}GITHUB_ENV
 
         if self.in_local_cache:
             self.runenv_info.append_path("PYTHONPATH", os.path.join(self.package_folder, "site-packages"))
+            self.env_info.PYTHONPATH.append(os.path.join(self.package_folder, "site-packages"))
             self.runenv_info.append_path("PYTHONPATH", os.path.join(self.package_folder, "plugins"))
+            self.env_info.PYTHONPATH.append(os.path.join(self.package_folder, "plugins"))
         else:
             self.runenv_info.append_path("PYTHONPATH", self.source_folder)
+            self.env_info.PYTHONPATH.append(self.source_folder)
             self.runenv_info.append_path("PYTHONPATH", os.path.join(self.source_folder, "plugins"))
+            self.env_info.PYTHONPATH.append(os.path.join(self.source_folder, "plugins"))
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
It will now use the Python Virtual env

# Description

> [!IMPORTANT]
> Yes that weird `{inner}` and `{outer}` construct is needed due to Windows Powershell behavior

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
