### PR TITLE
not clearing the current machinein case of UCP

### DIFF
--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -915,10 +915,6 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
 
                 # Prepare the machine
                 self._applyChangesToMachine(global_stack, extruder_stack_dict)
-            else:
-                # Just clear the settings now, so that we can change the active machine without conflicts
-                self._clearMachineSettings(global_stack, {})
-
 
             Logger.log("d", "Workspace loading is notifying rest of the code of changes...")
             # Actually change the active machine.


### PR DESCRIPTION
Not clearing the current machine in case of UCP
because we don't want to write again the same thing. 
(This was the cause of not writing the machine after clearing it)

CURA-11701

