### PR TITLE
Revert "Bump gradual flow plugin version"

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -5,7 +5,7 @@ requirements:
   - "curaengine/5.8.0-beta.1"
   - "cura_binary_data/5.8.0-beta.1"
   - "fdm_materials/5.8.0-beta.1"
-  - "curaengine_plugin_gradual_flow/0.1.0-beta.3"
+  - "curaengine_plugin_gradual_flow/0.1.0-beta.4"
   - "dulcificum/0.2.1"
   - "pysavitar/5.3.0"
   - "pynest2d/5.3.0"


### PR DESCRIPTION
This bump was not really required because the new grpc_definition is retro-compatible with the previous one, and bumping the version currently breaks the profiles settings which depend on a specific version.

Wait for the plugins settings to be refactored, or make an upgrade script.

CURA-12039