### PR TITLE
CURA-11655 Fix Method X/XL material selection

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Models/Http/CloudClusterWithConfigResponse.py
+++ b/plugins/UM3NetworkPrinting/src/Models/Http/CloudClusterWithConfigResponse.py
@@ -2,6 +2,8 @@
 # Cura is released under the terms of the LGPLv3 or higher.
 from typing import Optional, List
 
+import uuid
+
 from .CloudClusterResponse import CloudClusterResponse
 from .ClusterPrinterStatus import ClusterPrinterStatus
 
@@ -11,4 +13,20 @@ class CloudClusterWithConfigResponse(CloudClusterResponse):
 
     def __init__(self, **kwargs) -> None:
         self.configuration = self.parseModel(ClusterPrinterStatus, kwargs.get("host_printer"))
+
+        # Some printers will return a null UUID in the host_printer.uuid field. For those we can fall back using
+        # the host_guid field of the cluster data
+        valid_uuid = False
+        try:
+            parsed_uuid = uuid.UUID(self.configuration.uuid)
+            valid_uuid = parsed_uuid.int != 0
+        except:
+            pass
+
+        if not valid_uuid:
+            try:
+                self.configuration.uuid = kwargs.get("host_guid")
+            except:
+                pass
+
         super().__init__(**kwargs)


### PR DESCRIPTION
It appears that the Method X and Method XL printers don't return a proper uuid from the DF API. Thus when listing them inside Cura, we sometimes only use the first one because they all have the same null uuid.

This bug may be fixed someday on the DF API, but in the meantime we can use an other field as a fallback when the UUID can't be properly retrieved.