### PR TITLE
PP-389 Increase minimum retraction distance 

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -106,6 +106,7 @@
         "retraction_combing_max_distance": { "value": 15 },
         "retraction_count_max": { "value": 25 },
         "retraction_extrusion_window": { "value": 1 },
+        "retraction_min_travel": { "value": 5 },
         "roofing_layer_count": { "value": "1" },
         "roofing_material_flow": { "value": "material_flow" },
         "skin_angles": { "value": "[] if infill_pattern not in ['cross', 'cross_3d'] else [20, 110]" },

--- a/resources/definitions/ultimaker3.def.json
+++ b/resources/definitions/ultimaker3.def.json
@@ -156,7 +156,6 @@
         "retraction_hop": { "value": "2" },
         "retraction_hop_enabled": { "value": "extruders_enabled_count > 1" },
         "retraction_hop_only_when_collides": { "value": "True" },
-        "retraction_min_travel": { "value": "5" },
         "retraction_prime_speed": { "value": "15" },
         "skin_overlap": { "value": "10" },
         "speed_prime_tower": { "value": "speed_topbottom" },

--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -373,7 +373,6 @@
         "retraction_hop": { "value": 0.4 },
         "retraction_hop_enabled": { "value": true },
         "retraction_hop_only_when_collides": { "value": false },
-        "retraction_min_travel": { "value": "line_width * 4" },
         "retraction_prime_speed": { "value": "retraction_speed" },
         "retraction_speed": { "value": 5 },
         "roofing_layer_count": { "value": 2 },

--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -108,7 +108,6 @@
         "retraction_hop": { "value": "2" },
         "retraction_hop_enabled": { "value": "extruders_enabled_count > 1" },
         "retraction_hop_only_when_collides": { "value": "True" },
-        "retraction_min_travel": { "value": "5" },
         "retraction_prime_speed": { "value": "15" },
         "retraction_speed": { "value": "45" },
         "speed_prime_tower": { "value": "speed_topbottom" },

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -110,7 +110,6 @@
         "retraction_hop": { "value": "2" },
         "retraction_hop_enabled": { "value": "extruders_enabled_count > 1" },
         "retraction_hop_only_when_collides": { "value": "True" },
-        "retraction_min_travel": { "value": "5" },
         "retraction_prime_speed": { "value": "15" },
         "retraction_speed": { "value": "45" },
         "speed_prime_tower": { "value": "speed_topbottom" },

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_nylon_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_nylon_0.1mm.inst.cfg
@@ -17,7 +17,6 @@ machine_nozzle_heat_up_speed = 1.4
 material_print_temperature = =default_material_print_temperature - 20
 ooze_shield_angle = 40
 raft_airgap = 0.4
-retraction_min_travel = 5
 speed_print = 70
 speed_topbottom = =math.ceil(speed_print * 30 / 70)
 speed_wall = =math.ceil(speed_print * 30 / 70)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_pc_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_pc_0.1mm.inst.cfg
@@ -25,7 +25,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_pp_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_pp_0.1mm.inst.cfg
@@ -28,7 +28,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.2
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 retraction_prime_speed = 15
 speed_print = 25
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_pc_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_pc_0.06mm.inst.cfg
@@ -26,7 +26,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_pc_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_pc_0.15mm.inst.cfg
@@ -25,7 +25,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_pc_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_pc_0.1mm.inst.cfg
@@ -26,7 +26,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_pc_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_pc_0.2mm.inst.cfg
@@ -25,7 +25,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_pp_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_pp_0.15mm.inst.cfg
@@ -28,7 +28,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_pp_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_pp_0.1mm.inst.cfg
@@ -29,7 +29,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_pp_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_pp_0.2mm.inst.cfg
@@ -29,7 +29,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.15mm.inst.cfg
@@ -28,7 +28,6 @@ prime_tower_wipe_enabled = True
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 skin_line_width = =round(line_width / 0.8, 2)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 0.8)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.1mm.inst.cfg
@@ -29,7 +29,6 @@ prime_tower_wipe_enabled = True
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 skin_line_width = =round(line_width / 0.8, 2)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 0.8)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.2mm.inst.cfg
@@ -28,7 +28,6 @@ prime_tower_wipe_enabled = True
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 skin_line_width = =round(line_width / 0.8, 2)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 0.8)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_pp_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_pp_0.2mm.inst.cfg
@@ -24,7 +24,6 @@ prime_tower_min_volume = 10
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 0.5
-retraction_min_travel = 1.5
 retraction_prime_speed = 15
 speed_wall_x = =math.ceil(speed_wall * 30 / 30)
 switch_extruder_prime_speed = 15

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_pp_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_pp_0.3mm.inst.cfg
@@ -24,7 +24,6 @@ prime_tower_min_volume = 15
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 0.5
-retraction_min_travel = 1.5
 retraction_prime_speed = 15
 speed_wall_x = =math.ceil(speed_wall * 30 / 30)
 switch_extruder_prime_speed = 15

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_pp_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_pp_0.4mm.inst.cfg
@@ -24,7 +24,6 @@ prime_tower_min_volume = 20
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 0.5
-retraction_min_travel = 1.5
 retraction_prime_speed = 15
 speed_infill = =math.ceil(speed_wall * 30 / 30)
 speed_wall_x = =math.ceil(speed_wall * 30 / 30)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.2mm.inst.cfg
@@ -27,7 +27,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 speed_print = 30
 speed_topbottom = =math.ceil(speed_print * 25 / 30)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.3mm.inst.cfg
@@ -28,7 +28,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 speed_print = 30
 speed_topbottom = =math.ceil(speed_print * 23 / 30)

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.4mm.inst.cfg
@@ -27,7 +27,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 speed_infill = =speed_print
 speed_print = 30

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_nylon_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_nylon_0.1mm.inst.cfg
@@ -17,7 +17,6 @@ machine_nozzle_heat_up_speed = 1.4
 material_print_temperature = =default_material_print_temperature - 20
 ooze_shield_angle = 40
 raft_airgap = 0.4
-retraction_min_travel = 5
 speed_print = 70
 speed_topbottom = =math.ceil(speed_print * 30 / 70)
 speed_wall = =math.ceil(speed_print * 30 / 70)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_pc_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_pc_0.1mm.inst.cfg
@@ -25,7 +25,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_pp_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_pp_0.1mm.inst.cfg
@@ -28,7 +28,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.2
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 retraction_prime_speed = 15
 speed_print = 25
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_pc_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_pc_0.06mm.inst.cfg
@@ -26,7 +26,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_pc_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_pc_0.15mm.inst.cfg
@@ -25,7 +25,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_pc_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_pc_0.1mm.inst.cfg
@@ -26,7 +26,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_pc_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_pc_0.2mm.inst.cfg
@@ -25,7 +25,6 @@ prime_tower_wipe_enabled = True
 raft_airgap = 0.25
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 50
 speed_topbottom = =math.ceil(speed_print * 25 / 50)
 speed_wall = =math.ceil(speed_print * 40 / 50)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_pp_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_pp_0.15mm.inst.cfg
@@ -28,7 +28,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_pp_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_pp_0.1mm.inst.cfg
@@ -29,7 +29,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_pp_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_pp_0.2mm.inst.cfg
@@ -29,7 +29,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = 0.8
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 25 / 25)
 speed_wall = =math.ceil(speed_print * 25 / 25)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.15mm.inst.cfg
@@ -28,7 +28,6 @@ prime_tower_wipe_enabled = True
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 skin_line_width = =round(line_width / 0.8, 2)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 0.8)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.1mm.inst.cfg
@@ -29,7 +29,6 @@ prime_tower_wipe_enabled = True
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 skin_line_width = =round(line_width / 0.8, 2)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 0.8)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.2mm.inst.cfg
@@ -28,7 +28,6 @@ prime_tower_wipe_enabled = True
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.8
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 skin_line_width = =round(line_width / 0.8, 2)
 speed_print = 25
 speed_topbottom = =math.ceil(speed_print * 0.8)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_pp_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_pp_0.2mm.inst.cfg
@@ -24,7 +24,6 @@ prime_tower_min_volume = 10
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 0.5
-retraction_min_travel = 1.5
 retraction_prime_speed = 15
 speed_wall_x = =math.ceil(speed_wall * 30 / 30)
 switch_extruder_prime_speed = 15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_pp_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_pp_0.3mm.inst.cfg
@@ -24,7 +24,6 @@ prime_tower_min_volume = 15
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 0.5
-retraction_min_travel = 1.5
 retraction_prime_speed = 15
 speed_wall_x = =math.ceil(speed_wall * 30 / 30)
 switch_extruder_prime_speed = 15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_pp_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_pp_0.4mm.inst.cfg
@@ -24,7 +24,6 @@ prime_tower_min_volume = 20
 retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 0.5
-retraction_min_travel = 1.5
 retraction_prime_speed = 15
 speed_infill = =math.ceil(speed_wall * 30 / 30)
 speed_wall_x = =math.ceil(speed_wall * 30 / 30)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.2mm.inst.cfg
@@ -27,7 +27,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 speed_print = 30
 speed_topbottom = =math.ceil(speed_print * 25 / 30)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.3mm.inst.cfg
@@ -28,7 +28,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = 15
 speed_print = 30
 speed_topbottom = =math.ceil(speed_print * 23 / 30)

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.4mm.inst.cfg
@@ -27,7 +27,6 @@ retraction_count_max = 15
 retraction_extra_prime_amount = 0.5
 retraction_hop = 1.5
 retraction_hop_only_when_collides = False
-retraction_min_travel = =line_width * 2
 speed_infill = =speed_print
 speed_print = 30
 speed_topbottom = =math.ceil(speed_print * 20 / 30)

--- a/resources/variants/ultimaker_s3_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker_s3_aa0.25.inst.cfg
@@ -16,7 +16,6 @@ machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = AA 0.25
 machine_nozzle_size = 0.25
 machine_nozzle_tip_outer_diameter = 0.65
-retraction_min_travel = 0.7
 retraction_prime_speed = =retraction_speed
 speed_print = 55
 speed_topbottom = 20

--- a/resources/variants/ultimaker_s3_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker_s3_aa0.8.inst.cfg
@@ -29,7 +29,6 @@ raft_surface_layers = 1
 retraction_amount = 6.5
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 retraction_speed = 25
 speed_print = 35
 speed_topbottom = =math.ceil(speed_print * 25 / 35)

--- a/resources/variants/ultimaker_s3_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s3_aa04.inst.cfg
@@ -14,7 +14,6 @@ machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = AA 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 6.5
-retraction_min_travel = =line_width * 2
 speed_print = 70
 speed_topbottom = =math.ceil(speed_print * 30 / 70)
 speed_wall = =math.ceil(speed_print * 30 / 70)

--- a/resources/variants/ultimaker_s3_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb0.8.inst.cfg
@@ -30,7 +30,6 @@ prime_tower_wipe_enabled = True
 raft_surface_layers = 1
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 3
 speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 speed_print = 35
 speed_support = =math.ceil(speed_print * 25 / 35)

--- a/resources/variants/ultimaker_s3_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb04.inst.cfg
@@ -16,7 +16,6 @@ acceleration_support_interface = =math.ceil(acceleration_support * 1500 / 2000)
 machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = BB 0.4
 machine_nozzle_tip_outer_diameter = 1.0
-retraction_min_travel = =3 * line_width
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)

--- a/resources/variants/ultimaker_s3_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s3_cc04.inst.cfg
@@ -13,7 +13,6 @@ brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = CC 0.4
 machine_nozzle_size = 0.4
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = =retraction_speed
 speed_infill = =speed_print
 speed_print = 45

--- a/resources/variants/ultimaker_s3_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s3_cc06.inst.cfg
@@ -13,7 +13,6 @@ brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = CC 0.6
 machine_nozzle_size = 0.6
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = =retraction_speed
 speed_infill = =speed_print
 speed_print = 45

--- a/resources/variants/ultimaker_s5_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa0.25.inst.cfg
@@ -16,7 +16,6 @@ machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = AA 0.25
 machine_nozzle_size = 0.25
 machine_nozzle_tip_outer_diameter = 0.65
-retraction_min_travel = 0.7
 retraction_prime_speed = =retraction_speed
 speed_print = 55
 speed_topbottom = 20

--- a/resources/variants/ultimaker_s5_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa0.8.inst.cfg
@@ -29,7 +29,6 @@ raft_surface_layers = 1
 retraction_amount = 6.5
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 retraction_speed = 25
 speed_print = 35
 speed_topbottom = =math.ceil(speed_print * 25 / 35)

--- a/resources/variants/ultimaker_s5_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa04.inst.cfg
@@ -14,7 +14,6 @@ machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = AA 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 6.5
-retraction_min_travel = =line_width * 2
 speed_print = 70
 speed_topbottom = =math.ceil(speed_print * 30 / 70)
 speed_wall = =math.ceil(speed_print * 30 / 70)

--- a/resources/variants/ultimaker_s5_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb0.8.inst.cfg
@@ -30,7 +30,6 @@ prime_tower_wipe_enabled = True
 raft_surface_layers = 1
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 3
 speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 speed_print = 35
 speed_support = =math.ceil(speed_print * 25 / 35)

--- a/resources/variants/ultimaker_s5_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb04.inst.cfg
@@ -16,7 +16,6 @@ acceleration_support_interface = =math.ceil(acceleration_support * 1500 / 2000)
 machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = BB 0.4
 machine_nozzle_tip_outer_diameter = 1.0
-retraction_min_travel = =3 * line_width
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)

--- a/resources/variants/ultimaker_s5_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s5_cc04.inst.cfg
@@ -13,7 +13,6 @@ brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = CC 0.4
 machine_nozzle_size = 0.4
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = =retraction_speed
 speed_infill = =speed_print
 speed_print = 45

--- a/resources/variants/ultimaker_s5_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s5_cc06.inst.cfg
@@ -13,7 +13,6 @@ brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = CC 0.6
 machine_nozzle_size = 0.6
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = =retraction_speed
 speed_infill = =speed_print
 speed_print = 45

--- a/resources/variants/ultimaker_s7_aa0.25.inst.cfg
+++ b/resources/variants/ultimaker_s7_aa0.25.inst.cfg
@@ -16,7 +16,6 @@ machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = AA 0.25
 machine_nozzle_size = 0.25
 machine_nozzle_tip_outer_diameter = 0.65
-retraction_min_travel = 0.7
 retraction_prime_speed = =retraction_speed
 speed_print = 55
 speed_topbottom = 20

--- a/resources/variants/ultimaker_s7_aa0.8.inst.cfg
+++ b/resources/variants/ultimaker_s7_aa0.8.inst.cfg
@@ -29,7 +29,6 @@ raft_surface_layers = 1
 retraction_amount = 6.5
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 2
 retraction_speed = 25
 speed_print = 35
 speed_topbottom = =math.ceil(speed_print * 25 / 35)

--- a/resources/variants/ultimaker_s7_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s7_aa04.inst.cfg
@@ -14,7 +14,6 @@ machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = AA 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 6.5
-retraction_min_travel = =line_width * 2
 speed_print = 70
 speed_topbottom = =math.ceil(speed_print * 30 / 70)
 speed_wall = =math.ceil(speed_print * 30 / 70)

--- a/resources/variants/ultimaker_s7_bb0.8.inst.cfg
+++ b/resources/variants/ultimaker_s7_bb0.8.inst.cfg
@@ -31,7 +31,6 @@ raft_surface_layers = 1
 retraction_amount = 4.5
 retraction_hop = 2
 retraction_hop_only_when_collides = True
-retraction_min_travel = =line_width * 3
 speed_prime_tower = =math.ceil(speed_print * 7 / 35)
 speed_print = 35
 speed_support = =math.ceil(speed_print * 25 / 35)

--- a/resources/variants/ultimaker_s7_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s7_bb04.inst.cfg
@@ -17,7 +17,6 @@ machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = BB 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 4.5
-retraction_min_travel = =3 * line_width
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)
 speed_support_interface = =math.ceil(speed_support * 20 / 25)

--- a/resources/variants/ultimaker_s7_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s7_cc04.inst.cfg
@@ -13,7 +13,6 @@ brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = CC 0.4
 machine_nozzle_size = 0.4
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = =retraction_speed
 speed_infill = =speed_print
 speed_print = 45

--- a/resources/variants/ultimaker_s7_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s7_cc06.inst.cfg
@@ -13,7 +13,6 @@ brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = CC 0.6
 machine_nozzle_size = 0.6
-retraction_min_travel = =line_width * 2
 retraction_prime_speed = =retraction_speed
 speed_infill = =speed_print
 speed_print = 45


### PR DESCRIPTION
Set retraction_min_travel to 5mm for all S-line and Method machines. This improves the infill pattern wall overlaps (for TPU top surfaces and raft base layers) and reduces the amount of retracts in tree supports islands.

It also cleans up the settings.

PP-389