### PR TITLE
Implement syncing feature for Ultimaker account

### DIFF
--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -190,6 +190,20 @@ class Account(QObject):
     def isLoggedIn(self) -> bool:
         return self._logged_in
 
+    @pyqtSlot()
+    def stopSyncing(self) -> None:
+        Logger.debug(f"Stopping sync of cloud printers")
+        self._setManualSyncEnabled(True)
+        if self._update_timer.isActive():
+            self._update_timer.stop()
+
+    @pyqtSlot()
+    def startSyncing(self) -> None:
+        Logger.debug(f"Starting sync of cloud printers")
+        self._setManualSyncEnabled(False)
+        if not self._update_timer.isActive():
+            self._update_timer.start()
+
     def _onLoginStateChanged(self, logged_in: bool = False, error_message: Optional[str] = None) -> None:
         if error_message:
             if self._error_message:

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -864,6 +864,7 @@ UM.MainWindow
                 if(!visible)
                 {
                     wizardDialog = null
+                    Cura.API.account.startSyncing()
                 }
             }
         }
@@ -891,6 +892,7 @@ UM.MainWindow
         target: Cura.Actions.addMachine
         function onTriggered()
         {
+            Cura.API.account.stopSyncing()
             wizardDialog = addMachineDialogLoader.createObject()
             wizardDialog.show()
         }

--- a/resources/qml/WelcomePages/AddUltimakerPrinter.qml
+++ b/resources/qml/WelcomePages/AddUltimakerPrinter.qml
@@ -133,7 +133,7 @@ Control
                         text = catalog.i18nc("@button", "Waiting for new printers")
                         busy = true;
                         enabled = false;
-                        Cura.API.account.login();
+                        Cura.API.account.isLoggedIn? Cura.API.account.sync():Cura.API.account.login();
                     }
                 }
             }


### PR DESCRIPTION

CURA-11465

# Description
Updated account syncing functionality for logged-in and non-logged-in sessions in Ultimaker. More specifically, syncing is now engaged when the UI becomes visible and stopped when adding a machine action-> addmachinedialog is triggered. The modifications also include fallback to login if the user is not logged in.