### PR TITLE
Add setting for minimal prime tower shell thickness

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6902,6 +6902,20 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
+                "prime_tower_min_shell_thickness":
+                {
+                    "label": "Prime Tower Minimum Shell Thickness",
+                    "description": "The minimum thickness of the prime tower shell. You may increase it to make the prime tower stronger.",
+                    "unit": "mm",
+                    "type": "float",
+                    "default_value": 0.4,
+                    "minimum_value": "max(extruderValues('prime_tower_line_width'))",
+                    "maximum_value_warning": "10.0",
+                    "enabled": "prime_tower_enable and resolveOrValue('prime_tower_mode') == 'interleaved'",
+                    "resolve": "max(extruderValues('prime_tower_line_width'))",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
+                },
                 "prime_tower_position_x":
                 {
                     "label": "Prime Tower X Position",


### PR DESCRIPTION
This allows setting a minimal thickness for the interleaved prime tower. In some cases, the prime tower can become very thin and it may not be strong enough to support a high print. With this setting you can force some extra support to be printed, make the tower stronger but still not using too much filament.

![image](https://github.com/Ultimaker/Cura/assets/601114/bdb6fd7b-35b3-4063-8b28-9ff15baf2372)
![image](https://github.com/Ultimaker/Cura/assets/601114/6959828a-a942-47b5-927f-069638c15d1c)

Requires https://github.com/Ultimaker/CuraEngine/pull/2094