### PR TITLE
creating pyqtslot for desired functionality

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1101,6 +1101,10 @@ class CuraApplication(QtApplication):
             self._object_manager = ObjectsModel(self)
         return self._object_manager
 
+    @pyqtSlot(str, result = "QVariantList")
+    def getSupportedActionMachineList(self, definition_id: str) -> List["MachineAction"]:
+        return self._machine_action_manager.getSupportedActions(self._machine_manager.getDefinitionByMachineId(definition_id))
+
     @pyqtSlot(result = QObject)
     def getExtrudersModel(self, *args) -> "ExtrudersModel":
         if self._extruders_model is None:

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -12,7 +12,6 @@ import Cura 1.0 as Cura
 UM.ManagementPage
 {
     id: base
-    property var machineActionManager: CuraApplication.getMachineActionManager()
     Item { enabled: false; UM.I18nCatalog { id: catalog; name: "cura"} }
 
     title: catalog.i18nc("@title:tab", "Printers")
@@ -63,7 +62,7 @@ UM.ManagementPage
         Repeater
         {
             id: machineActionRepeater
-            model: base.currentItem.id ? machineActionManager.getSupportedActions(Cura.MachineManager.getDefinitionByMachineId(base.currentItem.id)) : null
+            model: base.currentItem ? CuraApplication.getSupportedActionMachineList(base.currentItem.id) : null
 
             Item
             {


### PR DESCRIPTION
CURA-11558

A crash was happening in Cura while opening the printer setting through preferences.
The function called in qml was bit tricky because it was calling a function of a "qtslot qobjcet" with a singleton class function as parameter. The resolve of the function was not aligned in sense of time. So I moved the calculation out to Cura_application. 
