### PR TITLE
Pp 528 unused extruder settings

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -166,6 +166,7 @@ class BuildVolume(SceneNode):
                 if active_extruder_changed is not None:
                     node.callDecoration("getActiveExtruderChangedSignal").disconnect(self._updateDisallowedAreasAndRebuild)
                 node.decoratorsChanged.disconnect(self._updateNodeListeners)
+            self._updateUsedExtruders()
             self.rebuild()
 
             self._scene_objects = new_scene_objects
@@ -202,7 +203,7 @@ class BuildVolume(SceneNode):
             per_mesh_stack.propertyChanged.connect(self._onSettingPropertyChanged)
         active_extruder_changed = node.callDecoration("getActiveExtruderChangedSignal")
         if active_extruder_changed is not None:
-            active_extruder_changed.connect(self._updateDisallowedAreasAndRebuild)
+            active_extruder_changed.connect(self._nodeActiveExtruderChanged)
 
     def setWidth(self, width: float) -> None:
         self._width = width
@@ -687,6 +688,7 @@ class BuildVolume(SceneNode):
             self._depth = self._global_container_stack.getProperty("machine_depth", "value")
             self._shape = self._global_container_stack.getProperty("machine_shape", "value")
 
+            self._updateUsedExtruders()
             self._updateDisallowedAreas()
             self._updateRaftThickness()
             self._extra_z_clearance = self._calculateExtraZClearance(ExtruderManager.getInstance().getUsedExtruderStacks())
@@ -713,6 +715,7 @@ class BuildVolume(SceneNode):
         update_disallowed_areas = False
         update_raft_thickness = False
         update_extra_z_clearance = True
+        update_used_extruders = False
 
         for setting_key in self._changed_settings_since_last_rebuild:
             if setting_key in ["print_sequence", "support_mesh", "infill_mesh", "cutting_mesh", "anti_overhang_mesh"]:
@@ -746,12 +749,17 @@ class BuildVolume(SceneNode):
 
             if setting_key in self._raft_settings:
                 update_raft_thickness = True
+                update_used_extruders = True
 
             if setting_key in self._extra_z_settings:
                 update_extra_z_clearance = True
 
             if setting_key in self._limit_to_extruder_settings:
                 update_disallowed_areas = True
+                update_used_extruders = True
+
+            if setting_key in self._extruder_settings:
+                update_used_extruders = True
 
             rebuild_me = update_extra_z_clearance or update_disallowed_areas or update_raft_thickness
 
@@ -764,6 +772,9 @@ class BuildVolume(SceneNode):
 
         if update_extra_z_clearance:
             self._extra_z_clearance = self._calculateExtraZClearance(ExtruderManager.getInstance().getUsedExtruderStacks())
+
+        if update_used_extruders:
+            self._updateUsedExtruders()
 
         if rebuild_me:
             self.rebuild()
@@ -790,6 +801,22 @@ class BuildVolume(SceneNode):
         self._width = self._global_container_stack.getProperty("machine_width", "value")
         self._depth = self._global_container_stack.getProperty("machine_depth", "value")
         self._shape = self._global_container_stack.getProperty("machine_shape", "value")
+
+    def _updateUsedExtruders(self):
+        Logger.info("Updating used extruders")
+        global_container_stack = self._application.getGlobalContainerStack()
+        if not global_container_stack:
+            return
+        used_extruders = ExtruderManager.getInstance().getUsedExtruderStacks()
+        for extruder in global_container_stack.extruderList:
+            used = extruder in used_extruders
+            Logger.info(f"- {extruder.getId()}: {used}")
+            changed = (used == extruder.getProperty("extruder_used", "value"))
+            extruder.setProperty("extruder_used", "value", used)
+
+    def _nodeActiveExtruderChanged(self):
+        self._updateDisallowedAreasAndRebuild()
+        self._updateUsedExtruders()
 
     def _updateDisallowedAreasAndRebuild(self):
         """Calls :py:meth:`cura.BuildVolume._updateDisallowedAreas` and makes sure the changes appear in the scene.

--- a/cura/Settings/CuraFormulaFunctions.py
+++ b/cura/Settings/CuraFormulaFunctions.py
@@ -67,16 +67,19 @@ class CuraFormulaFunctions:
 
         global_stack = machine_manager.activeMachine
 
-        result = []
+        enabled_extruders = []
+        used_extruders = []
         for extruder in extruder_manager.getActiveExtruderStacks():
             if not extruder.isEnabled:
                 continue
             # only include values from extruders that are "active" for the current machine instance
             if int(extruder.getMetaDataEntry("position")) >= global_stack.getProperty("machine_extruder_count", "value", context = context):
                 continue
-            result.append(extruder)
+            enabled_extruders.append(extruder)
+            if extruder.getProperty("extruder_used", "value"):
+                used_extruders.append(extruder)
 
-        return result
+        return used_extruders if used_extruders else enabled_extruders
 
     # Gets all extruder values as a list for the given property.
     def getValuesInAllExtruders(self, property_key: str,

--- a/cura/Settings/ExtruderManager.py
+++ b/cura/Settings/ExtruderManager.py
@@ -282,8 +282,8 @@ class ExtruderManager(QObject):
         adhesion_type = global_stack.getProperty("adhesion_type", "value")
         if adhesion_type == "skirt" and (global_stack.getProperty("skirt_line_count", "value") > 0 or global_stack.getProperty("skirt_brim_minimal_length", "value") > 0):
             used_adhesion_extruders.add("skirt_brim_extruder_nr")  # There's a skirt.
-        if (adhesion_type == "brim" or global_stack.getProperty("prime_tower_brim_enable", "value")) and (global_stack.getProperty("brim_line_count", "value") > 0 or global_stack.getProperty("skirt_brim_minimal_length", "value") > 0):
-            used_adhesion_extruders.add("skirt_brim_extruder_nr")  # There's a brim or prime tower brim.
+        if adhesion_type == "brim" and (global_stack.getProperty("brim_line_count", "value") > 0 or global_stack.getProperty("skirt_brim_minimal_length", "value") > 0):
+            used_adhesion_extruders.add("skirt_brim_extruder_nr")  # There's a brim.
         if adhesion_type == "raft":
             used_adhesion_extruders.add("raft_base_extruder_nr")
             if global_stack.getProperty("raft_interface_layers", "value") > 0:

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2494,7 +2494,7 @@
                     "enabled": "machine_heated_build_volume",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
-                    "depends_on_settings": ["extruder_used"]
+                    "depends_on_settings": [ "extruder_used" ]
                 },
                 "material_print_temperature":
                 {
@@ -2608,7 +2608,7 @@
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false,
-                    "depends_on_settings": ["extruder_used"]
+                    "depends_on_settings": [ "extruder_used" ]
                 },
                 "material_bed_temperature_layer_0":
                 {

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -289,6 +289,17 @@
                     "settable_per_extruder": false,
                     "settable_per_meshgroup": false
                 },
+                "extruder_used":
+                {
+                    "default_value": true,
+                    "description": "Is this extruder used for printing. This setting is controlled by Cura automatically.",
+                    "label": "Extruder Used",
+                    "settable_globally": false,
+                    "settable_per_extruder": true,
+                    "settable_per_mesh": false,
+                    "settable_per_meshgroup": false,
+                    "type": "bool"
+                },
                 "machine_nozzle_tip_outer_diameter":
                 {
                     "label": "Outer Nozzle Diameter",
@@ -2482,7 +2493,8 @@
                     "maximum_value_warning": "285",
                     "enabled": "machine_heated_build_volume",
                     "settable_per_mesh": false,
-                    "settable_per_extruder": false
+                    "settable_per_extruder": false,
+                    "depends_on_settings": ["extruder_used"]
                 },
                 "material_print_temperature":
                 {
@@ -2595,7 +2607,8 @@
                     "enabled": "machine_heated_bed and machine_gcode_flavor != \"UltiGCode\"",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
-                    "settable_per_meshgroup": false
+                    "settable_per_meshgroup": false,
+                    "depends_on_settings": ["extruder_used"]
                 },
                 "material_bed_temperature_layer_0":
                 {


### PR DESCRIPTION
# Description
Ever since the dawn of time Cura, having a material in Extruder 2 active influences the settings in Extruder 1. This is even when you only use the material in Extruder 1.

For example, PLA needs a buildplate temperature of 60°C on S-line, while ABS needs 80°C. Because there is only 1 bed to set the temperature of, the highest of the two is used to make sure the object sticks well to the bed. This, however, results in the PLA being quite droopy because it stays quite soft at that temperature - a compromise needed when printing the two materials together.

If, however, you only use the PLA in Extruder 1, you have to remember to manually disable Extruder 2, as otherwise the PLA uses a bed temperature of 80°C for no good reason.

This problem also applies to various other settings that cannot be set per extruder, like the Build Volume Temperature, Adhesion Type, Materials Shrinkage Compensation, Support Structure, …

# Solution
Turns out, Cura already has a function `ExtruderManager.getUsedExtruderStacks()`, which goes over a bunch of settings to check which extruders are _actually_ used, not just the enabled ones. For example, it checks:
- `support_..._extruder_nr` if support is enabled
- `skirt_brim_extruder_nr` if `adhesion_type` is `skirt` or `brim`
- `raft_..._extruder_nr` if `adhesion_type` is `raft`

The result of this function is now saved in new setting (`extruder_used`). This setting lives in the machine section, so is not settable by the user and is driven by Cura.  
The function `extruderValues` that is available in `SettingFunction`s then only gives the values of the actually used extruders. If there are no used extruders (yet), like when there is no mesh loaded, it falls back to the old behaviour of using all the enabled extruders.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
