### PR TITLE
Remove indirect conan dependency

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -9,7 +9,6 @@ requirements:
   - "dulcificum/latest@ultimaker/testing"
   - "pysavitar/5.3.0"
   - "pynest2d/5.3.0"
-  - "curaengine_grpc_definitions/0.2.0"
   - "native_cad_plugin/2.0.0"
 requirements_internal:
   - "fdm_materials/(latest)@internal/testing"

--- a/conanfile.py
+++ b/conanfile.py
@@ -329,7 +329,6 @@ class CuraConan(ConanFile):
         self.options["cpython"].shared = True
         self.options["boost"].header_only = True
         if self.settings.os == "Linux":
-            self.options["curaengine_grpc_definitions"].shared = True
             self.options["openssl"].shared = True
         if self.conf.get("user.curaengine:sentry_url", "", check_type=str) != "":
             self.options["curaengine"].enable_sentry = True


### PR DESCRIPTION
The curaengine_gprc_definitions package is not currently used directly by Cura, but only by CuraEngine. Thus it should not be defined here.