### PR TITLE
Update sovol_sv01.def.json Extruder ist titan style (bowden does not apply)

### DIFF
--- a/resources/definitions/sovol_sv01.def.json
+++ b/resources/definitions/sovol_sv01.def.json
@@ -1,11 +1,11 @@
 {
     "version": 2,
     "name": "Sovol SV01",
-    "inherits": "sovol_base_bowden",
+    "inherits": "sovol_base_titan",
     "metadata":
     {
         "visible": true,
-        "quality_definition": "sovol_base_bowden"
+        "quality_definition": "sovol_base_titan"
     },
     "overrides":
     {


### PR DESCRIPTION
Update sovol_sv01.def.json Extruder, is titan style (bowden does not apply)

# Description

Small update to sovol_sv01.def.json Extruder because titan style extruder (bowden does not apply).
This improves extruder performance. Furthermore it avoids crashing cura on material editing.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with Cura 5.8 and 5.9-beta-2
No more crashes on cura when editig material settings.

**Test Configuration**:
* Operating System: Windows 11

# Checklist:
n/a

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
