### PR TITLE
tweaks common terms for Japanese translation

### DIFF
--- a/resources/i18n/ja_JP/cura.po
+++ b/resources/i18n/ja_JP/cura.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-03-13 09:02+0100\n"
-"PO-Revision-Date: 2024-10-27 12:31+0000\n"
+"PO-Revision-Date: 2024-10-30 02:53+0000\n"
 "Last-Translator: h1data <h1data@users.noreply.github.com>\n"
 "Language-Team: Japanese <https://github.com/h1data/Cura/wiki>\n"
 "Language: ja_JP\n"
@@ -2806,7 +2806,7 @@ msgstr "G-codeは一度に1つしか読み込めません。{0}の取り込み�
 
 msgctxt "@message"
 msgid "Oops! We encountered an unexpected error during your slicing process. Rest assured, we've automatically received the crash logs for analysis, if you have not disabled data sharing in your preferences. To assist us further, consider sharing your project details on our issue tracker."
-msgstr "申し訳ありません。スライス処理中に予期せぬエラーが発生しました。設定でデータ共有を無効にしていない場合は、クラッシュログを自動的に受信し分析を行います。また、Issue trackerでプロジェクトの詳細を共有いただけると助かります。"
+msgstr "申し訳ありません。スライス処理中に予期せぬエラーが発生しました。環境設定でデータ共有を無効にしていない場合は、クラッシュログを自動的に受信し分析を行います。また、Issue trackerでプロジェクトの詳細を共有いただけると助かります。"
 
 msgctxt "@action:button"
 msgid "Open"
@@ -2926,7 +2926,7 @@ msgstr[0] "%1個の設定を上書きします。"
 
 msgctxt "@title:menu menubar:toplevel"
 msgid "P&references"
-msgstr "プレファレンス(&R)"
+msgstr "環境設定(&R)"
 
 msgctxt "@item:inlistbox"
 msgid "PNG Image"
@@ -3891,7 +3891,7 @@ msgstr "表示項目設定"
 
 msgctxt "@info:progress"
 msgid "Setting up preferences..."
-msgstr "プレファレンスをセットアップ中..."
+msgstr "環境設定をセットアップ中..."
 
 msgctxt "@info:progress"
 msgid "Setting up scene..."
@@ -4237,7 +4237,7 @@ msgstr "強度"
 
 msgctxt "description"
 msgid "Submits anonymous slice info. Can be disabled through preferences."
-msgstr "匿名のスライス情報を登録します。設定により無効になる可能性があります。"
+msgstr "匿名のスライス情報を登録します。環境設定により無効になる場合があります。"
 
 msgctxt "@info:status Don't translate the XML tag <filename>!"
 msgid "Successfully exported material to <filename>%1</filename>"

--- a/resources/i18n/ja_JP/fdmprinter.def.json.po
+++ b/resources/i18n/ja_JP/fdmprinter.def.json.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-03-13 09:02+0100\n"
-"PO-Revision-Date: 2024-10-27 13:38+0000\n"
+"PO-Revision-Date: 2024-10-30 02:17+0000\n"
 "Last-Translator: h1data <h1data@users.noreply.github.com>\n"
 "Language-Team: Japanese <https://github.com/h1data/Cura/wiki>\n"
 "Language: ja_JP\n"
@@ -1560,11 +1560,11 @@ msgstr "インフィルオーバーハング角度"
 
 msgctxt "infill_overlap_mm label"
 msgid "Infill Overlap"
-msgstr "インフィル重複"
+msgstr "インフィルの重なり"
 
 msgctxt "infill_overlap label"
 msgid "Infill Overlap Percentage"
-msgstr "インフィル重複率"
+msgstr "インフィルの重なり (%)"
 
 msgctxt "infill_pattern label"
 msgid "Infill Pattern"
@@ -3178,11 +3178,11 @@ msgstr "表面拡張距離"
 
 msgctxt "skin_overlap_mm label"
 msgid "Skin Overlap"
-msgstr "表面重複"
+msgstr "表面の重なり"
 
 msgctxt "skin_overlap label"
 msgid "Skin Overlap Percentage"
-msgstr "表面重複率"
+msgstr "表面の重なり (%)"
 
 msgctxt "skin_preshrink label"
 msgid "Skin Removal Width"
@@ -5741,11 +5741,11 @@ msgstr "ラフト土台フロー量"
 
 msgctxt "raft_base_infill_overlap_mm label"
 msgid "Raft Base Infill Overlap"
-msgstr "ラフト土台インフィル重複"
+msgstr "ラフト土台でのインフィルの重なり"
 
 msgctxt "raft_base_infill_overlap label"
 msgid "Raft Base Infill Overlap Percentage"
-msgstr "ラフト土台インフィル重複率"
+msgstr "ラフト土台でのインフィルの重なり (%)"
 
 msgctxt "raft_flow label"
 msgid "Raft Flow"
@@ -5757,11 +5757,11 @@ msgstr "ラフト境界面フロー量"
 
 msgctxt "raft_interface_infill_overlap_mm label"
 msgid "Raft Interface Infill Overlap"
-msgstr "ラフト境界面インフィル重複"
+msgstr "ラフト境界面でのインフィルの重なり"
 
 msgctxt "raft_interface_infill_overlap label"
 msgid "Raft Interface Infill Overlap Percentage"
-msgstr "ラフト境界面インフィル重複率"
+msgstr "ラフト境界面でのインフィルの重なり (%)"
 
 msgctxt "raft_interface_z_offset label"
 msgid "Raft Interface Z Offset"
@@ -5773,11 +5773,11 @@ msgstr "ラフト表層フロー量"
 
 msgctxt "raft_surface_infill_overlap_mm label"
 msgid "Raft Surface Infill Overlap"
-msgstr "ラフト表面インフィル重複"
+msgstr "ラフト表面でのインフィルの重なり"
 
 msgctxt "raft_surface_infill_overlap label"
 msgid "Raft Surface Infill Overlap Percentage"
-msgstr "ラフト表面インフィル重複率"
+msgstr "ラフト表面でのインフィルの重なり (%)"
 
 msgctxt "raft_surface_z_offset label"
 msgid "Raft Surface Z Offset"
@@ -5817,11 +5817,11 @@ msgstr "インフィルとラフト土台のウォールが重なる量（イン
 
 msgctxt "raft_base_infill_overlap_mm description"
 msgid "The amount of overlap between the infill and the walls of the raft base. A slight overlap allows the walls to connect firmly to the infill."
-msgstr "インフィルとラフト土台のウォールとの重なる量。わずかな重なりにより、ウォールがインフィルにしっかりと接続されます。"
+msgstr "インフィルとラフト土台のウォールが重なる量。わずかな重なりにより、ウォールがインフィルにしっかりと接続されます。"
 
 msgctxt "raft_interface_infill_overlap description"
 msgid "The amount of overlap between the infill and the walls of the raft interface, as a percentage of the infill line width. A slight overlap allows the walls to connect firmly to the infill."
-msgstr "インフィルとラフト境界面のウォールとの重なる量（インフィルラインの幅に対する割合）。わずかな重なりにより、ウォールがインフィルにしっかりと接続されます。"
+msgstr "インフィルとラフト境界面のウォールが重なる量（インフィルラインの幅に対する割合）。わずかな重なりにより、ウォールがインフィルにしっかりと接続されます。"
 
 msgctxt "raft_interface_infill_overlap_mm description"
 msgid "The amount of overlap between the infill and the walls of the raft interface. A slight overlap allows the walls to connect firmly to the infill."


### PR DESCRIPTION
# Description

Tweaks common terms for Japanese translation.
- preference: プレファレンス -> 環境設定
- overlap (i.e. infill) : 重複 -> 重なり

## Type of change

- [x] Translations

# How Has This Been Tested?

- [x] compiled to mo files and tested in 5.9.1.

**Test Configuration**:
* Operating System: Windows 11

# Checklist:
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
