### PR TITLE
Add intent profiles for Method High Speed

### DIFF
--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -33,12 +33,14 @@
     {
         "acceleration_enabled":
         {
-            "enabled": false,
+            "enabled": true,
             "value": true
         },
         "acceleration_infill":
         {
-            "enabled": false,
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
             "value": "acceleration_print"
         },
         "acceleration_layer_0":
@@ -48,12 +50,18 @@
         },
         "acceleration_prime_tower":
         {
-            "enabled": false,
+            "enabled": "acceleration_enabled and prime_tower_enable and extruders_enabled_count > 1",
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
             "value": "acceleration_print"
         },
         "acceleration_print":
         {
-            "enabled": false,
+            "enabled": "acceleration_enabled",
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
             "value": 800
         },
         "acceleration_print_layer_0":
@@ -63,33 +71,49 @@
         },
         "acceleration_roofing":
         {
-            "enabled": false,
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
             "value": "acceleration_print"
+        },
+        "acceleration_skirt_brim":
+        {
+            "enabled": "acceleration_enabled and (adhesion_type == 'skirt' or adhesion_type == 'brim')",
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
+            "value": 800
         },
         "acceleration_support":
         {
-            "enabled": false,
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
             "value": "acceleration_print"
         },
         "acceleration_support_bottom":
         {
             "enabled": false,
-            "value": "acceleration_print"
+            "value": "acceleration_support_interface"
         },
         "acceleration_support_infill":
         {
-            "enabled": false,
-            "value": "acceleration_print"
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
+            "value": "acceleration_support"
         },
         "acceleration_support_interface":
         {
-            "enabled": false,
-            "value": "acceleration_print"
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
+            "value": "acceleration_support"
         },
         "acceleration_support_roof":
         {
             "enabled": false,
-            "value": "acceleration_print"
+            "value": "acceleration_support_interface"
         },
         "acceleration_topbottom":
         {
@@ -98,7 +122,10 @@
         },
         "acceleration_travel":
         {
-            "enabled": false,
+            "enabled": "acceleration_enabled",
+            "maximum_value": 5000,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
             "value": 5000
         },
         "acceleration_travel_enabled":
@@ -113,28 +140,37 @@
         },
         "acceleration_wall":
         {
-            "enabled": false,
+            "enabled": "acceleration_enabled",
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
             "value": "acceleration_print"
         },
         "acceleration_wall_0":
         {
-            "enabled": false,
-            "value": "acceleration_print"
+            "enabled": "acceleration_enabled",
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
+            "value": "acceleration_wall"
         },
         "acceleration_wall_0_roofing":
         {
             "enabled": false,
-            "value": "acceleration_print"
+            "value": "acceleration_wall"
         },
         "acceleration_wall_x":
         {
-            "enabled": false,
-            "value": "acceleration_print"
+            "enabled": "acceleration_enabled",
+            "maximum_value": 3500,
+            "minimum_value": 200,
+            "minimum_value_warning": 750,
+            "value": "acceleration_wall"
         },
         "acceleration_wall_x_roofing":
         {
             "enabled": false,
-            "value": "acceleration_print"
+            "value": "acceleration_wall"
         },
         "adhesion_extruder_nr":
         {
@@ -203,12 +239,15 @@
         "inset_direction": { "value": "'inside_out'" },
         "jerk_enabled":
         {
-            "enabled": false,
+            "enabled": true,
             "value": true
         },
         "jerk_infill":
         {
-            "enabled": false,
+            "enabled": "jerk_enabled",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
             "value": "jerk_print"
         },
         "jerk_layer_0":
@@ -218,13 +257,19 @@
         },
         "jerk_prime_tower":
         {
-            "enabled": false,
+            "enabled": "jerk_enabled and prime_tower_enable and extruders_enabled_count > 1",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
             "value": "jerk_print"
         },
         "jerk_print":
         {
-            "enabled": false,
-            "value": 6.25
+            "enabled": "jerk_enabled",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
+            "value": 12.5
         },
         "jerk_print_layer_0":
         {
@@ -233,33 +278,50 @@
         },
         "jerk_roofing":
         {
-            "enabled": false,
+            "enabled": "jerk_enabled",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
             "value": "jerk_print"
+        },
+        "jerk_skirt_brim":
+        {
+            "enabled": "jerk_enabled and (adhesion_type == 'brim' or adhesion_type == 'skirt')",
+            "value": 12.5
         },
         "jerk_support":
         {
-            "enabled": false,
+            "enabled": "jerk_enabled and support_enable",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
             "value": "jerk_print"
         },
         "jerk_support_bottom":
         {
             "enabled": false,
-            "value": "jerk_print"
+            "value": "jerk_support_interface"
         },
         "jerk_support_infill":
         {
-            "enabled": false,
-            "value": "jerk_print"
+            "enabled": "jerk_enabled and support_enable",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
+            "value": "jerk_support"
         },
         "jerk_support_interface":
         {
-            "enabled": false,
-            "value": "jerk_print"
+            "enabled": "jerk_enabled and support_enable",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
+            "value": "jerk_support"
         },
         "jerk_support_roof":
         {
             "enabled": false,
-            "value": "jerk_print"
+            "value": "jerk_support_interface"
         },
         "jerk_topbottom":
         {
@@ -268,8 +330,11 @@
         },
         "jerk_travel":
         {
-            "enabled": false,
-            "value": "jerk_print"
+            "enabled": "jerk_enabled",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
+            "value": 12.5
         },
         "jerk_travel_enabled":
         {
@@ -283,12 +348,18 @@
         },
         "jerk_wall":
         {
-            "enabled": false,
+            "enabled": "jerk_enabled",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
             "value": "jerk_print"
         },
         "jerk_wall_0":
         {
-            "enabled": false,
+            "enabled": "jerk_enabled",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
             "value": "jerk_print"
         },
         "jerk_wall_0_roofing":
@@ -298,7 +369,10 @@
         },
         "jerk_wall_x":
         {
-            "enabled": false,
+            "enabled": "jerk_enabled",
+            "maximum_value": 35,
+            "minimum_value": 5,
+            "minimum_value_warning": 12,
             "value": "jerk_print"
         },
         "jerk_wall_x_roofing":
@@ -517,16 +591,86 @@
         "skirt_height": { "value": 3 },
         "small_skin_width": { "value": 4 },
         "speed_equalize_flow_width_factor": { "value": 0 },
-        "speed_prime_tower": { "value": "speed_topbottom" },
-        "speed_print": { "value": 50 },
-        "speed_roofing": { "value": "speed_wall_0" },
-        "speed_support": { "value": "speed_wall" },
-        "speed_support_interface": { "value": "speed_topbottom" },
-        "speed_topbottom": { "value": "speed_wall" },
+        "speed_infill":
+        {
+            "maximum_value": 350,
+            "maximum_value_warning": 325
+        },
+        "speed_prime_tower":
+        {
+            "maximum_value": 250,
+            "maximum_value_warning": 200,
+            "value": "speed_topbottom"
+        },
+        "speed_print":
+        {
+            "maximum_value": 350,
+            "maximum_value_warning": 325,
+            "value": 50
+        },
+        "speed_roofing":
+        {
+            "maximum_value": 300,
+            "maximum_value_warning": 275,
+            "value": "speed_wall_0"
+        },
+        "speed_support":
+        {
+            "maximum_value": 350,
+            "maximum_value_warning": 325,
+            "value": "speed_wall"
+        },
+        "speed_support_infill":
+        {
+            "maximum_value": 350,
+            "maximum_value_warning": 325
+        },
+        "speed_support_interface":
+        {
+            "maximum_value": 260,
+            "maximum_value_warning": 255,
+            "value": "speed_topbottom"
+        },
+        "speed_support_roof":
+        {
+            "maximum_value": 260,
+            "maximum_value_warning": 255
+        },
+        "speed_topbottom":
+        {
+            "maximum_value": 260,
+            "maximum_value_warning": 255,
+            "value": "speed_wall"
+        },
         "speed_travel": { "value": 250 },
-        "speed_wall": { "value": "speed_print * 40/50" },
-        "speed_wall_0": { "value": "speed_wall * 30/40" },
-        "speed_wall_x": { "value": "speed_wall" },
+        "speed_wall":
+        {
+            "maximum_value": 260,
+            "maximum_value_warning": 255,
+            "value": "speed_print * 40/50"
+        },
+        "speed_wall_0":
+        {
+            "maximum_value": 260,
+            "maximum_value_warning": 255,
+            "value": "speed_wall * 30/40"
+        },
+        "speed_wall_0_roofing":
+        {
+            "maximum_value": 260,
+            "maximum_value_warning": 255
+        },
+        "speed_wall_x":
+        {
+            "maximum_value": 260,
+            "maximum_value_warning": 255,
+            "value": "speed_wall"
+        },
+        "speed_wall_x_roofing":
+        {
+            "maximum_value": 260,
+            "maximum_value_warning": 255
+        },
         "support_angle": { "value": 40 },
         "support_bottom_height": { "value": "2*support_infill_sparse_thickness" },
         "support_bottom_line_width":

--- a/resources/intent/ultimaker_method/um_method_1a_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_1a_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_method
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_method/um_method_1a_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_1a_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_method
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_method/um_method_1a_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_1a_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_method
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_method/um_method_1a_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_1a_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_method
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_method/um_method_1c_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_1c_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_method
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_method/um_method_1c_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_1c_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_method
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_method/um_method_1c_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_1c_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_method
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_method/um_method_1c_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_1c_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_method
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_method/um_method_labs_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_labs_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_method
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_method/um_method_labs_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_labs_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_method
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_method/um_method_labs_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_labs_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_method
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_method/um_method_labs_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_method/um_method_labs_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_method
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1a_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1a_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1a_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1a_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1a_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1a_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1a_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1a_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1c_um-absr-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1c_um-absr-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_pattern = zigzag
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1c_um-absr-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1c_um-absr-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,38 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1c_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1c_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1c_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1c_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1c_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1c_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1c_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1c_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1xa_um-absr-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1xa_um-absr-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1XA
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_pattern = zigzag
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1xa_um-absr-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1xa_um-absr-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,38 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1XA
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_pattern = zigzag
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-absr-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,38 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_methodx
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 47
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1a_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1a_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1a_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1a_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,42 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 45
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+material_bed_temperature = 45
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1a_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1a_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1a_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1a_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,42 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1A
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 45
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+material_bed_temperature = 45
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-absr-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-absr-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_pattern = zigzag
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-absr-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-absr-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,38 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,42 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 45
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+material_bed_temperature = 45
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,42 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 45
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+material_bed_temperature = 45
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1xa_um-absr-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1xa_um-absr-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1XA
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_pattern = zigzag
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1xa_um-absr-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1xa_um-absr-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,38 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1XA
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_pattern = zigzag
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-absr-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,38 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_absr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+cool_min_temperature = 245.0
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+speed_layer_0 = 55
+speed_print = 300
+speed_support = 100
+speed_support_interface = 75
+speed_travel = 500
+speed_travel_layer_0 = 250
+speed_wall_0 = 40
+support_pattern = zigzag
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,42 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 45
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+material_bed_temperature = 45
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-tough-pla-175_0.2mm_highspeed.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-tough-pla-175_0.2mm_highspeed.inst.cfg
@@ -1,0 +1,34 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed
+version = 4
+
+[metadata]
+intent_category = highspeed
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bridge_wall_speed = 300
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_pattern = zigzag
+jerk_print = 35
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-tough-pla-175_0.2mm_highspeedsolid.inst.cfg
@@ -1,0 +1,42 @@
+[general]
+definition = ultimaker_methodxl
+name = High Speed Solid
+version = 4
+
+[metadata]
+intent_category = highspeedsolid
+is_experimental = True
+material = ultimaker_tough_pla_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+acceleration_print = 3500
+bottom_thickness = =top_bottom_thickness
+bridge_wall_speed = 300
+build_volume_temperature = 45
+cool_fan_enabled = True
+cool_fan_speed = 100
+cool_min_layer_time = 3
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+jerk_print = 35
+material_bed_temperature = 45
+speed_infill = 240.0
+speed_layer_0 = 55
+speed_print = 300
+speed_travel = 500
+speed_travel_layer_0 = 350.0
+speed_wall_0 = 45
+support_interface_line_width = 0.42
+support_line_width = 0.47
+support_material_flow = 100
+support_pattern = zigzag
+support_roof_line_width = 0.42
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+


### PR DESCRIPTION
These intent modes were tuned by Eric MacNeil.  The jerk & accel values will be converted into a accel_config by the Makerbot writer plugin, and the Method firmware will interpret these values for each path.

The self support speed settings were unchanged from the previous defaults, but the model speed was increased for ABSR, PLA & TPLA.

PP-544

New intent modes include:

ABSR High Speed (MX, MXL)
ABSR High Speed Solid (MX, MXL)
PLA High Speed (M, MX, MXL)
PLA High Speed Solid (M, MX, MXL)
TPLA High Speed (M, MX, MXL)
TPLA High Speed Solid (M, MX, MXL)

These changes were tested extensively in the New York printer lab, as well as by Alan in New Jersey.  The most commonly observed failure mode was self support under-extrusion. This failure mode was eliminated by reverting the self support settings to the previous defaults.

