### PR TITLE
Add visibility control for settings in 3MFWriter plugin

### DIFF
--- a/plugins/3MFWriter/SettingExport.py
+++ b/plugins/3MFWriter/SettingExport.py
@@ -6,13 +6,14 @@ from PyQt6.QtCore import QObject, pyqtProperty, pyqtSignal
 
 class SettingExport(QObject):
 
-    def __init__(self, id, name, value, selectable):
+    def __init__(self, id, name, value, selectable, show):
         super().__init__()
         self.id = id
         self._name = name
         self._value = value
         self._selected = selectable
         self._selectable = selectable
+        self._show_in_menu = show
 
     @pyqtProperty(str, constant=True)
     def name(self):
@@ -36,3 +37,7 @@ class SettingExport(QObject):
     @pyqtProperty(bool, constant=True)
     def selectable(self):
         return self._selectable
+
+    @pyqtProperty(bool, constant=True)
+    def isVisible(self):
+        return self._show_in_menu

--- a/plugins/3MFWriter/SettingsExportGroup.py
+++ b/plugins/3MFWriter/SettingsExportGroup.py
@@ -36,9 +36,7 @@ class SettingsExportGroup(QObject):
     @pyqtProperty(list, constant=True)
     def visibleSettings(self):
         if self._visible_settings == []:
-            for item in self._settings:
-                if item.isVisible:
-                    self._visible_settings.append(item)
+            self._visible_settings = list(filter(lambda item : item.isVisible, self._settings))
         return self._visible_settings
 
     @pyqtProperty(int, constant=True)

--- a/plugins/3MFWriter/SettingsExportGroup.py
+++ b/plugins/3MFWriter/SettingsExportGroup.py
@@ -23,6 +23,7 @@ class SettingsExportGroup(QObject):
         self._category_details = category_details
         self._extruder_index = extruder_index
         self._extruder_color = extruder_color
+        self._visible_settings = []
 
     @pyqtProperty(str, constant=True)
     def name(self):
@@ -31,6 +32,14 @@ class SettingsExportGroup(QObject):
     @pyqtProperty(list, constant=True)
     def settings(self):
         return self._settings
+
+    @pyqtProperty(list, constant=True)
+    def visibleSettings(self):
+        if self._visible_settings == []:
+            for item in self._settings:
+                if item.isVisible:
+                    self._visible_settings.append(item)
+        return self._visible_settings
 
     @pyqtProperty(int, constant=True)
     def category(self):

--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -117,6 +117,9 @@ class SettingsExportModel(QObject):
         is_exportable = any(key in SettingsExportModel.PER_MODEL_EXPORTABLE_SETTINGS_KEYS for key in user_keys)
 
         for setting_to_export in user_keys:
+            show_in_menu = True
+            if setting_to_export  in SettingsExportModel.PER_MODEL_EXPORTABLE_SETTINGS_KEYS:
+                show_in_menu = False
             label = settings_stack.getProperty(setting_to_export, "label")
             value = settings_stack.getProperty(setting_to_export, "value")
             unit = settings_stack.getProperty(setting_to_export, "unit")
@@ -130,6 +133,7 @@ class SettingsExportModel(QObject):
             settings_export.append(SettingExport(setting_to_export,
                                                  label,
                                                  value,
-                                                 is_exportable or setting_to_export in exportable_settings))
+                                                 is_exportable or setting_to_export in exportable_settings,
+                                                 show_in_menu))
 
         return settings_export

--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -117,9 +117,7 @@ class SettingsExportModel(QObject):
         is_exportable = any(key in SettingsExportModel.PER_MODEL_EXPORTABLE_SETTINGS_KEYS for key in user_keys)
 
         for setting_to_export in user_keys:
-            show_in_menu = True
-            if setting_to_export  in SettingsExportModel.PER_MODEL_EXPORTABLE_SETTINGS_KEYS:
-                show_in_menu = False
+            show_in_menu = setting_to_export not in SettingsExportModel.PER_MODEL_EXPORTABLE_SETTINGS_KEYS
             label = settings_stack.getProperty(setting_to_export, "label")
             value = settings_stack.getProperty(setting_to_export, "value")
             unit = settings_stack.getProperty(setting_to_export, "unit")

--- a/plugins/3MFWriter/SettingsSelectionGroup.qml
+++ b/plugins/3MFWriter/SettingsSelectionGroup.qml
@@ -71,8 +71,8 @@ ColumnLayout
         Layout.fillWidth: true
         Layout.preferredHeight: contentHeight
         spacing: 0
-        model: modelData.settings
-        visible: modelData.settings.length > 0
+        model: modelData.visibleSettings
+        visible: modelData.visibleSettings.length > 0
 
         delegate: SettingSelection { }
     }
@@ -80,8 +80,7 @@ ColumnLayout
     UM.Label
     {
         UM.I18nCatalog { id: catalog; name: "cura" }
-
         text: catalog.i18nc("@label", "No specific value has been set")
-        visible: modelData.settings.length === 0
+        visible: modelData.visibleSettings.length === 0
     }
 }


### PR DESCRIPTION
Introduced a new property 'show_in_menu' to control the visibility of individual settings in 3MFWriter plugin. Modified 'SettingExport' class constructor to store this visibility status. Also, updated the 'SettingsExportGroup' model to filter the settings based on visibility before presenting them in the GUI.

CURA-11723
