### PR TITLE
[PP-537] Introduce nominal_layer_height

### DIFF
--- a/cura/Machines/Models/MachineModelUtils.py
+++ b/cura/Machines/Models/MachineModelUtils.py
@@ -15,7 +15,7 @@ def fetchLayerHeight(quality_group: "QualityGroup") -> float:
     from cura.CuraApplication import CuraApplication
     global_stack = CuraApplication.getInstance().getMachineManager().activeMachine
 
-    default_layer_height = global_stack.definition.getProperty("layer_height", "value")
+    default_layer_height = global_stack.definition.getProperty("nominal_layer_height", "value")
 
     # Get layer_height from the quality profile for the GlobalStack
     if quality_group.node_for_global is None:
@@ -23,13 +23,13 @@ def fetchLayerHeight(quality_group: "QualityGroup") -> float:
     container = quality_group.node_for_global.container
 
     layer_height = default_layer_height
-    if container and container.hasProperty("layer_height", "value"):
-        layer_height = container.getProperty("layer_height", "value")
+    if container and container.hasProperty("nominal_layer_height", "value"):
+        layer_height = container.getProperty("nominal_layer_height", "value")
     else:
         # Look for layer_height in the GlobalStack from material -> definition
         container = global_stack.definition
-        if container and container.hasProperty("layer_height", "value"):
-            layer_height = container.getProperty("layer_height", "value")
+        if container and container.hasProperty("nominal_layer_height", "value"):
+            layer_height = container.getProperty("nominal_layer_height", "value")
 
     if isinstance(layer_height, SettingFunction):
         layer_height = layer_height(global_stack)

--- a/cura/Machines/Models/QualityProfilesDropDownMenuModel.py
+++ b/cura/Machines/Models/QualityProfilesDropDownMenuModel.py
@@ -71,7 +71,7 @@ class QualityProfilesDropDownMenuModel(ListModel):
             return
 
         if not self._layer_height_unit:
-            unit = global_stack.definition.getProperty("layer_height", "unit")
+            unit = global_stack.definition.getProperty("nominal_layer_height", "unit")
             if not unit:
                 unit = ""
             self._layer_height_unit = unit

--- a/cura/Settings/MachineManager.py
+++ b/cura/Settings/MachineManager.py
@@ -617,7 +617,7 @@ class MachineManager(QObject):
 
         if not self._global_container_stack:
             return 0
-        value = self._global_container_stack.getRawProperty("layer_height", "value", skip_until_container = self._global_container_stack.qualityChanges.getId())
+        value = self._global_container_stack.getRawProperty("nominal_layer_height", "value", skip_until_container = self._global_container_stack.qualityChanges.getId())
         if isinstance(value, SettingFunction):
             value = value(self._global_container_stack)
         return value

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -798,10 +798,10 @@
             "description": "All settings that influence the resolution of the print. These settings have a large impact on the quality (and print time)",
             "children":
             {
-                "layer_height":
+                "nominal_layer_height":
                 {
-                    "label": "Layer Height",
-                    "description": "The height of each layer in mm. Higher values produce faster prints in lower resolution, lower values produce slower prints in higher resolution.",
+                    "label": "Nominal Layer Height",
+                    "description": "The nominal layer height of the final printed part.",
                     "unit": "mm",
                     "type": "float",
                     "default_value": 0.1,
@@ -809,21 +809,38 @@
                     "minimum_value_warning": "0.04",
                     "maximum_value_warning": "0.8 * min(extruderValues('machine_nozzle_size'))",
                     "settable_per_mesh": false,
-                    "settable_per_extruder": false
-                },
-                "layer_height_0":
-                {
-                    "label": "Initial Layer Height",
-                    "description": "The height of the initial layer in mm. A thicker initial layer makes adhesion to the build plate easier.",
-                    "unit": "mm",
-                    "type": "float",
-                    "default_value": 0.3,
-                    "resolve": "min(extruderValues('layer_height_0'))",
-                    "minimum_value": "0.001",
-                    "minimum_value_warning": "0.1",
-                    "maximum_value_warning": "0.8 * min(extruderValues('machine_nozzle_size'))",
-                    "settable_per_mesh": false,
-                    "settable_per_extruder": false
+                    "settable_per_extruder": false,
+                    "children":
+                    {
+                        "layer_height":
+                        {
+                            "label": "Layer Height",
+                            "description": "The height of each layer in mm. Higher values produce faster prints in lower resolution, lower values produce slower prints in higher resolution.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 0.1,
+                            "value": "nominal_layer_height",
+                            "minimum_value": "0.001",
+                            "minimum_value_warning": "0.04",
+                            "maximum_value_warning": "0.8 * min(extruderValues('machine_nozzle_size'))",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": false
+                        },
+                        "layer_height_0":
+                        {
+                            "label": "Initial Layer Height",
+                            "description": "The height of the initial layer in mm. A thicker initial layer makes adhesion to the build plate easier.",
+                            "unit": "mm",
+                            "type": "float",
+                            "default_value": 0.3,
+                            "resolve": "min(extruderValues('layer_height_0'))",
+                            "minimum_value": "0.001",
+                            "minimum_value_warning": "0.1",
+                            "maximum_value_warning": "0.8 * min(extruderValues('machine_nozzle_size'))",
+                            "settable_per_mesh": false,
+                            "settable_per_extruder": false
+                        }
+                    }
                 },
                 "line_width":
                 {

--- a/resources/definitions/ultimaker_factor4.def.json
+++ b/resources/definitions/ultimaker_factor4.def.json
@@ -105,7 +105,8 @@
             "value": "5"
         },
         "jerk_travel_enabled": { "value": "True" },
-        "layer_height": { "value": "min(min(extruderValues('machine_nozzle_size')) / 2, 0.2)" },
+        "nominal_layer_height": { "value": "min(min(extruderValues('machine_nozzle_size')) / 2, 0.2)" },
+        "layer_height": { "value": "round(nominal_layer_height * material_shrinkage_percentage_z / 100, 5)" },
         "machine_acceleration": { "default_value": 3000 },
         "machine_depth": { "default_value": 240 },
         "machine_end_gcode": { "default_value": "" },

--- a/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml
+++ b/resources/qml/PrintSetupSelector/PrintSetupSelectorHeader.qml
@@ -26,7 +26,7 @@ RowLayout
         {
             id: layerHeight
             containerStack: Cura.MachineManager.activeStack
-            key: "layer_height"
+            key: "nominal_layer_height"
             watchedProperties: ["value"]
         }
     }

--- a/resources/quality/ultimaker_factor4/um_f4_global_Draft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_global_Draft_Quality.inst.cfg
@@ -11,5 +11,5 @@ type = quality
 weight = -2
 
 [values]
-layer_height = =round(0.2 * material_shrinkage_percentage_z / 100, 5)
+nominal_layer_height = 0.2
 

--- a/resources/quality/ultimaker_factor4/um_f4_global_Fast_Quality.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_global_Fast_Quality.inst.cfg
@@ -11,5 +11,5 @@ type = quality
 weight = -1
 
 [values]
-layer_height = =round(0.15 * material_shrinkage_percentage_z / 100, 5)
+nominal_layer_height = 0.15
 

--- a/resources/quality/ultimaker_factor4/um_f4_global_Normal_Quality.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_global_Normal_Quality.inst.cfg
@@ -11,5 +11,5 @@ type = quality
 weight = 0
 
 [values]
-layer_height = =round(0.1 * material_shrinkage_percentage_z / 100, 5)
+nominal_layer_height = 0.1
 

--- a/resources/quality/ultimaker_factor4/um_f4_global_Superdraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_global_Superdraft_Quality.inst.cfg
@@ -11,5 +11,5 @@ type = quality
 weight = -4
 
 [values]
-layer_height = =round(0.4 * material_shrinkage_percentage_z / 100, 5)
+nominal_layer_height = 0.4
 

--- a/resources/quality/ultimaker_factor4/um_f4_global_Verydraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_global_Verydraft_Quality.inst.cfg
@@ -11,5 +11,5 @@ type = quality
 weight = -3
 
 [values]
-layer_height = =round(0.3 * material_shrinkage_percentage_z / 100, 5)
+nominal_layer_height = 0.3
 


### PR DESCRIPTION
# PP-537 - CURA-12020: Introduce `nominal_layer_height`

## Description
This PR introduces the `nominal_layer_height` setting. This is the layer height that the final part should have. The real `layer_height` and `layer_height_0` become children of this setting.

## Rationale
For the Factor 4, we multiply the layer height with the material shrinkage factor. This is done so that an object of 20mm high printed with a 0.2mm layer height, will still have exactly 100 layers. This improves the dimensional accuracy, because otherwise the object might not have an exact whole number of layers.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?
Ran Cura from source with these changes

**Test Configuration**:
* Operating System: Ubuntu

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
