### PR TITLE
[CURA-11958] fix auto-select `.makerbot` format

### DIFF
--- a/cura/Settings/GlobalStack.py
+++ b/cura/Settings/GlobalStack.py
@@ -83,6 +83,15 @@ class GlobalStack(CuraContainerStack):
         """
         return self.getMetaDataEntry("supports_material_export", False)
 
+    @pyqtProperty("QVariantList", constant = True)
+    def getOutputFileFormats(self) -> List[str]:
+        """
+        Which output formats the printer supports.
+        :return: A list of strings with MIME-types.
+        """
+        all_formats_str = self.getMetaDataEntry("file_formats", "")
+        return all_formats_str.split(";")
+
     @classmethod
     def getLoadingPriority(cls) -> int:
         return 2

--- a/plugins/DigitalLibrary/resources/qml/SaveProjectFilesPage.qml
+++ b/plugins/DigitalLibrary/resources/qml/SaveProjectFilesPage.qml
@@ -208,7 +208,7 @@ Item
         anchors.rightMargin: UM.Theme.getSize("thin_margin").height
 
         enabled: UM.Backend.state == UM.Backend.Done
-        currentIndex: UM.Backend.state == UM.Backend.Done ? dfFilenameTextfield.text.startsWith("MM")? 1 : 0 : 2
+        currentIndex: UM.Backend.state == UM.Backend.Done ? (Cura.MachineManager.activeMachine.getOutputFileFormats.includes("application/x-makerbot") ? 1 : 0) : 2
 
         textRole: "text"
         valueRole: "value"


### PR DESCRIPTION
Fix a bug where the auto-selection of the right format didn't happen, because the old (hacky) condition on which this was decided is no longer valid.