### PR TITLE
[CURA-12188] Fix build plate z-fighting

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -262,9 +262,9 @@ class BuildVolume(SceneNode):
 
         renderer.queueNode(self, mode = RenderBatch.RenderMode.Lines)
         renderer.queueNode(self, mesh = self._origin_mesh, backface_cull = True)
-        renderer.queueNode(self, mesh = self._grid_mesh, shader = self._grid_shader, backface_cull = True)
+        renderer.queueNode(self, mesh = self._grid_mesh, shader = self._grid_shader, backface_cull = True, transparent = True, sort = -10)
         if self._disallowed_area_mesh:
-            renderer.queueNode(self, mesh = self._disallowed_area_mesh, shader = self._shader, transparent = True, backface_cull = True, sort = -9)
+            renderer.queueNode(self, mesh = self._disallowed_area_mesh, shader = self._shader, transparent = True, backface_cull = True, sort = -5)
 
         if self._error_mesh:
             renderer.queueNode(self, mesh=self._error_mesh, shader=self._shader, transparent=True,

--- a/plugins/SimulationView/layers3d.shader
+++ b/plugins/SimulationView/layers3d.shader
@@ -360,8 +360,8 @@ geometry41core =
             ((v_prev_line_type[0] != 1) && (v_line_type[0] == 1)) ||
             ((v_prev_line_type[0] != 4) && (v_line_type[0] == 4))
             )) {
-            float w = size_x;
-            float h = size_y;
+            float w = max(0.05, size_x);
+            float h = max(0.05, size_y);
 
             myEmitVertex(v_vertex[0] + vec3( w,  h,  w), u_starts_color, normalize(vec3( 1.0,  1.0,  1.0)), viewProjectionMatrix * (gl_in[0].gl_Position + vec4( w,  h,  w, 0.0))); // Front-top-left
             myEmitVertex(v_vertex[0] + vec3(-w,  h,  w), u_starts_color, normalize(vec3(-1.0,  1.0,  1.0)), viewProjectionMatrix * (gl_in[0].gl_Position + vec4(-w,  h,  w, 0.0))); // Front-top-right

--- a/resources/shaders/grid.shader
+++ b/resources/shaders/grid.shader
@@ -45,6 +45,7 @@ fragment =
         float majorLine = min(majorGrid.x, majorGrid.y);
 
         gl_FragColor = mix(minorGridColor, u_gridColor0, 1.0 - min(majorLine, 1.0));
+        gl_FragColor.a = 0.8;
     }
 
 vertex41core =
@@ -88,6 +89,7 @@ fragment41core =
         float majorLine = min(majorGrid.x, majorGrid.y);
 
         frag_color = mix(minorGridColor, u_gridColor0, 1.0 - min(majorLine, 1.0));
+        frag_color.a = 0.8;
     }
 
 [defaults]


### PR DESCRIPTION
The build-plate grid and the printer model where on top of each other, and the additional sorting didn't apply (properly) since both of them where a different render-type.

(With bonus commit that solves rendering outer-wall line-starts when doing seam-scarfs.)