### PR TITLE
Values now shown while saving UCP

### DIFF
--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -125,12 +125,16 @@ class SettingsExportModel(QObject):
             label = settings_catalog.i18nc(label_msgtxt, label_msgid)
             value = settings_stack.getProperty(setting_to_export, "value")
             unit = settings_stack.getProperty(setting_to_export, "unit")
-            options = settings_stack.getProperty(setting_to_export, "options")
-            value_msgctxt = f"{str(setting_to_export)} option {str(value)}"
-            value_msgid = options.get(value, "")
-            value_name = settings_catalog.i18nc(value_msgctxt, value_msgid)
-
             setting_type = settings_stack.getProperty(setting_to_export, "type")
+            value_name = str(SettingDefinition.settingValueToString(setting_type, value))
+            if unit:
+                value_name += " " + str(unit)
+            if setting_type == "enum":
+                options = settings_stack.getProperty(setting_to_export, "options")
+                value_msgctxt = f"{str(setting_to_export)} option {str(value)}"
+                value_msgid = options.get(value, "")
+                value_name = settings_catalog.i18nc(value_msgctxt, value_msgid)
+
             if setting_type is not None:
                 value = f"{str(SettingDefinition.settingValueToString(setting_type, value))} {unit}"
             else:


### PR DESCRIPTION
For all the values even numericals were passed through the translations. so nothing came out for numbers. Now we filter it for enums and then translate it.

CURA-11801

