### PR TITLE
Fix Cura 5.8 Material Export

### DIFF
--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -1084,9 +1084,8 @@ class XmlMaterialProfile(InstanceContainer):
             # Skip material properties (eg diameter) or metadata (eg GUID)
             return
 
-        truth_map = { True: "yes", False: "no" }
-        if tag_name != "cura:setting" and instance.value in truth_map:
-            data = truth_map[instance.value]
+        if tag_name != "cura:setting" and isinstance(instance.value, bool):
+            data = "yes" if instance.value else "no"
         else:
             data = str(instance.value)
 


### PR DESCRIPTION
# Description
Upon exporting a `.xml.fdm_material` profile, Cura writes a `0`/`0.0` or `1`/`1.0` as `yes` or `no`. The UltiMaker printers then can't import these profiles, as it expects a float in those fields. This PR solves this by explicitly checking if the value is a boolean before converting it to `yes`/`no`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Not yet... Waiting for a new build.

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
