### PR TITLE
[CURA-11999] Disable 'temp should be defined in material' warning for now.

### DIFF
--- a/.printer-linter
+++ b/.printer-linter
@@ -6,7 +6,7 @@ checks:
     diagnostic-resources-macos-app-directory-name: true
     diagnostic-incorrect-formula: true
     diagnostic-resource-file-deleted: true
-    diagnostic-material-temperature-defined: true
+    diagnostic-material-temperature-defined: false
     diagnostic-long-profile-names: true
 fixes:
     diagnostic-definition-redundant-override: true


### PR DESCRIPTION
There was an entire ticket for this specific warning previously (CURA-10904) so I'm disabling it rather than removing it outright.