### PR TITLE
Cura 11783 enum instead of text value

### DIFF
--- a/plugins/3MFReader/SpecificSettingsModel.py
+++ b/plugins/3MFReader/SpecificSettingsModel.py
@@ -20,7 +20,7 @@ class SpecificSettingsModel(ListModel):
         self.addRoleName(self.LabelRole, "label")
         self.addRoleName(self.ValueRole, "value")
 
-        self._i18n_catalog = i18nCatalog("cura")
+        self._settings_catalog = i18nCatalog("fdmprinter.def.json")
         self._update()
 
     modelChanged = pyqtSignal()
@@ -40,7 +40,7 @@ class SpecificSettingsModel(ListModel):
                     options = stack.getProperty(setting, "options")
                     msgctxt = f"{str(setting)} option {str(value)}"
                     msgid = options[stack.getProperty(setting, "value")]
-                    value = self._i18n_catalog.i18nc(msgctxt, msgid)
+                    value = self._settings_catalog.i18nc(msgctxt, msgid)
             else:
                 value = str(value)
 

--- a/plugins/3MFReader/SpecificSettingsModel.py
+++ b/plugins/3MFReader/SpecificSettingsModel.py
@@ -33,6 +33,10 @@ class SpecificSettingsModel(ListModel):
             if setting_type is not None:
                 # This is not very good looking, but will do for now
                 value = str(SettingDefinition.settingValueToString(setting_type, value)) + " " + str(unit)
+                if setting_type  == "enum":
+                    options = stack.getProperty(setting, "options")
+                    value = options[stack.getProperty(setting, "value")]
+
             else:
                 value = str(value)
 

--- a/plugins/3MFReader/SpecificSettingsModel.py
+++ b/plugins/3MFReader/SpecificSettingsModel.py
@@ -38,15 +38,19 @@ class SpecificSettingsModel(ListModel):
                     value += " " + str(unit)
                 if setting_type  == "enum":
                     options = stack.getProperty(setting, "options")
-                    msgctxt = f"{str(setting)} option {str(value)}"
-                    msgid = options[stack.getProperty(setting, "value")]
-                    value = self._settings_catalog.i18nc(msgctxt, msgid)
+                    value_msgctxt = f"{str(setting)} option {str(value)}"
+                    value_msgid = options[stack.getProperty(setting, "value")]
+                    value = self._settings_catalog.i18nc(value_msgctxt, value_msgid)
             else:
                 value = str(value)
 
+            label_msgctxt = f"{str(setting)} label"
+            label_msgid = stack.getProperty(setting, "label")
+            label = self._settings_catalog.i18nc(label_msgctxt, label_msgid)
+
             self.appendItem({
                 "category": category,
-                "label": stack.getProperty(setting, "label"),
+                "label": label,
                 "value": value
             })
         self.modelChanged.emit()

--- a/plugins/3MFReader/SpecificSettingsModel.py
+++ b/plugins/3MFReader/SpecificSettingsModel.py
@@ -3,6 +3,7 @@
 
 from PyQt6.QtCore import Qt, pyqtSignal
 
+from UM import i18nCatalog
 from UM.Logger import Logger
 from UM.Settings.SettingDefinition import SettingDefinition
 from UM.Qt.ListModel import ListModel
@@ -19,7 +20,7 @@ class SpecificSettingsModel(ListModel):
         self.addRoleName(self.LabelRole, "label")
         self.addRoleName(self.ValueRole, "value")
 
-        self._i18n_catalog = None
+        self._i18n_catalog = i18nCatalog("cura")
         self._update()
 
     modelChanged = pyqtSignal()
@@ -32,11 +33,14 @@ class SpecificSettingsModel(ListModel):
             setting_type = stack.getProperty(setting, "type")
             if setting_type is not None:
                 # This is not very good looking, but will do for now
-                value = str(SettingDefinition.settingValueToString(setting_type, value)) + " " + str(unit)
+                value = str(SettingDefinition.settingValueToString(setting_type, value))
+                if unit:
+                    value += " " + str(unit)
                 if setting_type  == "enum":
                     options = stack.getProperty(setting, "options")
-                    value = options[stack.getProperty(setting, "value")]
-
+                    msgctxt = f"{str(setting)} option {str(value)}"
+                    msgid = options[stack.getProperty(setting, "value")]
+                    value = self._i18n_catalog.i18nc(msgctxt, msgid)
             else:
                 value = str(value)
 

--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -216,6 +216,16 @@ UM.Dialog
                                 headers: ["category", "label", "value"]
                                 rows: manager.exportedSettingModelItems
                             }
+
+                            Connections
+                            {
+                                target: manager
+                                function onExportedSettingModelChanged()
+                                {
+                                    tableModel.clear()
+                                    tableModel.rows = manager.exportedSettingModelItems
+                                }
+                            }
                         }
                     }
 

--- a/plugins/3MFWriter/SettingExport.py
+++ b/plugins/3MFWriter/SettingExport.py
@@ -6,11 +6,12 @@ from PyQt6.QtCore import QObject, pyqtProperty, pyqtSignal
 
 class SettingExport(QObject):
 
-    def __init__(self, id, name, value, selectable, show):
+    def __init__(self, id, name, value, value_name, selectable, show):
         super().__init__()
         self.id = id
         self._name = name
         self._value = value
+        self._value_name = value_name
         self._selected = selectable
         self._selectable = selectable
         self._show_in_menu = show
@@ -22,6 +23,10 @@ class SettingExport(QObject):
     @pyqtProperty(str, constant=True)
     def value(self):
         return self._value
+
+    @pyqtProperty(str, constant=True)
+    def valuename(self):
+        return str(self._value_name)
 
     selectedChanged = pyqtSignal(bool)
 

--- a/plugins/3MFWriter/SettingSelection.qml
+++ b/plugins/3MFWriter/SettingSelection.qml
@@ -24,7 +24,7 @@ RowLayout
 
     UM.Label
     {
-        text: modelData.value
+        text: modelData.valuename
     }
 
     UM.HelpIcon

--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -120,13 +120,15 @@ class SettingsExportModel(QObject):
 
         for setting_to_export in user_keys:
             show_in_menu = setting_to_export not in SettingsExportModel.PER_MODEL_EXPORTABLE_SETTINGS_KEYS
-            label = settings_stack.getProperty(setting_to_export, "label")
+            label_msgtxt = settings_stack.getProperty(setting_to_export, "label")
+            label_msgid = f"{str(setting_to_export)} label"
+            label = settings_catalog.i18nc(label_msgtxt, label_msgid)
             value = settings_stack.getProperty(setting_to_export, "value")
             unit = settings_stack.getProperty(setting_to_export, "unit")
             options = settings_stack.getProperty(setting_to_export, "options")
-            msgctxt = f"{setting_to_export} option {value}"
-            msgid = options.get(value, "")
-            value_name = settings_catalog.i18nc(msgctxt, msgid)
+            value_msgctxt = f"{setting_to_export} option {value}"
+            value_msgid = options.get(value, "")
+            value_name = settings_catalog.i18nc(value_msgctxt, value_msgid)
 
             setting_type = settings_stack.getProperty(setting_to_export, "type")
             if setting_type is not None:

--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -6,6 +6,7 @@ from typing import Optional, cast, List, Dict, Pattern, Set
 
 from PyQt6.QtCore import QObject, pyqtProperty
 
+from UM import i18nCatalog
 from UM.Settings.SettingDefinition import SettingDefinition
 from UM.Settings.InstanceContainer import InstanceContainer
 from UM.Settings.SettingFunction import SettingFunction
@@ -109,6 +110,7 @@ class SettingsExportModel(QObject):
 
     @staticmethod
     def _exportSettings(settings_stack):
+        i18n_catalog = i18nCatalog("cura")
         user_settings_container = settings_stack.userChanges
         user_keys = user_settings_container.getAllKeys()
         exportable_settings = SettingsExportModel.EXPORTABLE_SETTINGS
@@ -122,7 +124,9 @@ class SettingsExportModel(QObject):
             value = settings_stack.getProperty(setting_to_export, "value")
             unit = settings_stack.getProperty(setting_to_export, "unit")
             options = settings_stack.getProperty(setting_to_export, "options")
-            value_name = value if options == {} else options[value]
+            msgctxt = f"{setting_to_export} option {value}"
+            msgid = options.get(value, "")
+            value_name = i18n_catalog.i18nc(msgctxt, msgid)
 
             setting_type = settings_stack.getProperty(setting_to_export, "type")
             if setting_type is not None:

--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -110,7 +110,7 @@ class SettingsExportModel(QObject):
 
     @staticmethod
     def _exportSettings(settings_stack):
-        i18n_catalog = i18nCatalog("cura")
+        settings_catalog = i18nCatalog("fdmprinter.def.json")
         user_settings_container = settings_stack.userChanges
         user_keys = user_settings_container.getAllKeys()
         exportable_settings = SettingsExportModel.EXPORTABLE_SETTINGS
@@ -126,7 +126,7 @@ class SettingsExportModel(QObject):
             options = settings_stack.getProperty(setting_to_export, "options")
             msgctxt = f"{setting_to_export} option {value}"
             msgid = options.get(value, "")
-            value_name = i18n_catalog.i18nc(msgctxt, msgid)
+            value_name = settings_catalog.i18nc(msgctxt, msgid)
 
             setting_type = settings_stack.getProperty(setting_to_export, "type")
             if setting_type is not None:

--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -121,6 +121,8 @@ class SettingsExportModel(QObject):
             label = settings_stack.getProperty(setting_to_export, "label")
             value = settings_stack.getProperty(setting_to_export, "value")
             unit = settings_stack.getProperty(setting_to_export, "unit")
+            options = settings_stack.getProperty(setting_to_export, "options")
+            value_name = value if options == {} else options[value]
 
             setting_type = settings_stack.getProperty(setting_to_export, "type")
             if setting_type is not None:
@@ -131,6 +133,7 @@ class SettingsExportModel(QObject):
             settings_export.append(SettingExport(setting_to_export,
                                                  label,
                                                  value,
+                                                 value_name,
                                                  is_exportable or setting_to_export in exportable_settings,
                                                  show_in_menu))
 

--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -120,13 +120,13 @@ class SettingsExportModel(QObject):
 
         for setting_to_export in user_keys:
             show_in_menu = setting_to_export not in SettingsExportModel.PER_MODEL_EXPORTABLE_SETTINGS_KEYS
-            label_msgtxt = settings_stack.getProperty(setting_to_export, "label")
-            label_msgid = f"{str(setting_to_export)} label"
+            label_msgtxt = f"{str(setting_to_export)} label"
+            label_msgid = settings_stack.getProperty(setting_to_export, "label")
             label = settings_catalog.i18nc(label_msgtxt, label_msgid)
             value = settings_stack.getProperty(setting_to_export, "value")
             unit = settings_stack.getProperty(setting_to_export, "unit")
             options = settings_stack.getProperty(setting_to_export, "options")
-            value_msgctxt = f"{setting_to_export} option {value}"
+            value_msgctxt = f"{str(setting_to_export)} option {str(value)}"
             value_msgid = options.get(value, "")
             value_name = settings_catalog.i18nc(value_msgctxt, value_msgid)
 


### PR DESCRIPTION
CURA-11783

# Description

Changed setting value to enum value while saving ucp and loading UCP

Added a connection in WorkspaceDialog.qml to call function whenever the 'exportedSettingModel' changes. This ensures that any changes in the model will now be reflected in the UI table. (This wasn't updating for me) 

