### PR TITLE
ZYYX Pro profile bugfix

### DIFF
--- a/resources/quality/zyyx_pro/carbon06/flex/zyyx_pro_06_flex_fast.inst.cfg
+++ b/resources/quality/zyyx_pro/carbon06/flex/zyyx_pro_06_flex_fast.inst.cfg
@@ -4,7 +4,6 @@ name = Fast
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = fast06
 setting_version = 24

--- a/resources/quality/zyyx_pro/carbon06/flex/zyyx_pro_06_flex_fine.inst.cfg
+++ b/resources/quality/zyyx_pro/carbon06/flex/zyyx_pro_06_flex_fine.inst.cfg
@@ -4,7 +4,6 @@ name = Fine
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = fine06
 setting_version = 24

--- a/resources/quality/zyyx_pro/carbon06/flex/zyyx_pro_06_flex_normal.inst.cfg
+++ b/resources/quality/zyyx_pro/carbon06/flex/zyyx_pro_06_flex_normal.inst.cfg
@@ -4,7 +4,6 @@ name = Normal
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = normal06
 setting_version = 24

--- a/resources/quality/zyyx_pro/carbon12/flex/zyyx_pro_12_flex_normal.inst.cfg
+++ b/resources/quality/zyyx_pro/carbon12/flex/zyyx_pro_12_flex_normal.inst.cfg
@@ -4,7 +4,6 @@ name = Normal
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = normal12
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi02/flex/zyyx_pro_02_flex_fast.inst.cfg
+++ b/resources/quality/zyyx_pro/multi02/flex/zyyx_pro_02_flex_fast.inst.cfg
@@ -4,7 +4,6 @@ name = Fast
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = fast02
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi02/flex/zyyx_pro_02_flex_fine.inst.cfg
+++ b/resources/quality/zyyx_pro/multi02/flex/zyyx_pro_02_flex_fine.inst.cfg
@@ -4,7 +4,6 @@ name = Fine
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = fine02
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi02/flex/zyyx_pro_02_flex_normal.inst.cfg
+++ b/resources/quality/zyyx_pro/multi02/flex/zyyx_pro_02_flex_normal.inst.cfg
@@ -4,7 +4,6 @@ name = Normal
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = normal02
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi04/flex/zyyx_pro_04_flex_fast.inst.cfg
+++ b/resources/quality/zyyx_pro/multi04/flex/zyyx_pro_04_flex_fast.inst.cfg
@@ -4,7 +4,6 @@ name = Fast
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = fast04
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi04/flex/zyyx_pro_04_flex_fine.inst.cfg
+++ b/resources/quality/zyyx_pro/multi04/flex/zyyx_pro_04_flex_fine.inst.cfg
@@ -4,7 +4,6 @@ name = Fine
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = fine04
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi04/flex/zyyx_pro_04_flex_normal.inst.cfg
+++ b/resources/quality/zyyx_pro/multi04/flex/zyyx_pro_04_flex_normal.inst.cfg
@@ -4,7 +4,6 @@ name = Normal
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = normal04
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi08/flex/zyyx_pro_08_flex_fast.inst.cfg
+++ b/resources/quality/zyyx_pro/multi08/flex/zyyx_pro_08_flex_fast.inst.cfg
@@ -4,7 +4,6 @@ name = Fast
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = fast08
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi08/flex/zyyx_pro_08_flex_fine.inst.cfg
+++ b/resources/quality/zyyx_pro/multi08/flex/zyyx_pro_08_flex_fine.inst.cfg
@@ -4,7 +4,6 @@ name = Fine
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = fine08
 setting_version = 24

--- a/resources/quality/zyyx_pro/multi08/flex/zyyx_pro_08_flex_normal.inst.cfg
+++ b/resources/quality/zyyx_pro/multi08/flex/zyyx_pro_08_flex_normal.inst.cfg
@@ -4,7 +4,6 @@ name = Normal
 version = 4
 
 [metadata]
-global_quality = True
 material = generic_tpu_175
 quality_type = normal08
 setting_version = 24


### PR DESCRIPTION
# Description

There was an issue with the ZYYX Pro's selection of profiles related to its many nozzles. It caused the wrong profile to be selected. 

Fixed by removing erroneous "global_quality=True" from material-specific quality profiles. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested the new profiles and they seem to update correctly now. The version before this does not update.

**Test Configuration**:
- [x] MacOS

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
