### PR TITLE
CURA-12046 git tag was not updated

### DIFF
--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -146,16 +146,9 @@ jobs:
       - name: Extract changelog
         run: python ./scripts/extract_changelog.py --version ${{ needs.parse-version.outputs.version_major }}.${{ needs.parse-version.outputs.version_minor }}.${{ needs.parse-version.outputs.version_patch }} --changelog ./resources/texts/change_log.txt > formatted_changelog.txt
 
-      - name: Get commit id for release
-        id: get-commit-id
-        uses: iawia002/get-tag-or-commit-id@v1.0.1
-        with:
-          length: 40
-
       - name: Create release
         uses: notpeelz/action-gh-create-release@v5.0.1
         with:
-          target: ${{ steps.get-commit-id.outputs.id }}
           tag: ${{ inputs.cura_version }}
           strategy: replace
           title: UltiMaker Cura ${{ inputs.cura_version }}

--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Export Cura tagged commit
         id: export-main-commit
-        if: ${{ matrix.repository == "Cura" }}
+        if: ${{ matrix.repository == 'Cura' }}
         run: |
           echo "main_commit=`git rev-parse HEAD`" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -65,6 +65,8 @@ jobs:
     name: Create tags
     runs-on: ubuntu-latest
     needs: [parse-version, find-rc-tag]
+    outputs:
+      main_commit: ${{ steps.export-main-commit.main_commit }}
     strategy:
       matrix:
         repository: [Cura, Uranium, CuraEngine, cura-binary-data, fdm_materials]
@@ -81,10 +83,17 @@ jobs:
           git tag ${{ needs.find-rc-tag.outputs.tag_name }}
           git push origin tag ${{ needs.find-rc-tag.outputs.tag_name }}
 
-      - name: Create release tag
+      - name: Create or update release tag
         run: |
           git tag -f ${{ inputs.cura_version }}
           git push -f origin tag ${{ inputs.cura_version }}
+
+      - name: Export Cura tagged commit
+        id: export-main-commit
+        if: ${{ matrix.repository == "Cura" }}
+        run: |
+          echo "main_commit=`git rev-parse HEAD`" >> "$GITHUB_OUTPUT"
+
 
   create-dependencies-packages:
     name: Create conan packages for dependencies
@@ -136,7 +145,7 @@ jobs:
   create-release-draft:
     name: Create the release draft
     runs-on: ubuntu-latest
-    needs: [create-installers, parse-version]
+    needs: [create-installers, parse-version, create-tags]
     steps:
       - name: Checkout Cura repo
         uses: actions/checkout@v4
@@ -149,6 +158,7 @@ jobs:
       - name: Create release
         uses: notpeelz/action-gh-create-release@v5.0.1
         with:
+          target: ${{ needs.create-tags.outputs.main_commit }}
           tag: ${{ inputs.cura_version }}
           strategy: replace
           title: UltiMaker Cura ${{ inputs.cura_version }}

--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -76,10 +76,15 @@ jobs:
           ref: ${{ needs.parse-version.outputs.branch_name }}
           token: ${{ secrets.CURA_AUTORELEASE_PAT }}
 
-      - name: Create tag
+      - name: Create RC tag
         run: |
           git tag ${{ needs.find-rc-tag.outputs.tag_name }}
           git push origin tag ${{ needs.find-rc-tag.outputs.tag_name }}
+
+      - name: Create release tag
+        run: |
+          git tag -f ${{ inputs.cura_version }}
+          git push -f origin tag ${{ inputs.cura_version }}
 
   create-dependencies-packages:
     name: Create conan packages for dependencies

--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [parse-version, find-rc-tag]
     outputs:
-      main_commit: ${{ steps.export-main-commit.main_commit }}
+      main_commit: ${{ steps.export-main-commit.outputs.main_commit }}
     strategy:
       matrix:
         repository: [Cura, Uranium, CuraEngine, cura-binary-data, fdm_materials]


### PR DESCRIPTION
The commit that was given to the release was retrieved by `get-tag-or-commit-id` and was actually wrong. Now we take the commit from which we actually create the tags.

Also added a manual creation of the release tag on dependency repositories, which was missing.

CURA-12046