### PR TITLE
Authenticate subsystem. Fix keyword too early in parameter list. (Unit-tests should work.)

### DIFF
--- a/cura/OAuth2/AuthorizationHelpers.py
+++ b/cura/OAuth2/AuthorizationHelpers.py
@@ -127,6 +127,8 @@ class AuthorizationHelpers:
             headers_dict = headers,
             callback = lambda reply: self._parseUserProfile(reply, success_callback, failed_callback),
             error_callback = lambda _, _2: failed_callback() if failed_callback is not None else None,
+            download_progress_callback = None,
+            upload_progress_callback = None,
             timeout = REQUEST_TIMEOUT
         )
 


### PR DESCRIPTION
The unit tests started failing after implementation of CURA-11406, which was meant to prevent the restarting network after a laptop or PC fell asleep for more than 10 mins screwing up the refresh token. This was because the added timeout was inserted too early in the parameter list.