### PR TITLE
Fix various issues reported via crash-logs.

### DIFF
--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -398,7 +398,7 @@ class MachineManager(QObject):
                 self.setVariantByName(extruder.getMetaDataEntry("position"), machine_node.preferred_variant_name)
                 variant_node = machine_node.variants.get(machine_node.preferred_variant_name)
 
-            material_node = variant_node.materials.get(extruder.material.getMetaDataEntry("base_file"))
+            material_node = variant_node.materials.get(extruder.material.getMetaDataEntry("base_file")) if variant_node else None
             if material_node is None:
                 Logger.log("w", "An extruder has an unknown material, switching it to the preferred material")
                 if not self.setMaterialById(extruder.getMetaDataEntry("position"), machine_node.preferred_material):

--- a/cura/UI/CuraSplashScreen.py
+++ b/cura/UI/CuraSplashScreen.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2020 Ultimaker B.V.
 # Uranium is released under the terms of the LGPLv3 or higher.
+import math
 
 from PyQt6.QtCore import Qt, QCoreApplication, QTimer
 from PyQt6.QtGui import QPixmap, QColor, QFont, QPen, QPainter
@@ -51,6 +52,7 @@ class CuraSplashScreen(QSplashScreen):
         self._last_update_time = time.time()
         # Since we don't know how much time actually passed, check how many intervals of 50 we had.
         self._loading_image_rotation_angle -= 10 * (time_since_last_update * 1000 / 50)
+        self._loading_image_rotation_angle = math.fmod(self._loading_image_rotation_angle, 360)
         self.repaint()
 
     # Override the mousePressEvent so the splashscreen doesn't disappear when clicked

--- a/cura/UI/WelcomePagesModel.py
+++ b/cura/UI/WelcomePagesModel.py
@@ -217,8 +217,7 @@ class WelcomePagesModel(ListModel):
     def _getBuiltinWelcomePagePath(page_filename: str) -> QUrl:
         """Convenience function to get QUrl path to pages that's located in "resources/qml/WelcomePages"."""
         from cura.CuraApplication import CuraApplication
-        return QUrl.fromLocalFile(Resources.getPath(CuraApplication.ResourceTypes.QmlFiles,
-                                                    os.path.join("WelcomePages", page_filename)))
+        return QUrl.fromLocalFile(Resources.getPath(CuraApplication.ResourceTypes.QmlFiles, "WelcomePages", page_filename))
 
     # FIXME: HACKs for optimization that we don't update the model every time the active machine gets changed.
     def _onActiveMachineChanged(self) -> None:


### PR DESCRIPTION
Fixes! Get them while they're hot!

- Fix error that could occur when `variant_node` was `None`.
- Fix loading screen being on for a long time would crash via overflow of angle of loading icon.
- Try to fix the welcome screen page(s) not being found.