### PR TITLE
Use proper gradual flow plugin version

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -4,7 +4,7 @@ requirements:
   - "curaengine/(latest)@ultimaker/testing"
   - "cura_binary_data/(latest)@ultimaker/testing"
   - "fdm_materials/(latest)@ultimaker/testing"
-  - "curaengine_plugin_gradual_flow/0.1.0-beta.2"
+  - "curaengine_plugin_gradual_flow/0.1.0-beta.3"
   - "dulcificum/latest@ultimaker/testing"
   - "pysavitar/5.3.0"
   - "pynest2d/5.3.0"


### PR DESCRIPTION
Bumping gradual flow plugin version to 0.1.0-beta.3, not 0.2.0 because we don't have a proper settings upgrade workflow for engine plugins yet.