### PR TITLE
CURA-12174 set start temperature for original plus

### DIFF
--- a/resources/definitions/ultimaker_original.def.json
+++ b/resources/definitions/ultimaker_original.def.json
@@ -68,6 +68,7 @@
         "machine_start_gcode": { "default_value": "G21 ;metric values\nG90 ;absolute positioning\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG28 X0 Y0 ;move X/Y to min endstops\nG28 Z0 ;move Z to min endstops\nG1 Z15.0 F9000 ;move the platform down 15mm\nG92 E0 ;zero the extruded length\nG1 F200 E6 ;extrude 6 mm of feed stock\nG92 E0 ;zero the extruded length again\nG1 Y50 F9000\n;Put printing message on LCD screen\nM117 Printing..." },
         "machine_use_extruder_offset_to_offset_coords": { "default_value": true },
         "machine_width": { "default_value": 205 },
+        "material_print_temp_wait": { "value": true },
         "speed_slowdown_layers": { "value": 2 }
     }
 }


### PR DESCRIPTION
This is apparently required for those printers. The default behavior was changed in previous release, and not having the wait temperature prevented them for setting the initial temperature. I assume they don't recognize the M104 command.

This change is so far untested on a real printer, but restores the exact same GCode as generated in 5.7, that worked.

CURA-12174