### PR TITLE
Fix qml warnings, python regular expression deprecated syntax with raw string

### DIFF
--- a/plugins/PostProcessingPlugin/Script.py
+++ b/plugins/PostProcessingPlugin/Script.py
@@ -122,7 +122,7 @@ class Script:
         if not key in line or (';' in line and line.find(key) > line.find(';')):
             return default
         sub_part = line[line.find(key) + 1:]
-        m = re.search('^-?[0-9]+\.?[0-9]*', sub_part)
+        m = re.search(r'^-?[0-9]+\.?[0-9]*', sub_part)
         if m is None:
             return default
         try:

--- a/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
+++ b/plugins/PostProcessingPlugin/scripts/PauseAtHeight.py
@@ -338,7 +338,7 @@ class PauseAtHeight(Script):
                     nbr_negative_layers += 1
 
                 #Track the latest printing temperature in order to resume at the correct temperature.
-                if re.match("T(\d*)", line):
+                if re.match(r"T(\d*)", line):
                     current_t = self.getValue(line, "T")
                 m = self.getValue(line, "M")
                 if m is not None and (m == 104 or m == 109) and self.getValue(line, "S") is not None:

--- a/plugins/UM3NetworkPrinting/src/ExportFileJob.py
+++ b/plugins/UM3NetworkPrinting/src/ExportFileJob.py
@@ -28,7 +28,7 @@ class ExportFileJob(WriteFileJob):
 
         # Determine the filename.
         job_name = CuraApplication.getInstance().getPrintInformation().jobName
-        job_name = re.sub("[^\w\-. ()]", "-", job_name)
+        job_name = re.sub(r"[^\w\-. ()]", "-", job_name)
         extension = self._mesh_format_handler.preferred_format.get("extension", "")
         self.setFileName("{}.{}".format(job_name, extension))
 

--- a/resources/qml/ActionPanel/OutputProcessWidget.qml
+++ b/resources/qml/ActionPanel/OutputProcessWidget.qml
@@ -10,7 +10,7 @@ import Cura 1.0 as Cura
 
 
 // This element contains all the elements the user needs to visualize the data
-// that is gather after the slicing process, such as printint time, material usage, ...
+// that is gather after the slicing process, such as printing time, material usage, ...
 // There are also two buttons: one to previsualize the output layers, and the other to
 // select what to do with it (such as print over network, save to file, ...)
 Column

--- a/resources/qml/Menus/RecentFilesMenu.qml
+++ b/resources/qml/Menus/RecentFilesMenu.qml
@@ -2,7 +2,7 @@
 // Cura is released under the terms of the LGPLv3 or higher.
 
 import QtQuick 2.2
-import QtQuick.Controls 2.1
+import QtQuick.Controls 2.15
 
 import UM 1.3 as UM
 import Cura 1.0 as Cura
@@ -30,6 +30,6 @@ Cura.Menu
             onTriggered: CuraApplication.readLocalFile(modelData)
         }
         onObjectAdded: (index, object) => menu.insertItem(index, object)
-        onObjectRemoved: (object) => menu.removeItem(object)
+        onObjectRemoved: (index, object) => menu.removeItem(object)
     }
 }

--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
@@ -57,7 +57,9 @@ RecommendedSettingSection
                 settingName: "support_structure"
                 propertyRemoveUnusedValue: false
                 updateAllExtruders: false
-                defaultExtruderIndex: supportExtruderProvider.properties.value
+                defaultExtruderIndex: supportExtruderProvider.properties.value != undefined ?
+                    supportExtruderProvider.properties.value :
+                    Cura.ExtruderManager.activeExtruderIndex
             }
         },
         RecommendedSettingItem
@@ -92,7 +94,9 @@ RecommendedSettingSection
                 width: parent.width
                 settingName: "support_type"
                 updateAllExtruders: true
-                defaultExtruderIndex: supportExtruderProvider.properties.value
+                defaultExtruderIndex: supportExtruderProvider.properties.value != undefined ?
+                    supportExtruderProvider.properties.value :
+                    Cura.ExtruderManager.activeExtruderIndex
             }
         }
     ]

--- a/scripts/extract_changelog.py
+++ b/scripts/extract_changelog.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
         args.version = args.version[:-2]
 
     start_token = f"[{args.version}]"
-    pattern_stop_log = "\[\d+(\.\d+){1,2}\]"
+    pattern_stop_log = r"\[\d+(\.\d+){1,2}\]"
     log_line = False
     first_chapter = True
 


### PR DESCRIPTION
# Description

This fixes:
* QML incompatible error in RecentFilesMenu.qml
* QML assign undefined to int in RecommendedSupportSelector.qml
* python invalid "\d" etc regular expressions

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] For QML, replacing the files from AppImage and verifying those errors were not printed
- [X] For python code inspection using grep to look for any other instance of \. \d \w that weren't already a raw string

**Test Configuration**:
* Operating System: Debian Linux

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
