### PR TITLE
CURA-11657 Fix crashes with USB printing

### DIFF
--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -132,8 +132,6 @@ ScrollView
             key: "material_bed_temperature"
             watchedProperties: ["value", "minimum_value", "maximum_value", "resolve"]
             storeIndex: 0
-
-            property var resolve: Cura.MachineManager.activeStack != Cura.MachineManager.activeMachine ? properties.resolve : "None"
         }
 
         UM.SettingPropertyProvider

--- a/resources/qml/PrinterOutput/ExtruderBox.qml
+++ b/resources/qml/PrinterOutput/ExtruderBox.qml
@@ -25,8 +25,6 @@ Item
         key: "material_print_temperature"
         watchedProperties: ["value", "minimum_value", "maximum_value", "resolve"]
         storeIndex: 0
-
-        property var resolve: Cura.MachineManager.activeStack != Cura.MachineManager.activeMachine ? properties.resolve : "None"
     }
 
     Rectangle

--- a/resources/qml/PrinterOutput/HeatedBedBox.qml
+++ b/resources/qml/PrinterOutput/HeatedBedBox.qml
@@ -199,17 +199,7 @@ Item
                     {
                         return "";
                     }
-                    if ((bedTemperature.resolve != "None" && bedTemperature.resolve) && (bedTemperature.stackLevels[0] != 0) && (bedTemperature.stackLevels[0] != 1))
-                    {
-                        // We have a resolve function. Indicates that the setting is not settable per extruder and that
-                        // we have to choose between the resolved value (default) and the global value
-                        // (if user has explicitly set this).
-                        return bedTemperature.resolve;
-                    }
-                    else
-                    {
-                        return bedTemperature.properties.value;
-                    }
+                    return bedTemperature.properties.value;
                 }
             }
         }


### PR DESCRIPTION
There is apparently a bug in Qt 6.6.0 that causes a segmentation fault when deleting a Python object that has been instanciated in QML, if a custom QML property has been set on this object. This bug has been [reported to Riverbank](https://www.riverbankcomputing.com/pipermail/pyqt/2024-March/045751.html).

In the meantime, I could still fix the crash because the properties set in QML are apparently useless now. They concern a resolve function on the "material_bed_temperature" which is a global setting. I am pretty sure this code has been copy-pasted from an other similar case, but in this case this is not needed. Please confirm this :)

However, the PyQt bug is not fixed yet and we may encounter other crashes. I just think/hope this is the only QML screen we ever destroy so this bug happens, and on other cases we don't destroy the screen so it doesn't trigger.

CURA-11657