### PR TITLE
Only allow prepend settings to be disabled

### DIFF
--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -554,12 +554,16 @@ class StartSliceJob(Job):
         start_gcode = settings["machine_start_gcode"]
         # Remove all the comments from the start g-code
         start_gcode = re.sub(r";.+?(\n|$)", "\n", start_gcode)
-        bed_temperature_settings = ["material_bed_temperature", "material_bed_temperature_layer_0"]
-        pattern = r"\{(%s)(,\s?\w+)?\}" % "|".join(bed_temperature_settings) # match {setting} as well as {setting, extruder_nr}
-        settings["material_bed_temp_prepend"] = re.search(pattern, start_gcode) == None
-        print_temperature_settings = ["material_print_temperature", "material_print_temperature_layer_0", "default_material_print_temperature", "material_initial_print_temperature", "material_final_print_temperature", "material_standby_temperature", "print_temperature"]
-        pattern = r"\{(%s)(,\s?\w+)?\}" % "|".join(print_temperature_settings) # match {setting} as well as {setting, extruder_nr}
-        settings["material_print_temp_prepend"] = re.search(pattern, start_gcode) is None
+
+        if settings["material_bed_temp_prepend"]:
+            bed_temperature_settings = ["material_bed_temperature", "material_bed_temperature_layer_0"]
+            pattern = r"\{(%s)(,\s?\w+)?\}" % "|".join(bed_temperature_settings) # match {setting} as well as {setting, extruder_nr}
+            settings["material_bed_temp_prepend"] = re.search(pattern, start_gcode) == None
+
+        if settings["material_print_temp_prepend"]:
+            print_temperature_settings = ["material_print_temperature", "material_print_temperature_layer_0", "default_material_print_temperature", "material_initial_print_temperature", "material_final_print_temperature", "material_standby_temperature", "print_temperature"]
+            pattern = r"\{(%s)(,\s?\w+)?\}" % "|".join(print_temperature_settings) # match {setting} as well as {setting, extruder_nr}
+            settings["material_print_temp_prepend"] = re.search(pattern, start_gcode) is None
 
         # Replace the setting tokens in start and end g-code.
         # Use values from the first used extruder by default so we get the expected temperatures


### PR DESCRIPTION
When the printer settings say they should be disabled, they could previously be enabled if the start GCode didn't contain temperature commands. Now we can only enable them if initially enabled.

This change is not actually required by the described bug, but it makes what users expect. We currently have printers definitions which override the default value of `material_print_temp_prepend` to `False`, and this was ignored. We now take care of it as described in the setting documentation.

Related to CURA-11967