### PR TITLE
[CURA-12223] Force extruder position to stick during retrieval of property.

### DIFF
--- a/cura/Settings/ExtruderStack.py
+++ b/cura/Settings/ExtruderStack.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Ultimaker B.V.
+# Copyright (c) 2024 UltiMaker
 # Cura is released under the terms of the LGPLv3 or higher.
 
 from typing import Any, Dict, TYPE_CHECKING, Optional
@@ -12,11 +12,8 @@ from UM.Settings.ContainerRegistry import ContainerRegistry
 from UM.Settings.Interfaces import ContainerInterface, PropertyEvaluationContext
 from UM.Util import parseBool
 
-import cura.CuraApplication
-
 from . import Exceptions
 from .CuraContainerStack import CuraContainerStack, _ContainerIndexes
-from .ExtruderManager import ExtruderManager
 
 if TYPE_CHECKING:
     from cura.Settings.GlobalStack import GlobalStack
@@ -141,7 +138,11 @@ class ExtruderStack(CuraContainerStack):
                 context.popContainer()
             return result
 
-        limit_to_extruder = super().getProperty(key, "limit_to_extruder", context)
+        if not context:
+            context = PropertyEvaluationContext(self)
+        if "extruder_position" not in context.context:
+            context.context["extruder_position"] = super().getProperty(key, "limit_to_extruder", context)
+        limit_to_extruder = context.context["extruder_position"]
         if limit_to_extruder is not None:
             limit_to_extruder = str(limit_to_extruder)
 


### PR DESCRIPTION
Otherwise other parts of the stack(s) could have another value for limit-to-extruder, depending on if the user updates the chosen extruder (for example for support) quickly enough that we're in the middle of the operation.