### PR TITLE
CURA-12048 Add option to publish release description

### DIFF
--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -9,6 +9,11 @@ on:
         required: true
         type: string
 
+      publish_release_description:
+        description: 'Publish the description of the release based on the changelog'
+        required: true
+        type: bool
+
 jobs:
   parse-version:
     name: Parse input version string
@@ -153,6 +158,7 @@ jobs:
           ref: ${{ needs.parse-version.outputs.branch_name }}
 
       - name: Extract changelog
+        if: ${{ inputs.publish_release_description }}
         run: python ./scripts/extract_changelog.py --version ${{ needs.parse-version.outputs.version_major }}.${{ needs.parse-version.outputs.version_minor }}.${{ needs.parse-version.outputs.version_patch }} --changelog ./resources/texts/change_log.txt > formatted_changelog.txt
 
       - name: Create release

--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -169,8 +169,8 @@ jobs:
           strategy: replace
           title: UltiMaker Cura ${{ inputs.cura_version }}
           draft: true
-          body-source: file
-          body: formatted_changelog.txt
+          body-source: ${{ inputs.publish_release_description && 'file' || 'literal' }}
+          body: ${{ inputs.publish_release_description && 'formatted_changelog.txt' || '' }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v4.1.7

--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -12,7 +12,7 @@ on:
       publish_release_description:
         description: 'Publish the description of the release based on the changelog'
         required: true
-        type: bool
+        type: boolean
 
 jobs:
   parse-version:

--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
       publish_release_description:
-        description: 'Publish the description of the release based on the changelog'
+        description: 'Create the GitHub release (if existing, the description will be overridden based on the changelog)'
         required: true
         type: boolean
 

--- a/.github/workflows/release-process_release-candidate.yml
+++ b/.github/workflows/release-process_release-candidate.yml
@@ -163,14 +163,15 @@ jobs:
 
       - name: Create release
         uses: notpeelz/action-gh-create-release@v5.0.1
+        if: ${{ inputs.publish_release_description }}
         with:
           target: ${{ needs.create-tags.outputs.main_commit }}
           tag: ${{ inputs.cura_version }}
           strategy: replace
           title: UltiMaker Cura ${{ inputs.cura_version }}
           draft: true
-          body-source: ${{ inputs.publish_release_description && 'file' || 'literal' }}
-          body: ${{ inputs.publish_release_description && 'formatted_changelog.txt' || '' }}
+          body-source: file
+          body: formatted_changelog.txt
 
       - name: Download artifacts
         uses: actions/download-artifact@v4.1.7


### PR DESCRIPTION
When creating a release candidate, we now have an option to create the GitHub release, so that the first time, it should be enabled, and if there are new release candidates, it is to be enabled only if the description has not been refined.