### PR TITLE
Make `Z Seam` sub-settings indented to improve visual usability

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1340,83 +1340,86 @@
                     },
                     "default_value": "sharpest_corner",
                     "limit_to_extruder": "wall_0_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "z_seam_position":
-                {
-                    "label": "Z Seam Position",
-                    "description": "The position near where to start printing each part in a layer.",
-                    "type": "enum",
-                    "options":
-                    {
-                        "backleft": "Back Left",
-                        "back": "Back",
-                        "backright": "Back Right",
-                        "right": "Right",
-                        "frontright": "Front Right",
-                        "front": "Front",
-                        "frontleft": "Front Left",
-                        "left": "Left"
-                    },
-                    "enabled": "z_seam_type == 'back'",
-                    "default_value": "back",
-                    "limit_to_extruder": "wall_0_extruder_nr",
                     "settable_per_mesh": true,
                     "children":
                     {
-                        "z_seam_x":
+                        "z_seam_position":
                         {
-                            "label": "Z Seam X",
-                            "description": "The X coordinate of the position near where to start printing each part in a layer.",
-                            "unit": "mm",
-                            "type": "float",
-                            "default_value": 100.0,
-                            "value": "(0 if (z_seam_position == 'frontleft' or z_seam_position == 'left' or z_seam_position == 'backleft') else machine_width / 2 if (z_seam_position == 'front' or z_seam_position == 'back') else machine_width) - (machine_width / 2 if z_seam_relative or machine_center_is_zero else 0)",
+                            "label": "Z Seam Position",
+                            "description": "The position near where to start printing each part in a layer.",
+                            "type": "enum",
+                            "options":
+                            {
+                                "backleft": "Back Left",
+                                "back": "Back",
+                                "backright": "Back Right",
+                                "right": "Right",
+                                "frontright": "Front Right",
+                                "front": "Front",
+                                "frontleft": "Front Left",
+                                "left": "Left"
+                            },
                             "enabled": "z_seam_type == 'back'",
+                            "default_value": "back",
+                            "limit_to_extruder": "wall_0_extruder_nr",
+                            "settable_per_mesh": true,
+                            "children":
+                            {
+                                "z_seam_x":
+                                {
+                                    "label": "Z Seam X",
+                                    "description": "The X coordinate of the position near where to start printing each part in a layer.",
+                                    "unit": "mm",
+                                    "type": "float",
+                                    "default_value": 100.0,
+                                    "value": "(0 if (z_seam_position == 'frontleft' or z_seam_position == 'left' or z_seam_position == 'backleft') else machine_width / 2 if (z_seam_position == 'front' or z_seam_position == 'back') else machine_width) - (machine_width / 2 if z_seam_relative or machine_center_is_zero else 0)",
+                                    "enabled": "z_seam_type == 'back'",
+                                    "limit_to_extruder": "wall_0_extruder_nr",
+                                    "settable_per_mesh": true
+                                },
+                                "z_seam_y":
+                                {
+                                    "label": "Z Seam Y",
+                                    "description": "The Y coordinate of the position near where to start printing each part in a layer.",
+                                    "unit": "mm",
+                                    "type": "float",
+                                    "default_value": 100.0,
+                                    "value": "(0 if (z_seam_position == 'frontleft' or z_seam_position == 'front' or z_seam_position == 'frontright') else machine_depth / 2 if (z_seam_position == 'left' or z_seam_position == 'right') else machine_depth) - (machine_depth / 2 if z_seam_relative or machine_center_is_zero else 0)",
+                                    "enabled": "z_seam_type == 'back'",
+                                    "limit_to_extruder": "wall_0_extruder_nr",
+                                    "settable_per_mesh": true
+                                }
+                            }
+                        },
+                        "z_seam_corner":
+                        {
+                            "label": "Seam Corner Preference",
+                            "description": "Control whether corners on the model outline influence the position of the seam. None means that corners have no influence on the seam position. Hide Seam makes the seam more likely to occur on an inside corner. Expose Seam makes the seam more likely to occur on an outside corner. Hide or Expose Seam makes the seam more likely to occur at an inside or outside corner. Smart Hiding allows both inside and outside corners, but chooses inside corners more frequently, if appropriate.",
+                            "type": "enum",
+                            "options":
+                            {
+                                "z_seam_corner_none": "None",
+                                "z_seam_corner_inner": "Hide Seam",
+                                "z_seam_corner_outer": "Expose Seam",
+                                "z_seam_corner_any": "Hide or Expose Seam",
+                                "z_seam_corner_weighted": "Smart Hiding"
+                            },
+                            "default_value": "z_seam_corner_inner",
+                            "enabled": "z_seam_type != 'random'",
                             "limit_to_extruder": "wall_0_extruder_nr",
                             "settable_per_mesh": true
                         },
-                        "z_seam_y":
+                        "z_seam_relative":
                         {
-                            "label": "Z Seam Y",
-                            "description": "The Y coordinate of the position near where to start printing each part in a layer.",
-                            "unit": "mm",
-                            "type": "float",
-                            "default_value": 100.0,
-                            "value": "(0 if (z_seam_position == 'frontleft' or z_seam_position == 'front' or z_seam_position == 'frontright') else machine_depth / 2 if (z_seam_position == 'left' or z_seam_position == 'right') else machine_depth) - (machine_depth / 2 if z_seam_relative or machine_center_is_zero else 0)",
+                            "label": "Z Seam Relative",
+                            "description": "When enabled, the z seam coordinates are relative to each part's centre. When disabled, the coordinates define an absolute position on the build plate.",
+                            "type": "bool",
+                            "default_value": false,
                             "enabled": "z_seam_type == 'back'",
                             "limit_to_extruder": "wall_0_extruder_nr",
                             "settable_per_mesh": true
                         }
                     }
-                },
-                "z_seam_corner":
-                {
-                    "label": "Seam Corner Preference",
-                    "description": "Control whether corners on the model outline influence the position of the seam. None means that corners have no influence on the seam position. Hide Seam makes the seam more likely to occur on an inside corner. Expose Seam makes the seam more likely to occur on an outside corner. Hide or Expose Seam makes the seam more likely to occur at an inside or outside corner. Smart Hiding allows both inside and outside corners, but chooses inside corners more frequently, if appropriate.",
-                    "type": "enum",
-                    "options":
-                    {
-                        "z_seam_corner_none": "None",
-                        "z_seam_corner_inner": "Hide Seam",
-                        "z_seam_corner_outer": "Expose Seam",
-                        "z_seam_corner_any": "Hide or Expose Seam",
-                        "z_seam_corner_weighted": "Smart Hiding"
-                    },
-                    "default_value": "z_seam_corner_inner",
-                    "enabled": "z_seam_type != 'random'",
-                    "limit_to_extruder": "wall_0_extruder_nr",
-                    "settable_per_mesh": true
-                },
-                "z_seam_relative":
-                {
-                    "label": "Z Seam Relative",
-                    "description": "When enabled, the z seam coordinates are relative to each part's centre. When disabled, the coordinates define an absolute position on the build plate.",
-                    "type": "bool",
-                    "default_value": false,
-                    "enabled": "z_seam_type == 'back'",
-                    "limit_to_extruder": "wall_0_extruder_nr",
-                    "settable_per_mesh": true
                 }
             }
         },


### PR DESCRIPTION
# Description

This PR simply makes the `Z Seam` sub-settings indented so that it is more readable and the location of these settings is more easily identified.

This is the fourth of several PRs to do this for other groups of settings.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have made this same update in my installation of Cura 5.6.0 and tested that the changes work.

**Test Configuration**:

* Windows 10
* Cura 5.6.0
* File: C:\Program Files\UltiMaker Cura 5.6.0\share\cura\resources\definitions\fdmprinter.def.json

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
