### PR TITLE
PP-511 Method Labs Extruder Materials

### DIFF
--- a/resources/bundled_packages/cura.json
+++ b/resources/bundled_packages/cura.json
@@ -1429,6 +1429,23 @@
             }
         }
     },
+    "BASFUltrafuse316L": {
+        "package_info": {
+            "package_id": "BASFUltrafuse316L",
+            "package_type": "material",
+            "display_name": "BASF Ultrafuse 316L",
+            "description": "An innovative filament to produce 316L grade stainless steel parts.",
+            "package_version": "1.0.1",
+            "sdk_version": "8.6.0",
+            "website": "https://forward-am.com/material-portfolio/ultrafuse-filaments-for-fused-filaments-fabrication-fff/metal-filaments/ultrafuse-316l/",
+            "author": {
+                "author_id": "BASF",
+                "display_name": "BASF",
+                "email": null,
+                "website": "https://forward-am.com/"
+            }
+        }
+    },
     "DagomaChromatikPLA": {
         "package_info": {
             "package_id": "DagomaChromatikPLA",
@@ -1582,6 +1599,23 @@
             }
         }
     },
+    "JabilTPE_SEBS1300_95a": {
+        "package_info": {
+            "package_id": "JabilTPE_SEBS1300_95a",
+            "package_type": "material",
+            "display_name": "Jabil TPE SEBS 1300 95a",
+            "description": "Soft material great for prototyping where rubber-like or elastomeric properties and durability are required.",
+            "package_version": "1.0.1",
+            "sdk_version": "8.6.0",
+            "website": "https://www.jabil.com/services/additive-manufacturing/additive-materials/compare-filaments/tpe-sebs-95a.html",
+            "author": {
+                "author_id": "Jabil",
+                "display_name": "Jabil",
+                "email": null,
+                "website": "https://www.jabil.com/"
+            }
+        }
+    },
     "OctofiberPLA": {
         "package_info": {
             "package_id": "OctofiberPLA",
@@ -1608,6 +1642,23 @@
             "package_version": "1.0.1",
             "sdk_version": "8.6.0",
             "website": "http://www.polymaker.com/shop/polyflex/",
+            "author": {
+                "author_id": "Polymaker",
+                "display_name": "Polymaker L.L.C.",
+                "email": "inquiry@polymaker.com",
+                "website": "https://www.polymaker.com"
+            }
+        }
+    },
+    "PolyMaxPC": {
+        "package_info": {
+            "package_id": "PolyMaxPC",
+            "package_type": "material",
+            "display_name": "PolyMax™ PC",
+            "description": "PolyMax™ PC is an engineered PC filament combining excellent strength, toughness, heat resistance and printing quality. It is the ideal choice for a wide range of engineering applications.",
+            "package_version": "1.0.1",
+            "sdk_version": "8.6.0",
+            "website": "http://www.polymaker.com/shop/polymax/",
             "author": {
                 "author_id": "Polymaker",
                 "display_name": "Polymaker L.L.C.",

--- a/resources/definitions/ultimaker_method.def.json
+++ b/resources/definitions/ultimaker_method.def.json
@@ -23,19 +23,7 @@
             "fabtotum_",
             "fdplast_",
             "filo3d_",
-            "generic_asa_175",
-            "generic_abs_175",
-            "generic_bvoh_175",
-            "generic_petg_175",
-            "generic_pla_175",
-            "generic_tough_pla_175",
-            "generic_pva_175",
-            "generic_cffpa_175",
-            "generic_cpe_175",
-            "generic_nylon_175",
-            "generic_hips_175",
-            "generic_pc_175",
-            "generic_tpu_175",
+            "generic_",
             "goofoo_",
             "ideagen3D_",
             "imade3d_",
@@ -44,6 +32,7 @@
             "leapfrog_",
             "polyflex_pla",
             "polymax_pla",
+            "polymaker_pc_175",
             "polyplus_pla",
             "polywood_pla",
             "redd_",
@@ -53,23 +42,22 @@
             "ultimaker_absr_175",
             "ultimaker_abscf_175",
             "ultimaker_bvoh_175",
-            "ultimaker_petg_175",
             "ultimaker_cffpa_175",
             "ultimaker_cpe_175",
-            "ultimaker_nylon_175",
             "ultimaker_hips_175",
             "ultimaker_pc_175",
             "ultimaker_tpu_175",
-            "ultimaker_tough_pla_175",
             "ultimaker_rapidrinse_175",
             "ultimaker_sr30",
+            "ultimaker_metallic_pla_175",
             "verbatim_",
             "Vertex_",
             "volumic_",
             "xyzprinting_",
             "zyyx_pro_",
             "octofiber_",
-            "fiberlogy_"
+            "fiberlogy_",
+            "ultimaker_metallic_pla_175"
         ],
         "has_machine_materials": true,
         "has_machine_quality": true,
@@ -98,7 +86,6 @@
     "overrides":
     {
         "build_volume_temperature": { "maximum_value": "67" },
-        "machine_depth": { "default_value": 236.48 },
         "machine_disallowed_areas":
         {
             "default_value": [
@@ -128,9 +115,7 @@
                 ]
             ]
         },
-        "machine_height": { "default_value": 196 },
         "machine_name": { "default_value": "UltiMaker Method" },
-        "machine_width": { "default_value": 283.3 },
         "prime_tower_position_x": { "value": "(150 / 2 + resolveOrValue('prime_tower_size') / 2) if resolveOrValue('machine_shape') == 'elliptic' else (150 - (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0) - max(max(extruderValues('travel_avoid_distance')) + max(extruderValues('support_offset')) + (extruderValue(skirt_brim_extruder_nr, 'skirt_brim_line_width') * extruderValue(skirt_brim_extruder_nr, 'skirt_line_count') * extruderValue(skirt_brim_extruder_nr, 'initial_layer_line_width_factor') / 100 + extruderValue(skirt_brim_extruder_nr, 'skirt_gap') if resolveOrValue('adhesion_type') == 'skirt' else 0) + (resolveOrValue('draft_shield_dist') if resolveOrValue('draft_shield_enabled') else 0), max(map(abs, extruderValues('machine_nozzle_offset_x'))), 1)) - (150 / 2 if resolveOrValue('machine_center_is_zero') else 0)" },
         "prime_tower_position_y": { "value": "190 - prime_tower_size - (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0) - max(max(extruderValues('travel_avoid_distance')) + max(extruderValues('support_offset')) + (extruderValue(skirt_brim_extruder_nr, 'skirt_brim_line_width') * extruderValue(skirt_brim_extruder_nr, 'skirt_line_count') * extruderValue(skirt_brim_extruder_nr, 'initial_layer_line_width_factor') / 100 + extruderValue(skirt_brim_extruder_nr, 'skirt_gap') if resolveOrValue('adhesion_type') == 'skirt' else 0) + (resolveOrValue('draft_shield_dist') if resolveOrValue('draft_shield_enabled') else 0), max(map(abs, extruderValues('machine_nozzle_offset_y'))), 1) - (190 / 2 if resolveOrValue('machine_center_is_zero') else 0)" }
     }

--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -9,42 +9,7 @@
         "manufacturer": "Ultimaker B.V.",
         "file_formats": "application/x-makerbot",
         "platform": "ultimaker_method_platform.stl",
-        "exclude_materials": [
-            "dsm_",
-            "Essentium_",
-            "imade3d_",
-            "chromatik_",
-            "3D-Fuel_",
-            "bestfilament_",
-            "emotiontech_",
-            "eryone_",
-            "eSUN_",
-            "Extrudr_",
-            "fabtotum_",
-            "fdplast_",
-            "filo3d_",
-            "generic_",
-            "ultimaker_rapidrinse_175",
-            "goofoo_",
-            "ideagen3D_",
-            "imade3d_",
-            "innofill_",
-            "layer_one_",
-            "leapfrog_",
-            "polyflex_pla",
-            "polymax_pla",
-            "polyplus_pla",
-            "polywood_pla",
-            "redd_",
-            "tizyx_",
-            "verbatim_",
-            "Vertex_",
-            "volumic_",
-            "xyzprinting_",
-            "zyyx_pro_",
-            "octofiber_",
-            "fiberlogy_"
-        ],
+        "exclude_materials": [],
         "has_machine_materials": true,
         "has_machine_quality": true,
         "has_materials": true,
@@ -170,8 +135,13 @@
             "enabled": false,
             "value": "acceleration_print"
         },
-        "adhesion_extruder_nr": { "value": 0 },
+        "adhesion_extruder_nr":
+        {
+            "enabled": false,
+            "value": "min(extruderValues('extruder_nr'))"
+        },
         "adhesion_type": { "value": "'raft'" },
+        "bottom_thickness": { "value": "top_bottom_thickness" },
         "bridge_enable_more_layers": { "value": true },
         "bridge_fan_speed": { "value": "cool_fan_speed_max" },
         "bridge_fan_speed_2": { "value": "(cool_fan_speed_max + cool_fan_speed_min) / 2" },
@@ -195,14 +165,38 @@
         {
             "force_depends_on_settings": [ "support_extruder_nr" ]
         },
+        "cool_fan_full_at_height": { "value": "1 if resolveOrValue('adhesion_type') == 'raft' else layer_height + layer_height_0" },
+        "cool_fan_full_layer": { "value": "1 if resolveOrValue('adhesion_type') == 'raft' else 3" },
         "default_material_bed_temperature": { "resolve": "min(extruderValues('default_material_bed_temperature'))" },
         "extruder_prime_pos_abs": { "default_value": true },
         "gradual_support_infill_steps": { "value": 0 },
+        "group_outer_walls": { "value": false },
+        "infill_angles":
+        {
+            "value": [
+                45,
+                45,
+                45,
+                45,
+                45,
+                135,
+                135,
+                135,
+                135,
+                135
+            ]
+        },
         "infill_before_walls": { "value": false },
         "infill_material_flow": { "value": "material_flow" },
         "infill_overlap": { "value": 0 },
-        "infill_pattern": { "value": "'grid' if infill_sparse_density < 80 else 'lines'" },
+        "infill_pattern": { "value": "'zigzag'" },
         "infill_wipe_dist": { "value": 0 },
+        "initial_layer_line_width_factor":
+        {
+            "maximum_value": 350,
+            "maximum_value_warning": 320,
+            "value": "100 if resolveOrValue('adhesion_type') == 'raft' else 200"
+        },
         "inset_direction": { "value": "'inside_out'" },
         "jerk_enabled":
         {
@@ -309,22 +303,66 @@
             "enabled": false,
             "value": "jerk_print"
         },
+        "layer_height_0": { "value": "layer_height if resolveOrValue('adhesion_type') == 'raft' else layer_height * 1.25" },
         "machine_acceleration": { "default_value": 3000 },
         "machine_center_is_zero": { "value": true },
+        "machine_depth": { "default_value": 236.48 },
+        "machine_disallowed_areas":
+        {
+            "default_value": [
+                [
+                    [-141.65, -118.11],
+                    [141.65, -118.11],
+                    [141.65, -95.205],
+                    [-141.65, -95.205]
+                ],
+                [
+                    [-141.65, 118.37],
+                    [141.65, 118.37],
+                    [141.65, 95.205],
+                    [-141.65, 95.205]
+                ],
+                [
+                    [-141.65, -118.11],
+                    [-76.149, -118.11],
+                    [-76.149, 118.37],
+                    [-141.65, 118.37]
+                ],
+                [
+                    [76.149, -118.11],
+                    [141.65, -118.11],
+                    [141.65, 118.37],
+                    [76.149, 118.37]
+                ]
+            ],
+            "value": "[ [ [-141.65, -118.11], [141.65, -118.11], [141.65, -95.205], [-141.65, -95.205] ], [ [-141.65, 118.37], [141.65, 118.37], [141.65, 95.205], [-141.65, 95.205] ], [ [-141.65, -118.11], [-114.249, -118.11], [-114.249, 118.37], [-141.65, 118.37] ], [ [76.149, -118.11], [141.65, -118.11], [141.65, 118.37], [76.149, 118.37] ] ] if max(extruderValues('extruder_nr')) == 0 else [ [ [-141.65, -118.11], [141.65, -118.11], [141.65, -95.205], [-141.65, -95.205] ], [ [-141.65, 118.37], [141.65, 118.37], [141.65, 95.205], [-141.65, 95.205] ], [ [-141.65, -118.11], [-76.149, -118.11], [-76.149, 118.37], [-141.65, 118.37] ], [ [76.149, -118.11], [141.65, -118.11], [141.65, 118.37], [76.149, 118.37] ] ]"
+        },
         "machine_end_gcode": { "default_value": "" },
         "machine_extruder_count": { "default_value": 2 },
         "machine_gcode_flavor": { "default_value": "Griffin" },
         "machine_heated_bed": { "default_value": false },
         "machine_heated_build_volume": { "default_value": true },
+        "machine_height": { "default_value": 196.749 },
         "machine_min_cool_heat_time_window": { "value": 15 },
         "machine_name": { "default_value": "UltiMaker Method" },
         "machine_nozzle_cool_down_speed": { "value": 0.8 },
         "machine_nozzle_heat_up_speed": { "value": 3.5 },
         "machine_scale_fan_speed_zero_to_one": { "value": true },
         "machine_start_gcode": { "default_value": "G0 Z20" },
+        "machine_width": { "default_value": 283.3 },
         "material_bed_temperature": { "enabled": "machine_heated_bed" },
+        "material_final_print_temperature":
+        {
+            "maximum_value": "material_print_temperature",
+            "minimum_value": "material_standby_temperature"
+        },
         "material_flow": { "value": 100 },
-        "material_initial_print_temperature": { "value": "material_print_temperature-10" },
+        "material_initial_print_temperature":
+        {
+            "maximum_value": "material_print_temperature",
+            "minimum_value": "material_standby_temperature",
+            "value": "material_print_temperature-5"
+        },
         "material_print_temperature":
         {
             "force_depends_on_settings": [ "support_extruder_nr" ]
@@ -339,17 +377,35 @@
         "prime_tower_base_curve_magnitude": { "value": 2 },
         "prime_tower_base_height": { "value": 6 },
         "prime_tower_base_size": { "value": 10 },
-        "prime_tower_enable": { "value": false },
+        "prime_tower_enable": { "value": "extruders_enabled_count > 1" },
         "prime_tower_flow": { "value": "material_flow" },
-        "prime_tower_line_width": { "value": 1 },
+        "prime_tower_line_width":
+        {
+            "maximum_value": 2,
+            "maximum_value_warning": 1.5,
+            "value": 1
+        },
+        "prime_tower_mode":
+        {
+            "resolve": "'normal'",
+            "value": "'normal'"
+        },
         "prime_tower_raft_base_line_spacing": { "value": "raft_base_line_width" },
         "prime_tower_wipe_enabled": { "value": true },
         "print_sequence": { "enabled": false },
+        "raft_acceleration": { "enabled": false },
         "raft_airgap":
         {
             "force_depends_on_settings": [ "support_extruder_nr" ]
         },
+        "raft_base_acceleration": { "enabled": false },
+        "raft_base_extruder_nr":
+        {
+            "enabled": false,
+            "value": "min(extruderValues('extruder_nr'))"
+        },
         "raft_base_fan_speed": { "value": 0 },
+        "raft_base_jerk": { "enabled": false },
         "raft_base_line_spacing":
         {
             "force_depends_on_settings": [ "raft_interface_extruder_nr" ],
@@ -358,9 +414,11 @@
         "raft_base_line_width":
         {
             "force_depends_on_settings": [ "raft_interface_extruder_nr" ],
+            "maximum_value": 2.5,
+            "maximum_value_warning": 1.8,
             "value": 1.4
         },
-        "raft_base_speed": { "value": 10 },
+        "raft_base_speed": { "value": "raft_speed" },
         "raft_base_thickness":
         {
             "force_depends_on_settings": [
@@ -369,24 +427,24 @@
             ],
             "value": 0.8
         },
-        "raft_base_wall_count":
-        {
-            "force_depends_on_settings": [ "support_extruder_nr" ],
-            "value": "raft_wall_count"
-        },
-        "raft_interface_extruder_nr": { "value": "raft_surface_extruder_nr" },
+        "raft_base_wall_count": { "value": "raft_wall_count" },
+        "raft_interface_acceleration": { "enabled": false },
+        "raft_interface_extruder_nr": { "value": "max(extruderValues('extruder_nr'))" },
         "raft_interface_fan_speed": { "value": 0 },
         "raft_interface_infill_overlap":
         {
             "force_depends_on_settings": [ "raft_interface_extruder_nr" ]
         },
+        "raft_interface_infill_overlap_mm": { "maximum_value_warning": "2 * machine_nozzle_size" },
+        "raft_interface_jerk": { "enabled": false },
         "raft_interface_layers": { "value": 2 },
         "raft_interface_line_spacing":
         {
             "force_depends_on_settings": [
                 "raft_base_thickness",
                 "raft_interface_extruder_nr"
-            ]
+            ],
+            "minimum_value_warning": "raft_interface_line_width * 0.8"
         },
         "raft_interface_line_width":
         {
@@ -396,7 +454,11 @@
             ],
             "value": 0.7
         },
-        "raft_interface_speed": { "value": 90 },
+        "raft_interface_speed":
+        {
+            "force_depends_on_settings": [ "support_extruder_nr" ],
+            "value": "raft_speed * 5"
+        },
         "raft_interface_thickness": { "value": 0.3 },
         "raft_interface_wall_count": { "value": "raft_wall_count" },
         "raft_interface_z_offset":
@@ -406,14 +468,18 @@
                 "raft_interface_extruder_nr"
             ]
         },
+        "raft_jerk": { "enabled": false },
         "raft_margin": { "value": 1.2 },
         "raft_smoothing": { "value": 9.5 },
-        "raft_surface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else raft_base_extruder_nr" },
+        "raft_speed": { "value": 10 },
+        "raft_surface_acceleration": { "enabled": false },
+        "raft_surface_extruder_nr": { "value": "max(extruderValues('extruder_nr'))" },
         "raft_surface_fan_speed": { "value": 0 },
         "raft_surface_flow":
         {
             "force_depends_on_settings": [ "support_extruder_nr" ]
         },
+        "raft_surface_jerk": { "enabled": false },
         "raft_surface_speed":
         {
             "force_depends_on_settings": [ "support_extruder_nr" ]
@@ -430,25 +496,52 @@
         "raft_wall_count": { "value": 2 },
         "retract_at_layer_change": { "value": true },
         "retraction_amount": { "value": 0.75 },
-        "retraction_combing": { "value": "'off'" },
+        "retraction_combing":
+        {
+            "enabled": false,
+            "value": "'off'"
+        },
         "retraction_combing_max_distance": { "value": "speed_travel / 10" },
         "retraction_count_max": { "value": 100 },
         "retraction_extrusion_window": { "value": 0 },
         "retraction_hop": { "value": 0.4 },
         "retraction_hop_enabled": { "value": true },
         "retraction_hop_only_when_collides": { "value": false },
-        "retraction_min_travel": { "value": "0.6" },
+        "retraction_min_travel":
+        {
+            "minimum_value_warning": "line_width * 1.25",
+            "value": 0.6
+        },
         "retraction_prime_speed": { "value": "retraction_speed" },
         "retraction_speed": { "value": 5 },
-        "roofing_layer_count": { "value": 2 },
+        "roofing_angles":
+        {
+            "value": [45, 135]
+        },
+        "roofing_layer_count":
+        {
+            "maximum_value_warning": 10,
+            "minimum_value": 0,
+            "minimum_value_warning": 1,
+            "value": 2
+        },
         "roofing_material_flow": { "value": "material_flow" },
         "roofing_monotonic": { "value": true },
+        "skin_angles":
+        {
+            "value": [0, 90]
+        },
         "skin_material_flow": { "value": "material_flow" },
         "skin_material_flow_layer_0": { "value": "material_flow" },
         "skin_monotonic": { "value": true },
         "skin_outline_count": { "value": 0 },
         "skin_overlap": { "value": 0 },
         "skin_preshrink": { "value": 0 },
+        "skirt_brim_extruder_nr":
+        {
+            "enabled": false,
+            "value": "min(extruderValues('extruder_nr'))"
+        },
         "skirt_brim_material_flow": { "value": "material_flow" },
         "skirt_brim_minimal_length": { "value": 500 },
         "small_skin_width": { "value": 4 },
@@ -465,34 +558,58 @@
         "speed_wall_x": { "value": "speed_wall" },
         "support_angle": { "value": 40 },
         "support_bottom_height": { "value": "2*support_infill_sparse_thickness" },
+        "support_bottom_line_width":
+        {
+            "maximum_value": 3,
+            "maximum_value_warning": 1.8
+        },
         "support_bottom_material_flow": { "value": "material_flow" },
-        "support_bottom_wall_count": { "value": "0" },
+        "support_bottom_wall_count":
+        {
+            "maximum_value": 8,
+            "maximum_value_warning": 6,
+            "value": 0
+        },
         "support_brim_enable": { "value": false },
         "support_conical_min_width": { "value": 10 },
         "support_enable": { "value": true },
         "support_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material'))" },
         "support_fan_enable": { "value": "True" },
+        "support_infill_angles":
+        {
+            "value": [
+                45
+            ]
+        },
         "support_infill_rate": { "value": 20.0 },
         "support_infill_sparse_thickness": { "value": "layer_height" },
         "support_interface_enable": { "value": true },
         "support_interface_height": { "value": "4*support_infill_sparse_thickness" },
         "support_interface_material_flow": { "value": "material_flow" },
         "support_interface_offset": { "value": "1" },
-        "support_interface_pattern": { "value": "'lines'" },
+        "support_interface_pattern": { "value": "'zigzag' if support_wall_count > 1 else 'lines'" },
         "support_interface_wall_count": { "value": "1" },
+        "support_join_distance": { "value": "4.5 if support_wall_count > 1 else 2" },
         "support_material_flow": { "value": "material_flow" },
-        "support_offset": { "value": "1.8" },
-        "support_pattern": { "value": "'lines'" },
+        "support_offset": { "value": "2.4 if support_wall_count > 1 else 1.8" },
+        "support_pattern": { "value": "'zigzag' if support_wall_count > 1 else 'lines'" },
         "support_roof_height": { "value": "4*layer_height" },
         "support_roof_material_flow": { "value": "material_flow" },
         "support_supported_skin_fan_speed": { "value": "cool_fan_speed_max" },
-        "support_use_towers": { "value": "False" },
+        "support_use_towers": { "value": false },
         "support_wall_count": { "value": "2 if support_conical_enabled or support_structure == 'tree' else 0" },
         "support_xy_distance": { "value": 0.2 },
         "support_xy_distance_overhang": { "value": "support_xy_distance" },
         "switch_extruder_retraction_amount": { "value": 0.5 },
         "switch_extruder_retraction_speeds": { "value": "retraction_speed" },
-        "top_bottom_thickness": { "value": "5*layer_height" },
+        "top_bottom_pattern": { "value": "'zigzag'" },
+        "top_bottom_pattern_0": { "value": "'zigzag'" },
+        "top_bottom_thickness":
+        {
+            "minimum_value_warning": 0.3,
+            "value": "4*layer_height"
+        },
+        "top_thickness": { "value": "top_bottom_thickness * 1.5" },
         "travel_avoid_distance": { "value": "3 if extruders_enabled_count > 1 else machine_nozzle_tip_outer_diameter / 2 * 1.5" },
         "travel_avoid_other_parts": { "value": false },
         "wall_0_inset": { "value": 0 },

--- a/resources/definitions/ultimaker_methodx.def.json
+++ b/resources/definitions/ultimaker_methodx.def.json
@@ -36,14 +36,14 @@
             "polywood_pla",
             "redd_",
             "tizyx_",
-            "ultimaker_tough_pla_175",
             "verbatim_",
             "Vertex_",
             "volumic_",
             "xyzprinting_",
             "zyyx_pro_",
             "octofiber_",
-            "fiberlogy_"
+            "fiberlogy_",
+            "ultimaker_metallic_pla_175"
         ],
         "has_machine_materials": true,
         "has_machine_quality": true,
@@ -72,7 +72,6 @@
     "overrides":
     {
         "build_volume_temperature": { "maximum_value": "107" },
-        "machine_depth": { "default_value": 236.48 },
         "machine_disallowed_areas":
         {
             "default_value": [
@@ -102,9 +101,7 @@
                 ]
             ]
         },
-        "machine_height": { "default_value": 196 },
         "machine_name": { "default_value": "UltiMaker Method X" },
-        "machine_width": { "default_value": 283.3 },
         "prime_tower_position_x": { "value": "(150 / 2 + resolveOrValue('prime_tower_size') / 2) if resolveOrValue('machine_shape') == 'elliptic' else (150 - (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0) - max(max(extruderValues('travel_avoid_distance')) + max(extruderValues('support_offset')) + (extruderValue(skirt_brim_extruder_nr, 'skirt_brim_line_width') * extruderValue(skirt_brim_extruder_nr, 'skirt_line_count') * extruderValue(skirt_brim_extruder_nr, 'initial_layer_line_width_factor') / 100 + extruderValue(skirt_brim_extruder_nr, 'skirt_gap') if resolveOrValue('adhesion_type') == 'skirt' else 0) + (resolveOrValue('draft_shield_dist') if resolveOrValue('draft_shield_enabled') else 0), max(map(abs, extruderValues('machine_nozzle_offset_x'))), 1)) - (150 / 2 if resolveOrValue('machine_center_is_zero') else 0)" },
         "prime_tower_position_y": { "value": "190 - prime_tower_size - (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0) - max(max(extruderValues('travel_avoid_distance')) + max(extruderValues('support_offset')) + (extruderValue(skirt_brim_extruder_nr, 'skirt_brim_line_width') * extruderValue(skirt_brim_extruder_nr, 'skirt_line_count') * extruderValue(skirt_brim_extruder_nr, 'initial_layer_line_width_factor') / 100 + extruderValue(skirt_brim_extruder_nr, 'skirt_gap') if resolveOrValue('adhesion_type') == 'skirt' else 0) + (resolveOrValue('draft_shield_dist') if resolveOrValue('draft_shield_enabled') else 0), max(map(abs, extruderValues('machine_nozzle_offset_y'))), 1) - (190 / 2 if resolveOrValue('machine_center_is_zero') else 0)" }
     }

--- a/resources/definitions/ultimaker_methodxl.def.json
+++ b/resources/definitions/ultimaker_methodxl.def.json
@@ -9,6 +9,42 @@
         "manufacturer": "Ultimaker B.V.",
         "file_formats": "application/x-makerbot",
         "platform": "ultimaker_method_xl_platform.stl",
+        "exclude_materials": [
+            "dsm_",
+            "Essentium_",
+            "imade3d_",
+            "chromatik_",
+            "3D-Fuel_",
+            "bestfilament_",
+            "emotiontech_",
+            "eryone_",
+            "eSUN_",
+            "Extrudr_",
+            "fabtotum_",
+            "fdplast_",
+            "filo3d_",
+            "generic_",
+            "goofoo_",
+            "ideagen3D_",
+            "imade3d_",
+            "innofill_",
+            "layer_one_",
+            "leapfrog_",
+            "polyflex_pla",
+            "polymax_pla",
+            "polyplus_pla",
+            "polywood_pla",
+            "redd_",
+            "tizyx_",
+            "verbatim_",
+            "Vertex_",
+            "volumic_",
+            "xyzprinting_",
+            "zyyx_pro_",
+            "octofiber_",
+            "fiberlogy_",
+            "ultimaker_metallic_pla_175"
+        ],
         "has_machine_materials": true,
         "has_machine_quality": true,
         "has_materials": true,
@@ -56,14 +92,26 @@
                     [205, 160],
                     [154.5, 160]
                 ]
-            ]
+            ],
+            "value": "[ [ [-204, -160], [204, -160], [204, -154.5], [-204, -154.5] ], [ [-204, 160], [204, 160], [204, 154.5], [-204, 154.5] ], [ [-205, -160], [-191.5, -160], [-191.5, 160], [-205, 160] ], [ [154.5, -160], [205, -160], [205, 160], [154.5, 160] ] ] if max(extruderValues('extruder_nr')) == 0 else [ [ [-204, -160], [204, -160], [204, -154.5], [-204, -154.5] ], [ [-204, 160], [204, 160], [204, 154.5], [-204, 154.5] ], [ [-205, -160], [-154.5, -160], [-154.5, 160], [-205, 160] ], [ [154.5, -160], [205, -160], [205, 160], [154.5, 160] ] ]"
         },
         "machine_heated_bed": { "default_value": true },
-        "machine_height": { "default_value": 320 },
+        "machine_height": { "default_value": 319.9 },
         "machine_name": { "default_value": "UltiMaker Method XL" },
         "machine_width": { "default_value": 410 },
         "prime_tower_position_x": { "value": "(305 - (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0) - max(max(extruderValues('travel_avoid_distance')) + max(extruderValues('support_offset')) + (extruderValue(skirt_brim_extruder_nr, 'skirt_brim_line_width') * extruderValue(skirt_brim_extruder_nr, 'skirt_line_count') * extruderValue(skirt_brim_extruder_nr, 'initial_layer_line_width_factor') / 100 + extruderValue(skirt_brim_extruder_nr, 'skirt_gap') if resolveOrValue('adhesion_type') == 'skirt' else 0) + (resolveOrValue('draft_shield_dist') if resolveOrValue('draft_shield_enabled') else 0), max(map(abs, extruderValues('machine_nozzle_offset_x'))), 1)) - (305 / 2)" },
         "prime_tower_position_y": { "value": "305 - prime_tower_size - (resolveOrValue('prime_tower_base_size') if (resolveOrValue('adhesion_type') == 'raft' or resolveOrValue('prime_tower_brim_enable')) else 0) - max(max(extruderValues('travel_avoid_distance')) + max(extruderValues('support_offset')) + (extruderValue(skirt_brim_extruder_nr, 'skirt_brim_line_width') * extruderValue(skirt_brim_extruder_nr, 'skirt_line_count') * extruderValue(skirt_brim_extruder_nr, 'initial_layer_line_width_factor') / 100 + extruderValue(skirt_brim_extruder_nr, 'skirt_gap') if resolveOrValue('adhesion_type') == 'skirt' else 0) + (resolveOrValue('draft_shield_dist') if resolveOrValue('draft_shield_enabled') else 0), max(map(abs, extruderValues('machine_nozzle_offset_y'))), 1) - (305 / 2)" },
-        "speed_travel": { "value": 500 }
+        "speed_travel":
+        {
+            "maximum_value": 500,
+            "maximum_value_warning": 450,
+            "value": 400
+        },
+        "speed_travel_layer_0":
+        {
+            "maximum_value": 500,
+            "maximum_value_warning": 450,
+            "value": 250
+        }
     }
 }

--- a/resources/extruders/ultimaker_method_extruder_left.def.json
+++ b/resources/extruders/ultimaker_method_extruder_left.def.json
@@ -16,7 +16,7 @@
         },
         "machine_extruder_cooling_fan_number": { "default_value": 0 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed_0/100}" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? fan_speed : fan_speed_0)}" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_method_extruder_right.def.json
+++ b/resources/extruders/ultimaker_method_extruder_right.def.json
@@ -16,7 +16,7 @@
         },
         "machine_extruder_cooling_fan_number": { "default_value": 1 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed_0/100}" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? fan_speed : fan_speed_0)}" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodx_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_left.def.json
@@ -16,7 +16,7 @@
         },
         "machine_extruder_cooling_fan_number": { "default_value": 0 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed_0/100}" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? fan_speed : fan_speed_0)}" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodx_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_right.def.json
@@ -16,7 +16,7 @@
         },
         "machine_extruder_cooling_fan_number": { "default_value": 1 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed_0/100}" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? fan_speed : fan_speed_0)}" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodxl_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_left.def.json
@@ -16,7 +16,7 @@
         },
         "machine_extruder_cooling_fan_number": { "default_value": 0 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed_0/100}" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? fan_speed : fan_speed_0)}" },
         "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodxl_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_right.def.json
@@ -16,7 +16,7 @@
         },
         "machine_extruder_cooling_fan_number": { "default_value": 1 },
         "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{cool_fan_speed_0/100}" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? fan_speed : fan_speed_0)}" },
         "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/quality/ultimaker_method/um_method_labs_basf-ultrafuse-316l-175_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_method/um_method_labs_basf-ultrafuse-316l-175_0.15mm.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_method
+name = Normal - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = basf_ultrafuse_316l_175
+quality_type = fast
+setting_version = 23
+type = quality
+variant = LABS
+weight = -1
+
+[values]
+adhesion_type = skirt
+bottom_thickness = =top_bottom_thickness
+cool_fan_full_at_height = 0
+infill_angles = [45,135]
+infill_overlap = 25
+infill_sparse_density = 100
+initial_layer_line_width_factor = 110
+layer_height_0 = =layer_height * 1.5
+material_flow_layer_0 = 110
+material_initial_print_temperature = 245
+retraction_amount = 1.5
+retraction_speed = 45
+roofing_line_width = 0.4
+skin_line_width = 0.45
+skin_material_flow_layer_0 = 110
+skin_overlap = 20.0
+skirt_brim_line_width = 1
+skirt_brim_minimal_length = 100.0
+skirt_height = 3
+speed_print = 25
+support_enable = False
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+wall_0_material_flow_layer_0 = 110
+wall_x_material_flow_layer_0 = 110
+

--- a/resources/quality/ultimaker_method/um_method_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_method/um_method_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
@@ -1,0 +1,36 @@
+[general]
+definition = ultimaker_method
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = jabil_tpe_sebs_1300_95a_175
+quality_type = draft
+setting_version = 23
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+infill_sparse_density = 50
+raft_airgap = 0.22
+raft_interface_speed = =speed_print * 1/2
+raft_surface_speed = =speed_print * 1/2
+speed_layer_0 = =speed_print * 1/4
+speed_prime_tower = =speed_print * 3/4
+speed_print = 40
+speed_roofing = =speed_print
+speed_support = =speed_print
+speed_support_bottom = =speed_print * 1/4
+speed_support_interface = =speed_print
+speed_topbottom = =speed_print
+speed_wall_0 = =speed_print
+speed_wall_x = =speed_print
+support_bottom_enable = False
+support_xy_distance = 0.3
+support_xy_distance_overhang = 0.26
+support_z_distance = 0.22
+wall_line_width = 0.5
+wall_thickness = =wall_line_width * 4
+

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_basf-ultrafuse-316l-175_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_basf-ultrafuse-316l-175_0.15mm.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_methodx
+name = Normal - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = basf_ultrafuse_316l_175
+quality_type = fast
+setting_version = 23
+type = quality
+variant = LABS
+weight = -1
+
+[values]
+adhesion_type = skirt
+bottom_thickness = =top_bottom_thickness
+cool_fan_full_at_height = 0
+infill_angles = [45,135]
+infill_overlap = 25
+infill_sparse_density = 100
+initial_layer_line_width_factor = 110
+layer_height_0 = =layer_height * 1.5
+material_flow_layer_0 = 110
+material_initial_print_temperature = 245
+retraction_amount = 1.5
+retraction_speed = 45
+roofing_line_width = 0.4
+skin_line_width = 0.45
+skin_material_flow_layer_0 = 110
+skin_overlap = 20.0
+skirt_brim_line_width = 1
+skirt_brim_minimal_length = 100.0
+skirt_height = 3
+speed_print = 25
+support_enable = False
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+wall_0_material_flow_layer_0 = 110
+wall_x_material_flow_layer_0 = 110
+

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
@@ -1,0 +1,36 @@
+[general]
+definition = ultimaker_methodx
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = jabil_tpe_sebs_1300_95a_175
+quality_type = draft
+setting_version = 23
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+infill_sparse_density = 50
+raft_airgap = 0.22
+raft_interface_speed = =speed_print * 1/2
+raft_surface_speed = =speed_print * 1/2
+speed_layer_0 = =speed_print * 1/4
+speed_prime_tower = =speed_print * 3/4
+speed_print = 40
+speed_roofing = =speed_print
+speed_support = =speed_print
+speed_support_bottom = =speed_print * 1/4
+speed_support_interface = =speed_print
+speed_topbottom = =speed_print
+speed_wall_0 = =speed_print
+speed_wall_x = =speed_print
+support_bottom_enable = False
+support_xy_distance = 0.3
+support_xy_distance_overhang = 0.26
+support_z_distance = 0.22
+wall_line_width = 0.5
+wall_thickness = =wall_line_width * 4
+

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_polymaker-polymax-pc-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_polymaker-polymax-pc-175_0.2mm.inst.cfg
@@ -1,0 +1,58 @@
+[general]
+definition = ultimaker_methodx
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = polymaker_polymax_pc_175
+quality_type = draft
+setting_version = 23
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+cool_fan_enabled = True
+cool_fan_full_layer = 6
+cool_fan_speed_max = 100
+cool_min_layer_time = 8
+cool_min_layer_time_fan_speed_max = 5
+cool_min_speed = 10
+raft_airgap = 0.22
+raft_interface_fan_speed = 0
+raft_interface_line_spacing = 0.7
+raft_interface_line_width = 0.55
+raft_interface_speed = 25
+raft_interface_thickness = 0.25
+raft_surface_fan_speed = 0
+raft_surface_speed = 50
+raft_surface_thickness = 0.25
+speed_print = 50
+speed_wall_0 = 30
+speed_wall_x = =speed_wall
+support_angle = 52
+support_bottom_distance = =layer_height
+support_bottom_enable = False
+support_bottom_stair_step_height = 0.3
+support_fan_enable = True
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 10
+support_interface_density = 83
+support_interface_height = =layer_height * 4
+support_interface_offset = 1.2
+support_interface_wall_count = 0
+support_line_width = 0.35
+support_material_flow = 90
+support_offset = 1.5
+support_roof_density = =extruderValue(support_roof_extruder_nr, 'support_interface_density')
+support_roof_height = =support_interface_height
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 100
+support_xy_distance = 0.35
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.22
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
@@ -1,0 +1,36 @@
+[general]
+definition = ultimaker_methodxl
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = jabil_tpe_sebs_1300_95a_175
+quality_type = draft
+setting_version = 23
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+infill_sparse_density = 50
+raft_airgap = 0.22
+raft_interface_speed = =speed_print * 1/2
+raft_surface_speed = =speed_print * 1/2
+speed_layer_0 = =speed_print * 1/4
+speed_prime_tower = =speed_print * 3/4
+speed_print = 40
+speed_roofing = =speed_print
+speed_support = =speed_print
+speed_support_bottom = =speed_print * 1/4
+speed_support_interface = =speed_print
+speed_topbottom = =speed_print
+speed_wall_0 = =speed_print
+speed_wall_x = =speed_print
+support_bottom_enable = False
+support_xy_distance = 0.3
+support_xy_distance_overhang = 0.26
+support_z_distance = 0.22
+wall_line_width = 0.5
+wall_thickness = =wall_line_width * 4
+

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_polymaker-polymax-pc-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_polymaker-polymax-pc-175_0.2mm.inst.cfg
@@ -1,0 +1,58 @@
+[general]
+definition = ultimaker_methodxl
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = polymaker_polymax_pc_175
+quality_type = draft
+setting_version = 23
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+cool_fan_enabled = True
+cool_fan_full_layer = 6
+cool_fan_speed_max = 100
+cool_min_layer_time = 8
+cool_min_layer_time_fan_speed_max = 5
+cool_min_speed = 10
+raft_airgap = 0.22
+raft_interface_fan_speed = 0
+raft_interface_line_spacing = 0.7
+raft_interface_line_width = 0.55
+raft_interface_speed = 25
+raft_interface_thickness = 0.25
+raft_surface_fan_speed = 0
+raft_surface_speed = 50
+raft_surface_thickness = 0.25
+speed_print = 50
+speed_wall_0 = 30
+speed_wall_x = =speed_wall
+support_angle = 52
+support_bottom_distance = =layer_height
+support_bottom_enable = False
+support_bottom_stair_step_height = 0.3
+support_fan_enable = True
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 10
+support_interface_density = 83
+support_interface_height = =layer_height * 4
+support_interface_offset = 1.2
+support_interface_wall_count = 0
+support_line_width = 0.35
+support_material_flow = 90
+support_offset = 1.5
+support_roof_density = =extruderValue(support_roof_extruder_nr, 'support_interface_density')
+support_roof_height = =support_interface_height
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 100
+support_xy_distance = 0.35
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.22
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+


### PR DESCRIPTION
This is to be reviewed & merged after the other PR for gets merged.

- Adding Jabil SEBS, Polymax PC and Ultrafuse 316L
- fix for extruder start gcode
- converted generic profiles to branded 3rd party profiles

NOTE:  Paul asked me to reach out to Bart & Kristel about the getting a new Package ID for the materials I added to cura.json.  For now, I used placeholder values and I'll update these with another PR as soon as I receive this information.  If you prefer, we can wait for the correct package IDs to merge this PR.


# How Has This Been Tested?

I tuned these materials using generic profiles, and once I converted these to branded profiles I sliced and printed one of each material.  Additionally, I tested the gcode start update by printing and monitoring the AC fan speeds, as well as manually searching through the print.jsontoolpath file for fan commands.

