### PR TITLE
[CURA-11703] Reset entire scene around center for UCP.

### DIFF
--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -941,7 +941,7 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
         if self._is_ucp:
             # We might be on a different printer than the one this project was made on.
             # The offset to the printers' center isn't saved; instead, try to just fit everything on the buildplate.
-            full_extents = None  # Don't initialize to 'Null'!
+            full_extents = None
             for node in nodes:
                 extents = node.getMeshData().getExtents() if node.getMeshData() else None
                 if extents is not None:


### PR DESCRIPTION
Since we can't rely on the build-volume --because we can't know on which printer we open-- the safest bet (and the thing allowed by 3mf if I recall) is to just center the entire scene on the buildplate for Universal Cura Project files.