### PR TITLE
[CURA-12050] Start using the 'force_depends_on_settings' property.

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -414,6 +414,9 @@ class CuraApplication(QtApplication):
         SettingDefinition.addSupportedProperty("settable_globally", DefinitionPropertyType.Any, default=True,
                                                read_only=True)
 
+        SettingDefinition.addSupportedProperty("force_depends_on_settings", DefinitionPropertyType.Any, default=[],
+                                               read_only=True)
+
         # From which stack the setting would inherit if not defined per object (handled in the engine)
         # AND for settings which are not settable_per_mesh:
         # which extruder is the only extruder this setting is obtained from

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6499,7 +6499,8 @@
                     "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
-                    "limit_to_extruder": "raft_interface_extruder_nr"
+                    "limit_to_extruder": "raft_interface_extruder_nr",
+                    "force_depends_on_settings": [ "raft_base_thickness" ]
                 },
                 "raft_interface_line_spacing":
                 {
@@ -6515,7 +6516,8 @@
                     "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
-                    "limit_to_extruder": "raft_interface_extruder_nr"
+                    "limit_to_extruder": "raft_interface_extruder_nr",
+                    "force_depends_on_settings": [ "raft_base_thickness" ]
                 },
                 "raft_interface_z_offset":
                 {
@@ -6531,7 +6533,8 @@
                     "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
-                    "limit_to_extruder": "raft_interface_extruder_nr"
+                    "limit_to_extruder": "raft_interface_extruder_nr",
+                    "force_depends_on_settings": [ "raft_base_thickness" ]
                 },
                 "raft_interface_infill_overlap":
                 {
@@ -6784,7 +6787,8 @@
                             "enabled": "resolveOrValue('adhesion_type') == 'raft' and raft_interface_layers > 0",
                             "settable_per_mesh": false,
                             "settable_per_extruder": true,
-                            "limit_to_extruder": "raft_interface_extruder_nr"
+                            "limit_to_extruder": "raft_interface_extruder_nr",
+                            "force_depends_on_settings": [ "raft_base_thickness" ]
                         },
                         "raft_surface_speed":
                         {


### PR DESCRIPTION
This is useful if the relations between settings are cross-extruder, which can happen when a setting that is currently limited to one extruder, depends on another setting (in a value-formula of the like) which is currently limited to _another_ extruder.

Note that I renamed the 'depends_on_settings' to 'force_depends_on_settings' as the former may imply that you should do it for _all_ dependant settings, instead of it being the exception (as we expect that this will occur rarely -- for example in multi-material rafts).

See backend PR: https://github.com/Ultimaker/Uranium/pull/959