### PR TITLE
Update MaterialNode initialization and metadata retrieval

### DIFF
--- a/cura/Machines/MaterialNode.py
+++ b/cura/Machines/MaterialNode.py
@@ -21,18 +21,25 @@ class MaterialNode(ContainerNode):
     Its subcontainers are quality profiles.
     """
 
-    def __init__(self, container_id: str, variant: "VariantNode") -> None:
+    def __init__(self, container_id: str, variant: "VariantNode", *,  container: ContainerInterface = None) -> None:
         super().__init__(container_id)
         self.variant = variant
         self.qualities = {}  # type: Dict[str, QualityNode] # Mapping container IDs to quality profiles.
         self.materialChanged = Signal()  # Triggered when the material is removed or its metadata is updated.
 
         container_registry = ContainerRegistry.getInstance()
-        my_metadata = container_registry.findContainersMetadata(id = container_id)[0]
-        self.base_file = my_metadata["base_file"]
-        self.material_type = my_metadata["material"]
-        self.brand = my_metadata["brand"]
-        self.guid = my_metadata["GUID"]
+
+        if container is not None:
+            self.base_file = container.getMetaDataEntry("base_file")
+            self.material_type = container.getMetaDataEntry("material")
+            self.brand = container.getMetaDataEntry("brand")
+            self.guid = container.getMetaDataEntry("GUID")
+        else:
+            my_metadata = container_registry.findContainersMetadata(id = container_id)[0]
+            self.base_file = my_metadata["base_file"]
+            self.material_type = my_metadata["material"]
+            self.brand = my_metadata["brand"]
+            self.guid = my_metadata["GUID"]
         self._loadAll()
         container_registry.containerRemoved.connect(self._onRemoved)
         container_registry.containerMetaDataChanged.connect(self._onMetadataChanged)

--- a/cura/Machines/VariantNode.py
+++ b/cura/Machines/VariantNode.py
@@ -148,7 +148,7 @@ class VariantNode(ContainerNode):
 
         if "empty_material" in self.materials:
             del self.materials["empty_material"]
-        self.materials[base_file] = MaterialNode(container.getId(), variant = self)
+        self.materials[base_file] = MaterialNode(container.getId(), variant = self, container = container)
         self.materials[base_file].materialChanged.connect(self.materialsChanged)
         self.materialsChanged.emit(self.materials[base_file])
 


### PR DESCRIPTION
Although this is rare scenario.This allows for metadata retrieval from the container directly if one is provided, otherwise metadata is fetched using the container_id from the ContainerRegistry. Updated the MaterialNode creation in the VariantNode class(only one scenario) to pass the container.

CURA-11748
