### PR TITLE
CURA-11795 Activate fans during switch

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4612,6 +4612,21 @@
                     "maximum_value": "365",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
+                },
+                "cool_during_extruder_switch":
+                {
+                    "label": "Cooling during extruder switch",
+                    "description": "<html>Whether to activate the cooling fans during a nozzle switch. This can help reducing oozing by cooling the nozzle faster:<ul><li><b>Unchanged:</b> keep the fans as they were previously</li><li><b>Only last extruder:</b> turn on the fan of the last used extruder, but turn the others off. This is useful if you have completely separate extruders.</li><li><b>All fans:</b> turn on all fans during nozzle switch. This is useful if you have multiple fans that stay close to each other.</li></ul></html>",
+                    "type": "enum",
+                    "options":
+                    {
+                        "unchanged": "Unchanged",
+                        "only_last_extruder": "Only last extruder",
+                        "all_fans": "All fans"
+                    },
+                    "default_value": "unchanged",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false
                 }
             }
         },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4616,7 +4616,7 @@
                 "cool_during_extruder_switch":
                 {
                     "label": "Cooling during extruder switch",
-                    "description": "<html>Whether to activate the cooling fans during a nozzle switch. This can help reducing oozing by cooling the nozzle faster:<ul><li><b>Unchanged:</b> keep the fans as they were previously</li><li><b>Only last extruder:</b> turn on the fan of the last used extruder, but turn the others off. This is useful if you have completely separate extruders.</li><li><b>All fans:</b> turn on all fans during nozzle switch. This is useful if you have multiple fans that stay close to each other.</li></ul></html>",
+                    "description": "<html>Whether to activate the cooling fans during a nozzle switch. This can help reducing oozing by cooling the nozzle faster:<ul><li><b>Unchanged:</b> keep the fans as they were previously</li><li><b>Only last extruder:</b> turn on the fan of the last used extruder, but turn the others off (if any). This is useful if you have completely separate extruders.</li><li><b>All fans:</b> turn on all fans during nozzle switch. This is useful if you have a single cooling fan, or multiple fans that stay close to each other.</li></ul></html>",
                     "type": "enum",
                     "options":
                     {

--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -36,6 +36,7 @@
         "bridge_wall_coast": { "value": 0 },
         "bridge_wall_material_flow": { "value": "wall_material_flow" },
         "bridge_wall_speed": { "value": "bridge_skin_speed" },
+        "cool_during_extruder_switch": { "value": "'all_fans'" },
         "cool_fan_speed_0": { "value": "cool_fan_speed_min" },
         "cool_fan_speed_max": { "value": "100" },
         "cool_min_layer_time": { "value": 6 },

--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -36,7 +36,6 @@
         "bridge_wall_coast": { "value": 0 },
         "bridge_wall_material_flow": { "value": "wall_material_flow" },
         "bridge_wall_speed": { "value": "bridge_skin_speed" },
-        "cool_during_extruder_switch": { "value": "'all_fans'" },
         "cool_fan_speed_0": { "value": "cool_fan_speed_min" },
         "cool_fan_speed_max": { "value": "100" },
         "cool_min_layer_time": { "value": 6 },

--- a/resources/extruders/ultimaker_methodx_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_left.def.json
@@ -14,9 +14,8 @@
             "default_value": 0,
             "maximum_value": "1"
         },
-        "machine_extruder_cooling_fan_number": { "default_value": 0 },
-        "machine_extruder_end_code": { "default_value": "G91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90" },
+        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodx_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_left.def.json
@@ -14,8 +14,9 @@
             "default_value": 0,
             "maximum_value": "1"
         },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
+        "machine_extruder_cooling_fan_number": { "default_value": 0 },
+        "machine_extruder_end_code": { "default_value": "G91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodx_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_left.def.json
@@ -14,6 +14,7 @@
             "default_value": 0,
             "maximum_value": "1"
         },
+        "machine_extruder_cooling_fan_number": { "default_value": 0 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
         "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
         "machine_extruder_start_code_duration": { "default_value": 8 },

--- a/resources/extruders/ultimaker_methodx_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_right.def.json
@@ -14,9 +14,8 @@
             "default_value": 1,
             "maximum_value": "1"
         },
-        "machine_extruder_cooling_fan_number": { "default_value": 1 },
-        "machine_extruder_end_code": { "default_value": "G91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90" },
+        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodx_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_right.def.json
@@ -14,6 +14,7 @@
             "default_value": 1,
             "maximum_value": "1"
         },
+        "machine_extruder_cooling_fan_number": { "default_value": 1 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
         "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
         "machine_extruder_start_code_duration": { "default_value": 8 },

--- a/resources/extruders/ultimaker_methodx_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_right.def.json
@@ -14,8 +14,9 @@
             "default_value": 1,
             "maximum_value": "1"
         },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
+        "machine_extruder_cooling_fan_number": { "default_value": 1 },
+        "machine_extruder_end_code": { "default_value": "G91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodxl_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_left.def.json
@@ -14,9 +14,8 @@
             "default_value": 0,
             "maximum_value": "1"
         },
-        "machine_extruder_cooling_fan_number": { "default_value": 0 },
-        "machine_extruder_end_code": { "default_value": "G91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90" },
+        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
         "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodxl_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_left.def.json
@@ -14,6 +14,7 @@
             "default_value": 0,
             "maximum_value": "1"
         },
+        "machine_extruder_cooling_fan_number": { "default_value": 0 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
         "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
         "machine_extruder_start_code_duration": { "default_value": 10 },

--- a/resources/extruders/ultimaker_methodxl_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_left.def.json
@@ -14,8 +14,9 @@
             "default_value": 0,
             "maximum_value": "1"
         },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
+        "machine_extruder_cooling_fan_number": { "default_value": 0 },
+        "machine_extruder_end_code": { "default_value": "G91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodxl_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_right.def.json
@@ -14,9 +14,8 @@
             "default_value": 1,
             "maximum_value": "1"
         },
-        "machine_extruder_cooling_fan_number": { "default_value": 1 },
-        "machine_extruder_end_code": { "default_value": "G91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90" },
+        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
         "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodxl_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_right.def.json
@@ -14,6 +14,7 @@
             "default_value": 1,
             "maximum_value": "1"
         },
+        "machine_extruder_cooling_fan_number": { "default_value": 1 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
         "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
         "machine_extruder_start_code_duration": { "default_value": 10 },

--- a/resources/extruders/ultimaker_methodxl_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_right.def.json
@@ -14,8 +14,9 @@
             "default_value": 1,
             "maximum_value": "1"
         },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed/100}" },
+        "machine_extruder_cooling_fan_number": { "default_value": 1 },
+        "machine_extruder_end_code": { "default_value": "G91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },


### PR DESCRIPTION
Add a new setting to better control the fans speeds during a nozzle switch. The purpose is to enable the fans while switching extruders in order to cool down the active extruder as quickly as possible to avoid oozing.

CURA-11795