### PR TITLE
[CURA-11761] Make extra sure cache is emptied when objects get altered.

### DIFF
--- a/cura/Settings/CuraContainerStack.py
+++ b/cura/Settings/CuraContainerStack.py
@@ -5,7 +5,7 @@ from typing import Any, cast, List, Optional, Dict
 from PyQt6.QtCore import pyqtProperty, pyqtSignal, QObject
 
 from UM.Application import Application
-from UM.Decorators import override
+from UM.Decorators import CachedMemberFunctions, override
 from UM.FlameProfiler import pyqtSlot
 from UM.Logger import Logger
 from UM.Settings.ContainerStack import ContainerStack, InvalidContainerStackError
@@ -237,6 +237,7 @@ class CuraContainerStack(ContainerStack):
         :param new_value: The new value to set the property to.
         """
 
+        CachedMemberFunctions.clearInstanceCache(self)
         container_index = _ContainerIndexes.UserChanges
         self._containers[container_index].setProperty(key, property_name, property_value, container, set_from_cache)
 

--- a/cura/Settings/ExtruderStack.py
+++ b/cura/Settings/ExtruderStack.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, TYPE_CHECKING, Optional
 
 from PyQt6.QtCore import pyqtProperty, pyqtSignal
 
-from UM.Decorators import override
+from UM.Decorators import CachedMemberFunctions, override
 from UM.MimeTypeDatabase import MimeType, MimeTypeDatabase
 from UM.Settings.ContainerStack import ContainerStack
 from UM.Settings.ContainerRegistry import ContainerRegistry
@@ -86,6 +86,7 @@ class ExtruderStack(CuraContainerStack):
     def setCompatibleMaterialDiameter(self, value: float) -> None:
         old_approximate_diameter = self.getApproximateMaterialDiameter()
         if self.getCompatibleMaterialDiameter() != value:
+            CachedMemberFunctions.clearInstanceCache(self)
             self.definitionChanges.setProperty("material_diameter", "value", value)
             self.compatibleMaterialDiameterChanged.emit()
 

--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ET
 from UM.PluginRegistry import PluginRegistry
 from UM.Resources import Resources
 from UM.Logger import Logger
+from UM.Decorators import CachedMemberFunctions
 import UM.Dictionary
 from UM.Settings.InstanceContainer import InstanceContainer
 from UM.Settings.ContainerRegistry import ContainerRegistry
@@ -70,6 +71,8 @@ class XmlMaterialProfile(InstanceContainer):
         if registry.isReadOnly(self.getId()):
             Logger.log("w", "Can't change metadata {key} of material {material_id} because it's read-only.".format(key = key, material_id = self.getId()))
             return
+
+        CachedMemberFunctions.clearInstanceCache(self)
 
         # Some metadata such as diameter should also be instantiated to be a setting. Go though all values for the
         # "properties" field and apply the new values to SettingInstances as well.
@@ -480,6 +483,7 @@ class XmlMaterialProfile(InstanceContainer):
                     first.append(element)
 
     def clearData(self):
+        CachedMemberFunctions.clearInstanceCache(self)
         self._metadata = {
             "id": self.getId(),
             "name": ""
@@ -518,6 +522,8 @@ class XmlMaterialProfile(InstanceContainer):
 
     def deserialize(self, serialized, file_name = None):
         """Overridden from InstanceContainer"""
+
+        CachedMemberFunctions.clearInstanceCache(self)
 
         containers_to_add = []
         # update the serialized data first


### PR DESCRIPTION
See the (new) `cachePerInstance` decorator in UM/Decorators, and the accompanying `CachedMemberFunctions` handler-class in the 'main' PR in the backend: https://github.com/Ultimaker/Uranium/pull/966