### PR TITLE
Improve overhang quality T-PLA 0.2mm engineering mode

### DIFF
--- a/resources/intent/ultimaker_factor4/um_f4_aa0.4_tough-pla_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_factor4/um_f4_aa0.4_tough-pla_0.2mm_engineering.inst.cfg
@@ -12,10 +12,8 @@ type = intent
 variant = AA 0.4
 
 [values]
-build_volume_temperature = 35
 jerk_print = 30
-material_bed_temperature = =default_material_bed_temperature + 5
-material_print_temperature = =default_material_print_temperature + 15
+material_print_temperature = =default_material_print_temperature + 10
 speed_print = 80
 wall_thickness = =line_width * 3
 


### PR DESCRIPTION
Reduce the build plate, build volume and print temperature of the T-PLA 0.2mm engineering mode with 5C to improve the overhang quality. Strength and dimensional accuracy were not affected by this change.

PP-488