### PR TITLE
CURA-11904 Fix crash when slicing with first extruder disabled

### DIFF
--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -544,7 +544,7 @@ class CuraEngineBackend(QObject, Backend):
 
         if job.getResult() == StartJobResult.ObjectsWithDisabledExtruder:
             self._error_message = Message(catalog.i18nc("@info:status",
-                                                        "Unable to slice because there are objects associated with disabled Extruder %s.") % job.getMessage(),
+                                                        "Unable to slice because there are objects associated with disabled Extruder %s.") % job.getAssociatedDisabledExtruders(),
                                           title = catalog.i18nc("@info:title", "Unable to slice"),
                                           message_type = Message.MessageType.WARNING)
             self._error_message.show()

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -146,12 +146,16 @@ class StartSliceJob(Job):
         self._slice_message: Arcus.PythonMessage = slice_message
         self._is_cancelled: bool = False
         self._build_plate_number: Optional[int] = None
+        self._associated_disabled_extruders: Optional[str] = None
 
         # cache for all setting values from all stacks (global & extruder) for the current machine
         self._all_extruders_settings: Optional[Dict[str, Any]] = None
 
     def getSliceMessage(self) -> Arcus.PythonMessage:
         return self._slice_message
+
+    def getAssociatedDisabledExtruders(self) -> Optional[str]:
+        return self._associated_disabled_extruders
 
     def setBuildPlate(self, build_plate_number: int) -> None:
         self._build_plate_number = build_plate_number
@@ -334,7 +338,7 @@ class StartSliceJob(Job):
         if has_model_with_disabled_extruders:
             self.setResult(StartJobResult.ObjectsWithDisabledExtruder)
             associated_disabled_extruders = {p + 1 for p in associated_disabled_extruders}
-            self.setMessage(", ".join(map(str, sorted(associated_disabled_extruders))))
+            self._associated_disabled_extruders = ", ".join(map(str, sorted(associated_disabled_extruders)))
             return
 
         # There are cases when there is nothing to slice. This can happen due to one at a time slicing not being


### PR DESCRIPTION
Following the removal of the get/setMessage methods in the Job class, the StartSliceJob has not been updated and still used them. We now use a specific variable for storing the disabled extruders and properly display them.

CURA-11904
Associated PR https://github.com/Ultimaker/Uranium/pull/951