### PR TITLE
[CURA-12112] Quality groups names are case-sensitive, so don't lower-case search.

### DIFF
--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -1354,7 +1354,6 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
                     return
                 machine_manager.setQualityChangesGroup(quality_changes_group, no_dialog = True)
             else:
-                self._quality_type_to_apply = self._quality_type_to_apply.lower() if self._quality_type_to_apply else None
                 quality_group_dict = container_tree.getCurrentQualityGroups()
                 if self._quality_type_to_apply in quality_group_dict:
                     quality_group = quality_group_dict[self._quality_type_to_apply]


### PR DESCRIPTION
This caused some settings not to load silently, since it has a fall-back to default.