### PR TITLE
Add detection for deleted files in printer linter

### DIFF
--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Check Deleted Files(s)
         if: env.GIT_DIFF
-        run: python printer-linter/src/terminal.py --deleted --report printer-linter-result/fixes.yml ${{ env.GIT_DIFF_FILTERED }}
+        run: python printer-linter/src/terminal.py --deleted --report printer-linter-result/comment.md ${{ env.GIT_DIFF_FILTERED }}
 
       - name: Save PR metadata
         run: |

--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -61,5 +61,5 @@ jobs:
         uses: platisd/clang-tidy-pr-comments@bc0bb7da034a8317d54e7fe1e819159002f4cc40
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          clang_tidy_fixes: results.yml
+          clang_tidy_fixes: result.yml
           request_changes: true

--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -18,6 +18,7 @@ jobs:
 
       - uses: technote-space/get-diff-action@v6
         with:
+          DIFF_FILTER: AMRCD
           PATTERNS: |
             resources/+(extruders|definitions)/*.def.json
             resources/+(intent|quality|variants)/**/*.inst.cfg
@@ -37,14 +38,13 @@ jobs:
       - name: Create results directory
         run: mkdir printer-linter-result
 
-      - name: Check Deleted Files(s)
-        run:  |
-          git diff --name-only --diff-filter=D origin/main
-          python printer-linter/src/terminal.py --deleted --report printer-linter-result/fixes.yml $(echo "$deletedFiles")
-
       - name: Diagnose file(s)
         if: env.GIT_DIFF && !env.MATCHED_FILES
         run: python printer-linter/src/terminal.py --diagnose --report printer-linter-result/fixes.yml ${{ env.GIT_DIFF_FILTERED }}
+
+      - name: Check Deleted Files(s)
+        if: env.GIT_DIFF
+        run: python printer-linter/src/terminal.py --deleted --report printer-linter-result/fixes.yml ${{ env.GIT_DIFF_FILTERED }}
 
       - name: Save PR metadata
         run: |
@@ -61,5 +61,5 @@ jobs:
         uses: platisd/clang-tidy-pr-comments@bc0bb7da034a8317d54e7fe1e819159002f4cc40
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          clang_tidy_fixes: printer-linter-pr-post.yml
+          clang_tidy_fixes: results.yml
           request_changes: true

--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -38,9 +38,9 @@ jobs:
         run: mkdir printer-linter-result
 
       - name: Check Deleted Files(s)
-
         run:  |
-          deletedFiles="$(git log -m -1 --name-status --pretty="format:" | awk '/^D/ {print $2}' | tr '\n' ' ')"
+          - name: Get deleted files
+          git diff --name-only --diff-filter=D origin/main
           python printer-linter/src/terminal.py --deleted --report printer-linter-result/fixes.yml $(echo "$deletedFiles")
 
       - name: Diagnose file(s)

--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -39,7 +39,6 @@ jobs:
 
       - name: Check Deleted Files(s)
         run:  |
-          - name: Get deleted files
           git diff --name-only --diff-filter=D origin/main
           python printer-linter/src/terminal.py --deleted --report printer-linter-result/fixes.yml $(echo "$deletedFiles")
 

--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Create results directory
         run: mkdir printer-linter-result
 
+      - name: Check Deleted Files(s)
+        if: env.GIT_DIFF
+        run: python printer-linter/src/terminal.py --deleted --report printer-linter-result/fixes.yml $(echo "$GIT_DIFF" | grep '^D')
+
       - name: Diagnose file(s)
         if: env.GIT_DIFF && !env.MATCHED_FILES
         run: python printer-linter/src/terminal.py --diagnose --report printer-linter-result/fixes.yml ${{ env.GIT_DIFF_FILTERED }}
@@ -56,5 +60,5 @@ jobs:
         uses: platisd/clang-tidy-pr-comments@bc0bb7da034a8317d54e7fe1e819159002f4cc40
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          clang_tidy_fixes: result.yml
+          clang_tidy_fixes: printer-linter-pr-post.yml
           request_changes: true

--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -38,8 +38,10 @@ jobs:
         run: mkdir printer-linter-result
 
       - name: Check Deleted Files(s)
-        if: env.GIT_DIFF
-        run: python printer-linter/src/terminal.py --deleted --report printer-linter-result/fixes.yml $(echo "$GIT_DIFF" | grep '^D')
+
+        run:  |
+          deletedFiles="$(git log -m -1 --name-status --pretty="format:" | awk '/^D/ {print $2}' | tr '\n' ' ')"
+          python printer-linter/src/terminal.py --deleted --report printer-linter-result/fixes.yml $(echo "$deletedFiles")
 
       - name: Diagnose file(s)
         if: env.GIT_DIFF && !env.MATCHED_FILES

--- a/.github/workflows/printer-linter-pr-post.yml
+++ b/.github/workflows/printer-linter-pr-post.yml
@@ -72,14 +72,16 @@ jobs:
           mkdir printer-linter-result
           unzip printer-linter-result.zip -d printer-linter-result
 
-      - name: Get PR Number
-        id: get-pr-number
-        uses: mgaitan/gha-get-pr-number
+      - name: Get Pull Request Number
+        id: pr
+        run: echo "::set-output name=pull_request_number::$(gh pr view --json number -q .number || echo "")"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run PR Comments
         uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: ${{ steps.get-pr-number.outputs.number }}
+          issue-number: ${{ steps.pr.outputs.pull_request_number }}
           body-path: 'printer-linter-result/comment.md'
 
       - name: Run clang-tidy-pr-comments action

--- a/.github/workflows/printer-linter-pr-post.yml
+++ b/.github/workflows/printer-linter-pr-post.yml
@@ -72,6 +72,13 @@ jobs:
           mkdir printer-linter-result
           unzip printer-linter-result.zip -d printer-linter-result
 
+      - name: Run PR Comments
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-path: printer-linter-result/comment.md
+
       - name: Run clang-tidy-pr-comments action
         uses: platisd/clang-tidy-pr-comments@bc0bb7da034a8317d54e7fe1e819159002f4cc40
         with:

--- a/.github/workflows/printer-linter-pr-post.yml
+++ b/.github/workflows/printer-linter-pr-post.yml
@@ -72,12 +72,15 @@ jobs:
           mkdir printer-linter-result
           unzip printer-linter-result.zip -d printer-linter-result
 
+      - name: Get PR Number
+        id: get-pr-number
+        uses: mgaitan/gha-get-pr-number
+
       - name: Run PR Comments
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-path: printer-linter-result/comment.md
+          issue-number: ${{ steps.get-pr-number.outputs.number }}
+          body-path: 'printer-linter-result/comment.md'
 
       - name: Run clang-tidy-pr-comments action
         uses: platisd/clang-tidy-pr-comments@bc0bb7da034a8317d54e7fe1e819159002f4cc40

--- a/.printer-linter
+++ b/.printer-linter
@@ -3,6 +3,7 @@ checks:
     diagnostic-mesh-file-size: true
     diagnostic-definition-redundant-override: true
     diagnostic-resources-macos-app-directory-name: true
+    diagnostic-resource-file-deleted: true
 fixes:
     diagnostic-definition-redundant-override: true
 format:

--- a/printer-linter/pyproject.toml
+++ b/printer-linter/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "printerlinter"
 description = "Cura UltiMaker printer linting tool"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     { name = "UltiMaker", email = "cura@ultimaker.com" }
 ]

--- a/printer-linter/src/printerlinter/diagnostic.py
+++ b/printer-linter/src/printerlinter/diagnostic.py
@@ -32,3 +32,13 @@ class Diagnostic:
                 },
                 "Level": self.level
                 }
+
+class GitComment:
+    def __init__(self, comment: str) -> None:
+        """
+        @param comment: The comment text.
+        """
+        self.comment = comment
+
+    def toDict(self) -> Dict[str, Any]:
+        return self.comment

--- a/printer-linter/src/printerlinter/factory.py
+++ b/printer-linter/src/printerlinter/factory.py
@@ -11,7 +11,7 @@ from .linters.directory import Directory
 def getLinter(file: Path, settings: dict) -> Optional[List[Linter]]:
     """ Returns a Linter depending on the file format """
     if not file.exists():
-        return None
+        return [Directory(file, settings)]
 
     if ".inst" in file.suffixes and ".cfg" in file.suffixes:
         return [Directory(file, settings), Profile(file, settings)]

--- a/printer-linter/src/printerlinter/linters/defintion.py
+++ b/printer-linter/src/printerlinter/linters/defintion.py
@@ -90,7 +90,7 @@ class Definition(Linter):
 
                     yield Diagnostic(
                         file=self._file,
-                        diagnostic_name="diagnostic-definition-redundant-override",
+                        diagnostic_name="diagnostic-material-temperature-defined",
                         message=f"Overriding {key} as it belongs to material temperature catagory and shouldn't be placed in machine definitions",
                         level="Warning",
                         offset=found.span(0)[0],

--- a/printer-linter/src/printerlinter/linters/directory.py
+++ b/printer-linter/src/printerlinter/linters/directory.py
@@ -11,8 +11,11 @@ class Directory(Linter):
         super().__init__(file, settings)
 
     def check(self) -> Iterator[Diagnostic]:
-        if self._settings["checks"].get("diagnostic-resources-macos-app-directory-name", False):
+        if self._file.exists() and self._settings["checks"].get("diagnostic-resources-macos-app-directory-name", False):
             for check in self.checkForDotInDirName():
+                yield check
+        if self._settings["checks"].get("diagnostic-resource-file-deleted", False):
+            for check in self.checkFilesDeleted():
                 yield check
 
         yield
@@ -29,3 +32,14 @@ class Directory(Linter):
             )
         yield
 
+    def checkFilesDeleted(self) -> Iterator[Diagnostic]:
+        """ Check if there is a file that is deleted, this causes upgrade scripts to not work properly """
+
+        yield Diagnostic(
+            file = self._file,
+            diagnostic_name = "diagnostic-resource-file-deleted",
+            message = f"File: {self._file} must not be deleted as it is not allowed. It will create issues upgrading Cura",
+            level = "Error",
+            offset = 1
+        )
+        yield

--- a/printer-linter/src/printerlinter/linters/directory.py
+++ b/printer-linter/src/printerlinter/linters/directory.py
@@ -36,7 +36,7 @@ class Directory(Linter):
         """ Check if there is a file that is deleted, this causes upgrade scripts to not work properly """
 
         yield Diagnostic(
-            file = self._file,
+            file = self._file.parent,
             diagnostic_name = "diagnostic-resource-file-deleted",
             message = f"File: {self._file} must not be deleted as it is not allowed. It will create issues upgrading Cura",
             level = "Error",

--- a/printer-linter/src/printerlinter/linters/directory.py
+++ b/printer-linter/src/printerlinter/linters/directory.py
@@ -35,5 +35,5 @@ class Directory(Linter):
     def checkFilesDeleted(self) -> Iterator[GitComment]:
         if not self._file.exists():
             """ Check if there is a file that is deleted, this causes upgrade scripts to not work properly """
-            yield GitComment( f"File: {self._file} must not be deleted as it is not allowed. It will create issues upgrading Cura" )
+            yield GitComment( f'File: **{self._file}** must not be deleted as it is not allowed. It will create issues upgrading Cura' )
         yield

--- a/printer-linter/src/printerlinter/linters/directory.py
+++ b/printer-linter/src/printerlinter/linters/directory.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Iterator
 
-from ..diagnostic import Diagnostic
+from ..diagnostic import Diagnostic, GitComment
 from .linter import Linter
 
 
@@ -14,7 +14,7 @@ class Directory(Linter):
         if self._file.exists() and self._settings["checks"].get("diagnostic-resources-macos-app-directory-name", False):
             for check in self.checkForDotInDirName():
                 yield check
-        if self._settings["checks"].get("diagnostic-resource-file-deleted", False):
+        elif self._settings["checks"].get("diagnostic-resource-file-deleted", False):
             for check in self.checkFilesDeleted():
                 yield check
 
@@ -32,14 +32,8 @@ class Directory(Linter):
             )
         yield
 
-    def checkFilesDeleted(self) -> Iterator[Diagnostic]:
-        """ Check if there is a file that is deleted, this causes upgrade scripts to not work properly """
-
-        yield Diagnostic(
-            file = self._file.parent,
-            diagnostic_name = "diagnostic-resource-file-deleted",
-            message = f"File: {self._file} must not be deleted as it is not allowed. It will create issues upgrading Cura",
-            level = "Error",
-            offset = 1
-        )
+    def checkFilesDeleted(self) -> Iterator[GitComment]:
+        if not self._file.exists():
+            """ Check if there is a file that is deleted, this causes upgrade scripts to not work properly """
+            yield GitComment( f"File: {self._file} must not be deleted as it is not allowed. It will create issues upgrading Cura" )
         yield

--- a/printer-linter/src/terminal.py
+++ b/printer-linter/src/terminal.py
@@ -42,18 +42,19 @@ def main() -> None:
         settings = yaml.load(f, yaml.FullLoader)
 
     full_body_check = {"Diagnostics": []}
+    comments_check = {"Git Comment": []}
 
     for file in files:
         if not path.exists(file):
             print(f"Can't find the file: {file}")
             return
 
-    if args.deleted and files ==[]:
+    if args.deleted:
         for file in args.Files:
             deletedFiles = diagnoseIssuesWithFile(file, settings )
-            full_body_check["Diagnostics"].extend([d.toDict() for d in deletedFiles])
+            comments_check["GitComment"].extend([d.toDict() for d in deletedFiles])
 
-            results = yaml.dump(full_body_check, default_flow_style=False, indent=4, width=240)
+            results = yaml.dump(comments_check, default_flow_style=False, indent=4, width=240)
 
             if report:
                 report.write_text(results)

--- a/printer-linter/src/terminal.py
+++ b/printer-linter/src/terminal.py
@@ -51,15 +51,16 @@ def main() -> None:
 
     if args.deleted:
         for file in args.Files:
-            deletedFiles = diagnoseIssuesWithFile(file, settings )
-            comments_check["Error Files"].extend([d.toDict() for d in deletedFiles])
+            if file not in files:
+                deletedFiles = diagnoseIssuesWithFile(file, settings)
+                comments_check["Error Files"].extend([d.toDict() for d in deletedFiles])
 
-            results = yaml.dump(comments_check, default_flow_style=False, indent=4, width=240)
+                results = yaml.dump(comments_check, default_flow_style=False, indent=4, width=240)
 
-            if report:
-                report.write_text(results)
-            else:
-                print(results)
+                if report:
+                    report.write_text(results)
+                else:
+                    print(results)
 
     if to_fix or to_diagnose:
         for file in files:

--- a/printer-linter/src/terminal.py
+++ b/printer-linter/src/terminal.py
@@ -52,7 +52,7 @@ def main() -> None:
     if args.deleted:
         for file in args.Files:
             deletedFiles = diagnoseIssuesWithFile(file, settings )
-            comments_check["GitComment"].extend([d.toDict() for d in deletedFiles])
+            comments_check["Git Comment"].extend([d.toDict() for d in deletedFiles])
 
             results = yaml.dump(comments_check, default_flow_style=False, indent=4, width=240)
 

--- a/printer-linter/src/terminal.py
+++ b/printer-linter/src/terminal.py
@@ -42,7 +42,7 @@ def main() -> None:
         settings = yaml.load(f, yaml.FullLoader)
 
     full_body_check = {"Diagnostics": []}
-    comments_check = {"Git Comment": []}
+    comments_check = {"Error Files": []}
 
     for file in files:
         if not path.exists(file):
@@ -52,7 +52,7 @@ def main() -> None:
     if args.deleted:
         for file in args.Files:
             deletedFiles = diagnoseIssuesWithFile(file, settings )
-            comments_check["Git Comment"].extend([d.toDict() for d in deletedFiles])
+            comments_check["Error Files"].extend([d.toDict() for d in deletedFiles])
 
             results = yaml.dump(comments_check, default_flow_style=False, indent=4, width=240)
 

--- a/printer-linter/src/terminal.py
+++ b/printer-linter/src/terminal.py
@@ -19,6 +19,7 @@ def main() -> None:
     parser.add_argument("--report", required=False, type=Path, help="Path where the diagnostic report should be stored")
     parser.add_argument("--format", action="store_true", help="Format the files")
     parser.add_argument("--diagnose", action="store_true", help="Diagnose the files")
+    parser.add_argument("--deleted", action="store_true", help="Check for deleted files")
     parser.add_argument("--fix", action="store_true", help="Attempt to apply the suggested fixes on the files")
     parser.add_argument("Files", metavar="F", type=Path, nargs="+", help="Files or directories to format")
 
@@ -46,6 +47,18 @@ def main() -> None:
         if not path.exists(file):
             print(f"Can't find the file: {file}")
             return
+
+    if args.deleted and files ==[]:
+        for file in args.Files:
+            deletedFiles = diagnoseIssuesWithFile(file, settings )
+            full_body_check["Diagnostics"].extend([d.toDict() for d in deletedFiles])
+
+            results = yaml.dump(full_body_check, default_flow_style=False, indent=4, width=240)
+
+            if report:
+                report.write_text(results)
+            else:
+                print(results)
 
     if to_fix or to_diagnose:
         for file in files:
@@ -81,7 +94,6 @@ def diagnoseIssuesWithFile(file: Path, settings: dict) -> List[Diagnostic]:
         linter_results.extend(list(filter(lambda d: d is not None, linter.check())))
 
     return linter_results
-
 
 def applyFixesToFile(file, settings, full_body_check) -> None:
     if not file.exists():


### PR DESCRIPTION
This update adds a new check for deleted files in the printer linter. This will alert the user when a file has been deleted that could potentially disrupt upgrade scripts. An argument "--deleted" is also added to terminal.py to facilitate this new check. Additionally, the printer-linter version has been incremented to 0.1.2.

CURA-10903

