### PR TITLE
[PP-484] Create Factor 4 "fast" global quality

### DIFF
--- a/resources/quality/ultimaker_factor4/um_f4_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_global_Fast_Quality.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = ultimaker_factor4
+name = Normal
+version = 4
+
+[metadata]
+global_quality = True
+quality_type = fast
+setting_version = 23
+type = quality
+weight = -1
+
+[values]
+layer_height = =round(0.15 * material_shrinkage_percentage_z / 100, 5)
+


### PR DESCRIPTION
# Description
Create the `fast`/`0.15mm` global quality for the Factor 4. This quality has never been made, as our own profiles do not make use of this layer height. This however, breaks 3rd party materials that _do_ make use of that layer height.