### PR TITLE
Update Monitor Preheat boxes

### DIFF
--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -129,7 +129,7 @@ ScrollView
         {
             id: bedTemperature
             containerStack: Cura.MachineManager.activeMachine
-            key: "material_bed_temperature"
+            key: "material_bed_temperature_layer_0"
             watchedProperties: ["value", "minimum_value", "maximum_value", "resolve"]
             storeIndex: 0
         }

--- a/resources/qml/PrinterOutput/ExtruderBox.qml
+++ b/resources/qml/PrinterOutput/ExtruderBox.qml
@@ -22,7 +22,7 @@ Item
     {
         id: extruderTemperature
         containerStackId: Cura.ExtruderManager.extruderIds[position]
-        key: "material_print_temperature"
+        key: "material_print_temperature_layer_0"
         watchedProperties: ["value", "minimum_value", "maximum_value", "resolve"]
         storeIndex: 0
     }


### PR DESCRIPTION
The current values in the Monitor Page Preheat boxes are "Print Temperature" and "Bed Temperature".  This PR changes that to "Initial Layer Print temperature" and "Initial Layer Bed Temperature".

Change the initial values in "PrintMonitor.qml" preheat box from
material_bed_temperature to
material_bed_temperature_layer_0

and in "ExtruderBox.qml" preheat box from
material_print_temperature to
material_print_temperature_layer_0

This PR is in response to #17155 .  An earlier PR was closed due to a personal Git problem.

# Description

This change involves a single line in each file.

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* Operating System:  Wndows 10 Pro

# Checklist:

- [ X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have uploaded any files required to test this change
