### PR TITLE
CURA-11931 set interleaved prime tower from material

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6821,7 +6821,7 @@
                     "label": "Prime Tower Type",
                     "description": "<html>How to generate the prime tower:<ul><li><b>Normal:</b> create a bucket in which secondary materials are primed</li><li><b>Interleaved:</b> create a prime tower as sparse as possible. This will save time and filament, but is only possible if the used materials adhere to each other</li></ul></html>",
                     "type": "enum",
-                    "resolve": "'interleaved' if (all(material_type_var == extruderValues('material_type')[0] for material_type_var in extruderValues('material_type')) and all(material_brand_var == extruderValues('material_brand')[0] for material_brand_var in extruderValues('material_brand'))) else 'normal'",
+                    "resolve": "'interleaved' if all(mode == 'interleaved' for mode in extruderValues('prime_tower_mode')) else 'interleaved' if (all(material_type_var == extruderValues('material_type')[0] for material_type_var in extruderValues('material_type')) and all(material_brand_var == extruderValues('material_brand')[0] for material_brand_var in extruderValues('material_brand'))) else 'normal'",
                     "options":
                     {
                         "normal": "Normal",


### PR DESCRIPTION
This adds a new condition to the `prime_tower_mode` resolve function, so that it is now possible to define the mode on materials, and if all the selected materials have the same "interleaved" option, then interleaved mode is selected.

Although this is not perfect because the mode should be set depending on specific material combinations, we have decided that it will be good enough for now.

CURA-11931