### PR TITLE
[CURA-12076] Directly update permissions after login.

### DIFF
--- a/cura/API/Account.py
+++ b/cura/API/Account.py
@@ -232,6 +232,7 @@ class Account(QObject):
 
     def _onProfileChanged(self, profile: Optional[UserProfile]) -> None:
         self._user_profile = profile
+        self._updatePermissions()
         self.userProfileChanged.emit()
 
     def _sync(self) -> None:


### PR DESCRIPTION
Otherwise you have to wait until the access token refreshes, and are in a weird state in between that time where you _are_ logged in, and we even have the subscription-level, but the permission-list are empty. Now you just have to wait until the permissions return from the server after login, which shouldn't be a problem unless our users are speedrunners.