### PR TITLE
CURA-10914 Order backend plugins by name

### DIFF
--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -366,7 +366,12 @@ class StartSliceJob(Job):
         for extruder_stack in global_stack.extruderList:
             self._buildExtruderMessage(extruder_stack)
 
-        for plugin in CuraApplication.getInstance().getBackendPlugins():
+        backend_plugins = CuraApplication.getInstance().getBackendPlugins()
+
+        # Sort backend plugins by name. Not a very good strategy, but at least it is repeatable. This will be improved later.
+        backend_plugins = sorted(backend_plugins, key=lambda backend_plugin: backend_plugin.getId())
+
+        for plugin in backend_plugins:
             if not plugin.usePlugin():
                 continue
             for slot in plugin.getSupportedSlots():


### PR DESCRIPTION
The engine processes the plugins based on the order they were given in. By ordering them beforehand, we ensure that they will always be processed with the same logic.

CURA-10914