### PR TITLE
Significantly improve the speed of the version upgrader (and boot time!)

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1218,6 +1218,8 @@ class CuraApplication(QtApplication):
             # Once we're at this point, everything should have been flushed already (past OnExitCallbackManager).
             # It's more difficult to call sys.exit(0): That requires that it happens as the result of a pyqtSignal-emit.
             # (See https://doc.qt.io/qt-6/qcoreapplication.html#quit)
+            # WARNING: With this in place you CAN NOT use cProfile. You will need to replace the next line with pass
+            # for it to work!
             os._exit(0)
 
         return super().event(event)

--- a/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
+++ b/plugins/VersionUpgrade/VersionUpgrade22to24/VersionUpgrade.py
@@ -152,9 +152,3 @@ class VersionUpgrade22to24(VersionUpgrade):
         config.write(output)
         return [filename], [output.getvalue()]
 
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version

--- a/plugins/VersionUpgrade/VersionUpgrade27to30/VersionUpgrade27to30.py
+++ b/plugins/VersionUpgrade/VersionUpgrade27to30/VersionUpgrade27to30.py
@@ -33,23 +33,6 @@ _renamed_i18n = {
 
 
 class VersionUpgrade27to30(VersionUpgrade):
-    ##  Gets the version number from a CFG file in Uranium's 2.7 format.
-    #
-    #   Since the format may change, this is implemented for the 2.7 format only
-    #   and needs to be included in the version upgrade system rather than
-    #   globally in Uranium.
-    #
-    #   \param serialised The serialised form of a CFG file.
-    #   \return The version number stored in the CFG file.
-    #   \raises ValueError The format of the version number in the file is
-    #   incorrect.
-    #   \raises KeyError The format of the file is incorrect.
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version")) #Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
 
     ##  Upgrades a preferences file from version 2.7 to 3.0.
     #

--- a/plugins/VersionUpgrade/VersionUpgrade460to462/VersionUpgrade460to462.py
+++ b/plugins/VersionUpgrade/VersionUpgrade460to462/VersionUpgrade460to462.py
@@ -33,12 +33,6 @@ default_qualities_per_nozzle_and_material = {
 
 
 class VersionUpgrade460to462(VersionUpgrade):
-    def getCfgVersion(self, serialised: str) -> int:
-        parser = configparser.ConfigParser(interpolation = None)
-        parser.read_string(serialised)
-        format_version = int(parser.get("general", "version"))  # Explicitly give an exception when this fails. That means that the file format is not recognised.
-        setting_version = int(parser.get("metadata", "setting_version", fallback = "0"))
-        return format_version * 1000000 + setting_version
 
     def upgradePreferences(self, serialized: str, filename: str) -> Tuple[List[str], List[str]]:
         """


### PR DESCRIPTION
This knocked about 10 seconds from my boot time. Huzzah :D

The issue was basically that the old style getCFG version was being used. These still used the full cfg config parser which isn't fast. So by removing these functions it becomes a lot faster! 