### PR TITLE
Using the new cool_during_extruder_switch feature to switch the Metho…

### DIFF
--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -158,6 +158,7 @@
         "bridge_wall_material_flow": { "value": "material_flow" },
         "bridge_wall_speed": { "value": "speed_wall" },
         "brim_width": { "value": 5 },
+        "cool_during_extruder_switch": { "value": "'only_last_extruder'" },
         "cool_fan_enabled":
         {
             "force_depends_on_settings": [ "support_extruder_nr" ]

--- a/resources/extruders/ultimaker_method_extruder_left.def.json
+++ b/resources/extruders/ultimaker_method_extruder_left.def.json
@@ -15,8 +15,8 @@
             "maximum_value": 1
         },
         "machine_extruder_cooling_fan_number": { "default_value": 0 },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? cool_fan_speed/100 : cool_fan_speed_0/100)}" },
+        "machine_extruder_end_code": { "default_value": "M104 S{material_standby_temperature}\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_method_extruder_right.def.json
+++ b/resources/extruders/ultimaker_method_extruder_right.def.json
@@ -15,8 +15,8 @@
             "maximum_value": 1
         },
         "machine_extruder_cooling_fan_number": { "default_value": 1 },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? cool_fan_speed/100 : cool_fan_speed_0/100)}" },
+        "machine_extruder_end_code": { "default_value": "M104 S{material_standby_temperature}\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodx_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_left.def.json
@@ -15,8 +15,8 @@
             "maximum_value": "1"
         },
         "machine_extruder_cooling_fan_number": { "default_value": 0 },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? cool_fan_speed/100 : cool_fan_speed_0/100)}" },
+        "machine_extruder_end_code": { "default_value": "M104 S{material_standby_temperature}\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodx_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodx_extruder_right.def.json
@@ -15,8 +15,8 @@
             "maximum_value": "1"
         },
         "machine_extruder_cooling_fan_number": { "default_value": 1 },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? cool_fan_speed/100 : cool_fan_speed_0/100)}" },
+        "machine_extruder_end_code": { "default_value": "M104 S{material_standby_temperature}\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 8 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodxl_extruder_left.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_left.def.json
@@ -15,8 +15,8 @@
             "maximum_value": "1"
         },
         "machine_extruder_cooling_fan_number": { "default_value": 0 },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? cool_fan_speed/100 : cool_fan_speed_0/100)}" },
+        "machine_extruder_end_code": { "default_value": "M104 S{material_standby_temperature}\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },

--- a/resources/extruders/ultimaker_methodxl_extruder_right.def.json
+++ b/resources/extruders/ultimaker_methodxl_extruder_right.def.json
@@ -15,8 +15,8 @@
             "maximum_value": "1"
         },
         "machine_extruder_cooling_fan_number": { "default_value": 1 },
-        "machine_extruder_end_code": { "default_value": "M106 P{extruder_nr} S1.0\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
-        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nM104 S{material_print_temperature}\nG4 S5\nG91\nG0 Z-0.4 F600\nG90\nM107 P{(extruder_nr+1)%2}\nM106 P{extruder_nr} S{(layer_z > 1 ? cool_fan_speed/100 : cool_fan_speed_0/100)}" },
+        "machine_extruder_end_code": { "default_value": "M104 S{material_standby_temperature}\nG91\nG0 Z0.4 F600\nG90\nG0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000" },
+        "machine_extruder_start_code": { "default_value": "G0 X{prime_tower_position_x - prime_tower_size/2} Y{prime_tower_position_y + prime_tower_size/2} F6000\nG91\nG0 Z-0.4 F600\nG90" },
         "machine_extruder_start_code_duration": { "default_value": 10 },
         "machine_nozzle_offset_x": { "default_value": 0 },
         "machine_nozzle_offset_y": { "default_value": 0 },


### PR DESCRIPTION
The Method machines actively cool the nozzle at the end of a layer switch. Use the new cool_during_extruder_switch feature to enable this behavior and remove it from the start and end GCode template.

PP-530