### PR TITLE
Add "instance0" entry to gaggles

### DIFF
--- a/plugins/MakerbotWriter/MakerbotWriter.py
+++ b/plugins/MakerbotWriter/MakerbotWriter.py
@@ -70,6 +70,8 @@ class MakerbotWriter(MeshWriter):
             return
         try:
             snapshot = Snapshot.isometricSnapshot(width, height)
+            snapshot.save(
+                "/Users/c.lamboo/Library/Application Support/cura/5.7/plugins/ElegooNeptune3Thumbnails/ElegooNeptune3Thumbnails/img/b.png")
 
             thumbnail_buffer = QBuffer()
             thumbnail_buffer.open(QBuffer.OpenModeFlag.WriteOnly)
@@ -231,7 +233,7 @@ class MakerbotWriter(MeshWriter):
             "printMode": CuraApplication.getInstance().getIntentManager().currentIntentCategory,
         }
 
-        meta["miracle_config"] = {"gaggles": {str(node.getName()): {} for node in nodes}}
+        meta["miracle_config"] = {"gaggles": {"instance0": {}}}
 
         version_info = dict()
         cura_engine_info = ConanInstalls.get("curaengine", {"version": "unknown", "revision": "unknown"})

--- a/plugins/MakerbotWriter/MakerbotWriter.py
+++ b/plugins/MakerbotWriter/MakerbotWriter.py
@@ -70,8 +70,6 @@ class MakerbotWriter(MeshWriter):
             return
         try:
             snapshot = Snapshot.isometricSnapshot(width, height)
-            snapshot.save(
-                "/Users/c.lamboo/Library/Application Support/cura/5.7/plugins/ElegooNeptune3Thumbnails/ElegooNeptune3Thumbnails/img/b.png")
 
             thumbnail_buffer = QBuffer()
             thumbnail_buffer.open(QBuffer.OpenModeFlag.WriteOnly)


### PR DESCRIPTION
With the commits https://github.com/Ultimaker/Cura/commit/fdfc5dcc67f8efac60404421e86b357b5ef3a5af and https://github.com/Ultimaker/Cura/commit/2f8fc2cabef19b23f2d024105b21ad7ccd5b09a4 the instance list was changed from containing all model instances to a single instance called "instance0". Digital factory expects the same instances to be present in the gaggles object.