### PR TITLE
CURA-11501 Fix excluded materials being sometimes visible

### DIFF
--- a/cura/Machines/MachineNode.py
+++ b/cura/Machines/MachineNode.py
@@ -14,7 +14,6 @@ from cura.Machines.QualityChangesGroup import QualityChangesGroup  # To construc
 from cura.Machines.QualityGroup import QualityGroup  # To construct groups of quality profiles that belong together.
 from cura.Machines.QualityNode import QualityNode
 from cura.Machines.VariantNode import VariantNode
-from cura.Machines.MaterialNode import MaterialNode
 import UM.FlameProfiler
 
 
@@ -168,10 +167,10 @@ class MachineNode(ContainerNode):
 
         return self.global_qualities.get(self.preferred_quality_type, next(iter(self.global_qualities.values())))
 
-    def isExcludedMaterial(self, material: MaterialNode) -> bool:
+    def isExcludedMaterial(self, material_base_file: str) -> bool:
         """Returns whether the material should be excluded from the list of materials."""
         for exclude_material in self.exclude_materials:
-            if exclude_material in material["id"]:
+            if exclude_material in material_base_file:
                 return True
         return False
 

--- a/cura/Machines/VariantNode.py
+++ b/cura/Machines/VariantNode.py
@@ -60,7 +60,7 @@ class VariantNode(ContainerNode):
             materials = list(materials_per_base_file.values())
 
         # Filter materials based on the exclude_materials property.
-        filtered_materials = [material for material in materials if not self.machine.isExcludedMaterial(material)]
+        filtered_materials = [material for material in materials if not self.machine.isExcludedMaterial(material["id"])]
 
         for material in filtered_materials:
             base_file = material["base_file"]
@@ -127,7 +127,7 @@ class VariantNode(ContainerNode):
         material_definition = container.getMetaDataEntry("definition")
 
         base_file = container.getMetaDataEntry("base_file")
-        if base_file in self.machine.exclude_materials:
+        if self.machine.isExcludedMaterial(base_file):
             return  # Material is forbidden for this printer.
         if base_file not in self.materials:  # Completely new base file. Always better than not having a file as long as it matches our set-up.
             if material_definition != "fdmprinter" and material_definition != self.machine.container_id:


### PR DESCRIPTION
Apparently the `exclude_materials` property of `MachineNode` has changed over time, and one of its use has not been updated, leading to some cases where materials could be non excluded.