### PR TITLE
Post-ABR Requests for Kedge

### DIFF
--- a/resources/definitions/ultimaker_sketch_sprint.def.json
+++ b/resources/definitions/ultimaker_sketch_sprint.def.json
@@ -132,7 +132,7 @@
         "infill_pattern": { "value": "'lines'" },
         "infill_sparse_density": { "value": 15 },
         "infill_wipe_dist": { "value": 0 },
-        "initial_layer_line_width_factor": { "value": 150 },
+        "initial_layer_line_width_factor": { "value": "100 if adhesion_type == 'raft' else 150" },
         "inset_direction": { "value": "'inside_out'" },
         "jerk_enabled":
         {
@@ -140,7 +140,13 @@
             "value": false
         },
         "jerk_travel_enabled": { "enabled": false },
-        "layer_height_0": { "value": "layer_height if adhesion_type == 'raft' else layer_height * 1.25" },
+        "layer_height":
+        {
+            "maximum_value": 0.4,
+            "maximum_value_warning": 0.2,
+            "value": 0.2
+        },
+        "layer_height_0": { "value": "layer_height if adhesion_type == 'raft' else 0.25" },
         "line_width": { "value": 0.42 },
         "machine_center_is_zero": { "default_value": true },
         "machine_depth": { "default_value": 221.5 },
@@ -177,32 +183,39 @@
         "min_bead_width": { "value": 0.3 },
         "multiple_mesh_overlap": { "value": "0" },
         "print_sequence": { "enabled": false },
-        "raft_airgap": { "value": 0.35 },
+        "raft_airgap": { "value": 0.2 },
         "raft_base_acceleration": { "value": "acceleration_layer_0" },
         "raft_base_speed":
         {
             "maximum_value": "raft_speed",
-            "maximum_value_warning": "raft_speed * 1/2",
-            "value": "raft_speed * 1/4"
+            "maximum_value_warning": "raft_speed * 0.6",
+            "value": "raft_speed * 0.35"
         },
         "raft_interface_acceleration": { "value": "acceleration_print * 0.2" },
-        "raft_interface_line_width": { "value": 0.7 },
+        "raft_interface_line_width": { "value": 0.5 },
         "raft_interface_speed":
         {
-            "maximum_value": 300,
-            "maximum_value_warning": 275,
-            "value": "raft_speed * 3/4"
+            "maximum_value": "speed_print",
+            "maximum_value_warning": "speed_print * 22/25",
+            "value": "raft_speed * 0.9"
         },
         "raft_interface_wall_count": { "value": "raft_wall_count" },
         "raft_margin": { "value": "1.5" },
         "raft_smoothing": { "value": "9.5" },
-        "raft_speed": { "value": 200 },
+        "raft_speed":
+        {
+            "maximum_value": "speed_print",
+            "maximum_value_warning": "speed_print * 24/25",
+            "value": "speed_print * 4/5"
+        },
         "raft_surface_acceleration": { "value": "acceleration_print * 0.5" },
+        "raft_surface_infill_overlap": { "value": 50 },
         "raft_surface_line_width": { "value": 0.4 },
         "raft_surface_speed":
         {
-            "maximum_value": 300,
-            "maximum_value_warning": 275
+            "maximum_value": "speed_print",
+            "maximum_value_warning": "speed_print * 24/25",
+            "value": "raft_speed"
         },
         "raft_surface_wall_count": { "value": "raft_wall_count" },
         "raft_wall_count": { "value": 2 },
@@ -218,10 +231,13 @@
         "retraction_min_travel": { "value": 0.8 },
         "retraction_prime_speed": { "value": "35" },
         "retraction_speed": { "value": "35" },
+        "scarf_joint_seam_length": { "value": 3 },
+        "scarf_joint_seam_start_height_ratio": { "value": 25 },
+        "scarf_split_distance": { "value": 0.1 },
         "seam_overhang_angle": { "value": 30 },
         "skin_edge_support_thickness": { "value": 0 },
         "skin_material_flow": { "value": "material_flow" },
-        "skin_material_flow_layer_0": { "value": "material_flow * 0.95" },
+        "skin_material_flow_layer_0": { "value": "material_flow if adhesion_type == 'raft' else material_flow * 0.95" },
         "skin_monotonic": { "value": true },
         "skin_outline_count": { "value": 0 },
         "skin_overlap": { "value": 10 },
@@ -373,7 +389,7 @@
         "travel_avoid_distance": { "value": 0.625 },
         "travel_avoid_supports": { "value": true },
         "wall_0_inset": { "value": "0" },
-        "wall_0_material_flow_layer_0": { "value": "material_flow * 0.95" },
+        "wall_0_material_flow_layer_0": { "value": "skin_material_flow_layer_0" },
         "wall_0_wipe_dist": { "value": 0.2 },
         "wall_line_width_x": { "value": 0.58 },
         "wall_overhang_angle": { "value": 35 },
@@ -385,7 +401,7 @@
         "wall_thickness": { "value": 1 },
         "wall_x_material_flow_layer_0": { "value": "material_flow" },
         "xy_offset": { "value": 0 },
-        "xy_offset_layer_0": { "value": -0.1 },
+        "xy_offset_layer_0": { "value": "0 if adhesion_type == 'raft' else -0.1" },
         "z_seam_corner": { "value": "'z_seam_corner_inner'" },
         "z_seam_position": { "value": "'backleft'" },
         "z_seam_type": { "value": "'sharpest_corner'" },

--- a/resources/intent/ultimaker_sketch/um_sketch_0.4mm_um-pla-175_0.2mm_metallic.inst.cfg
+++ b/resources/intent/ultimaker_sketch/um_sketch_0.4mm_um-pla-175_0.2mm_metallic.inst.cfg
@@ -1,0 +1,20 @@
+[general]
+definition = ultimaker_sketch
+name = Metallic
+version = 4
+
+[metadata]
+intent_category = metallic
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 0.4mm
+
+[values]
+cool_min_temperature = 230
+material_final_print_temperature = 230
+material_initial_print_temperature = 230
+material_print_temperature = 230
+material_print_temperature_layer_0 = 235
+

--- a/resources/intent/ultimaker_sketch_large/um_sketch_large_0.4mm_um-pla-175_0.2mm_metallic.inst.cfg
+++ b/resources/intent/ultimaker_sketch_large/um_sketch_large_0.4mm_um-pla-175_0.2mm_metallic.inst.cfg
@@ -1,0 +1,20 @@
+[general]
+definition = ultimaker_sketch_large
+name = Metallic
+version = 4
+
+[metadata]
+intent_category = metallic
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 0.4mm
+
+[values]
+cool_min_temperature = 230
+material_final_print_temperature = 230
+material_initial_print_temperature = 230
+material_print_temperature = 230
+material_print_temperature_layer_0 = 235
+

--- a/resources/intent/ultimaker_sketch_sprint/um_sketch_sprint_0.4mm_um-pla-175_0.2mm_metallic.inst.cfg
+++ b/resources/intent/ultimaker_sketch_sprint/um_sketch_sprint_0.4mm_um-pla-175_0.2mm_metallic.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_sketch_sprint
+name = Metallic
+version = 4
+
+[metadata]
+intent_category = metallic
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 0.4mm
+
+[values]
+cool_min_temperature = 230
+infill_angles = [135,135,135,135,135, 45,45,45,45,45]
+material_final_print_temperature = 230
+material_initial_print_temperature = 230
+material_print_temperature = 230
+material_print_temperature_layer_0 = 235
+speed_print = 125
+speed_roofing = =speed_topbottom
+speed_support_bottom = =speed_support * 4/5
+speed_support_interface = =speed_support
+speed_topbottom = =speed_print * 4/5
+speed_wall = =speed_print * 3/5
+speed_wall_x = =speed_print * 4/5
+support_material_flow = 92
+wall_overhang_speed_factor = 23
+

--- a/resources/quality/ultimaker_method/um_method_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_method/um_method_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
@@ -13,7 +13,7 @@ variant = LABS
 weight = -2
 
 [values]
-infill_sparse_density = 50
+infill_sparse_density = 30
 raft_airgap = 0.22
 raft_interface_flow = 110
 raft_interface_infill_overlap = 25
@@ -37,6 +37,6 @@ support_bottom_enable = False
 support_xy_distance = 0.3
 support_xy_distance_overhang = 0.26
 support_z_distance = 0.22
-wall_line_width = 0.5
-wall_thickness = =wall_line_width * 4
+wall_line_width = 0.45
+wall_thickness = =wall_line_width * 3
 

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
@@ -13,7 +13,7 @@ variant = LABS
 weight = -2
 
 [values]
-infill_sparse_density = 50
+infill_sparse_density = 30
 raft_airgap = 0.22
 raft_interface_flow = 110
 raft_interface_infill_overlap = 25
@@ -37,6 +37,6 @@ support_bottom_enable = False
 support_xy_distance = 0.3
 support_xy_distance_overhang = 0.26
 support_z_distance = 0.22
-wall_line_width = 0.5
-wall_thickness = =wall_line_width * 4
+wall_line_width = 0.45
+wall_thickness = =wall_line_width * 3
 

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_polymaker-polymax-pc-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_polymaker-polymax-pc-175_0.2mm.inst.cfg
@@ -20,16 +20,22 @@ cool_min_layer_time = 8
 cool_min_layer_time_fan_speed_max = 5
 cool_min_speed = 10
 raft_airgap = 0.22
+raft_base_infill_overlap = 25
 raft_interface_fan_speed = 0
+raft_interface_flow = 110
+raft_interface_infill_overlap = 25
 raft_interface_line_spacing = 0.7
 raft_interface_line_width = 0.55
-raft_interface_speed = 25
+raft_interface_speed = =speed_print * 1/2
 raft_interface_thickness = 0.25
+raft_interface_z_offset = -0.1
 raft_surface_fan_speed = 0
-raft_surface_speed = 50
+raft_surface_flow = 110
+raft_surface_infill_overlap = 50
+raft_surface_speed = =speed_print
 raft_surface_thickness = 0.25
 speed_print = 50
-speed_wall_0 = 30
+speed_wall_0 = =speed_print * 3/5
 speed_wall_x = =speed_wall
 support_angle = 52
 support_bottom_distance = =layer_height

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_jabil-tpe-sebs-1300-95a-175_0.2mm.inst.cfg
@@ -13,7 +13,7 @@ variant = LABS
 weight = -2
 
 [values]
-infill_sparse_density = 50
+infill_sparse_density = 30
 raft_airgap = 0.22
 raft_interface_flow = 110
 raft_interface_infill_overlap = 25
@@ -37,6 +37,6 @@ support_bottom_enable = False
 support_xy_distance = 0.3
 support_xy_distance_overhang = 0.26
 support_z_distance = 0.22
-wall_line_width = 0.5
-wall_thickness = =wall_line_width * 4
+wall_line_width = 0.45
+wall_thickness = =wall_line_width * 3
 

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_polymaker-polymax-pc-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_polymaker-polymax-pc-175_0.2mm.inst.cfg
@@ -20,16 +20,22 @@ cool_min_layer_time = 8
 cool_min_layer_time_fan_speed_max = 5
 cool_min_speed = 10
 raft_airgap = 0.22
+raft_base_infill_overlap = 25
 raft_interface_fan_speed = 0
+raft_interface_flow = 110
+raft_interface_infill_overlap = 25
 raft_interface_line_spacing = 0.7
 raft_interface_line_width = 0.55
-raft_interface_speed = 25
+raft_interface_speed = =speed_print * 1/2
 raft_interface_thickness = 0.25
+raft_interface_z_offset = -0.1
 raft_surface_fan_speed = 0
-raft_surface_speed = 50
+raft_surface_flow = 110
+raft_surface_infill_overlap = 50
+raft_surface_speed = =speed_print
 raft_surface_thickness = 0.25
 speed_print = 50
-speed_wall_0 = 30
+speed_wall_0 = =speed_print * 3/5
 speed_wall_x = =speed_wall
 support_angle = 52
 support_bottom_distance = =layer_height


### PR DESCRIPTION
add Kedge warning for Layer Height > 0.2
decrease metallic PLA print speeds
fix Kedge Z seam gap with scarf settings
improve Polymax PC and SEBS adhesion
     --this came out of Method printing on the Beta QA build
    --SEBS was curling severely off of a PVA raft
    --large Polymax PC raft middle layers did not adhere well to the raft base

PP-534

Z Seam prints were completed using the Oct18th Cura build, Metallic PLA tuning was completed with a build shared on Oct15th.  Polymax & SEBS tuning were completed using the Oct15th build (with bug fix for Method fans)