### PR TITLE
Add metallic PLA quality files for Sketch printers

### DIFF
--- a/resources/definitions/ultimaker_sketch.def.json
+++ b/resources/definitions/ultimaker_sketch.def.json
@@ -58,8 +58,7 @@
             "ultimaker_rapidrinse",
             "ultimaker_sr30",
             "ultimaker_petg",
-            "ultimaker_pva",
-            "ultimaker_metallic_pla"
+            "ultimaker_pva"
         ],
         "has_machine_quality": true,
         "has_materials": true,

--- a/resources/definitions/ultimaker_sketch.def.json
+++ b/resources/definitions/ultimaker_sketch.def.json
@@ -52,7 +52,6 @@
             "ultimaker_rapidrinse",
             "ultimaker_sr30",
             "ultimaker_petg",
-            "ultimaker_metallic_pla",
             "basf_",
             "jabil_",
             "polymaker_",

--- a/resources/definitions/ultimaker_sketch_sprint.def.json
+++ b/resources/definitions/ultimaker_sketch_sprint.def.json
@@ -53,8 +53,7 @@
             "ultimaker_pva",
             "ultimaker_rapidrinse",
             "ultimaker_sr30",
-            "ultimaker_petg",
-            "ultimaker_metallic_pla"
+            "ultimaker_petg"
         ],
         "has_machine_quality": true,
         "has_materials": true,

--- a/resources/quality/ultimaker_sketch/um_sketch_0.4mm_um-metallic-pla-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_sketch/um_sketch_0.4mm_um-metallic-pla-175_0.2mm.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = ultimaker_sketch
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_metallic_pla_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 0.4mm
+weight = -2
+
+[values]
+

--- a/resources/quality/ultimaker_sketch_large/um_sketch_large_0.4mm_um-metallic-pla-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_sketch_large/um_sketch_large_0.4mm_um-metallic-pla-175_0.2mm.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = ultimaker_sketch_large
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_metallic_pla_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 0.4mm
+weight = -2
+
+[values]
+

--- a/resources/quality/ultimaker_sketch_sprint/um_sketch_sprint_0.4mm_um-metallic-pla-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_sketch_sprint/um_sketch_sprint_0.4mm_um-metallic-pla-175_0.2mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_sketch_sprint
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_metallic_pla_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 0.4mm
+weight = -2
+
+[values]
+cool_min_temperature = 230
+infill_angles = [45,45,45,45,45,135,135,135,135,135]
+material_final_print_temperature = 230
+material_initial_print_temperature = 230
+speed_print = 125
+speed_roofing = 100
+speed_support_bottom = 100
+speed_support_interface = 125
+speed_topbottom = 100
+speed_wall = 75
+speed_wall_x = 100
+support_material_flow = 92
+wall_overhang_speed_factor = 23
+


### PR DESCRIPTION
Previously we used the PLA quality files to print Metallic PLA. There were drastic differences in surface quality (matte vs shiny). The temperature increase to 230 addresses the surface differences. We reduced the print speed to stay within the max flow rate of 12 mm^3/s.  Additionally, the infill rotation was enabled for Metallic PLA (Similar to Sketch PLA infill).

Some other speed adjustments were made (walls, roof, support interface, support bottom).  These were paths that got slowed down too much when adjusting the global print speed. These adjustments were made to make up some of the lost speed without sacrificing print quality.

The previous support material flow value was set to 90%.  We increased it by 2% to limit under-extrusion, which is more pronounced at the higher nozzle temperature.

An ABR was completed to validate this profile change.

PP-552