### PR TITLE
Add DraftShift Design Voron2 based StealthChanger profiles

### DIFF
--- a/resources/definitions/voron2_stealthchanger_250.def.json
+++ b/resources/definitions/voron2_stealthchanger_250.def.json
@@ -1,0 +1,18 @@
+{
+    "version": 2,
+    "name": "Voron2 StealthChanger 250",
+    "inherits": "voron2_stealthchanger_base",
+    "metadata":
+    {
+        "visible": true,
+        "platform": "voron2_250_bed.3mf",
+        "quality_definition": "voron2_base"
+    },
+    "overrides":
+    {
+        "machine_depth": { "default_value": 250 },
+        "machine_height": { "default_value": 250 },
+        "machine_name": { "default_value": "VORON2 StealthChanger 250" },
+        "machine_width": { "default_value": 250 }
+    }
+}

--- a/resources/definitions/voron2_stealthchanger_300.def.json
+++ b/resources/definitions/voron2_stealthchanger_300.def.json
@@ -1,0 +1,18 @@
+{
+    "version": 2,
+    "name": "Voron2 StealthChanger 300",
+    "inherits": "voron2_stealthchanger_base",
+    "metadata":
+    {
+        "visible": true,
+        "platform": "voron2_300_bed.3mf",
+        "quality_definition": "voron2_base"
+    },
+    "overrides":
+    {
+        "machine_depth": { "default_value": 300 },
+        "machine_height": { "default_value": 300 },
+        "machine_name": { "default_value": "VORON2 StealthChanger 300" },
+        "machine_width": { "default_value": 300 }
+    }
+}

--- a/resources/definitions/voron2_stealthchanger_350.def.json
+++ b/resources/definitions/voron2_stealthchanger_350.def.json
@@ -1,0 +1,18 @@
+{
+    "version": 2,
+    "name": "Voron2 StealthChanger 350",
+    "inherits": "voron2_stealthchanger_base",
+    "metadata":
+    {
+        "visible": true,
+        "platform": "voron2_350_bed.3mf",
+        "quality_definition": "voron2_base"
+    },
+    "overrides":
+    {
+        "machine_depth": { "default_value": 350 },
+        "machine_height": { "default_value": 350 },
+        "machine_name": { "default_value": "VORON2 StealthChanger 350" },
+        "machine_width": { "default_value": 350 }
+    }
+}

--- a/resources/definitions/voron2_stealthchanger_base.def.json
+++ b/resources/definitions/voron2_stealthchanger_base.def.json
@@ -1,0 +1,29 @@
+{
+    "version": 2,
+    "name": "Voron2 StealthChanger Base",
+    "inherits": "voron2_base",
+    "metadata":
+    {
+        "visible": false,
+        "author": "Thessien",
+        "manufacturer": "DraftShift Design",
+        "machine_extruder_trains":
+        {
+            "0": "voron2_stealthchanger_extruder_0",
+            "1": "voron2_stealthchanger_extruder_1",
+            "2": "voron2_stealthchanger_extruder_2",
+            "3": "voron2_stealthchanger_extruder_3",
+            "4": "voron2_stealthchanger_extruder_4",
+            "5": "voron2_stealthchanger_extruder_5",
+            "6": "voron2_stealthchanger_extruder_6",
+            "7": "voron2_stealthchanger_extruder_7"
+        }
+    },
+    "overrides":
+    {
+        "machine_name": { "default_value": "VORON2 StealthChanger" },
+        "machine_end_gcode": { "default_value": "PRINT_END" },
+        "machine_extruder_count": { "default_value": 1 },
+        "machine_start_gcode": { "default_value": "PRINT_START TOOL_TEMP={material_print_temperature_layer_0} T{initial_extruder_nr}_TEMP={material_print_temperature_layer_0} BED_TEMP={material_bed_temperature_layer_0} TOOL={initial_extruder_nr}" }
+    }
+}

--- a/resources/extruders/voron2_stealthchanger_extruder_0.def.json
+++ b/resources/extruders/voron2_stealthchanger_extruder_0.def.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "name": "Toolhead 0",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "voron2_stealthchanger_base",
+        "position": "0"
+    },
+    "overrides":
+    {
+        "extruder_nr":
+        {
+            "default_value": 0,
+            "maximum_value": 7
+        },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y" }
+    }
+}

--- a/resources/extruders/voron2_stealthchanger_extruder_1.def.json
+++ b/resources/extruders/voron2_stealthchanger_extruder_1.def.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "name": "Toolhead 1",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "voron2_stealthchanger_base",
+        "position": "1"
+    },
+    "overrides":
+    {
+        "extruder_nr":
+        {
+            "default_value": 1,
+            "maximum_value": 7
+        },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y" }
+    }
+}

--- a/resources/extruders/voron2_stealthchanger_extruder_2.def.json
+++ b/resources/extruders/voron2_stealthchanger_extruder_2.def.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "name": "Toolhead 2",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "voron2_stealthchanger_base",
+        "position": "2"
+    },
+    "overrides":
+    {
+        "extruder_nr":
+        {
+            "default_value": 2,
+            "maximum_value": 7
+        },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y" }
+    }
+}

--- a/resources/extruders/voron2_stealthchanger_extruder_3.def.json
+++ b/resources/extruders/voron2_stealthchanger_extruder_3.def.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "name": "Toolhead 3",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "voron2_stealthchanger_base",
+        "position": "3"
+    },
+    "overrides":
+    {
+        "extruder_nr":
+        {
+            "default_value": 3,
+            "maximum_value": 7
+        },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y" }
+    }
+}

--- a/resources/extruders/voron2_stealthchanger_extruder_4.def.json
+++ b/resources/extruders/voron2_stealthchanger_extruder_4.def.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "name": "Toolhead 4",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "voron2_stealthchanger_base",
+        "position": "4"
+    },
+    "overrides":
+    {
+        "extruder_nr":
+        {
+            "default_value": 4,
+            "maximum_value": 7
+        },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y" }
+    }
+}

--- a/resources/extruders/voron2_stealthchanger_extruder_5.def.json
+++ b/resources/extruders/voron2_stealthchanger_extruder_5.def.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "name": "Toolhead 5",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "voron2_stealthchanger_base",
+        "position": "5"
+    },
+    "overrides":
+    {
+        "extruder_nr":
+        {
+            "default_value": 5,
+            "maximum_value": 7
+        },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y" }
+    }
+}

--- a/resources/extruders/voron2_stealthchanger_extruder_6.def.json
+++ b/resources/extruders/voron2_stealthchanger_extruder_6.def.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "name": "Toolhead 6",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "voron2_stealthchanger_base",
+        "position": "6"
+    },
+    "overrides":
+    {
+        "extruder_nr":
+        {
+            "default_value": 6,
+            "maximum_value": 7
+        },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y" }
+    }
+}

--- a/resources/extruders/voron2_stealthchanger_extruder_7.def.json
+++ b/resources/extruders/voron2_stealthchanger_extruder_7.def.json
@@ -1,0 +1,25 @@
+{
+    "version": 2,
+    "name": "Toolhead 7",
+    "inherits": "fdmextruder",
+    "metadata":
+    {
+        "machine": "voron2_stealthchanger_base",
+        "position": "7"
+    },
+    "overrides":
+    {
+        "extruder_nr":
+        {
+            "default_value": 7,
+            "maximum_value": 7
+        },
+        "material_diameter": { "default_value": 1.75 },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y" }
+    }
+}

--- a/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.25.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.25.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = V6 0.25mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.25
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.30.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.30.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = V6 0.30mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.30
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.35.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.35.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = V6 0.35mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.35
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.40.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.40.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = V6 0.40mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.50.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.50.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = V6 0.50mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.5
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.60.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.60.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = V6 0.60mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.80.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_v6_0.80.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = V6 0.80mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_volcano_0.40.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_volcano_0.40.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = Volcano 0.40mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_volcano_0.60.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_volcano_0.60.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = Volcano 0.60mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_volcano_0.80.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_volcano_0.80.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = Volcano 0.80mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_volcano_1.00.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_volcano_1.00.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = Volcano 1.00mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 1.0
+

--- a/resources/variants/draftshift/voron2_stealthchanger_250_volcano_1.20.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_250_volcano_1.20.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_250
+name = Volcano 1.20mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 1.2
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.25.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.25.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = V6 0.25mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.25
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.30.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.30.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = V6 0.30mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.30
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.35.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.35.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = V6 0.35mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.35
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.40.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.40.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = V6 0.40mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.50.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.50.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = V6 0.50mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.5
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.60.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.60.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = V6 0.60mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.80.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_v6_0.80.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = V6 0.80mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_volcano_0.40.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_volcano_0.40.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = Volcano 0.40mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_volcano_0.60.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_volcano_0.60.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = Volcano 0.60mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_volcano_0.80.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_volcano_0.80.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = Volcano 0.80mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_volcano_1.00.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_volcano_1.00.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = Volcano 1.00mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 1.0
+

--- a/resources/variants/draftshift/voron2_stealthchanger_300_volcano_1.20.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_300_volcano_1.20.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_300
+name = Volcano 1.20mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 1.2
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.25.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.25.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = V6 0.25mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.25
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.30.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.30.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = V6 0.30mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.30
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.35.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.35.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = V6 0.35mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.35
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.40.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.40.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = V6 0.40mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.50.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.50.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = V6 0.50mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.5
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.60.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.60.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = V6 0.60mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.80.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_v6_0.80.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = V6 0.80mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_volcano_0.40.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_volcano_0.40.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = Volcano 0.40mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.4
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_volcano_0.60.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_volcano_0.60.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = Volcano 0.60mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.6
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_volcano_0.80.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_volcano_0.80.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = Volcano 0.80mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 0.8
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_volcano_1.00.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_volcano_1.00.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = Volcano 1.00mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 1.0
+

--- a/resources/variants/draftshift/voron2_stealthchanger_350_volcano_1.20.inst.cfg
+++ b/resources/variants/draftshift/voron2_stealthchanger_350_volcano_1.20.inst.cfg
@@ -1,0 +1,13 @@
+[general]
+definition = voron2_stealthchanger_350
+name = Volcano 1.20mm
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 23
+type = variant
+
+[values]
+machine_nozzle_size = 1.2
+


### PR DESCRIPTION
# Description

Add Printer Profiles for the DraftShift Design Voron2 based StealthChanger line.  Added to new manufacturer as more to come from other manufacturers, felt this was the best way to organize them, if you'd like them under VoronDesign, please let me know.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

- [x] Created new printer from profiles

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
