### PR TITLE
remove legacy material linkage

### DIFF
--- a/cura/PrinterOutput/FormatMaps.py
+++ b/cura/PrinterOutput/FormatMaps.py
@@ -34,13 +34,12 @@ class FormatMaps:
          "asa": {"name": "ASA", "guid": "f79bc612-21eb-482e-ad6c-87d75bdde066"},
          "nylon12-cf": {"name": "Nylon 12 CF", "guid": "3c6f2877-71cc-4760-84e6-4b89ab243e3b"},
          "nylon-cf": {"name": "Nylon CF", "guid": "17abb865-ca73-4ccd-aeda-38e294c9c60b"},
-         "nylon": {"name": "Nylon", "guid": "9475b03d-fd19-48a2-b7b5-be1fb46abb02"},
-         "petg": {"name": "PETG", "guid": "2d004bbd-d1bb-47f8-beac-b066702d5273"},
+         "pet": {"name": "PETG", "guid": "2d004bbd-d1bb-47f8-beac-b066702d5273"},
          "pla": {"name": "PLA", "guid": "abb9c58e-1f56-48d1-bd8f-055fde3a5b56"},
          "pva": {"name": "PVA", "guid": "add51ef2-86eb-4c39-afd5-5586564f0715"},
          "wss1": {"name": "RapidRinse", "guid": "a140ef8f-4f26-4e73-abe0-cfc29d6d1024"},
          "sr30": {"name": "SR-30", "guid": "77873465-83a9-4283-bc44-4e542b8eb3eb"},
-         "im-pla": {"name": "Tough", "guid": "96fca5d9-0371-4516-9e96-8e8182677f3c"}
+         "im-pla": {"name": "Tough", "guid": "de031137-a8ca-4a72-bd1b-17bb964033ad"}
          # /!\ When changing this list, make sure the changes are reported accordingly on Digital Factory
     }
 


### PR DESCRIPTION
CURA-12242

These material maps point to generic 175 GUIDs. We don't support generic on Sketch/Makerbot series so removed as legacy code.