### PR TITLE
CURA-12005 Include slicemetadata in makerbot file

### DIFF
--- a/plugins/MakerbotWriter/MakerbotWriter.py
+++ b/plugins/MakerbotWriter/MakerbotWriter.py
@@ -137,6 +137,9 @@ class MakerbotWriter(MeshWriter):
                 for png_file in png_files:
                     file, data = png_file["file"], png_file["data"]
                     zip_stream.writestr(file, data)
+                api = CuraApplication.getInstance().getCuraAPI()
+                slice_metadata = json.dumps(api.interface.settings.getSliceMetadata(), separators=(", ", ": "), indent=4)
+                zip_stream.writestr("slicemetadata.json", slice_metadata)
         except (IOError, OSError, BadZipFile) as ex:
             Logger.log("e", f"Could not write to (.makerbot) file because: '{ex}'.")
             self.setInformation(catalog.i18nc("@error", "MakerbotWriter could not save to the designated path."))


### PR DESCRIPTION
Include the very same file as generted into UFP files. The existing export method has been moved from UFPWriter top `API/Settings` in order to make it easily callable by the two plugins.

:warning: In the makerbot archive, the file is placed at the root with the other files, because there is no folder structure. In the UFP this file is placed in the `Cura` subfolder.