### PR TITLE
PP-521: Fix resolve logic for adhesion_type

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -6063,7 +6063,7 @@
                         "none": "None"
                     },
                     "default_value": "brim",
-                    "resolve": "extruderValue(adhesion_extruder_nr, 'adhesion_type')",
+                    "resolve": "min(extruderValues('adhesion_type'), key=('raft', 'brim', 'skirt', 'none').index)",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false
                 },


### PR DESCRIPTION
[PP-512] Fix resolve logic for `adhesion_type`
Pick the most "sticky" option of all the enabled extruders for `adhesion_type`

# Problem
Currently, the resolve function for adhesion_type is extruderValue(adhesion_extruder_nr, 'adhesion_type'). But when using dual extrusion, Cura makes the brim from multiple materials, depending on what material that piece of brim touches.

For example with (1) PVA and (2) PPS-CF on a Factor 4, the current logic is that the global adhesion_extruder_nr defaults to 1 (left), and so it uses the adhesion_type value of the PVA, which doesn’t have any set, so defaults to the global skirt, even though the PPS-CF wants brim.

# Solution
Make the resolve of adhesion_type a function that picks the first option from the list ['raft', 'brim', 'skirt', 'none'] that any of the used extruders selects.

"resolve": "min(extruderValues('adhesion_type'), key=lambda v: ('raft', 'brim', 'skirt', 'none').index(v))"

In this screenshot, left is the current/old profile, and right is with the new resolve function where Cura correctly picks up the brim preference of the PPS-CF.
