### PR TITLE
Cura 10542 drop to buildplate permodel

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -355,7 +355,6 @@ class CuraConan(ConanFile):
         self.requires("spdlog/1.12.0")
         self.requires("fmt/10.1.1")
         self.requires("zlib/1.2.13")
-        self.requires("protobuf/3.21.12")
 
     def build_requirements(self):
         if self.options.get_safe("enable_i18n", False):

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1087,7 +1087,7 @@ class CuraApplication(QtApplication):
 
     @pyqtSlot()
     def setWorkplaceDropToBuildplate(self):
-        return self._physics.setAppPerModelDropDown()
+        return self._physics.setAppAllModelDropDown()
 
     def getCuraFormulaFunctions(self, *args) -> "CuraFormulaFunctions":
         if self._cura_formula_functions is None:

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1085,9 +1085,9 @@ class CuraApplication(QtApplication):
     def getTextManager(self, *args) -> "TextManager":
         return self._text_manager
 
-    @pyqtSlot(bool)
-    def getWorkplaceDropToBuildplate(self, drop_to_build_plate: bool) ->None:
-        return self._physics.setAppPerModelDropDown(drop_to_build_plate)
+    @pyqtSlot()
+    def setWorkplaceDropToBuildplate(self):
+        return self._physics.setAppPerModelDropDown()
 
     def getCuraFormulaFunctions(self, *args) -> "CuraFormulaFunctions":
         if self._cura_formula_functions is None:

--- a/cura/PlatformPhysics.py
+++ b/cura/PlatformPhysics.py
@@ -38,7 +38,7 @@ class PlatformPhysics:
         self._minimum_gap = 2  # It is a minimum distance (in mm) between two models, applicable for small models
 
         Application.getInstance().getPreferences().addPreference("physics/automatic_push_free", False)
-        Application.getInstance().getPreferences().addPreference("physics/automatic_drop_down", False)
+        Application.getInstance().getPreferences().addPreference("physics/automatic_drop_down", True)
         self._app_per_model_drop = None
 
     def getAppPerModelDropDown(self):

--- a/cura/PlatformPhysics.py
+++ b/cura/PlatformPhysics.py
@@ -41,11 +41,9 @@ class PlatformPhysics:
         Application.getInstance().getPreferences().addPreference("physics/automatic_drop_down", True)
         self._app_per_model_drop = None
 
-    def getAppPerModelDropDown(self):
-        return self._app_per_model_drop
-
-    def setAppPerModelDropDown(self, drop_to_buildplate):
-        self._app_per_model_drop = drop_to_buildplate
+    def setAppPerModelDropDown(self):
+        self._app_per_model_drop = True
+        self._onChangeTimerFinished()
 
     def _onSceneChanged(self, source):
         if not source.callDecoration("isSliceable"):
@@ -79,13 +77,7 @@ class PlatformPhysics:
         # By shuffling the order of the nodes, this might happen a few times, but at some point it will resolve.
         random.shuffle(nodes)
         drop_down = False
-        # drop down in case nodes are asked to drop down from the user from workspaceDialog while opening 3mf
-        if self._app_per_model_drop and (self._app_per_model_drop != app_automatic_drop_down):
-            drop_down = True
-        # drop down in case the user has selected automated drop down preference for 3mf opening
-        if self._app_per_model_drop and app_automatic_drop_down:
-            drop_down= True
-
+        if self._app_per_model_drop == True: drop_down = True
 
         for node in nodes:
             if node is root or not isinstance(node, SceneNode) or node.getBoundingBox() is None:

--- a/cura/PlatformPhysics.py
+++ b/cura/PlatformPhysics.py
@@ -39,10 +39,10 @@ class PlatformPhysics:
 
         Application.getInstance().getPreferences().addPreference("physics/automatic_push_free", False)
         Application.getInstance().getPreferences().addPreference("physics/automatic_drop_down", True)
-        self._app_per_model_drop = None
+        self._app_all_model_drop = False
 
-    def setAppPerModelDropDown(self):
-        self._app_per_model_drop = True
+    def setAppAllModelDropDown(self):
+        self._app_all_model_drop = True
         self._onChangeTimerFinished()
 
     def _onSceneChanged(self, source):
@@ -76,9 +76,6 @@ class PlatformPhysics:
         # We try to shuffle all the nodes to prevent "locked" situations, where iteration B inverts iteration A.
         # By shuffling the order of the nodes, this might happen a few times, but at some point it will resolve.
         random.shuffle(nodes)
-        drop_down = False
-        if self._app_per_model_drop == True: drop_down = True
-
         for node in nodes:
             if node is root or not isinstance(node, SceneNode) or node.getBoundingBox() is None:
                 continue
@@ -88,7 +85,7 @@ class PlatformPhysics:
             # Move it downwards if bottom is above platform
             move_vector = Vector()
 
-            if (node.getSetting(SceneNodeSettings.AutoDropDown, app_automatic_drop_down) or drop_down) and not (node.getParent() and node.getParent().callDecoration("isGroup") or node.getParent() != root)  and node.isEnabled():
+            if (node.getSetting(SceneNodeSettings.AutoDropDown, app_automatic_drop_down) or self._app_all_model_drop) and not (node.getParent() and node.getParent().callDecoration("isGroup") or node.getParent() != root)  and node.isEnabled():
                 z_offset = node.callDecoration("getZOffset") if node.getDecorator(ZOffsetDecorator.ZOffsetDecorator) else 0
                 move_vector = move_vector.set(y=-bbox.bottom + z_offset)
 
@@ -177,7 +174,7 @@ class PlatformPhysics:
                 op.push()
 
         # setting this drop to model same as app_automatic_drop_down
-        self._app_per_model_drop = None
+        self._app_all_model_drop = False
         # After moving, we have to evaluate the boundary checks for nodes
         build_volume.updateNodeBoundaryCheck()
 

--- a/cura/Scene/CuraSceneNode.py
+++ b/cura/Scene/CuraSceneNode.py
@@ -27,7 +27,6 @@ class CuraSceneNode(SceneNode):
             self.addDecorator(SettingOverrideDecorator())  # Now we always have a getActiveExtruderPosition, unless explicitly disabled
         self._outside_buildarea = False
         self._print_order = 0
-        self._drop_down = Application.getInstance().getPreferences().getValue("physics/automatic_drop_down")
 
     def setOutsideBuildArea(self, new_value: bool) -> None:
         self._outside_buildarea = new_value
@@ -45,7 +44,7 @@ class CuraSceneNode(SceneNode):
 
     @property
     def isDropDownEnabled(self) ->bool:
-        return self.getSetting(SceneNodeSettings.AutoDropDown, self._drop_down)
+        return self.getSetting(SceneNodeSettings.AutoDropDown, Application.getInstance().getPreferences().getValue("physics/automatic_drop_down"))
 
     def isVisible(self) -> bool:
         return super().isVisible() and self.callDecoration("getBuildPlateNumber") == cura.CuraApplication.CuraApplication.getInstance().getMultiBuildPlateModel().activeBuildPlate

--- a/cura/Scene/CuraSceneNode.py
+++ b/cura/Scene/CuraSceneNode.py
@@ -11,6 +11,7 @@ from UM.Scene.SceneNode import SceneNode
 from UM.Scene.SceneNodeDecorator import SceneNodeDecorator  # To cast the deepcopy of every decorator back to SceneNodeDecorator.
 
 import cura.CuraApplication  # To get the build plate.
+from UM.Scene.SceneNodeSettings import SceneNodeSettings
 from cura.Settings.ExtruderStack import ExtruderStack  # For typing.
 from cura.Settings.SettingOverrideDecorator import SettingOverrideDecorator  # For per-object settings.
 
@@ -26,6 +27,7 @@ class CuraSceneNode(SceneNode):
             self.addDecorator(SettingOverrideDecorator())  # Now we always have a getActiveExtruderPosition, unless explicitly disabled
         self._outside_buildarea = False
         self._print_order = 0
+        self._drop_down = Application.getInstance().getPreferences().getValue("physics/automatic_drop_down")
 
     def setOutsideBuildArea(self, new_value: bool) -> None:
         self._outside_buildarea = new_value
@@ -40,6 +42,10 @@ class CuraSceneNode(SceneNode):
 
     def isOutsideBuildArea(self) -> bool:
         return self._outside_buildarea or self.callDecoration("getBuildPlateNumber") < 0
+
+    @property
+    def isDropDownEnabled(self) ->bool:
+        return self.getSetting(SceneNodeSettings.AutoDropDown, self._drop_down)
 
     def isVisible(self) -> bool:
         return super().isVisible() and self.callDecoration("getBuildPlateNumber") == cura.CuraApplication.CuraApplication.getInstance().getMultiBuildPlateModel().activeBuildPlate

--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -16,6 +16,7 @@ from UM.Mesh.MeshReader import MeshReader
 from UM.MimeTypeDatabase import MimeTypeDatabase, MimeType
 from UM.Scene.GroupDecorator import GroupDecorator
 from UM.Scene.SceneNode import SceneNode  # For typing.
+from UM.Scene.SceneNodeSettings import SceneNodeSettings
 from cura.CuraApplication import CuraApplication
 from cura.Machines.ContainerTree import ContainerTree
 from cura.Scene.BuildPlateDecorator import BuildPlateDecorator
@@ -179,6 +180,9 @@ class ThreeMFReader(MeshReader):
                     continue
                 if key == "print_order":
                     um_node.printOrder = int(setting_value)
+                    continue
+                if key =="drop_to_buildplate":
+                    um_node.setSetting(SceneNodeSettings.AutoDropDown, eval(setting_value))
                     continue
                 if key in known_setting_keys:
                     setting_container.setProperty(key, "value", setting_value)

--- a/plugins/3MFReader/WorkspaceDialog.py
+++ b/plugins/3MFReader/WorkspaceDialog.py
@@ -353,11 +353,6 @@ class WorkspaceDialog(QObject):
 
         Application.getInstance().getBackend().close()
 
-    @pyqtSlot(bool)
-    def setDropToBuildPlateForModel(self, drop_to_buildplate: bool) -> None:
-        CuraApplication.getInstance().getWorkplaceDropToBuildplate(drop_to_buildplate)
-
-
     def setMaterialConflict(self, material_conflict: bool) -> None:
         if self._has_material_conflict != material_conflict:
             self._has_material_conflict = material_conflict

--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -366,7 +366,7 @@ UM.Dialog
                     }
                     function reloadValue()
                     {
-                        manager.manager.setDropToBuildPlateForModel(checkDropModels.checked)
+                        manager.setDropToBuildPlateForModel(checkDropModels.checked)
                         checkDropModels.checked = UM.Preferences.getValue("physics/automatic_drop_down")
                     }
                 }

--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -366,6 +366,7 @@ UM.Dialog
                     }
                     function reloadValue()
                     {
+                        manager.manager.setDropToBuildPlateForModel(checkDropModels.checked)
                         checkDropModels.checked = UM.Preferences.getValue("physics/automatic_drop_down")
                     }
                 }

--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -353,26 +353,6 @@ UM.Dialog
 
                 Row
                 {
-                    id: dropToBuildPlate
-                    width: parent.width
-                    height: childrenRect.height
-                    spacing: UM.Theme.getSize("default_margin").width
-                    UM.CheckBox
-                    {
-                        id: checkDropModels
-                        text: catalog.i18nc("@text:window", "Drop models to buildplate")
-                        checked: UM.Preferences.getValue("physics/automatic_drop_down")
-                        onCheckedChanged: manager.setDropToBuildPlateForModel(checked)
-                    }
-                    function reloadValue()
-                    {
-                        manager.setDropToBuildPlateForModel(checkDropModels.checked)
-                        checkDropModels.checked = UM.Preferences.getValue("physics/automatic_drop_down")
-                    }
-                }
-
-                Row
-                {
                     id: clearBuildPlateWarning
                     width: parent.width
                     height: childrenRect.height
@@ -493,7 +473,6 @@ UM.Dialog
             materialSection.reloadValues()
             profileSection.reloadValues()
             printerSection.reloadValues()
-            dropToBuildPlate.reloadValue()
         }
     }
 }

--- a/plugins/3MFWriter/ThreeMFWriter.py
+++ b/plugins/3MFWriter/ThreeMFWriter.py
@@ -155,6 +155,7 @@ class ThreeMFWriter(MeshWriter):
 
         if isinstance(um_node, CuraSceneNode):
             savitar_node.setSetting("cura:print_order", str(um_node.printOrder))
+            savitar_node.setSetting("cura:drop_to_buildplate", str(um_node.isDropDownEnabled))
 
         # Store the metadata.
         for key, value in um_node.metadata.items():

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -39,7 +39,7 @@ Item
     property alias printObjectAfterNext: printObjectAfterNextAction
 
     property alias multiplyObject: multiplyObjectAction
-
+    property alias dropAll: dropAllAction
     property alias selectAll: selectAllAction
     property alias deleteAll: deleteAllAction
     property alias reloadAll: reloadAllAction
@@ -488,6 +488,14 @@ Item
         text: catalog.i18nc("@action:inmenu menubar:edit","Arrange All Models in a grid")
         onTriggered: Printer.arrangeAllInGrid()
         shortcut: "Shift+Ctrl+R"
+    }
+
+    Action
+    {
+        id: dropAllAction
+        text: catalog.i18nc("@action:inmenu menubar:edit","Drop All Models to buildplate")
+        shortcut: "Ctrl+B"
+        onTriggered: CuraApplication.setWorkplaceDropToBuildplate()
     }
 
     Action

--- a/resources/qml/Menus/ContextMenu.qml
+++ b/resources/qml/Menus/ContextMenu.qml
@@ -71,6 +71,7 @@ Cura.Menu
     Cura.MenuItem { action: Cura.Actions.reloadAll }
     Cura.MenuItem { action: Cura.Actions.resetAllTranslation }
     Cura.MenuItem { action: Cura.Actions.resetAll }
+    Cura.MenuItem { action: Cura.Actions.dropAll }
 
     // Group actions
     Cura.MenuSeparator {}

--- a/resources/qml/Menus/EditMenu.qml
+++ b/resources/qml/Menus/EditMenu.qml
@@ -21,6 +21,7 @@ Cura.Menu
     Cura.MenuItem { action: Cura.Actions.deleteAll }
     Cura.MenuItem { action: Cura.Actions.resetAllTranslation }
     Cura.MenuItem { action: Cura.Actions.resetAll }
+    Cura.MenuItem { action: Cura.Actions.dropAll }
     Cura.MenuSeparator { }
     Cura.MenuItem { action: Cura.Actions.groupObjects }
     Cura.MenuItem { action: Cura.Actions.mergeObjects }

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -513,7 +513,6 @@ UM.PreferencesPage
                     onCheckedChanged:
                     {
                         UM.Preferences.setValue("physics/automatic_drop_down", checked)
-                        CuraApplication.getWorkplaceDropToBuildplate(checked)
                     }
                 }
             }


### PR DESCRIPTION
# Description

 the “drop to build plate” is a per model property. When loading a 3mf drop to build plate is restored from the model data.

Unfortunately for older project files (and non project files such as stl's) this property will not be present. When the property is not present. When we are in this situation we use the “drop to build plate” setting from the configuration as a default value for the per model drop to build plate property.

To summarize, this should be behavior for the following scenarios.
- [x] New project files -> Restore from model data
- [x] Older project files -> Copy from user preferences
- [x] Non project files -> Copy from user preferences

Along, with this a user can see while opening a project file the preference selected for drop to buildplate and can change it while opening the model. After opening the model with drop_to_buildplate preference enabled, the property of individual model of the project is preserved,