### PR TITLE
Make `Use Adaptive Layers` sub-settings indented to improve visual usability

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -7941,45 +7941,48 @@
                     "default_value": false,
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
-                    "settable_per_meshgroup": false
-                },
-                "adaptive_layer_height_variation":
-                {
-                    "label": "Adaptive Layers Maximum Variation",
-                    "description": "The maximum allowed height different from the base layer height.",
-                    "type": "float",
-                    "enabled": "adaptive_layer_height_enabled",
-                    "unit": "mm",
-                    "default_value": 0.1,
-                    "minimum_value": "0.0",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": false,
-                    "settable_per_meshgroup": false
-                },
-                "adaptive_layer_height_variation_step":
-                {
-                    "label": "Adaptive Layers Variation Step Size",
-                    "description": "The difference in height of the next layer height compared to the previous one.",
-                    "type": "float",
-                    "enabled": "adaptive_layer_height_enabled",
-                    "default_value": 0.01,
-                    "unit": "mm",
-                    "settable_per_mesh": false,
-                    "minimum_value": "0.001",
-                    "settable_per_extruder": false,
-                    "settable_per_meshgroup": false
-                },
-                "adaptive_layer_height_threshold":
-                {
-                    "label": "Adaptive Layers Topography Size",
-                    "description": "Target horizontal distance between two adjacent layers. Reducing this setting causes thinner layers to be used to bring the edges of the layers closer together.",
-                    "type": "float",
-                    "enabled": "adaptive_layer_height_enabled",
-                    "default_value": 0.2,
-                    "unit": "mm",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": false,
-                    "settable_per_meshgroup": false
+                    "settable_per_meshgroup": false,
+                    "children":
+                    {
+                        "adaptive_layer_height_variation":
+                        {
+                            "label": "Adaptive Layers Maximum Variation",
+                            "description": "The maximum allowed height different from the base layer height.",
+                            "type": "float",
+                            "enabled": "adaptive_layer_height_enabled",
+                            "unit": "mm",
+                            "default_value": 0.1,
+                            "minimum_value": "0.0",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": false,
+                            "settable_per_meshgroup": false
+                        },
+                        "adaptive_layer_height_variation_step":
+                        {
+                            "label": "Adaptive Layers Variation Step Size",
+                            "description": "The difference in height of the next layer height compared to the previous one.",
+                            "type": "float",
+                            "enabled": "adaptive_layer_height_enabled",
+                            "default_value": 0.01,
+                            "unit": "mm",
+                            "settable_per_mesh": false,
+                            "minimum_value": "0.001",
+                            "settable_per_extruder": false,
+                            "settable_per_meshgroup": false
+                        },
+                        "adaptive_layer_height_threshold":
+                        {
+                            "label": "Adaptive Layers Topography Size",
+                            "description": "Target horizontal distance between two adjacent layers. Reducing this setting causes thinner layers to be used to bring the edges of the layers closer together.",
+                            "type": "float",
+                            "enabled": "adaptive_layer_height_enabled",
+                            "default_value": 0.2,
+                            "unit": "mm",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": false,
+                            "settable_per_meshgroup": false
+                        }
+                    }
                 },
                 "wall_overhang_angle":
                 {


### PR DESCRIPTION
# Description

This PR simply makes the `Use Adaptive Layers` sub-settings indented under the enable setting so that the list of Experimental Settings - which is a long long list - is more readable and the location of these settings is more easily identified.

It is intended that this is the first of several PRs to do this for other groups of settings.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have made this same update in my installation of Cura 5.6.0 and tested that the changes work.

**Test Configuration**:

* Windows 10
* Cura 5.6.0
* File: C:\Program Files\UltiMaker Cura 5.6.0\share\cura\resources\definitions\fdmprinter.def.json

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
