### PR TITLE
Create startHeatingAtPercentage.py

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/startHeatingAtPercentage.py
+++ b/plugins/PostProcessingPlugin/scripts/startHeatingAtPercentage.py
@@ -1,0 +1,73 @@
+#------------------------------------------------------------------------------------------------------------------------------------
+#
+# Cura PostProcessing Script
+# Author:   Ricardo Ortega Magaña
+# Date:     August 06, 2024
+#
+# Description:  Modify M190 line
+#               
+#
+#------------------------------------------------------------------------------------------------------------------------------------
+#   
+#   Version 1.2 08/06/2024 Continue heating bed after waiting.
+#   Version 1.1 08/03/2024 Default percentage is now 80%
+#   Version 1.0 01/03/2024 Change the M190 temperature to a percentage to start heating the nozzle
+#   
+#------------------------------------------------------------------------------------------------------------------------------------
+
+from ..Script import Script
+from UM.Logger import Logger
+from UM.Application import Application
+
+from enum import Enum
+
+__version__ = '1.2'
+
+class startHeatingAtPercentage(Script):
+    def __init__(self):
+        super().__init__()
+
+    def getSettingDataString(self):
+        return """{
+            "name": "startHeatingAtPercentage",
+            "key": "startHeatingAtPercentage",
+            "metadata": {},
+            "version": 2,
+            "settings":
+            {
+                "bedTempPercentage":
+                {
+                    "label": "Bed temperature percentage to start heating the nozzle",
+                    "description": "What is the percentage of bed heating to start heating the nozzle.",
+                    "type": "float",
+                    "unit": "%",
+                    "default_value": 80,
+                    "minimum_value": "50",
+                    "maximum_value": "100"
+                }                     
+            }
+        }"""
+
+    def execute(self, data):
+
+        bedTempPercentage = float(self.getSettingValueByKey("bedTempPercentage")) 
+        OnlyFirst=True
+        for layer in data:
+            layer_index = data.index(layer)
+            lines = layer.split("\n")
+            resLines=[]
+            for line in lines:                  
+               
+                if ("M190" in line) and OnlyFirst:
+                    temp=line.split("S")
+                    if(len(temp)==2):
+                        percTemp=int((float(temp[1])*bedTempPercentage)/100)
+                        resLines.append(f"M190 S{percTemp}")
+                        resLines.append(f"M140 S{temp[1]}")
+                        OnlyFirst=False
+                else:
+                    resLines.append(line)
+            result = "\n".join(resLines)
+            data[layer_index] = result
+
+        return data


### PR DESCRIPTION
# Description

This new file add a Post Processing Script that change the initial selected bed temperature, to a percentage set in the script properties, the heating process then, will wait to that percentage, instead of the 100%, once the selected percentage temperature is reached, the nozzle will start heating.

With a correct calibration of this percentage, the full nozzle time heatup process could be spared.

This is a usual heating process, where once the bed heating process end, the nozzle start heating:

![image](https://github.com/user-attachments/assets/50509ec9-13f2-4425-a7d1-16f19b9ac645)

This is the heating process after running the startHeatingAtPercentage script:

![image](https://github.com/user-attachments/assets/1c5117a6-b472-42db-b8b0-94ff4307f122)


## Type of change

- [**X**] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [**X** ] Tested with Creality Ender 3-Max (KLIPPER) printing process, 80% default value set

After a print, when the bed is still hot, running this script will wait to cooldown to the percentage temperature in klipper, since the G-Code is not compilant, changing the Klipper command to the following code, fix this problem:


```
[gcode_macro M190]
rename_existing: M99190
gcode:
    #Parameters
    {% set s = params.S|float %}

    M140 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}  
    {% if s != 0 %}
        TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={s} 
    {% endif %}

```

- [**X**] Tested with Creality CR-10 Smart (MARLIN) printing process, 80% default value set.

**Test Configuration**:

* Operating System:  Windows
* Cura 5.8.0
* Printing thru OCtorpint (Marlin, CR-10 Smart)
* Printing thru Mainsail/Moonraker/Klipper (Klipper, Ender 3 Max)


- [**X**] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [**X**] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [**X**] I have commented my code, particularly in hard-to-understand areas
- [**X**] I have uploaded any files required to test this change
