### PR TITLE
Remove unnecessary override

### DIFF
--- a/resources/definitions/ankermake_m5c.def.json
+++ b/resources/definitions/ankermake_m5c.def.json
@@ -67,7 +67,6 @@
             ]
         },
         "infill_extruder_nr": { "value": -1 },
-        "infill_line_distance": { "default_value": 8 },
         "infill_material_flow": { "value": 90 },
         "infill_pattern": { "value": "'lines' if infill_sparse_density >= 25 else 'grid'" },
         "infill_sparse_density": { "value": 10 },


### PR DESCRIPTION
Bug fix, value should not be overridden since it cancels out the formula calculating the distance based on the sparse  
Update, the override is setting the value to the value that the parent definition would calculate.
Resolves https://github.com/Ultimaker/Cura/issues/19716

![image](https://github.com/user-attachments/assets/a6260f85-e370-452c-bba1-f7d3f72ef9b9)
![image](https://github.com/user-attachments/assets/3f5a2005-86de-4271-bf3e-b022838dcf7e)
