### PR TITLE
GUID of material ASA was from generic ASA, now given Ultimaker ASA GUID

### DIFF
--- a/cura/PrinterOutput/Models/MaterialOutputModel.py
+++ b/cura/PrinterOutput/Models/MaterialOutputModel.py
@@ -25,9 +25,9 @@ class MaterialOutputModel(QObject):
     def getMaterialFromDefinition(guid, type, brand, name):
 
         _MATERIAL_MAP = {	"abs"       :{"name" :"ABS"           ,"guid": "2780b345-577b-4a24-a2c5-12e6aad3e690"},
-                             "abs-cf10": {"name": "ABS-CF", "guid": "495a0ce5-9daf-4a16-b7b2-06856d82394d"},
+                            "abs-cf10"  :{"name": "ABS-CF"        ,"guid": "495a0ce5-9daf-4a16-b7b2-06856d82394d"},
                             "abs-wss1"  :{"name" :"ABS-R"         ,"guid": "88c8919c-6a09-471a-b7b6-e801263d862d"},
-                            "asa"       :{"name" :"ASA"           ,"guid": "416eead4-0d8e-4f0b-8bfc-a91a519befa5"},
+                            "asa"       :{"name" :"ASA"           ,"guid": "f79bc612-21eb-482e-ad6c-87d75bdde066"},
                             "nylon12-cf":{"name": "Nylon 12 CF"   ,"guid": "3c6f2877-71cc-4760-84e6-4b89ab243e3b"},
                             "nylon"     :{"name" :"Nylon"         ,"guid": "283d439a-3490-4481-920c-c51d8cdecf9c"},
                             "pc"        :{"name" :"PC"            ,"guid": "62414577-94d1-490d-b1e4-7ef3ec40db02"},

--- a/cura/PrinterOutput/Models/MaterialOutputModel.py
+++ b/cura/PrinterOutput/Models/MaterialOutputModel.py
@@ -24,12 +24,22 @@ class MaterialOutputModel(QObject):
     @staticmethod
     def getMaterialFromDefinition(guid, type, brand, name):
 
-        _MATERIAL_MAP = {	"abs-cf10"  :{"name": "ABS-CF"        ,"guid": "495a0ce5-9daf-4a16-b7b2-06856d82394d"},
+        _MATERIAL_MAP = {	"abs"       :{"name" :"ABS"           ,"guid": "2780b345-577b-4a24-a2c5-12e6aad3e690"},
+                            "abs-cf10"  :{"name": "ABS-CF"        ,"guid": "495a0ce5-9daf-4a16-b7b2-06856d82394d"},
                             "abs-wss1"  :{"name" :"ABS-R"         ,"guid": "88c8919c-6a09-471a-b7b6-e801263d862d"},
                             "asa"       :{"name" :"ASA"           ,"guid": "f79bc612-21eb-482e-ad6c-87d75bdde066"},
                             "nylon12-cf":{"name": "Nylon 12 CF"   ,"guid": "3c6f2877-71cc-4760-84e6-4b89ab243e3b"},
+                            "nylon"     :{"name" :"Nylon"         ,"guid": "283d439a-3490-4481-920c-c51d8cdecf9c"},
+                            "pc"        :{"name" :"PC"            ,"guid": "62414577-94d1-490d-b1e4-7ef3ec40db02"},
+                            "petg"      :{"name" :"PETG"          ,"guid": "69386c85-5b6c-421a-bec5-aeb1fb33f060"},
+                            "pla"       :{"name" :"PLA"           ,"guid": "0ff92885-617b-4144-a03c-9989872454bc"},
+                            "pva"       :{"name" :"PVA"           ,"guid": "a4255da2-cb2a-4042-be49-4a83957a2f9a"},
                             "wss1"      :{"name" :"RapidRinse"    ,"guid": "a140ef8f-4f26-4e73-abe0-cfc29d6d1024"},
-                            "sr30"      :{"name" :"SR-30"         ,"guid": "77873465-83a9-4283-bc44-4e542b8eb3eb"}
+                            "sr30"      :{"name" :"SR-30"         ,"guid": "77873465-83a9-4283-bc44-4e542b8eb3eb"},
+                            "bvoh"      :{"name" :"BVOH"          ,"guid": "923e604c-8432-4b09-96aa-9bbbd42207f4"},
+                            "cpe"       :{"name" :"CPE"           ,"guid": "da1872c1-b991-4795-80ad-bdac0f131726"},
+                            "hips"      :{"name" :"HIPS"          ,"guid": "a468d86a-220c-47eb-99a5-bbb47e514eb0"},
+                            "tpu"       :{"name" :"TPU 95A"       ,"guid": "19baa6a9-94ff-478b-b4a1-8157b74358d2"}
                         }
 
 

--- a/cura/PrinterOutput/Models/MaterialOutputModel.py
+++ b/cura/PrinterOutput/Models/MaterialOutputModel.py
@@ -24,22 +24,12 @@ class MaterialOutputModel(QObject):
     @staticmethod
     def getMaterialFromDefinition(guid, type, brand, name):
 
-        _MATERIAL_MAP = {	"abs"       :{"name" :"ABS"           ,"guid": "2780b345-577b-4a24-a2c5-12e6aad3e690"},
-                            "abs-cf10"  :{"name": "ABS-CF"        ,"guid": "495a0ce5-9daf-4a16-b7b2-06856d82394d"},
+        _MATERIAL_MAP = {	"abs-cf10"  :{"name": "ABS-CF"        ,"guid": "495a0ce5-9daf-4a16-b7b2-06856d82394d"},
                             "abs-wss1"  :{"name" :"ABS-R"         ,"guid": "88c8919c-6a09-471a-b7b6-e801263d862d"},
                             "asa"       :{"name" :"ASA"           ,"guid": "f79bc612-21eb-482e-ad6c-87d75bdde066"},
                             "nylon12-cf":{"name": "Nylon 12 CF"   ,"guid": "3c6f2877-71cc-4760-84e6-4b89ab243e3b"},
-                            "nylon"     :{"name" :"Nylon"         ,"guid": "283d439a-3490-4481-920c-c51d8cdecf9c"},
-                            "pc"        :{"name" :"PC"            ,"guid": "62414577-94d1-490d-b1e4-7ef3ec40db02"},
-                            "petg"      :{"name" :"PETG"          ,"guid": "69386c85-5b6c-421a-bec5-aeb1fb33f060"},
-                            "pla"       :{"name" :"PLA"           ,"guid": "0ff92885-617b-4144-a03c-9989872454bc"},
-                            "pva"       :{"name" :"PVA"           ,"guid": "a4255da2-cb2a-4042-be49-4a83957a2f9a"},
                             "wss1"      :{"name" :"RapidRinse"    ,"guid": "a140ef8f-4f26-4e73-abe0-cfc29d6d1024"},
-                            "sr30"      :{"name" :"SR-30"         ,"guid": "77873465-83a9-4283-bc44-4e542b8eb3eb"},
-                            "bvoh"      :{"name" :"BVOH"          ,"guid": "923e604c-8432-4b09-96aa-9bbbd42207f4"},
-                            "cpe"       :{"name" :"CPE"           ,"guid": "da1872c1-b991-4795-80ad-bdac0f131726"},
-                            "hips"      :{"name" :"HIPS"          ,"guid": "a468d86a-220c-47eb-99a5-bbb47e514eb0"},
-                            "tpu"       :{"name" :"TPU 95A"       ,"guid": "19baa6a9-94ff-478b-b4a1-8157b74358d2"}
+                            "sr30"      :{"name" :"SR-30"         ,"guid": "77873465-83a9-4283-bc44-4e542b8eb3eb"}
                         }
 
 


### PR DESCRIPTION
CURA-11729

# Description
The GUID of the ASA material for mapping was taken from generic which should have been the ultimaker material to start with.
I want to recommend other materials to be deleted from the material map if they are generic. I see the only 6 materials are used in case of Makerbot, and they are all ultimaker GUID in the list. others are generic.
![Capture](https://github.com/Ultimaker/Cura/assets/70144862/7f315c80-1c3f-4234-83a6-6c0f3e77db0d)
