### PR TITLE
[PP-452][CURA-11786] Clean up the CloudAPIClient

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py
@@ -5,6 +5,7 @@ import urllib.parse
 from json import JSONDecodeError
 from time import time
 from typing import Callable, List, Type, TypeVar, Union, Optional, Tuple, Dict, Any, cast
+from pathlib import Path
 
 from PyQt6.QtCore import QUrl
 from PyQt6.QtNetwork import QNetworkRequest, QNetworkReply
@@ -28,6 +29,14 @@ from ..Models.Http.CloudPrintResponse import CloudPrintResponse
 
 CloudApiClientModel = TypeVar("CloudApiClientModel", bound=BaseModel)
 """The generic type variable used to document the methods below."""
+
+
+try:
+    with open(Path(__file__).parent / "machine_id_to_name.json", "rt") as f:
+        MACHINE_ID_TO_NAME: Dict[str, str] = json.load(f)
+except Exception as e:
+    Logger.logException("e", f"Could not load machine_id_to_name.json: '{e}'")
+    MACHINE_ID_TO_NAME = {}
 
 
 class CloudApiClient:
@@ -84,13 +93,8 @@ class CloudApiClient:
         # conversion!
         # API points to "MakerBot Method" for a makerbot printertypes which we already changed to allign with other printer_type
 
-        method_x = {
-            "ultimaker_method":"MakerBot Method",
-            "ultimaker_methodx":"MakerBot Method X",
-            "ultimaker_methodxl":"MakerBot Method XL"
-        }
-        if machine_type in method_x:
-            machine_type = method_x[machine_type]
+        if machine_type in MACHINE_ID_TO_NAME:
+            machine_type = MACHINE_ID_TO_NAME[machine_type]
         else:
             machine_type = machine_type.replace("_plus", "+")
             machine_type = machine_type.replace("_", " ")

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py
@@ -82,10 +82,10 @@ class CloudApiClient:
 
         url = f"{self.CLUSTER_API_ROOT}/clusters?status=active"
         self._http.get(url,
-                       scope = self._scope,
-                       callback = self._parseCallback(on_finished, CloudClusterResponse, failed),
-                       error_callback = failed,
-                       timeout = self.DEFAULT_REQUEST_TIMEOUT)
+                       scope=self._scope,
+                       callback=self._parseCallback(on_finished, CloudClusterResponse, failed),
+                       error_callback=failed,
+                       timeout=self.DEFAULT_REQUEST_TIMEOUT)
 
     def getClustersByMachineType(self, machine_type, on_finished: Callable[[List[CloudClusterWithConfigResponse]], Any], failed: Callable) -> None:
         # HACK: There is something weird going on with the API, as it reports printer types in formats like
@@ -118,9 +118,9 @@ class CloudApiClient:
 
         url = f"{self.CLUSTER_API_ROOT}/clusters/{cluster_id}/status"
         self._http.get(url,
-                       scope = self._scope,
-                       callback = self._parseCallback(on_finished, CloudClusterStatus),
-                       timeout = self.DEFAULT_REQUEST_TIMEOUT)
+                       scope=self._scope,
+                       callback=self._parseCallback(on_finished, CloudClusterStatus),
+                       timeout=self.DEFAULT_REQUEST_TIMEOUT)
 
     def requestUpload(self, request: CloudPrintJobUploadRequest,
                       on_finished: Callable[[CloudPrintJobResponse], Any]) -> None:
@@ -135,10 +135,10 @@ class CloudApiClient:
         data = json.dumps({"data": request.toDict()}).encode()
 
         self._http.put(url,
-                        scope = self._scope,
-                        data = data,
-                        callback = self._parseCallback(on_finished, CloudPrintJobResponse),
-                        timeout = self.DEFAULT_REQUEST_TIMEOUT)
+                       scope=self._scope,
+                       data=data,
+                       callback=self._parseCallback(on_finished, CloudPrintJobResponse),
+                       timeout=self.DEFAULT_REQUEST_TIMEOUT)
 
     def uploadToolPath(self, print_job: CloudPrintJobResponse, mesh: bytes, on_finished: Callable[[], Any],
                        on_progress: Callable[[int], Any], on_error: Callable[[], Any]):
@@ -164,11 +164,11 @@ class CloudApiClient:
     def requestPrint(self, cluster_id: str, job_id: str, on_finished: Callable[[CloudPrintResponse], Any], on_error) -> None:
         url = f"{self.CLUSTER_API_ROOT}/clusters/{cluster_id}/print/{job_id}"
         self._http.post(url,
-                       scope = self._scope,
-                       data = b"",
-                       callback = self._parseCallback(on_finished, CloudPrintResponse),
-                       error_callback = on_error,
-                       timeout = self.DEFAULT_REQUEST_TIMEOUT)
+                        scope=self._scope,
+                        data=b"",
+                        callback=self._parseCallback(on_finished, CloudPrintResponse),
+                        error_callback=on_error,
+                        timeout=self.DEFAULT_REQUEST_TIMEOUT)
 
     def doPrintJobAction(self, cluster_id: str, cluster_job_id: str, action: str,
                          data: Optional[Dict[str, Any]] = None) -> None:
@@ -178,14 +178,15 @@ class CloudApiClient:
         :param cluster_id: The ID of the cluster.
         :param cluster_job_id: The ID of the print job within the cluster.
         :param action: The name of the action to execute.
+        :param data: Optional data to send with the POST request
         """
 
         body = json.dumps({"data": data}).encode() if data else b""
         url = f"{self.CLUSTER_API_ROOT}/clusters/{cluster_id}/print_jobs/{cluster_job_id}/action/{action}"
         self._http.post(url,
-                        scope = self._scope,
-                        data = body,
-                        timeout = self.DEFAULT_REQUEST_TIMEOUT)
+                        scope=self._scope,
+                        data=body,
+                        timeout=self.DEFAULT_REQUEST_TIMEOUT)
 
     def _createEmptyRequest(self, path: str, content_type: Optional[str] = "application/json") -> QNetworkRequest:
         """We override _createEmptyRequest in order to add the user credentials.
@@ -220,8 +221,11 @@ class CloudApiClient:
             Logger.logException("e", "Could not parse the stardust response: %s", error.toDict())
             return status_code, {"errors": [error.toDict()]}
 
-    def _parseResponse(self, response: Dict[str, Any], on_finished: Union[Callable[[CloudApiClientModel], Any],
-                                                                          Callable[[List[CloudApiClientModel]], Any]], model_class: Type[CloudApiClientModel]) -> None:
+    def _parseResponse(self,
+                       response: Dict[str, Any],
+                       on_finished: Union[Callable[[CloudApiClientModel], Any],
+                                          Callable[[List[CloudApiClientModel]], Any]],
+                       model_class: Type[CloudApiClientModel]) -> None:
         """Parses the given response and calls the correct callback depending on the result.
 
         :param response: The response from the server, after being converted to a dict.

--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudApiClient.py
@@ -47,8 +47,8 @@ class CloudApiClient:
 
     # The cloud URL to use for this remote cluster.
     ROOT_PATH = UltimakerCloudConstants.CuraCloudAPIRoot
-    CLUSTER_API_ROOT = "{}/connect/v1".format(ROOT_PATH)
-    CURA_API_ROOT = "{}/cura/v1".format(ROOT_PATH)
+    CLUSTER_API_ROOT = f"{ROOT_PATH}/connect/v1"
+    CURA_API_ROOT = f"{ROOT_PATH}/cura/v1"
 
     DEFAULT_REQUEST_TIMEOUT = 10  # seconds
 

--- a/plugins/UM3NetworkPrinting/src/Cloud/machine_id_to_name.json
+++ b/plugins/UM3NetworkPrinting/src/Cloud/machine_id_to_name.json
@@ -1,0 +1,5 @@
+{
+    "ultimaker_method": "MakerBot Method",
+    "ultimaker_methodx": "MakerBot Method X",
+    "ultimaker_methodxl": "MakerBot Method XL"
+}


### PR DESCRIPTION
## Cleaned up CloudAPIClient.py
- The `method_x` machine id to DF cluster name dictionary in the `getClustersByMachineType` method was hard-coded in the python module. This is now moved to a separate json file.
- str.format() converted to f-string
- Properly formatted some function calls, and a function definition