### PR TITLE
CURA-12270 rename setting to avoid confusions

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -8982,7 +8982,7 @@
                 },
                 "wall_0_acceleration":
                 {
-                    "label": "Outer Wall Acceleration",
+                    "label": "Outer Wall Start Acceleration",
                     "description": "This is the acceleration with which to reach the top speed when printing an outer wall.",
                     "enabled": "wall_0_start_speed_ratio < 100.0",
                     "type": "float",
@@ -9009,7 +9009,7 @@
                 },
                 "wall_0_deceleration":
                 {
-                    "label": "Outer Wall Deceleration",
+                    "label": "Outer Wall End Deceleration",
                     "description": "This is the deceleration with which to end printing an outer wall.",
                     "enabled": "wall_0_end_speed_ratio < 100.0",
                     "type": "float",


### PR DESCRIPTION
We had two settings called exactly "Outer Wall Acceleration", which is really confusing. The new setting has then been renamed.
It won't be translated for 5.9, which is assumed and acceptable because it is an experimental setting.

CURA-12270