### PR TITLE
PlugIn GCodeReader - Process M82 and M83 command for Marlin flavoured GCode

### DIFF
--- a/plugins/GCodeReader/FlavorParser.py
+++ b/plugins/GCodeReader/FlavorParser.py
@@ -298,8 +298,14 @@ class FlavorParser:
             position.e.extend([0] * (self._extruder_number - len(position.e) + 1))
         return position
 
-    def processMCode(self, M: int, line: str, position: Position, path: List[List[Union[float, int]]]) -> Position:
-        pass
+    def processMCode(self, M: int, line: str, position: Position, path: List[List[Union[float, int]]]) -> None:
+        # Set extrusion mode
+        if M == 82:
+            # Set absolute extrusion mode
+            self._is_absolute_extrusion = True
+        elif M == 83:
+            # Set relative extrusion mode
+            self._is_absolute_extrusion = False
 
     _type_keyword = ";TYPE:"
     _layer_keyword = ";LAYER:"

--- a/plugins/GCodeReader/RepRapFlavorParser.py
+++ b/plugins/GCodeReader/RepRapFlavorParser.py
@@ -11,14 +11,6 @@ class RepRapFlavorParser(FlavorParser.FlavorParser):
     def __init__(self):
         super().__init__()
 
-    def processMCode(self, M, line, position, path):
-        if M == 82:
-            # Set absolute extrusion mode
-            self._is_absolute_extrusion = True
-        elif M == 83:
-            # Set relative extrusion mode
-            self._is_absolute_extrusion = False
-
     def _gCode90(self, position, params, path):
         """Set the absolute positioning
 


### PR DESCRIPTION
# Description

This fixes https://github.com/Ultimaker/Cura/issues/19514, where the relative extrusion command was only recognized in RepRap flavoured GCode, but it is the same for Marlin flavoured GCode.
Moved the corresponding method to the superclass and removed it from the RepRap flavoured Reader

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Tested with local installation

**Test Configuration**:
* Operating System: Windows 10

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
