### PR TITLE
Make `Retraction` sub-settings indented to improve visual usability

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4152,7 +4152,128 @@
                     "type": "bool",
                     "default_value": true,
                     "settable_per_mesh": false,
-                    "settable_per_extruder": true
+                    "settable_per_extruder": true,
+                    "children":
+                    {
+                        "retraction_amount":
+                        {
+                            "label": "Retraction Distance",
+                            "description": "The length of material retracted during a retraction move.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 6.5,
+                            "minimum_value_warning": "-0.0001",
+                            "maximum_value_warning": "10.0",
+                            "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        },
+                        "retraction_speed":
+                        {
+                            "label": "Retraction Speed",
+                            "description": "The speed at which the filament is retracted and primed during a retraction move.",
+                            "unit": "mm/s",
+                            "type": "float",
+                            "default_value": 25,
+                            "minimum_value": "0.0001",
+                            "minimum_value_warning": "1",
+                            "maximum_value": "machine_max_feedrate_e if retraction_enable else float('inf')",
+                            "maximum_value_warning": "70",
+                            "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
+                            "settable_per_mesh": true,
+                            "settable_per_extruder": true,
+                            "children":
+                            {
+                                "retraction_retract_speed":
+                                {
+                                    "label": "Retraction Retract Speed",
+                                    "description": "The speed at which the filament is retracted during a retraction move.",
+                                    "unit": "mm/s",
+                                    "type": "float",
+                                    "default_value": 25,
+                                    "minimum_value": "0.0001",
+                                    "maximum_value": "machine_max_feedrate_e if retraction_enable else float('inf')",
+                                    "minimum_value_warning": "1",
+                                    "maximum_value_warning": "70",
+                                    "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
+                                    "value": "retraction_speed",
+                                    "settable_per_mesh": true,
+                                    "settable_per_extruder": true
+                                },
+                                "retraction_prime_speed":
+                                {
+                                    "label": "Retraction Prime Speed",
+                                    "description": "The speed at which the filament is primed during a retraction move.",
+                                    "unit": "mm/s",
+                                    "type": "float",
+                                    "default_value": 25,
+                                    "minimum_value": "0.0001",
+                                    "maximum_value": "machine_max_feedrate_e if retraction_enable else float('inf')",
+                                    "minimum_value_warning": "1",
+                                    "maximum_value_warning": "70",
+                                    "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
+                                    "value": "retraction_speed",
+                                    "settable_per_mesh": true,
+                                    "settable_per_extruder": true
+                                }
+                            }
+                        },
+                        "retraction_extra_prime_amount":
+                        {
+                            "label": "Retraction Extra Prime Amount",
+                            "description": "Some material can ooze away during a travel move, which can be compensated for here.",
+                            "unit": "mm\u00b3",
+                            "type": "float",
+                            "default_value": 0,
+                            "minimum_value_warning": "-0.0001",
+                            "maximum_value_warning": "5.0",
+                            "enabled": "retraction_enable",
+                            "settable_per_mesh": true,
+                            "settable_per_extruder": true
+                        },
+                        "retraction_min_travel":
+                        {
+                            "label": "Retraction Minimum Travel",
+                            "description": "The minimum distance of travel needed for a retraction to happen at all. This helps to get fewer retractions in a small area.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 1.5,
+                            "value": "line_width * 2",
+                            "minimum_value": "0",
+                            "minimum_value_warning": "line_width * 1.5",
+                            "maximum_value_warning": "10",
+                            "enabled": "retraction_enable",
+                            "settable_per_mesh": true,
+                            "settable_per_extruder": true
+                        },
+                        "retraction_count_max":
+                        {
+                            "label": "Maximum Retraction Count",
+                            "description": "This setting limits the number of retractions occurring within the minimum extrusion distance window. Further retractions within this window will be ignored. This avoids retracting repeatedly on the same piece of filament, as that can flatten the filament and cause grinding issues.",
+                            "default_value": 90,
+                            "minimum_value": "0",
+                            "maximum_value_warning": "100",
+                            "maximum_value": 999999999,
+                            "type": "int",
+                            "enabled": "retraction_enable",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        },
+                        "retraction_extrusion_window":
+                        {
+                            "label": "Minimum Extrusion Distance Window",
+                            "description": "The window in which the maximum retraction count is enforced. This value should be approximately the same as the retraction distance, so that effectively the number of times a retraction passes the same patch of material is limited.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 4.5,
+                            "minimum_value": "0",
+                            "maximum_value_warning": "retraction_amount * 2",
+                            "value": "retraction_amount",
+                            "enabled": "retraction_enable",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        }
+                    }
                 },
                 "retract_at_layer_change":
                 {
@@ -4160,125 +4281,79 @@
                     "description": "Retract the filament when the nozzle is moving to the next layer.",
                     "type": "bool",
                     "default_value": false,
+                    "enabled": "retraction_enable",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
-                "retraction_amount":
+                "travel_retract_before_outer_wall":
                 {
-                    "label": "Retraction Distance",
-                    "description": "The length of material retracted during a retraction move.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 6.5,
-                    "minimum_value_warning": "-0.0001",
-                    "maximum_value_warning": "10.0",
-                    "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
+                    "label": "Retract Before Outer Wall",
+                    "description": "Always retract when moving to start an outer wall.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": "retraction_enable",
                     "settable_per_mesh": false,
-                    "settable_per_extruder": true
+                    "settable_per_extruder": false
                 },
-                "retraction_speed":
+                "retraction_hop_enabled":
                 {
-                    "label": "Retraction Speed",
-                    "description": "The speed at which the filament is retracted and primed during a retraction move.",
-                    "unit": "mm/s",
-                    "type": "float",
-                    "default_value": 25,
-                    "minimum_value": "0.0001",
-                    "minimum_value_warning": "1",
-                    "maximum_value": "machine_max_feedrate_e if retraction_enable else float('inf')",
-                    "maximum_value_warning": "70",
-                    "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
-                    "settable_per_mesh": true,
+                    "label": "Z Hop When Retracted",
+                    "description": "Whenever a retraction is done, the build plate is lowered to create clearance between the nozzle and the print. It prevents the nozzle from hitting the print during travel moves, reducing the chance to knock the print from the build plate.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": "retraction_enable",
+                    "settable_per_mesh": false,
                     "settable_per_extruder": true,
                     "children":
                     {
-                        "retraction_retract_speed":
+                        "retraction_hop_only_when_collides":
                         {
-                            "label": "Retraction Retract Speed",
-                            "description": "The speed at which the filament is retracted during a retraction move.",
-                            "unit": "mm/s",
-                            "type": "float",
-                            "default_value": 25,
-                            "minimum_value": "0.0001",
-                            "maximum_value": "machine_max_feedrate_e if retraction_enable else float('inf')",
-                            "minimum_value_warning": "1",
-                            "maximum_value_warning": "70",
-                            "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
-                            "value": "retraction_speed",
+                            "label": "Z Hop Only Over Printed Parts",
+                            "description": "Only perform a Z Hop when moving over printed parts which cannot be avoided by horizontal motion by Avoid Printed Parts when Traveling.",
+                            "type": "bool",
+                            "default_value": false,
+                            "enabled": "retraction_enable and retraction_hop_enabled and travel_avoid_other_parts",
                             "settable_per_mesh": true,
                             "settable_per_extruder": true
                         },
-                        "retraction_prime_speed":
+                        "retraction_hop":
                         {
-                            "label": "Retraction Prime Speed",
-                            "description": "The speed at which the filament is primed during a retraction move.",
-                            "unit": "mm/s",
+                            "label": "Z Hop Height",
+                            "description": "The height difference when performing a Z Hop.",
+                            "unit": "mm",
                             "type": "float",
-                            "default_value": 25,
-                            "minimum_value": "0.0001",
-                            "maximum_value": "machine_max_feedrate_e if retraction_enable else float('inf')",
-                            "minimum_value_warning": "1",
-                            "maximum_value_warning": "70",
-                            "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
-                            "value": "retraction_speed",
+                            "default_value": 1,
+                            "minimum_value_warning": "0",
+                            "maximum_value_warning": "10",
+                            "enabled": "retraction_enable and retraction_hop_enabled",
                             "settable_per_mesh": true,
+                            "settable_per_extruder": true
+                        },
+                        "retraction_hop_after_extruder_switch":
+                        {
+                            "label": "Z Hop After Extruder Switch",
+                            "description": "After the machine switched from one extruder to the other, the build plate is lowered to create clearance between the nozzle and the print. This prevents the nozzle from leaving oozed material on the outside of a print.",
+                            "type": "bool",
+                            "default_value": true,
+                            "enabled": "retraction_hop_enabled and extruders_enabled_count > 1",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        },
+                        "retraction_hop_after_extruder_switch_height":
+                        {
+                            "label": "Z Hop After Extruder Switch Height",
+                            "description": "The height difference when performing a Z Hop after extruder switch.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 1,
+                            "value": "retraction_hop",
+                            "minimum_value_warning": "0",
+                            "maximum_value_warning": "10",
+                            "enabled": "retraction_enable and retraction_hop_after_extruder_switch and extruders_enabled_count > 1",
+                            "settable_per_mesh": false,
                             "settable_per_extruder": true
                         }
                     }
-                },
-                "retraction_extra_prime_amount":
-                {
-                    "label": "Retraction Extra Prime Amount",
-                    "description": "Some material can ooze away during a travel move, which can be compensated for here.",
-                    "unit": "mm\u00b3",
-                    "type": "float",
-                    "default_value": 0,
-                    "minimum_value_warning": "-0.0001",
-                    "maximum_value_warning": "5.0",
-                    "enabled": "retraction_enable",
-                    "settable_per_mesh": true,
-                    "settable_per_extruder": true
-                },
-                "retraction_min_travel":
-                {
-                    "label": "Retraction Minimum Travel",
-                    "description": "The minimum distance of travel needed for a retraction to happen at all. This helps to get fewer retractions in a small area.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 1.5,
-                    "value": "line_width * 2",
-                    "minimum_value": "0",
-                    "minimum_value_warning": "line_width * 1.5",
-                    "maximum_value_warning": "10",
-                    "settable_per_mesh": true,
-                    "settable_per_extruder": true
-                },
-                "retraction_count_max":
-                {
-                    "label": "Maximum Retraction Count",
-                    "description": "This setting limits the number of retractions occurring within the minimum extrusion distance window. Further retractions within this window will be ignored. This avoids retracting repeatedly on the same piece of filament, as that can flatten the filament and cause grinding issues.",
-                    "default_value": 90,
-                    "minimum_value": "0",
-                    "maximum_value_warning": "100",
-                    "maximum_value": 999999999,
-                    "type": "int",
-                    "enabled": "retraction_enable",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
-                },
-                "retraction_extrusion_window":
-                {
-                    "label": "Minimum Extrusion Distance Window",
-                    "description": "The window in which the maximum retraction count is enforced. This value should be approximately the same as the retraction distance, so that effectively the number of times a retraction passes the same patch of material is limited.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 4.5,
-                    "minimum_value": "0",
-                    "maximum_value_warning": "retraction_amount * 2",
-                    "value": "retraction_amount",
-                    "enabled": "retraction_enable",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
                 },
                 "retraction_combing":
                 {
@@ -4297,64 +4372,57 @@
                     "value": "'no_outer_surfaces' if (any(extruderValues('skin_monotonic')) or any(extruderValues('ironing_enabled')) or (any(extruderValues('roofing_monotonic')) and any(extruderValues('roofing_layer_count')))) else 'all'",
                     "resolve": "'noskin' if 'noskin' in extruderValues('retraction_combing') else ('infill' if 'infill' in extruderValues('retraction_combing') else ('all' if 'all' in extruderValues('retraction_combing') else ('no_outer_surfaces' if 'no_outer_surfaces' in extruderValues('retraction_combing') else 'off')))",
                     "settable_per_mesh": false,
-                    "settable_per_extruder": false
-                },
-                "retraction_combing_max_distance":
-                {
-                    "label": "Max Comb Distance With No Retract",
-                    "description": "When greater than zero, combing travel moves that are longer than this distance will use retraction. If set to zero, there is no maximum and combing moves will not use retraction.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 0,
-                    "minimum_value": "0",
-                    "enabled": "resolveOrValue('retraction_combing') != 'off'",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
-                },
-                "travel_retract_before_outer_wall":
-                {
-                    "label": "Retract Before Outer Wall",
-                    "description": "Always retract when moving to start an outer wall.",
-                    "type": "bool",
-                    "default_value": false,
-                    "enabled": "retraction_enable",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": false
-                },
-                "travel_avoid_other_parts":
-                {
-                    "label": "Avoid Printed Parts When Traveling",
-                    "description": "The nozzle avoids already printed parts when traveling. This option is only available when combing is enabled.",
-                    "type": "bool",
-                    "default_value": true,
-                    "enabled": "resolveOrValue('retraction_combing') != 'off'",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
-                },
-                "travel_avoid_supports":
-                {
-                    "label": "Avoid Supports When Traveling",
-                    "description": "The nozzle avoids already printed supports when traveling. This option is only available when combing is enabled.",
-                    "type": "bool",
-                    "default_value": false,
-                    "enabled": "resolveOrValue('retraction_combing') != 'off' and travel_avoid_other_parts",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
-                },
-                "travel_avoid_distance":
-                {
-                    "label": "Travel Avoid Distance",
-                    "description": "The distance between the nozzle and already printed parts when avoiding during travel moves.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 0.625,
-                    "value": "machine_nozzle_tip_outer_diameter / 2 * 1.25",
-                    "minimum_value": "0",
-                    "minimum_value_warning": "machine_nozzle_tip_outer_diameter * 0.5",
-                    "maximum_value_warning": "machine_nozzle_tip_outer_diameter * 5",
-                    "enabled": "resolveOrValue('retraction_combing') != 'off' and travel_avoid_other_parts",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
+                    "settable_per_extruder": false,
+                    "children":
+                    {
+                        "retraction_combing_max_distance":
+                        {
+                            "label": "Max Comb Distance With No Retract",
+                            "description": "When greater than zero, combing travel moves that are longer than this distance will use retraction. If set to zero, there is no maximum and combing moves will not use retraction.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 0,
+                            "minimum_value": "0",
+                            "enabled": "resolveOrValue('retraction_combing') != 'off'",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        },
+                        "travel_avoid_other_parts":
+                        {
+                            "label": "Avoid Printed Parts When Traveling",
+                            "description": "The nozzle avoids already printed parts when traveling. This option is only available when combing is enabled.",
+                            "type": "bool",
+                            "default_value": true,
+                            "enabled": "resolveOrValue('retraction_combing') != 'off'",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        },
+                        "travel_avoid_supports":
+                        {
+                            "label": "Avoid Supports When Traveling",
+                            "description": "The nozzle avoids already printed supports when traveling. This option is only available when combing is enabled.",
+                            "type": "bool",
+                            "default_value": false,
+                            "enabled": "resolveOrValue('retraction_combing') != 'off' and travel_avoid_other_parts",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        },
+                        "travel_avoid_distance":
+                        {
+                            "label": "Travel Avoid Distance",
+                            "description": "The distance between the nozzle and already printed parts when avoiding during travel moves.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 0.625,
+                            "value": "machine_nozzle_tip_outer_diameter / 2 * 1.25",
+                            "minimum_value": "0",
+                            "minimum_value_warning": "machine_nozzle_tip_outer_diameter * 0.5",
+                            "maximum_value_warning": "machine_nozzle_tip_outer_diameter * 5",
+                            "enabled": "resolveOrValue('retraction_combing') != 'off' and travel_avoid_other_parts",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": true
+                        }
+                    }
                 },
                 "layer_start_x":
                 {
@@ -4380,63 +4448,6 @@
                     "settable_per_extruder": true,
                     "settable_per_meshgroup": true
                 },
-                "retraction_hop_enabled":
-                {
-                    "label": "Z Hop When Retracted",
-                    "description": "Whenever a retraction is done, the build plate is lowered to create clearance between the nozzle and the print. It prevents the nozzle from hitting the print during travel moves, reducing the chance to knock the print from the build plate.",
-                    "type": "bool",
-                    "default_value": false,
-                    "enabled": "retraction_enable",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
-                },
-                "retraction_hop_only_when_collides":
-                {
-                    "label": "Z Hop Only Over Printed Parts",
-                    "description": "Only perform a Z Hop when moving over printed parts which cannot be avoided by horizontal motion by Avoid Printed Parts when Traveling.",
-                    "type": "bool",
-                    "default_value": false,
-                    "enabled": "retraction_enable and retraction_hop_enabled and travel_avoid_other_parts",
-                    "settable_per_mesh": true,
-                    "settable_per_extruder": true
-                },
-                "retraction_hop":
-                {
-                    "label": "Z Hop Height",
-                    "description": "The height difference when performing a Z Hop.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 1,
-                    "minimum_value_warning": "0",
-                    "maximum_value_warning": "10",
-                    "enabled": "retraction_enable and retraction_hop_enabled",
-                    "settable_per_mesh": true,
-                    "settable_per_extruder": true
-                },
-                "retraction_hop_after_extruder_switch":
-                {
-                    "label": "Z Hop After Extruder Switch",
-                    "description": "After the machine switched from one extruder to the other, the build plate is lowered to create clearance between the nozzle and the print. This prevents the nozzle from leaving oozed material on the outside of a print.",
-                    "type": "bool",
-                    "default_value": true,
-                    "enabled": "retraction_hop_enabled and extruders_enabled_count > 1",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
-                },
-                "retraction_hop_after_extruder_switch_height":
-                {
-                    "label": "Z Hop After Extruder Switch Height",
-                    "description": "The height difference when performing a Z Hop after extruder switch.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 1,
-                    "value": "retraction_hop",
-                    "minimum_value_warning": "0",
-                    "maximum_value_warning": "10",
-                    "enabled": "retraction_enable and retraction_hop_after_extruder_switch and extruders_enabled_count > 1",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": true
-                }
             }
         },
         "cooling":


### PR DESCRIPTION
# Description

This PR simply makes the `Retraction` sub-settings indented so that it is more readable and the location of these settings is more easily identified.

This is the seventh of several PRs to do this for other groups of settings.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have made this same update in my installation of Cura 5.6.0 and tested that the changes work.

**Test Configuration**:

* Windows 10
* Cura 5.6.0
* File: C:\Program Files\UltiMaker Cura 5.6.0\share\cura\resources\definitions\fdmprinter.def.json

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change

 # Additional Comments

The `Retract Before Outer Wall` setting remains visible even when Retraction is disabled and despite the setting definition have the exact same `enabled` property as the `Retract at Layer Change` setting which isn't shown. I haven't managed to track this down, but I suspect that the same setting is being defined elsewhere without or with a different `enabled` property.