### PR TITLE
Reduce permissions on printer-linter GitHub actions

### DIFF
--- a/.github/workflows/printer-linter-pr-diagnose.yml
+++ b/.github/workflows/printer-linter-pr-diagnose.yml
@@ -5,6 +5,9 @@ on:
     path:
       - "resources/**"
 
+permissions:
+  contents: read
+
 jobs:
   printer-linter-diagnose:
     name: Printer linter PR diagnose

--- a/.github/workflows/printer-linter-pr-post.yml
+++ b/.github/workflows/printer-linter-pr-post.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["printer-linter-pr-diagnose"]
     types: [completed]
 
+permissions:
+  issues: write
+
 jobs:
   clang-tidy-results:
     # Trigger the job only if the previous (insecure) workflow completed successfully


### PR DESCRIPTION
Previously they had no permission set, so by default all write access. We now specify only the required permissions for each of them.