### PR TITLE
Typo fix in fdmprinter.def.json.pot

### DIFF
--- a/resources/i18n/fdmprinter.def.json.pot
+++ b/resources/i18n/fdmprinter.def.json.pot
@@ -857,7 +857,7 @@ msgid "Wall Ordering"
 msgstr ""
 
 msgctxt "inset_direction description"
-msgid "Determines the order in which walls are printed. Printing outer walls earlier helps with dimensional accuracy, as faults from inner walls cannot propagate to the outside. However printing them later allows them to stack better when overhangs are printed. When there is an uneven amount of total innner walls, the 'center last line' is always printed last."
+msgid "Determines the order in which walls are printed. Printing outer walls earlier helps with dimensional accuracy, as faults from inner walls cannot propagate to the outside. However printing them later allows them to stack better when overhangs are printed. When there is an uneven amount of total inner walls, the 'center last line' is always printed last."
 msgstr ""
 
 msgctxt "inset_direction option inside_out"


### PR DESCRIPTION
Fixed a typo in fdmprinter.def.json.pot