### PR TITLE
Fix duplicated file reloading

### DIFF
--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -132,6 +132,7 @@ class ThreeMFReader(MeshReader):
         vertices = numpy.resize(data, (int(data.size / 3), 3))
         mesh_builder.setVertices(vertices)
         mesh_builder.calculateNormals(fast=True)
+        mesh_builder.setMeshId(node_id)
         if file_name:
             # The filename is used to give the user the option to reload the file if it is changed on disk
             # It is only set for the root node of the 3mf file


### PR DESCRIPTION
Instead of using the object name for reloading meshes inside a 3MF file, use a dedicated mesh ID property that is only stored internally, doesn't have to be unique (because the combination filename+ID will be) and can't be changed by the user. This should improve 3MF file reloading, and also fixes reloading of duplicated instances, because multiple meshes can now have the same mesh ID.

CURA-11905
Comes with https://github.com/Ultimaker/Uranium/pull/971