### PR TITLE
Fix UM to savitar transformation in 3MFWriter

### DIFF
--- a/plugins/3MFWriter/ThreeMFWriter.py
+++ b/plugins/3MFWriter/ThreeMFWriter.py
@@ -114,22 +114,24 @@ class ThreeMFWriter(MeshWriter):
 
         mesh_data = um_node.getMeshData()
 
+        node_matrix = um_node.getLocalTransformation()
+        node_matrix.preMultiply(transformation)
+        
         if center_mesh:
-            node_matrix = Matrix()
+            center_matrix = Matrix()
             # compensate for original center position, if object(s) is/are not around its zero position
             if mesh_data is not None:
                 extents = mesh_data.getExtents()
                 if extents is not None:
                     # We use a different coordinate space while writing, so flip Z and Y
-                    center_vector = Vector(extents.center.x, extents.center.y, extents.center.z)
-                    node_matrix.setByTranslation(center_vector)
-            node_matrix.multiply(um_node.getLocalTransformation())
-        else:
-            node_matrix = um_node.getLocalTransformation()
+                    center_vector = Vector(-extents.center.x, -extents.center.y, -extents.center.z)
+                    center_matrix.setByTranslation(center_vector)
+            node_matrix.preMultiply(center_matrix)
 
-        matrix_string = ThreeMFWriter._convertMatrixToString(node_matrix.preMultiply(transformation))
+        matrix_string = ThreeMFWriter._convertMatrixToString(node_matrix)
 
         savitar_node.setTransformation(matrix_string)
+
         if mesh_data is not None:
             savitar_node.getMeshData().setVerticesFromBytes(mesh_data.getVerticesAsByteArray())
             indices_array = mesh_data.getIndicesAsByteArray()


### PR DESCRIPTION
# Description

The transformation from UM to savitar in the 3MFWriter does not invert the transformation in the 3MFReader. This usually doesn't cause any problems as the center mesh extension is zero and the resulting matrix the identity. However if the extent is not zero the final transformation is incorrect.

I fixed the transformation as shown below

## 3MFReader (savitar to UM)

$$
T_{\text{UM}} = T_{\text{Printer}} \cdot T_{\text{Centre}} \cdot T_{\text{Savitor}}
$$

## 3MFWriter (UM to savitar)
**Fixed implementation**

$$
T_{\text{Savitor}} = T_{\text{Centre}}^{-1} \cdot T_{\text{Printer}}^{-1} \cdot T_{\text{UM}}
$$

**Current implementation**

$$
T_{\text{Savitor}} = T_{\text{Printer}}^{-1} \cdot T_{\text{Centre}} \cdot T_{\text{UM}}
$$

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Opened, saved and reopened multiple projects and the objects reload in the same position as expected

**Test Configuration**:
* Operating System:

Windows 11

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
