### PR TITLE
Monitor Page Preheat values

### DIFF
--- a/resources/qml/PrintMonitor.qml
+++ b/resources/qml/PrintMonitor.qml
@@ -129,7 +129,7 @@ ScrollView
         {
             id: bedTemperature
             containerStack: Cura.MachineManager.activeMachine
-            key: "material_bed_temperature"
+            key: "material_bed_temperature_layer_0"
             watchedProperties: ["value", "minimum_value", "maximum_value", "resolve"]
             storeIndex: 0
         }

--- a/resources/qml/PrinterOutput/ExtruderBox.qml
+++ b/resources/qml/PrinterOutput/ExtruderBox.qml
@@ -22,7 +22,7 @@ Item
     {
         id: extruderTemperature
         containerStackId: Cura.ExtruderManager.extruderIds[position]
-        key: "material_print_temperature"
+        key: "material_print_temperature_layer_0"
         watchedProperties: ["value", "minimum_value", "maximum_value", "resolve"]
         storeIndex: 0
     }


### PR DESCRIPTION
Currently, the preheat values on the Monitor stage are for "bed temperature" and "print temperature".
This PR changes them to "Print Temperature Initial Layer" and "Bed Temperature Initial Layer".
The changes involve a single line in each file.

# Description

## Type of change

<!-- Please delete options that are not relevant. -->

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:
* Cura Version:   5.7.0
* Operating System:  Win 10 Pro

# Checklist:
<!-- Check if relevant -->

- [ X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have uploaded any files required to test this change
