### PR TITLE
PP-424 Changed max. value warning level z support distance

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5135,7 +5135,7 @@
                     "unit": "mm",
                     "type": "float",
                     "minimum_value": "0",
-                    "maximum_value_warning": "machine_nozzle_size",
+                    "maximum_value_warning": "5*layer_height",
                     "default_value": 0.1,
                     "limit_to_extruder": "support_interface_extruder_nr if support_interface_enable else support_infill_extruder_nr",
                     "enabled": "support_enable or support_meshes_present",


### PR DESCRIPTION
Changed max. value warning level z support distance to prevent warnings for AA0.25 nozzle using default profiles.

PP-424
