### PR TITLE
Update Top/Bottom Layers formula

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1595,7 +1595,7 @@
                                     "maximum_value": "999999",
                                     "type": "int",
                                     "minimum_value_warning": "2",
-                                    "value": "math.ceil(round(top_thickness / resolveOrValue('layer_height'), 4))"
+                                    "value": "math.ceil(round(top_thickness / resolveOrValue('layer_height'), 4))",
                                     "limit_to_extruder": "top_bottom_extruder_nr",
                                     "settable_per_mesh": true
                                 }
@@ -1625,7 +1625,7 @@
                                     "default_value": 6,
                                     "maximum_value": "999999",
                                     "type": "int",
-                                    "value": "math.ceil(round(bottom_thickness / resolveOrValue('layer_height'), 4))"
+                                    "value": "math.ceil(round(bottom_thickness / resolveOrValue('layer_height'), 4))",
                                     "limit_to_extruder": "top_bottom_extruder_nr",
                                     "settable_per_mesh": true
                                 },

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1595,7 +1595,7 @@
                                     "maximum_value": "999999",
                                     "type": "int",
                                     "minimum_value_warning": "2",
-                                    "value": "0 if infill_sparse_density == 100 else math.ceil(round(top_thickness / resolveOrValue('layer_height'), 4))",
+                                    "value": "math.ceil(round(top_thickness / resolveOrValue('layer_height'), 4))"
                                     "limit_to_extruder": "top_bottom_extruder_nr",
                                     "settable_per_mesh": true
                                 }
@@ -1625,7 +1625,7 @@
                                     "default_value": 6,
                                     "maximum_value": "999999",
                                     "type": "int",
-                                    "value": "999999 if infill_sparse_density == 100 and not magic_spiralize else math.ceil(round(bottom_thickness / resolveOrValue('layer_height'), 4))",
+                                    "value": "math.ceil(round(bottom_thickness / resolveOrValue('layer_height'), 4))"
                                     "limit_to_extruder": "top_bottom_extruder_nr",
                                     "settable_per_mesh": true
                                 },

--- a/resources/definitions/ultimaker.def.json
+++ b/resources/definitions/ultimaker.def.json
@@ -16,7 +16,6 @@
     {
         "acceleration_layer_0": { "value": "acceleration_topbottom" },
         "acceleration_travel_enabled": { "value": false },
-        "bottom_layers": { "value": "math.ceil(round(bottom_thickness / resolveOrValue('layer_height'), 4))" },
         "bridge_enable_more_layers": { "value": false },
         "bridge_fan_speed": { "value": "cool_fan_speed_max" },
         "bridge_fan_speed_2": { "value": "cool_fan_speed_min" },
@@ -131,7 +130,6 @@
         "support_wall_count": { "value": "1 if support_structure == 'tree' else 0" },
         "support_xy_distance_overhang": { "value": "0.2" },
         "support_z_distance": { "value": "0" },
-        "top_layers": { "value": "math.ceil(round(top_thickness / resolveOrValue('layer_height'), 4))" },
         "wall_0_material_flow_layer_0": { "value": "1.10 * material_flow_layer_0" },
         "wall_thickness": { "value": "wall_line_width_0 + wall_line_width_x" },
         "wall_x_material_flow_layer_0": { "value": "0.95 * material_flow_layer_0" },


### PR DESCRIPTION
# Description

Replaces the global default values for both *Top Layers* and *Bottom Layers* with those found in the Ultimaker definition. This removes the unexpected behaviour where a model will become solid Bottom Layers instead of Infill when setting the *Infill Density* to 100%, allowing all appropriate Infill properties - speed, line width, layer thickness, extruder, etc - to be applied where they are supposed to be. This also prevents any interference with the *Top Surface Skin Layers* feature by no longer setting the *Top Layers* to zero.

Removes the corresponding declarations from the Ultimaker definition as they now match the inherited values.

## Type of change

- [x] Printer definition file(s)

# How Has This Been Tested?

* With an updated local configuration matching the new settings, Cura behaves as expected.

**Test Configuration**:
* Microsoft Windows 11 Pro (build 22631.4317)
* AMD Ryzen 5 5800X3D
* 32GB RAM
* NVidia GeForce RTX 3080 10GB

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
