### PR TITLE
CURA-12091 fix infill plugin start crash

### DIFF
--- a/cura/BackendPlugin.py
+++ b/cura/BackendPlugin.py
@@ -95,8 +95,8 @@ class BackendPlugin(AdditionalSettingDefinitionsAppender, PluginObject):
                     popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
                 plugin_env = os.environ
-                if "APPRUN_RUNTIME" in plugin_env and "APPRUN_ORIGINAL_APPRUN_RUNTIME" in plugin_env:
-                    plugin_env["APPRUN_RUNTIME"] = plugin_env["APPRUN_ORIGINAL_APPRUN_RUNTIME"]
+                if "LD_PRELOAD" in plugin_env and "APPRUN_ORIGINAL_LD_PRELOAD" in plugin_env:
+                    plugin_env["LD_PRELOAD"] = plugin_env["APPRUN_ORIGINAL_LD_PRELOAD"]
 
                 Logger.info(plugin_env)
 

--- a/cura/BackendPlugin.py
+++ b/cura/BackendPlugin.py
@@ -93,6 +93,8 @@ class BackendPlugin(AdditionalSettingDefinitionsAppender, PluginObject):
                 }
                 if Platform.isWindows():
                     popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+
+                Logger.info(os.environ)
                 self._process = subprocess.Popen(self._validatePluginCommand(), **popen_kwargs)
             self._is_running = True
             return True

--- a/cura/BackendPlugin.py
+++ b/cura/BackendPlugin.py
@@ -102,8 +102,6 @@ class BackendPlugin(AdditionalSettingDefinitionsAppender, PluginObject):
                     # part of the AppImage and uses the sames libraries
                     plugin_env["APPDIR_MODULE_DIR"] = str(pathlib.Path(validated_plugin_command[0]).parent.absolute())
 
-                Logger.info(plugin_env)
-
                 self._process = subprocess.Popen(validated_plugin_command, env=plugin_env, **popen_kwargs)
             self._is_running = True
             return True

--- a/cura/BackendPlugin.py
+++ b/cura/BackendPlugin.py
@@ -94,8 +94,13 @@ class BackendPlugin(AdditionalSettingDefinitionsAppender, PluginObject):
                 if Platform.isWindows():
                     popen_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
 
-                Logger.info(os.environ)
-                self._process = subprocess.Popen(self._validatePluginCommand(), **popen_kwargs)
+                plugin_env = os.environ
+                if "APPRUN_RUNTIME" in plugin_env and "APPRUN_ORIGINAL_APPRUN_RUNTIME" in plugin_env:
+                    plugin_env["APPRUN_RUNTIME"] = plugin_env["APPRUN_ORIGINAL_APPRUN_RUNTIME"]
+
+                Logger.info(plugin_env)
+
+                self._process = subprocess.Popen(self._validatePluginCommand(), env=plugin_env, **popen_kwargs)
             self._is_running = True
             return True
         except PermissionError:


### PR DESCRIPTION
When starting an engine plugin executable from within an AppImage, the AppImage hooks make some black magic to make sure the called executable is started from the OS environment. In our case this is not what we want, as the plugin is supposed to use the environment provided with the AppImage, which is compatible with more platforms.

This PR adds an environment variable before starting the engine plugin executable, to tell AppImage to consider the executable as if it was part of its environment.

This can also be achieved by starting cura with e.g. `APPDIR_MODULE_DIR=$HOME/.local/share/cura/5.8/plugins/CuraEngineTiledInfill/CuraEngineTiledInfill/x86_64/Linux ./UltiMaker-Cura-5.8.0-linux-X64.AppImage`. Thus, one can use the Infil plugin version 2.0.1 with Cura 5.8.0 on platforms where it would not run (e.g. Mint 20). In 5.9.0 it will work out of the box.

Requires https://github.com/Ultimaker/CuraEngine_plugin_infill_generate/pull/19 (Or Infill plugin package 2.0.1)

May fix https://github.com/Ultimaker/Cura/issues/17441
Fixes https://github.com/Ultimaker/Cura/issues/17551
Fixes https://github.com/Ultimaker/Cura/issues/17739
Fixes https://github.com/Ultimaker/Cura/issues/18530

CURA-12091