### PR TITLE
Update support extruder settings behavior

### DIFF
--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
@@ -56,7 +56,7 @@ RecommendedSettingSection
                 width: parent.width
                 settingName: "support_structure"
                 propertyRemoveUnusedValue: false
-                updateAllExtruders: true
+                updateAllExtruders: false
                 defaultExtruderIndex: supportExtruderProvider.properties.value
             }
         },
@@ -73,7 +73,12 @@ RecommendedSettingSection
             settingControl: Cura.SingleSettingExtruderSelectorBar
             {
                 extruderSettingName: "support_extruder_nr"
-                onSelectedIndexChanged: support.forceUpdateSettings()
+                onSelectedIndexChanged:
+                {
+                    support.updateAllExtruders = true
+                    support.forceUpdateSettings()
+                    support.updateAllExtruders = false
+                }
             }
         },
         RecommendedSettingItem


### PR DESCRIPTION
Changed the settings in RecommendedSupportSelector.qml so that now all extruders will not be updated by default. However, when a user changes the selected index, a temporary update to all extruders will be triggered. This allows for specific user-directed changes to propagate correctly across all extruders.

CURA-11776

