### PR TITLE
Enable monotonic raft surface

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -96,6 +96,7 @@
         "raft_interface_thickness": { "value": "(raft_base_thickness + raft_surface_thickness) / 2" },
         "raft_speed": { "value": 15 },
         "raft_surface_fan_speed": { "value": "cool_fan_speed_min" },
+        "raft_surface_monotonic": { "value": true },
         "raft_surface_speed": { "value": "speed_topbottom" },
         "relative_extrusion":
         {

--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -380,7 +380,6 @@
         "roofing_material_flow": { "value": "material_flow" },
         "roofing_monotonic": { "value": true },
         "skin_material_flow": { "value": "0.95*material_flow" },
-        "skin_monotonic": { "value": true },
         "skin_outline_count": { "value": 0 },
         "skin_overlap": { "value": 0 },
         "skin_preshrink": { "value": 0 },


### PR DESCRIPTION
Enable monotonic raft surface for all Ultimaker machines.
Disable skin_monotonic for Method XL machines (=speed increase), roofing_monotonic is still enable to ensure a good top surface quality.

PP-430
