### PR TITLE
Create TestPrinterExtruderTrains.py

### DIFF
--- a/tests/TestPrinterExtruderTrains.py
+++ b/tests/TestPrinterExtruderTrains.py
@@ -1,0 +1,81 @@
+import os
+import json
+import pytest
+
+# Global Counters
+CORRUPTION_COUNTER = []
+KEYERROR_COUNTER = []
+VALUEERROR_COUNTER = []
+
+
+def assert_corruption_error():
+    assert len(CORRUPTION_COUNTER) == 0
+
+
+def assert_key_error():
+    assert len(KEYERROR_COUNTER) == 0
+
+
+def assert_value_error():
+    assert len(VALUEERROR_COUNTER) == 0
+
+
+def find_extruder(file, extruder_trains, extruders):
+    if len(extruder_trains) == 1:
+        if '0' in extruder_trains.keys():
+            value = f"{extruder_trains['0']}.def.json"
+        else:
+            value = f"{extruder_trains['1']}.def.json"
+        if value in extruders or value == "fdmextruder.def.json":
+            pass
+        else:
+            VALUEERROR_COUNTER.append(f"No value found for {file} pointing to {value}")
+    elif len(extruder_trains) > 1:
+        for key, value in extruder_trains.items():
+            value = f"{value}.def.json"
+            if value in extruders:
+                pass
+            else:
+                VALUEERROR_COUNTER.append(f"No value found for {file} with {value}")
+    else:
+        raise Exception(f"No extruder train found for {file}")
+
+
+def find_inheritance(base_path, parent):
+    if parent == "fdmprinter":
+        return {'0': 'fdmextruder'}
+
+    with open(f"{base_path}/definitions/{parent}.def.json", 'r') as f:
+        json_file = json.load(f)
+
+    if "metadata" in json_file.keys() and "machine_extruder_trains" in json_file["metadata"].keys():
+        return json_file["metadata"]["machine_extruder_trains"]
+    elif "inherits" in json_file.keys():
+        return find_inheritance(base_path, json_file["inherits"])
+    else:
+        KEYERROR_COUNTER.append(f"Could not find the either a parent or extruder train for {parent}")
+
+
+def test_printer_definition_checker():
+    base_path = os.path.dirname(os.getcwd())
+    base_path = os.path.join(base_path, "resources")
+    definitions = next(os.walk(f"{base_path}/definitions"), (None, None, []))[2]
+    extruders = next(os.walk(f"{base_path}/extruders"), (None, None, []))[2]
+
+    for file in definitions:
+        if file in ["fdmprinter.def.json", "fdmextruder.def.json"]:
+            continue
+        with open(f"{base_path}/definitions/{file}", 'r') as f:
+            json_file = json.load(f)
+
+        if "metadata" in json_file.keys() and "machine_extruder_trains" in json_file["metadata"].keys():
+            extruder_trains = json_file["metadata"]["machine_extruder_trains"]
+        elif "inherits" in json_file.keys():
+            extruder_trains = find_inheritance(base_path, json_file["inherits"])
+        else:
+            CORRUPTION_COUNTER.append(f"{file} is likely to be corrupted please investigate.")
+
+        find_extruder(file, extruder_trains, extruders)
+    assert_corruption_error()
+    assert_value_error()
+    assert_key_error()


### PR DESCRIPTION
# Description

Test that validates every printer is pointing to either an extruder definition or inherits from a printer with an extruder definition.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
