### PR TITLE
Fix for slow file opening

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
+++ b/plugins/USBPrinting/USBPrinterOutputDeviceManager.py
@@ -84,8 +84,8 @@ class USBPrinterOutputDeviceManager(QObject, OutputDevicePlugin):
             if container_stack.getMetaDataEntry("supports_usb_connection"):
                 machine_file_formats = [file_type.strip() for file_type in container_stack.getMetaDataEntry("file_formats").split(";")]
                 if "text/x-gcode" in machine_file_formats:
-                    # We only limit listing usb on windows is a fix for connecting tty/cu printers on MacOS and Linux
-                    port_list = self.getSerialPortList(only_list_usb=Platform.isWindows())
+                    # We only list usb, otherwise scanning all serial ports might take too long
+                    port_list = self.getSerialPortList(only_list_usb=True)
             self._addRemovePorts(port_list)
             time.sleep(5)
 


### PR DESCRIPTION
# Description

This fixes #16249 .

After looking at my logs (pretty much identical to [this](https://github.com/Ultimaker/Cura/issues/16249#issuecomment-2045990821)), I decided to take a deeper look into the code. As it turns out, 32 tty ports were being tested, 4 at a time, with 15s timeout, twice each. This would give me an expected wait of 32 * 15 * 2 / 4 = 240s of wait, or about 4 minutes. My logs actually match this expected time, so it took Cura 4 minutes between me selecting a file to open and it actually opening on Cura.

Ideally, this wouldn't be a hard-coded ```True```. But I'm not that familiar with Qt - or the Cura project as a whole - so I wouldn't know the best way to handle this. Some suggestions are:

- Add a boolean to the configurations, something like "Auto Detect Serial Ports" or "Auto Detect Baud Rates". And please, make the default ```False```.
- Instead of scanning for tty ports and trying every baud rate, have the user supply this data. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I had the same problem as listed on #16249. After building with the new source code, it opened files quickly - as expected. 

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
