### PR TITLE
Avoid Actions.qml cyclic dependency

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1296,6 +1296,9 @@ class CuraApplication(QtApplication):
         qmlRegisterSingletonType(CuraSceneController, "Cura", 1, 0, self.getCuraSceneController, "SceneController")
         qmlRegisterSingletonType(ExtruderManager, "Cura", 1, 0, self.getExtruderManager, "ExtruderManager")
         qmlRegisterSingletonType(MachineManager, "Cura", 1, 0, self.getMachineManager, "MachineManager")
+	# Give Actions.qml another namespace to import instead of "Cura" which
+	# it is a member of and causes a cyclic dependency.
+        qmlRegisterSingletonType(MachineManager, "_CuraActionsDependencies", 1, 5, self.getMachineManager, "MachineManager")
         qmlRegisterSingletonType(IntentManager, "Cura", 1, 6, self.getIntentManager, "IntentManager")
         qmlRegisterSingletonType(SettingInheritanceManager, "Cura", 1, 0, self.getSettingInheritanceManager, "SettingInheritanceManager")
         qmlRegisterSingletonType(SimpleModeSettingsManager, "Cura", 1, 0, self.getSimpleModeSettingsManagerWrapper, "SimpleModeSettingsManager")
@@ -1346,6 +1349,9 @@ class CuraApplication(QtApplication):
         qmlRegisterType(MachineNameValidator, "Cura", 1, 0, "MachineNameValidator")
         qmlRegisterType(UserChangesModel, "Cura", 1, 0, "UserChangesModel")
         qmlRegisterSingletonType(ContainerManager, "Cura", 1, 0, ContainerManager.getInstance, "ContainerManager")
+	# Give Actions.qml another namespace to import instead of "Cura" which
+	# it is a member of and causes a cyclic dependency.
+        qmlRegisterSingletonType(ContainerManager, "_CuraActionsDependencies", 1, 5, ContainerManager.getInstance, "ContainerManager")
         qmlRegisterType(SidebarCustomMenuItemsModel, "Cura", 1, 0, "SidebarCustomMenuItemsModel")
 
         qmlRegisterType(PrinterOutputDevice, "Cura", 1, 0, "PrinterOutputDevice")

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -6,7 +6,10 @@ pragma Singleton
 import QtQuick 2.10
 import QtQuick.Controls 2.4
 import UM 1.1 as UM
-import Cura 1.5 as Cura
+import _CuraActionsDependencies 1.5 as Cura
+// Was "import Cura 1.5 as Cura", except that results in
+// "Cyclic dependency detected between" Actions.qml and Actions.qml
+// Actions can't import the namespace that it has already been registered to.
 
 Item
 {


### PR DESCRIPTION
# Description

qt.qml.typeresolution.cycle: Cyclic dependency detected between "File:///Cura/resources/qml/Actions.qml" and "file:///Cura/resources/qml/Actions.qml"

Create a different namespace for Actions to import that has the dependencies it needs, but one that Actions isn't already part of.

While this solution works, I don't know what is extra special about Actions.qml that it can't import Cura without "Cyclic dependency detected" and other components like Menus/MaterialMenu.qml  which is registered in cura/CuraApplication.py as a part of `qmlRegisterType(QUrl.fromLocalFile(path), "Cura", 1, 0, type_name)`, but it seems to be okay.

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This fixes... OR This improves... -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Verified I no longer get "Cyclic dependency detected" on startup
- [X] Verified that Hot keys, such as F5 still triggers the reload all

**Test Configuration**:
* Operating System: Linux Debian

# Checklist:
<!-- Check if relevant -->

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
