### PR TITLE
Use single extruder when exporting for Replicator+

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -5,7 +5,7 @@ requirements:
   - "curaengine/5.10.0-alpha.0@ultimaker/testing"
   - "cura_binary_data/5.10.0-alpha.0@ultimaker/testing"
   - "fdm_materials/5.10.0-alpha.0@ultimaker/testing"
-  - "dulcificum/0.2.1@ultimaker/stable"
+  - "dulcificum/0.3.0@ultimaker/cura_12313"
   - "pysavitar/5.4.0-alpha.0@ultimaker/stable"
   - "pynest2d/5.4.0-alpha.0@ultimaker/stable"
 requirements_internal:

--- a/plugins/MakerbotWriter/MakerbotWriter.py
+++ b/plugins/MakerbotWriter/MakerbotWriter.py
@@ -46,6 +46,13 @@ class MakerbotWriter(MeshWriter):
                 suffixes=["makerbot"]
             )
         )
+        MimeTypeDatabase.addMimeType(
+            MimeType(
+                name="application/x-makerbot-replicator_plus",
+                comment="Makerbot Toolpath Package",
+                suffixes=["makerbot"]
+            )
+        )
 
     _PNG_FORMAT = [
         {"prefix": "isometric_thumbnail", "width": 120, "height": 120},
@@ -114,6 +121,8 @@ class MakerbotWriter(MeshWriter):
                 filename, filedata = "print.gcode", gcode_text_io.getvalue()
             case "application/x-makerbot":
                 filename, filedata = "print.jsontoolpath", du.gcode_2_miracle_jtp(gcode_text_io.getvalue())
+            case "application/x-makerbot-replicator_plus":
+                filename, filedata = "print.jsontoolpath", du.gcode_2_miracle_jtp(gcode_text_io.getvalue(), nb_extruders=1)
             case _:
                 raise Exception("Unsupported Mime type")
 

--- a/plugins/MakerbotWriter/__init__.py
+++ b/plugins/MakerbotWriter/__init__.py
@@ -25,6 +25,12 @@ def getMetaData():
                     "description": catalog.i18nc("@item:inlistbox", "Makerbot Sketch Printfile"),
                     "mime_type": "application/x-makerbot-sketch",
                     "mode": MakerbotWriter.MakerbotWriter.OutputMode.BinaryMode,
+                },
+                {
+                    "extension": file_extension,
+                    "description": catalog.i18nc("@item:inlistbox", "Makerbot Replicator+ Printfile"),
+                    "mime_type": "application/x-makerbot-replicator_plus",
+                    "mode": MakerbotWriter.MakerbotWriter.OutputMode.BinaryMode,
                 }
             ]
         },


### PR DESCRIPTION
For Makerbot Replicator+, we now need to give the number of export extruders to dulcificum. To that purpose, we add a new mimetype to differentiate at export time.

:warning: Remember to change the `conandata.yml` when merging to use `stable` channel

CURA-12313