### PR TITLE
Profile corrections for final 5.8 release

### DIFF
--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -129,7 +129,6 @@
         "support_line_distance": { "minimum_value_warning": "0 if support_structure == 'tree' else support_line_width" },
         "support_tower_maximum_supported_diameter": { "value": "support_tower_diameter" },
         "support_tower_roof_angle": { "value": "0 if support_interface_enable else 65" },
-        "support_use_towers": { "value": false },
         "support_wall_count": { "value": "1 if support_structure == 'tree' else 0" },
         "support_xy_distance_overhang": { "value": "0.2" },
         "support_z_distance": { "value": "0" },
@@ -139,7 +138,8 @@
         "wall_x_material_flow_layer_0": { "value": "0.95 * material_flow_layer_0" },
         "xy_offset": { "value": "-layer_height * 0.1" },
         "xy_offset_layer_0": { "value": "-wall_line_width_0 / 5 + xy_offset" },
-        "z_seam_corner": { "value": "'z_seam_corner_none'" },
+        "z_seam_corner": { "value": "'z_seam_corner_weighted'" },
+        "z_seam_relative": { "value": "True" },
         "zig_zaggify_support": { "value": true }
     }
 }

--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -405,6 +405,7 @@
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "4*support_infill_sparse_thickness" },
         "support_interface_material_flow": { "value": "material_flow" },
+        "support_interface_offset": { "value": "1" },
         "support_interface_pattern": { "value": "'lines'" },
         "support_interface_wall_count": { "value": "1" },
         "support_material_flow": { "value": "material_flow" },

--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -413,6 +413,7 @@
         "support_roof_height": { "value": "4*layer_height" },
         "support_roof_material_flow": { "value": "material_flow" },
         "support_supported_skin_fan_speed": { "value": "cool_fan_speed_max" },
+        "support_use_towers": { "value": "False" },
         "support_wall_count": { "value": "2 if support_conical_enabled or support_structure == 'tree' else 0" },
         "support_xy_distance": { "value": 0.2 },
         "support_xy_distance_overhang": { "value": "support_xy_distance" },

--- a/resources/quality/ultimaker_method/um_method_1c_um-nylon12-cf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_method/um_method_1c_um-nylon12-cf-175_0.2mm.inst.cfg
@@ -38,7 +38,6 @@ support_bottom_stair_step_height = 0
 support_infill_rate = 12.0
 support_line_width = =line_width * 0.75
 support_roof_density = 85
-support_use_towers = True
 support_xy_distance = 0.3
 support_z_distance = 0.25
 

--- a/resources/quality/ultimaker_method/um_method_2a_um-pva-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_method/um_method_2a_um-pva-175_0.2mm.inst.cfg
@@ -56,14 +56,14 @@ support_conical_min_width = 20
 support_fan_enable = False
 support_infill_density_multiplier_initial_layer = 2
 support_infill_rate = 12
-support_interface_offset = 1
+support_interface_offset = 0
 support_interface_wall_count = 2
 support_offset = 1.8
 support_pattern = grid
 support_roof_density = 95
 support_roof_height = =layer_height*8
-support_roof_line_width = 0.25
-support_top_distance = 0.4
+support_roof_line_width = 0.4
+support_use_towers = True
 switch_extruder_extra_prime_amount = 1
 switch_extruder_retraction_amount = 2.5
 switch_extruder_retraction_speeds = 3

--- a/resources/quality/ultimaker_method/um_method_labs_um-nylon12-cf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_method/um_method_labs_um-nylon12-cf-175_0.2mm.inst.cfg
@@ -38,7 +38,6 @@ support_bottom_stair_step_height = 0
 support_infill_rate = 12.0
 support_line_width = =line_width * 0.75
 support_roof_density = 85
-support_use_towers = True
 support_xy_distance = 0.3
 support_z_distance = 0.25
 

--- a/resources/quality/ultimaker_methodx/um_methodx_1c_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1c_um-abscf-175_0.2mm.inst.cfg
@@ -50,7 +50,6 @@ support_line_width = 0.35
 support_material_flow = 90
 support_roof_density = 82
 support_roof_line_width = 0.4
-support_use_towers = True
 support_xy_distance = 0.3
 support_xy_distance_overhang = 0.25
 support_z_distance = 0.15

--- a/resources/quality/ultimaker_methodx/um_methodx_1c_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1c_um-abscf-175_0.2mm.inst.cfg
@@ -45,7 +45,6 @@ support_bottom_stair_step_height = 0
 support_fan_enable = False
 support_infill_angles = [ 45,45,45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135,135,135]
 support_infill_rate = 15.0
-support_interface_offset = 1.2
 support_line_width = 0.35
 support_material_flow = 90
 support_roof_density = 82

--- a/resources/quality/ultimaker_methodx/um_methodx_1c_um-absr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1c_um-absr-175_0.2mm.inst.cfg
@@ -55,7 +55,6 @@ support_roof_density = 85
 support_roof_wall_count = 1
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodx/um_methodx_1c_um-asa-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1c_um-asa-175_0.2mm.inst.cfg
@@ -52,7 +52,6 @@ support_material_flow = =0.85*material_flow
 support_roof_density = 85
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodx/um_methodx_1c_um-nylon12-cf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1c_um-nylon12-cf-175_0.2mm.inst.cfg
@@ -38,7 +38,6 @@ support_bottom_stair_step_height = 0
 support_infill_rate = 12.0
 support_line_width = =line_width * 0.75
 support_roof_density = 85
-support_use_towers = True
 support_xy_distance = 0.3
 support_z_distance = 0.25
 

--- a/resources/quality/ultimaker_methodx/um_methodx_1xa_um-absr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1xa_um-absr-175_0.2mm.inst.cfg
@@ -55,7 +55,6 @@ support_roof_density = 85
 support_roof_wall_count = 1
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodx/um_methodx_1xa_um-asa-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1xa_um-asa-175_0.2mm.inst.cfg
@@ -52,7 +52,6 @@ support_material_flow = =0.85*material_flow
 support_roof_density = 85
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodx/um_methodx_2a_um-pva-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_2a_um-pva-175_0.2mm.inst.cfg
@@ -56,14 +56,14 @@ support_conical_min_width = 20
 support_fan_enable = False
 support_infill_density_multiplier_initial_layer = 2
 support_infill_rate = 12
-support_interface_offset = 1
+support_interface_offset = 0
 support_interface_wall_count = 2
 support_offset = 1.8
 support_pattern = grid
 support_roof_density = 95
 support_roof_height = =layer_height*8
-support_roof_line_width = 0.25
-support_top_distance = 0.4
+support_roof_line_width = 0.4
+support_use_towers = True
 switch_extruder_extra_prime_amount = 1
 switch_extruder_retraction_amount = 2.5
 switch_extruder_retraction_speeds = 3

--- a/resources/quality/ultimaker_methodx/um_methodx_2xa_um-rapidrinse-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_2xa_um-rapidrinse-175_0.2mm.inst.cfg
@@ -32,10 +32,11 @@ support_conical_angle = 20
 support_conical_enabled = True
 support_conical_min_width = 20
 support_fan_enable = False
-support_interface_offset = 1
+support_interface_offset = 0
 support_interface_wall_count = 2
 support_offset = 1.8
 support_roof_height = =5*layer_height
 support_roof_line_width = 0.25
+support_use_towers = True
 support_xy_distance_overhang = 0.15
 

--- a/resources/quality/ultimaker_methodx/um_methodx_2xa_um-sr30-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_2xa_um-sr30-175_0.2mm.inst.cfg
@@ -36,8 +36,9 @@ support_conical_angle = 20
 support_conical_enabled = True
 support_conical_min_width = 20
 support_fan_enable = False
-support_interface_offset = 1
+support_interface_offset = 0
 support_interface_wall_count = 2
 support_offset = 0.8
 support_roof_height = =5*layer_height
+support_use_towers = True
 

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-abscf-175_0.2mm.inst.cfg
@@ -50,7 +50,6 @@ support_line_width = 0.35
 support_material_flow = 90
 support_roof_density = 82
 support_roof_line_width = 0.4
-support_use_towers = True
 support_xy_distance = 0.3
 support_xy_distance_overhang = 0.25
 support_z_distance = 0.15

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-abscf-175_0.2mm.inst.cfg
@@ -45,7 +45,6 @@ support_bottom_stair_step_height = 0
 support_fan_enable = False
 support_infill_angles = [ 45,45,45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135,135,135]
 support_infill_rate = 15.0
-support_interface_offset = 1.2
 support_line_width = 0.35
 support_material_flow = 90
 support_roof_density = 82

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm.inst.cfg
@@ -55,7 +55,6 @@ support_roof_density = 85
 support_roof_wall_count = 1
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-asa-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-asa-175_0.2mm.inst.cfg
@@ -52,7 +52,6 @@ support_material_flow = =0.85*material_flow
 support_roof_density = 85
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-nylon12-cf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-nylon12-cf-175_0.2mm.inst.cfg
@@ -38,7 +38,6 @@ support_bottom_stair_step_height = 0
 support_infill_rate = 12.0
 support_line_width = =line_width * 0.75
 support_roof_density = 85
-support_use_towers = True
 support_xy_distance = 0.3
 support_z_distance = 0.25
 

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-abscf-175_0.2mm.inst.cfg
@@ -47,7 +47,6 @@ support_bottom_stair_step_height = 0
 support_fan_enable = False
 support_infill_angles = [ 45,45,45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135,135,135]
 support_infill_rate = 15.0
-support_interface_offset = 1.2
 support_line_width = 0.35
 support_material_flow = 90
 support_roof_density = 82

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-abscf-175_0.2mm.inst.cfg
@@ -52,7 +52,6 @@ support_line_width = 0.35
 support_material_flow = 90
 support_roof_density = 82
 support_roof_line_width = 0.4
-support_use_towers = True
 support_xy_distance = 0.3
 support_xy_distance_overhang = 0.25
 support_z_distance = 0.15

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-absr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-absr-175_0.2mm.inst.cfg
@@ -54,7 +54,6 @@ support_roof_density = 85
 support_roof_wall_count = 1
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-asa-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-asa-175_0.2mm.inst.cfg
@@ -52,7 +52,6 @@ support_material_flow = =0.85*material_flow
 support_roof_density = 85
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-nylon12-cf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-nylon12-cf-175_0.2mm.inst.cfg
@@ -38,7 +38,6 @@ support_bottom_stair_step_height = 0
 support_infill_rate = 12.0
 support_line_width = =line_width * 0.75
 support_roof_density = 85
-support_use_towers = True
 support_xy_distance = 0.3
 support_z_distance = 0.25
 

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-absr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-absr-175_0.2mm.inst.cfg
@@ -54,7 +54,6 @@ support_roof_density = 85
 support_roof_wall_count = 1
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-asa-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-asa-175_0.2mm.inst.cfg
@@ -52,7 +52,6 @@ support_material_flow = =0.85*material_flow
 support_roof_density = 85
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodxl/um_methodxl_2a_um-pva-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_2a_um-pva-175_0.2mm.inst.cfg
@@ -56,14 +56,14 @@ support_conical_min_width = 20
 support_fan_enable = False
 support_infill_density_multiplier_initial_layer = 2
 support_infill_rate = 12
-support_interface_offset = 1
+support_interface_offset = 0
 support_interface_wall_count = 2
 support_offset = 1.8
 support_pattern = grid
 support_roof_density = 95
 support_roof_height = =layer_height*8
-support_roof_line_width = 0.25
-support_top_distance = 0.4
+support_roof_line_width = 0.4
+support_use_towers = True
 switch_extruder_extra_prime_amount = 1
 switch_extruder_retraction_amount = 2.5
 switch_extruder_retraction_speeds = 3

--- a/resources/quality/ultimaker_methodxl/um_methodxl_2xa_um-rapidrinse-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_2xa_um-rapidrinse-175_0.2mm.inst.cfg
@@ -32,10 +32,11 @@ support_conical_angle = 20
 support_conical_enabled = True
 support_conical_min_width = 20
 support_fan_enable = False
-support_interface_offset = 1
+support_interface_offset = 0
 support_interface_wall_count = 2
 support_offset = 1.8
 support_roof_height = =5*layer_height
 support_roof_line_width = 0.25
+support_use_towers = True
 support_xy_distance_overhang = 0.15
 

--- a/resources/quality/ultimaker_methodxl/um_methodxl_2xa_um-sr30-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_2xa_um-sr30-175_0.2mm.inst.cfg
@@ -36,8 +36,9 @@ support_conical_angle = 20
 support_conical_enabled = True
 support_conical_min_width = 20
 support_fan_enable = False
-support_interface_offset = 1
+support_interface_offset = 0
 support_interface_wall_count = 2
 support_offset = 0.8
 support_roof_height = =5*layer_height
+support_use_towers = True
 

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-abscf-175_0.2mm.inst.cfg
@@ -47,7 +47,6 @@ support_bottom_stair_step_height = 0
 support_fan_enable = False
 support_infill_angles = [ 45,45,45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135,135,135]
 support_infill_rate = 15.0
-support_interface_offset = 1.2
 support_line_width = 0.35
 support_material_flow = 90
 support_roof_density = 82

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-abscf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-abscf-175_0.2mm.inst.cfg
@@ -52,7 +52,6 @@ support_line_width = 0.35
 support_material_flow = 90
 support_roof_density = 82
 support_roof_line_width = 0.4
-support_use_towers = True
 support_xy_distance = 0.3
 support_xy_distance_overhang = 0.25
 support_z_distance = 0.15

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm.inst.cfg
@@ -54,7 +54,6 @@ support_roof_density = 85
 support_roof_wall_count = 1
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-asa-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-asa-175_0.2mm.inst.cfg
@@ -52,7 +52,6 @@ support_material_flow = =0.85*material_flow
 support_roof_density = 85
 support_supported_skin_fan_speed = 60.0
 support_top_distance = =support_z_distance
-support_use_towers = False
 support_xy_distance = 0.35
 support_xy_distance_overhang = 0.25
 support_xy_overrides_z = xy_overrides_z

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-nylon12-cf-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-nylon12-cf-175_0.2mm.inst.cfg
@@ -38,7 +38,6 @@ support_bottom_stair_step_height = 0
 support_infill_rate = 12.0
 support_line_width = =line_width * 0.75
 support_roof_density = 85
-support_use_towers = True
 support_xy_distance = 0.3
 support_z_distance = 0.25
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-abs_0.1mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-petg_0.1mm.inst.cfg
@@ -66,7 +66,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-pla_0.1mm.inst.cfg
@@ -66,7 +66,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-tough-pla_0.1mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
@@ -69,7 +69,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
@@ -74,7 +74,5 @@ top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_x_material_flow = =1.05 * wall_material_flow
 wall_x_material_flow_roofing = =wall_material_flow
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
@@ -71,7 +71,5 @@ support_z_distance = 0.4
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.06mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
@@ -73,7 +73,5 @@ top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_x_material_flow = =1.1 * wall_material_flow
 wall_x_material_flow_roofing = =wall_material_flow
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
@@ -70,7 +70,5 @@ support_z_distance = 0.4
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.06mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.1mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
@@ -73,7 +73,5 @@ top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_x_material_flow = =1.1 * wall_material_flow
 wall_x_material_flow_roofing = =wall_material_flow
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
@@ -70,7 +70,5 @@ support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.06mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -69,7 +69,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.35
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.1mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -73,7 +73,5 @@ top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_x_material_flow = =1.1 * wall_material_flow
 wall_x_material_flow_roofing = =wall_material_flow
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -71,7 +71,5 @@ support_z_distance = 0.4
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
@@ -71,7 +71,5 @@ support_interface_enable = False
 support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
@@ -69,7 +69,5 @@ support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
@@ -69,7 +69,5 @@ support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
@@ -70,7 +70,5 @@ support_interface_enable = False
 support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
@@ -70,7 +70,5 @@ support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
@@ -70,7 +70,5 @@ support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
@@ -70,7 +70,5 @@ support_interface_enable = False
 support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
@@ -68,7 +68,5 @@ support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
@@ -68,7 +68,5 @@ support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -71,7 +71,5 @@ support_interface_enable = False
 support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -69,7 +69,5 @@ support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -69,7 +69,5 @@ support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-abs_0.1mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-petg_0.1mm.inst.cfg
@@ -66,7 +66,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-pla_0.1mm.inst.cfg
@@ -66,7 +66,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-tough-pla_0.1mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
@@ -69,7 +69,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
@@ -74,7 +74,5 @@ top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_x_material_flow = =1.05 * wall_material_flow
 wall_x_material_flow_roofing = =wall_material_flow
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
@@ -71,7 +71,5 @@ support_z_distance = 0.4
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.06mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
@@ -73,7 +73,5 @@ top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_x_material_flow = =1.1 * wall_material_flow
 wall_x_material_flow_roofing = =wall_material_flow
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
@@ -70,7 +70,5 @@ support_z_distance = 0.4
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.06mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.1mm.inst.cfg
@@ -67,7 +67,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
@@ -73,7 +73,5 @@ top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_x_material_flow = =1.1 * wall_material_flow
 wall_x_material_flow_roofing = =wall_material_flow
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
@@ -70,7 +70,5 @@ support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.06mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -69,7 +69,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.35
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.1mm.inst.cfg
@@ -68,7 +68,5 @@ support_top_distance = =support_z_distance
 support_z_distance = 0.3
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -73,7 +73,5 @@ top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_x_material_flow = =1.1 * wall_material_flow
 wall_x_material_flow_roofing = =wall_material_flow
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -71,7 +71,5 @@ support_z_distance = 0.4
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
@@ -71,7 +71,5 @@ support_interface_enable = False
 support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
@@ -69,7 +69,5 @@ support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
@@ -69,7 +69,5 @@ support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
@@ -70,7 +70,5 @@ support_interface_enable = False
 support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
@@ -70,7 +70,5 @@ support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
@@ -70,7 +70,5 @@ support_structure = tree
 top_bottom_thickness = =max(1.2 , layer_height * 6)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
@@ -70,7 +70,5 @@ support_interface_enable = False
 support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
@@ -68,7 +68,5 @@ support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
@@ -68,7 +68,5 @@ support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -71,7 +71,5 @@ support_interface_enable = False
 support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -69,7 +69,5 @@ support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -69,7 +69,5 @@ support_structure = tree
 top_bottom_thickness = =max(1 , layer_height * 5)
 wall_0_wipe_dist = 0.8
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
-z_seam_relative = True
-z_seam_type = back
 zig_zaggify_infill = True
 


### PR DESCRIPTION
* Fix z distance Method PVA from 0.4 to 0 and interface line width from 0.25mm to 0.4mm
* Set seam position to sharpest corner + smart hiding (all Ultimaker machines, [not affecting Method machines, was already set to this])
* Enable Use support towers for Method supports materials and all Ultimaker materials, disable for Method model materials.
* Interface support horizontal expansion: 0mm for all Method support materials

PP-504