### PR TITLE
0.15mm modes for the factor 4 for PVA and BAM.

### DIFF
--- a/resources/quality/ultimaker_factor4/um_f4_aa0.4_bam_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_aa0.4_bam_0.15mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_factor4
+name = Normal
+version = 4
+
+[metadata]
+material = generic_bam
+quality_type = fast
+setting_version = 23
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.1
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+brim_replaces_support = False
+machine_nozzle_heat_up_speed = 1.56
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
+skin_material_flow = =material_flow * 0.965
+speed_print = 60
+support_angle = 45
+support_bottom_distance = =math.ceil(min(extruderValues('material_adhesion_tendency')) / 2) * layer_height
+support_interface_density = =min(extruderValues('material_surface_energy'))
+support_interface_enable = True
+support_join_distance = 5
+support_top_distance = =math.ceil(min(extruderValues('material_adhesion_tendency')) / 1) * layer_height
+

--- a/resources/quality/ultimaker_factor4/um_f4_bb0.4_pva_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_bb0.4_pva_0.15mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_factor4
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pva
+quality_type = fast
+setting_version = 23
+type = quality
+variant = BB 0.4
+weight = -1
+
+[values]
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_discretisation_step_size = 0.1
+_plugin__curaenginegradualflow__0_1_0__gradual_flow_enabled = True
+_plugin__curaenginegradualflow__0_1_0__max_flow_acceleration = 1
+acceleration_support_bottom = 100
+acceleration_support_interface = 1500
+brim_replaces_support = False
+prime_tower_min_volume = 15
+skin_material_flow = =material_flow * 0.93
+speed_print = 50
+support_infill_sparse_thickness = =min(layer_height * 2, machine_nozzle_size * 3 / 4) if layer_height <= 0.15 / 0.4 * machine_nozzle_size else layer_height
+support_interface_offset = 1
+support_offset = 3
+support_z_distance = 0
+


### PR DESCRIPTION
Needed by 3rd party material profiles that require support PVA or BAM support.

PP-485
