### PR TITLE
Trigger machine error checking during startup. Otherwise slicing often randomly fails.

### DIFF
--- a/cura/Machines/MachineErrorChecker.py
+++ b/cura/Machines/MachineErrorChecker.py
@@ -61,6 +61,7 @@ class MachineErrorChecker(QObject):
         self._machine_manager.globalContainerChanged.connect(self.startErrorCheck)
 
         self._onMachineChanged()
+        self.startErrorCheck()
 
     def _setCheckTimer(self) -> None:
         """A QTimer to regulate error check frequency


### PR DESCRIPTION
# Description

Cura slicing hangs fails randomly, all just because printers are initialized before MachineErrorChecker (on which slicing depends) and the asynchronous checks never trigger as the checker stays in faulty initial state.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Run cura, configure printer. close. run cura, try to silce (it will use the previously configured printer). it hangs for quite a long time, then gives unspecified error on every slicing.

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
