### PR TITLE
Longer-printers-additional-definitions

### DIFF
--- a/resources/quality/longer/ABS/longer_0.2_ABS_super.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.2_ABS_super.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_abs
+variant = 0.2mm Nozzle
+
+[values]
+wall_thickness = =line_width*8

--- a/resources/quality/longer/ABS/longer_0.2_ABS_ultra.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.2_ABS_ultra.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Ultra Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = ultra
+material = generic_abs
+variant = 0.2mm Nozzle
+
+[values]
+wall_thickness = =line_width*8

--- a/resources/quality/longer/ABS/longer_0.3_ABS_adaptive.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.3_ABS_adaptive.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Dynamic Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = adaptive
+material = generic_abs
+variant = 0.3mm Nozzle
+
+[values]
+wall_thickness = =line_width*4

--- a/resources/quality/longer/ABS/longer_0.3_ABS_low.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.3_ABS_low.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Low Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = low
+material = generic_abs
+variant = 0.3mm Nozzle
+
+[values]
+wall_thickness = =line_width*4

--- a/resources/quality/longer/ABS/longer_0.3_ABS_standard.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.3_ABS_standard.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_abs
+variant = 0.3mm Nozzle
+
+[values]
+wall_thickness = =line_width*4

--- a/resources/quality/longer/ABS/longer_0.3_ABS_super.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.3_ABS_super.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_abs
+variant = 0.3mm Nozzle
+
+[values]
+wall_thickness = =line_width*4

--- a/resources/quality/longer/ABS/longer_0.5_ABS_adaptive.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.5_ABS_adaptive.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Dynamic Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = adaptive
+material = generic_abs
+variant = 0.5mm Nozzle
+
+[values]
+wall_thickness = =line_width*4

--- a/resources/quality/longer/ABS/longer_0.5_ABS_low.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.5_ABS_low.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Low Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = low
+material = generic_abs
+variant = 0.5mm Nozzle
+
+[values]
+wall_thickness = =line_width*4

--- a/resources/quality/longer/ABS/longer_0.5_ABS_standard.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.5_ABS_standard.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_abs
+variant = 0.5mm Nozzle
+
+[values]
+wall_thickness = =line_width*4

--- a/resources/quality/longer/ABS/longer_0.5_ABS_super.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.5_ABS_super.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_abs
+variant = 0.5mm Nozzle
+
+[values]
+wall_thickness = =line_width*4

--- a/resources/quality/longer/ABS/longer_0.6_ABS_standard.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.6_ABS_standard.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_abs
+variant = 0.6mm Nozzle
+
+[values]
+wall_thickness = =line_width*3

--- a/resources/quality/longer/ABS/longer_0.8_ABS_draft.inst.cfg
+++ b/resources/quality/longer/ABS/longer_0.8_ABS_draft.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_abs
+variant = 0.8mm Nozzle
+
+[values]
+wall_thickness = =line_width*3

--- a/resources/quality/longer/ABS/longer_1.0_ABS_draft.inst.cfg
+++ b/resources/quality/longer/ABS/longer_1.0_ABS_draft.inst.cfg
@@ -1,0 +1,14 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_abs
+variant = 1.0mm Nozzle
+
+[values]
+wall_thickness = =line_width*3

--- a/resources/quality/longer/PETG/longer_0.2_PETG_super.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.2_PETG_super.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_petg
+variant = 0.2mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*8

--- a/resources/quality/longer/PETG/longer_0.2_PETG_ultra.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.2_PETG_ultra.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+version = 4
+name = Ultra Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = ultra
+material = generic_petg
+variant = 0.2mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*8
+

--- a/resources/quality/longer/PETG/longer_0.3_PETG_adaptive.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.3_PETG_adaptive.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+version = 4
+name = Dynamic Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = adaptive
+material = generic_petg
+variant = 0.3mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*4
+

--- a/resources/quality/longer/PETG/longer_0.3_PETG_low.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.3_PETG_low.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+version = 4
+name = Low Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = low
+material = generic_petg
+variant = 0.3mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*4
+

--- a/resources/quality/longer/PETG/longer_0.3_PETG_standard.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.3_PETG_standard.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_petg
+variant = 0.3mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*4
+

--- a/resources/quality/longer/PETG/longer_0.3_PETG_super.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.3_PETG_super.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_petg
+variant = 0.3mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*4
+

--- a/resources/quality/longer/PETG/longer_0.5_PETG_adaptive.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.5_PETG_adaptive.inst.cfg
@@ -1,0 +1,16 @@
+[general]
+version = 4
+name = Dynamic Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = adaptive
+material = generic_petg
+variant = 0.5mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*4
+

--- a/resources/quality/longer/PETG/longer_0.5_PETG_low.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.5_PETG_low.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+version = 4
+name = Low Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = low
+material = generic_petg
+variant = 0.5mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*4

--- a/resources/quality/longer/PETG/longer_0.5_PETG_standard.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.5_PETG_standard.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_petg
+variant = 0.5mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*4

--- a/resources/quality/longer/PETG/longer_0.5_PETG_super.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.5_PETG_super.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_petg
+variant = 0.5mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*4

--- a/resources/quality/longer/PETG/longer_0.6_PETG_standard.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.6_PETG_standard.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_petg
+variant = 0.6mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*3

--- a/resources/quality/longer/PETG/longer_0.8_PETG_draft.inst.cfg
+++ b/resources/quality/longer/PETG/longer_0.8_PETG_draft.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_petg
+variant = 0.8mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*3

--- a/resources/quality/longer/PETG/longer_1.0_PETG_draft.inst.cfg
+++ b/resources/quality/longer/PETG/longer_1.0_PETG_draft.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_petg
+variant = 1.0mm Nozzle
+
+[values]
+speed_layer_0 = 15
+wall_thickness = =line_width*3

--- a/resources/quality/longer/PLA/longer_0.2_PLA_super.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.2_PLA_super.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_pla
+variant = 0.2mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.2_PLA_ultra.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.2_PLA_ultra.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Ultra Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = ultra
+material = generic_pla
+variant = 0.2mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.3_PLA_adaptive.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.3_PLA_adaptive.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Dynamic Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = adaptive
+material = generic_pla
+variant = 0.3mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.3_PLA_low.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.3_PLA_low.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Low Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = low
+material = generic_pla
+variant = 0.3mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.3_PLA_standard.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.3_PLA_standard.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_pla
+variant = 0.3mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.3_PLA_super.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.3_PLA_super.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_pla
+variant = 0.3mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.5_PLA_adaptive.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.5_PLA_adaptive.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Dynamic Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = adaptive
+material = generic_pla
+variant = 0.5mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.5_PLA_low.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.5_PLA_low.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Low Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = low
+material = generic_pla
+variant = 0.5mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.5_PLA_standard.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.5_PLA_standard.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_pla
+variant = 0.5mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.5_PLA_super.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.5_PLA_super.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_pla
+variant = 0.5mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.6_PLA_draft.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.6_PLA_draft.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_pla
+variant = 0.6mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.6_PLA_low.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.6_PLA_low.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Low Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = low
+material = generic_pla
+variant = 0.6mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.6_PLA_standard.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.6_PLA_standard.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_pla
+variant = 0.6mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_0.8_PLA_draft.inst.cfg
+++ b/resources/quality/longer/PLA/longer_0.8_PLA_draft.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_pla
+variant = 0.8mm Nozzle
+
+[values]

--- a/resources/quality/longer/PLA/longer_1.0_PLA_draft.inst.cfg
+++ b/resources/quality/longer/PLA/longer_1.0_PLA_draft.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_pla
+variant = 1.0mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_0.3_TPU_adaptive.inst.cfg
+++ b/resources/quality/longer/TPU/longer_0.3_TPU_adaptive.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Dynamic Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = adaptive
+material = generic_tpu
+variant = 0.3mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_0.3_TPU_standard.inst.cfg
+++ b/resources/quality/longer/TPU/longer_0.3_TPU_standard.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_tpu
+variant = 0.3mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_0.3_TPU_super.inst.cfg
+++ b/resources/quality/longer/TPU/longer_0.3_TPU_super.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_tpu
+variant = 0.3mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_0.5_TPU_adaptive.inst.cfg
+++ b/resources/quality/longer/TPU/longer_0.5_TPU_adaptive.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Dynamic Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = adaptive
+material = generic_tpu
+variant = 0.5mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_0.5_TPU_standard.inst.cfg
+++ b/resources/quality/longer/TPU/longer_0.5_TPU_standard.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_tpu
+variant = 0.5mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_0.5_TPU_super.inst.cfg
+++ b/resources/quality/longer/TPU/longer_0.5_TPU_super.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Super Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = super
+material = generic_tpu
+variant = 0.5mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_0.6_TPU_standard.inst.cfg
+++ b/resources/quality/longer/TPU/longer_0.6_TPU_standard.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Standard Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = standard
+material = generic_tpu
+variant = 0.6mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_0.8_TPU_draft.inst.cfg
+++ b/resources/quality/longer/TPU/longer_0.8_TPU_draft.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_tpu
+variant = 0.8mm Nozzle
+
+[values]

--- a/resources/quality/longer/TPU/longer_1.0_TPU_draft.inst.cfg
+++ b/resources/quality/longer/TPU/longer_1.0_TPU_draft.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+version = 4
+name = Draft Quality
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = quality
+quality_type = draft
+material = generic_tpu
+variant = 1.0mm Nozzle
+
+[values]

--- a/resources/variants/longer/longer_base_0.2.inst.cfg
+++ b/resources/variants/longer/longer_base_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_base_0.3.inst.cfg
+++ b/resources/variants/longer/longer_base_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_base_0.5.inst.cfg
+++ b/resources/variants/longer/longer_base_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_base_0.6.inst.cfg
+++ b/resources/variants/longer/longer_base_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_base_0.8.inst.cfg
+++ b/resources/variants/longer/longer_base_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_base_1.0.inst.cfg
+++ b/resources/variants/longer/longer_base_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_base
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0

--- a/resources/variants/longer/longer_cube2_0.2.inst.cfg
+++ b/resources/variants/longer/longer_cube2_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_cube2
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_cube2_0.3.inst.cfg
+++ b/resources/variants/longer/longer_cube2_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_cube2
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_cube2_0.5.inst.cfg
+++ b/resources/variants/longer/longer_cube2_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_cube2
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_cube2_0.6.inst.cfg
+++ b/resources/variants/longer/longer_cube2_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_cube2
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_cube2_0.8.inst.cfg
+++ b/resources/variants/longer/longer_cube2_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_cube2
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_cube2_1.0.inst.cfg
+++ b/resources/variants/longer/longer_cube2_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_cube2
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0

--- a/resources/variants/longer/longer_lk1_0.2.inst.cfg
+++ b/resources/variants/longer/longer_lk1_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_lk1
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_lk1_0.3.inst.cfg
+++ b/resources/variants/longer/longer_lk1_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_lk1
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_lk1_0.5.inst.cfg
+++ b/resources/variants/longer/longer_lk1_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_lk1
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_lk1_0.6.inst.cfg
+++ b/resources/variants/longer/longer_lk1_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_lk1
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_lk1_0.8.inst.cfg
+++ b/resources/variants/longer/longer_lk1_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_lk1
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_lk1_1.0.inst.cfg
+++ b/resources/variants/longer/longer_lk1_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_lk1
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0

--- a/resources/variants/longer/longer_lk1plus_0.2.inst.cfg
+++ b/resources/variants/longer/longer_lk1plus_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_lk1plus
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_lk1plus_0.3.inst.cfg
+++ b/resources/variants/longer/longer_lk1plus_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_lk1plus
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_lk1plus_0.5.inst.cfg
+++ b/resources/variants/longer/longer_lk1plus_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_lk1plus
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_lk1plus_0.6.inst.cfg
+++ b/resources/variants/longer/longer_lk1plus_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_lk1plus
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_lk1plus_0.8.inst.cfg
+++ b/resources/variants/longer/longer_lk1plus_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_lk1plus
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_lk1plus_1.0.inst.cfg
+++ b/resources/variants/longer/longer_lk1plus_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_lk1plus
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0

--- a/resources/variants/longer/longer_lk1pro_0.2.inst.cfg
+++ b/resources/variants/longer/longer_lk1pro_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_lk1pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_lk1pro_0.3.inst.cfg
+++ b/resources/variants/longer/longer_lk1pro_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_lk1pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_lk1pro_0.5.inst.cfg
+++ b/resources/variants/longer/longer_lk1pro_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_lk1pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_lk1pro_0.6.inst.cfg
+++ b/resources/variants/longer/longer_lk1pro_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_lk1pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_lk1pro_0.8.inst.cfg
+++ b/resources/variants/longer/longer_lk1pro_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_lk1pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_lk1pro_1.0.inst.cfg
+++ b/resources/variants/longer/longer_lk1pro_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_lk1pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0

--- a/resources/variants/longer/longer_lk4_0.2.inst.cfg
+++ b/resources/variants/longer/longer_lk4_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_lk4
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_lk4_0.3.inst.cfg
+++ b/resources/variants/longer/longer_lk4_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_lk4
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_lk4_0.5.inst.cfg
+++ b/resources/variants/longer/longer_lk4_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_lk4
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_lk4_0.6.inst.cfg
+++ b/resources/variants/longer/longer_lk4_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_lk4
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_lk4_0.8.inst.cfg
+++ b/resources/variants/longer/longer_lk4_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_lk4
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_lk4_1.0.inst.cfg
+++ b/resources/variants/longer/longer_lk4_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_lk4
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0

--- a/resources/variants/longer/longer_lk4pro_0.2.inst.cfg
+++ b/resources/variants/longer/longer_lk4pro_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_lk4pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_lk4pro_0.3.inst.cfg
+++ b/resources/variants/longer/longer_lk4pro_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_lk4pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_lk4pro_0.5.inst.cfg
+++ b/resources/variants/longer/longer_lk4pro_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_lk4pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_lk4pro_0.6.inst.cfg
+++ b/resources/variants/longer/longer_lk4pro_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_lk4pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_lk4pro_0.8.inst.cfg
+++ b/resources/variants/longer/longer_lk4pro_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_lk4pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_lk4pro_1.0.inst.cfg
+++ b/resources/variants/longer/longer_lk4pro_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_lk4pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0

--- a/resources/variants/longer/longer_lk5_0.2.inst.cfg
+++ b/resources/variants/longer/longer_lk5_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_lk5
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_lk5_0.3.inst.cfg
+++ b/resources/variants/longer/longer_lk5_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_lk5
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_lk5_0.5.inst.cfg
+++ b/resources/variants/longer/longer_lk5_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_lk5
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_lk5_0.6.inst.cfg
+++ b/resources/variants/longer/longer_lk5_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_lk5
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_lk5_0.8.inst.cfg
+++ b/resources/variants/longer/longer_lk5_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_lk5
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_lk5_1.0.inst.cfg
+++ b/resources/variants/longer/longer_lk5_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_lk5
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0

--- a/resources/variants/longer/longer_lk5pro_0.2.inst.cfg
+++ b/resources/variants/longer/longer_lk5pro_0.2.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.2mm Nozzle
+version = 4
+definition = longer_lk5pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.2

--- a/resources/variants/longer/longer_lk5pro_0.3.inst.cfg
+++ b/resources/variants/longer/longer_lk5pro_0.3.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.3mm Nozzle
+version = 4
+definition = longer_lk5pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.3

--- a/resources/variants/longer/longer_lk5pro_0.5.inst.cfg
+++ b/resources/variants/longer/longer_lk5pro_0.5.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.5mm Nozzle
+version = 4
+definition = longer_lk5pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.5

--- a/resources/variants/longer/longer_lk5pro_0.6.inst.cfg
+++ b/resources/variants/longer/longer_lk5pro_0.6.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.6mm Nozzle
+version = 4
+definition = longer_lk5pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.6

--- a/resources/variants/longer/longer_lk5pro_0.8.inst.cfg
+++ b/resources/variants/longer/longer_lk5pro_0.8.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 0.8mm Nozzle
+version = 4
+definition = longer_lk5pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 0.8

--- a/resources/variants/longer/longer_lk5pro_1.0.inst.cfg
+++ b/resources/variants/longer/longer_lk5pro_1.0.inst.cfg
@@ -1,0 +1,12 @@
+[general]
+name = 1.0mm Nozzle
+version = 4
+definition = longer_lk5pro
+
+[metadata]
+setting_version = 23
+type = variant
+hardware_type = nozzle
+
+[values]
+machine_nozzle_size = 1.0


### PR DESCRIPTION
# Description

This adds configuration files for different nozzle sizes to support 0.2mm, 0.3mm, 0.5mm, 0.6mm, 0.8mm, and 1.0mm nozzles for various longer printers. These appear to have been removed in ec03dd9727c558cf925f2540f7fc83469822cc13 by @LONGER3D. I would argue these provide value to be worth maintaining, as many users will use different nozzle sizes and out of the box support in Cura is nice to have.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ X ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ X ] Manual Test on local environment.
  - Using Mac OS, Copied files into Cura 5.7.0 app package and successfully generated gcode using .6mm nozzle profile with standard quality. Other profles showed up and could be selected.

**Test Configuration**:
* Operating System: Mac OS 14.4.1 running modied Cura 5.7.0 package connected to Octoprint.

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ X ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
