### PR TITLE
CURA-10899 Warn if experimental settings are used

### DIFF
--- a/.printer-linter
+++ b/.printer-linter
@@ -2,6 +2,7 @@ checks:
     diagnostic-mesh-file-extension: true
     diagnostic-mesh-file-size: true
     diagnostic-definition-redundant-override: true
+    diagnostic-definition-experimental-setting: true
     diagnostic-resources-macos-app-directory-name: true
     diagnostic-incorrect-formula: true
     diagnostic-resource-file-deleted: true

--- a/printer-linter/src/printerlinter/factory.py
+++ b/printer-linter/src/printerlinter/factory.py
@@ -14,10 +14,10 @@ def getLinter(file: Path, settings: dict) -> Optional[List[Linter]]:
     if not file.exists():
         return [Directory(file, settings)]
 
-    if ".inst" in file.suffixes and ".cfg" in file.suffixes:
+    if ".inst" in file.suffixes and file.suffixes[-1] == ".cfg":
         return [Directory(file, settings), Profile(file, settings), Formulas(file, settings)]
 
-    if ".def" in file.suffixes and ".json" in file.suffixes:
+    if ".def" in file.suffixes and file.suffixes[-1] == ".json":
         if file.stem in ("fdmprinter.def", "fdmextruder.def"):
             return  [Formulas(file, settings)]
         return [Directory(file, settings), Definition(file, settings), Formulas(file, settings)]

--- a/printer-linter/src/printerlinter/linters/defintion.py
+++ b/printer-linter/src/printerlinter/linters/defintion.py
@@ -14,6 +14,7 @@ class Definition(Linter):
         super().__init__(file, settings)
         self._definitions = {}
         self._definition_name = None
+        self._experimental_settings = []
         self._loadDefinitionFiles(file)
         self._content = self._file.read_text()
         self._loadExperimentalSettings()
@@ -176,7 +177,10 @@ class Definition(Linter):
         return False, None, None, None, None
 
     def _loadExperimentalSettings(self):
-        self._experimental_settings = self._definitions[self.base_def]["settings"]["experimental"]["children"].keys()
+        try:
+            self._experimental_settings = self._definitions[self.base_def]["settings"]["experimental"]["children"].keys()
+        except:
+            pass
 
     def _loadBasePrinterSettings(self):
         settings = {}

--- a/printer-linter/src/printerlinter/linters/defintion.py
+++ b/printer-linter/src/printerlinter/linters/defintion.py
@@ -109,7 +109,6 @@ class Definition(Linter):
                 if setting in self._experimental_settings:
                     redefined = re.compile(setting)
                     found = redefined.search(self._content)
-                    print(f"using exp setting {setting}")
                     yield Diagnostic(
                         file=self._file,
                         diagnostic_name="diagnostic-definition-experimental-setting",

--- a/printer-linter/src/printerlinter/linters/formulas.py
+++ b/printer-linter/src/printerlinter/linters/formulas.py
@@ -146,12 +146,13 @@ class Formulas(Linter):
 
         available_sections = ["values"]
         for section in available_sections:
-            options = config.options(section)
-            for option in options:
-                values ={}
-                values["value"] = config.get(section, option)
-                overrides[option] = values
-            file_data["overrides"]= overrides# Process the value here
+            if config.has_section(section):
+                options = config.options(section)
+                for option in options:
+                    values ={}
+                    values["value"] = config.get(section, option)
+                    overrides[option] = values
+                file_data["overrides"]= overrides# Process the value here
 
         return file_data
 

--- a/printer-linter/src/printerlinter/linters/profile.py
+++ b/printer-linter/src/printerlinter/linters/profile.py
@@ -37,6 +37,6 @@ class Profile(Linter):
         config = ConfigParser()
         config.read([self._file])
         name_of_profile = config.get("general", "name")
-        redefined = re.compile(name_of_profile)
+        redefined = re.compile(re.escape(name_of_profile))
         found = redefined.search(self._content)
         return name_of_profile, found


### PR DESCRIPTION
This adds a simple printer-linter check against any use of experimental settings in printer/extruder definitions.

It also fixes a few printer-linter crashes I encountered (see dedicated commits for details)

CURA-10899