### PR TITLE
CURA-11634 Show any color in color submenu for machines that support it 

### DIFF
--- a/cura/Machines/MachineNode.py
+++ b/cura/Machines/MachineNode.py
@@ -48,6 +48,7 @@ class MachineNode(ContainerNode):
         self.preferred_variant_name = my_metadata.get("preferred_variant_name", "")
         self.preferred_material = my_metadata.get("preferred_material", "")
         self.preferred_quality_type = my_metadata.get("preferred_quality_type", "")
+        self.supports_abstract_color = parseBool(my_metadata.get("supports_abstract_color", "false"))
 
         self._loadAll()
 

--- a/cura/Machines/VariantNode.py
+++ b/cura/Machines/VariantNode.py
@@ -63,6 +63,9 @@ class VariantNode(ContainerNode):
         filtered_materials = [material for material in materials if not self.machine.isExcludedMaterialBaseFile(material["id"])]
 
         for material in filtered_materials:
+            if material.get("abstract_color", False):
+                if not self.machine.supports_abstract_color:
+                    continue  # do not show abstract color profiles if the machine does not support them
             base_file = material["base_file"]
             if base_file not in self.materials:
                 self.materials[base_file] = MaterialNode(material["id"], variant = self)

--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -919,7 +919,9 @@ class XmlMaterialProfile(InstanceContainer):
         base_metadata["definition"] = "fdmprinter"
 
         # Certain materials are loaded but should not be visible / selectable to the user.
-        base_metadata["visible"] = not base_metadata.get("abstract_color", False)
+        # Only show abstract color profiles (Any Color) if the machine supports them
+        base_metadata["visible"] = (not base_metadata.get("abstract_color", False)
+                                    or base_metadata.get("supports_abstract_color", False))
 
         compatible_entries = data.iterfind("./um:settings/um:setting[@key='hardware compatible']", cls.__namespaces)
         try:

--- a/plugins/XmlMaterialProfile/XmlMaterialProfile.py
+++ b/plugins/XmlMaterialProfile/XmlMaterialProfile.py
@@ -918,11 +918,6 @@ class XmlMaterialProfile(InstanceContainer):
         base_metadata["properties"] = property_values
         base_metadata["definition"] = "fdmprinter"
 
-        # Certain materials are loaded but should not be visible / selectable to the user.
-        # Only show abstract color profiles (Any Color) if the machine supports them
-        base_metadata["visible"] = (not base_metadata.get("abstract_color", False)
-                                    or base_metadata.get("supports_abstract_color", False))
-
         compatible_entries = data.iterfind("./um:settings/um:setting[@key='hardware compatible']", cls.__namespaces)
         try:
             common_compatibility = cls._parseCompatibleValue(next(compatible_entries).text) # type: ignore

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -16,7 +16,8 @@
         "preferred_quality_type": "normal",
         "machine_extruder_trains": { "0": "fdmextruder" },
         "supports_usb_connection": true,
-        "supports_network_connection": false
+        "supports_network_connection": false,
+        "supports_abstract_color": false
     },
     "settings":
     {

--- a/resources/definitions/ultimaker_factor4.def.json
+++ b/resources/definitions/ultimaker_factor4.def.json
@@ -42,6 +42,7 @@
         "supports_material_export": true,
         "supports_network_connection": true,
         "supports_usb_connection": false,
+        "supports_abstract_color": true,
         "variants_name": "Print core",
         "weight": -1
     },

--- a/resources/definitions/ultimaker_s5.def.json
+++ b/resources/definitions/ultimaker_s5.def.json
@@ -51,6 +51,7 @@
         "supports_material_export": true,
         "supports_network_connection": true,
         "supports_usb_connection": false,
+        "supports_abstract_color": true,
         "variants_name": "Print core",
         "weight": -2
     },

--- a/resources/definitions/ultimaker_s7.def.json
+++ b/resources/definitions/ultimaker_s7.def.json
@@ -39,6 +39,7 @@
         "supports_material_export": true,
         "supports_network_connection": true,
         "supports_usb_connection": false,
+        "supports_abstract_color": true,
         "variants_name": "Print core",
         "weight": -2
     },


### PR DESCRIPTION
# Description

Currently Abstract color profiles are filtered out of the color options sub menu. This pull request will only filter these profiles out for machines that do not supports_abstract_colors (default = false). S5 and S7 line and factor 4 machines support abstract color profiles and will therefore be shown

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

Tested that the Any Color profiles show up for S5, S7 and factor 4, but nor for the S3.

**Test Configuration**:
* Operating System: windows 

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
