### PR TITLE
Do not get user profile by loading auth data

### DIFF
--- a/cura/OAuth2/AuthorizationService.py
+++ b/cura/OAuth2/AuthorizationService.py
@@ -305,7 +305,8 @@ class AuthorizationService:
                                                                        message_type = Message.MessageType.ERROR)
                             Logger.warning("Unable to get user profile using auth data from preferences.")
                             self._unable_to_get_data_message.show()
-                self.getUserProfile(callback)
+                if self._get_user_profile:
+                    self.getUserProfile(callback)
         except (ValueError, TypeError):
             Logger.logException("w", "Could not load auth data from preferences")
 


### PR DESCRIPTION
I previously made a change on AuthorizationService to allow using it for other services (Onshape in my case) : https://github.com/Ultimaker/Cura/commit/b794989468653d04c3e0e24044cb8ea61ce29dff

Now I'm using the `loadAuthDataFromPreferences` method which also has a direct call to `getUserProfile`. This allows using stored auth preference without loading the user profile.