### PR TITLE
[CURA-12155] Was too small to fit in the start/end-gcode in new printers.

### DIFF
--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -642,7 +642,7 @@
         "monitor_preheat_temperature_control": [4.5, 2.0],
 
         "welcome_wizard_window": [46, 50],
-        "modal_window_minimum": [60.0, 45],
+        "modal_window_minimum": [60.0, 50.0],
         "wizard_progress": [10.0, 0.0],
 
         "message": [30.0, 5.0],


### PR DESCRIPTION
This might have some impact on the min window size you can use Cura with, but it was getting a bit silly.