### PR TITLE
PC-ABS & PC-ABS-FR 175 Updates

### DIFF
--- a/resources/definitions/ultimaker_method.def.json
+++ b/resources/definitions/ultimaker_method.def.json
@@ -59,6 +59,8 @@
             "zyyx_pro_",
             "octofiber_",
             "fiberlogy_",
+            "ultimaker_pc-abs",
+            "ultimaker_pc-abs-fr",
             "ultimaker_metallic_pla_175"
         ],
         "has_machine_materials": true,

--- a/resources/definitions/ultimaker_sketch.def.json
+++ b/resources/definitions/ultimaker_sketch.def.json
@@ -60,6 +60,8 @@
             "ultimaker_sr30",
             "ultimaker_petg",
             "ultimaker_pva",
+            "ultimaker_pc-abs",
+            "ultimaker_pc-abs-fr",
             "ultimaker_metallic_pla"
         ],
         "has_machine_quality": true,

--- a/resources/definitions/ultimaker_sketch_sprint.def.json
+++ b/resources/definitions/ultimaker_sketch_sprint.def.json
@@ -54,6 +54,8 @@
             "ultimaker_rapidrinse",
             "ultimaker_sr30",
             "ultimaker_petg",
+            "ultimaker_pc-abs",
+            "ultimaker_pc-abs-fr",
             "ultimaker_metallic_pla"
         ],
         "has_machine_quality": true,

--- a/resources/intent/ultimaker_methodx/um_methodx_1c_um-pc-abs-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1c_um-pc-abs-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodx
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1c_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1c_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodx
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1xa_um-pc-abs-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1xa_um-pc-abs-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodx
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1XA
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_1xa_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_1xa_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodx
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1XA
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-pc-abs-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-pc-abs-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodx
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodx/um_methodx_labs_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodx/um_methodx_labs_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodx
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodxl
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodxl
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1C
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodxl
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1XA
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodxl
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = 1XA
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodxl
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
+++ b/resources/intent/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-fr-175_0.2mm_solid.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_methodxl
+name = Solid
+version = 4
+
+[metadata]
+intent_category = solid
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = intent
+variant = LABS
+
+[values]
+bottom_thickness = =top_bottom_thickness
+infill_angles = [45,135]
+infill_material_flow = 97
+infill_pattern = zigzag
+infill_sparse_density = 99
+top_bottom_thickness = =layer_height * 2
+top_thickness = =top_bottom_thickness
+

--- a/resources/quality/ultimaker_methodx/um_methodx_1c_um-pc-abs-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1c_um-pc-abs-175_0.2mm.inst.cfg
@@ -1,0 +1,66 @@
+[general]
+definition = ultimaker_methodx
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 1C
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.1 if extruder_nr == support_extruder_nr else 0
+raft_base_thickness = =0.6 if extruder_nr == support_extruder_nr else 0.8
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodx/um_methodx_1c_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1c_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -1,0 +1,66 @@
+[general]
+definition = ultimaker_methodx
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 1C
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.1 if extruder_nr == support_extruder_nr else 0
+raft_base_thickness = =0.6 if extruder_nr == support_extruder_nr else 0.8
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodx/um_methodx_1c_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1c_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -31,7 +31,7 @@ speed_layer_0 = =speed_print * 7/24
 speed_prime_tower = =speed_print * 1/4
 speed_print = 120.0
 speed_roofing = =speed_print * 13/24
-speed_support = =speed_print * 5/6
+speed_support = =speed_print * 1/2
 speed_support_bottom = 25
 speed_support_interface = =speed_print * 15/24
 speed_topbottom = =speed_print * 11/24
@@ -50,7 +50,7 @@ support_interface_density = 85
 support_interface_enable = True
 support_interface_pattern = zigzag
 support_line_width = 0.3
-support_material_flow = 95
+support_material_flow = 100
 support_pattern = zigzag
 support_roof_density = 85
 support_roof_wall_count = 1

--- a/resources/quality/ultimaker_methodx/um_methodx_1xa_um-pc-abs-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1xa_um-pc-abs-175_0.2mm.inst.cfg
@@ -1,0 +1,66 @@
+[general]
+definition = ultimaker_methodx
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 1XA
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.1 if extruder_nr == support_extruder_nr else 0
+raft_base_thickness = =0.6 if extruder_nr == support_extruder_nr else 0.8
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodx/um_methodx_1xa_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1xa_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -1,0 +1,66 @@
+[general]
+definition = ultimaker_methodx
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 1XA
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.1 if extruder_nr == support_extruder_nr else 0
+raft_base_thickness = =0.6 if extruder_nr == support_extruder_nr else 0.8
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodx/um_methodx_1xa_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_1xa_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -31,7 +31,7 @@ speed_layer_0 = =speed_print * 7/24
 speed_prime_tower = =speed_print * 1/4
 speed_print = 120.0
 speed_roofing = =speed_print * 13/24
-speed_support = =speed_print * 5/6
+speed_support = =speed_print * 1/2
 speed_support_bottom = 25
 speed_support_interface = =speed_print * 15/24
 speed_topbottom = =speed_print * 11/24
@@ -50,7 +50,7 @@ support_interface_density = 85
 support_interface_enable = True
 support_interface_pattern = zigzag
 support_line_width = 0.3
-support_material_flow = 95
+support_material_flow = 100
 support_pattern = zigzag
 support_roof_density = 85
 support_roof_wall_count = 1

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-pc-abs-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-pc-abs-175_0.2mm.inst.cfg
@@ -1,0 +1,66 @@
+[general]
+definition = ultimaker_methodx
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.1 if extruder_nr == support_extruder_nr else 0
+raft_base_thickness = =0.6 if extruder_nr == support_extruder_nr else 0.8
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -1,0 +1,66 @@
+[general]
+definition = ultimaker_methodx
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.1 if extruder_nr == support_extruder_nr else 0
+raft_base_thickness = =0.6 if extruder_nr == support_extruder_nr else 0.8
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodx/um_methodx_labs_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodx/um_methodx_labs_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -31,7 +31,7 @@ speed_layer_0 = =speed_print * 7/24
 speed_prime_tower = =speed_print * 1/4
 speed_print = 120.0
 speed_roofing = =speed_print * 13/24
-speed_support = =speed_print * 5/6
+speed_support = =speed_print * 1/2
 speed_support_bottom = 25
 speed_support_interface = =speed_print * 15/24
 speed_topbottom = =speed_print * 11/24
@@ -50,7 +50,7 @@ support_interface_density = 85
 support_interface_enable = True
 support_interface_pattern = zigzag
 support_line_width = 0.3
-support_material_flow = 95
+support_material_flow = 100
 support_pattern = zigzag
 support_roof_density = 85
 support_roof_wall_count = 1

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-175_0.2mm.inst.cfg
@@ -1,0 +1,65 @@
+[general]
+definition = ultimaker_methodxl
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 1C
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.12 if extruder_nr == support_extruder_nr else 0
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -30,7 +30,7 @@ speed_layer_0 = =speed_print * 7/24
 speed_prime_tower = =speed_print * 1/4
 speed_print = 120.0
 speed_roofing = =speed_print * 13/24
-speed_support = =speed_print * 5/6
+speed_support = =speed_print * 1/2
 speed_support_bottom = 25
 speed_support_interface = =speed_print * 15/24
 speed_topbottom = =speed_print * 11/24
@@ -49,7 +49,7 @@ support_interface_density = 85
 support_interface_enable = True
 support_interface_pattern = zigzag
 support_line_width = 0.3
-support_material_flow = 95
+support_material_flow = 100
 support_pattern = zigzag
 support_roof_density = 85
 support_roof_wall_count = 1

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1c_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -1,0 +1,65 @@
+[general]
+definition = ultimaker_methodxl
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 1C
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.12 if extruder_nr == support_extruder_nr else 0
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-175_0.2mm.inst.cfg
@@ -1,0 +1,65 @@
+[general]
+definition = ultimaker_methodxl
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 1XA
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.12 if extruder_nr == support_extruder_nr else 0
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -1,0 +1,65 @@
+[general]
+definition = ultimaker_methodxl
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = 1XA
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.12 if extruder_nr == support_extruder_nr else 0
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_1xa_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -30,7 +30,7 @@ speed_layer_0 = =speed_print * 7/24
 speed_prime_tower = =speed_print * 1/4
 speed_print = 120.0
 speed_roofing = =speed_print * 13/24
-speed_support = =speed_print * 5/6
+speed_support = =speed_print * 1/2
 speed_support_bottom = 25
 speed_support_interface = =speed_print * 15/24
 speed_topbottom = =speed_print * 11/24
@@ -49,7 +49,7 @@ support_interface_density = 85
 support_interface_enable = True
 support_interface_pattern = zigzag
 support_line_width = 0.3
-support_material_flow = 95
+support_material_flow = 100
 support_pattern = zigzag
 support_roof_density = 85
 support_roof_wall_count = 1

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-175_0.2mm.inst.cfg
@@ -1,0 +1,65 @@
+[general]
+definition = ultimaker_methodxl
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.12 if extruder_nr == support_extruder_nr else 0
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -30,7 +30,7 @@ speed_layer_0 = =speed_print * 7/24
 speed_prime_tower = =speed_print * 1/4
 speed_print = 120.0
 speed_roofing = =speed_print * 13/24
-speed_support = =speed_print * 5/6
+speed_support = =speed_print * 1/2
 speed_support_bottom = 25
 speed_support_interface = =speed_print * 15/24
 speed_topbottom = =speed_print * 11/24
@@ -49,7 +49,7 @@ support_interface_density = 85
 support_interface_enable = True
 support_interface_pattern = zigzag
 support_line_width = 0.3
-support_material_flow = 95
+support_material_flow = 100
 support_pattern = zigzag
 support_roof_density = 85
 support_roof_wall_count = 1

--- a/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-fr-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_methodxl/um_methodxl_labs_um-pc-abs-fr-175_0.2mm.inst.cfg
@@ -1,0 +1,65 @@
+[general]
+definition = ultimaker_methodxl
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pc-abs-fr_175
+quality_type = draft
+setting_version = 24
+type = quality
+variant = LABS
+weight = -2
+
+[values]
+cool_fan_enabled = =extruder_nr == support_extruder_nr
+cool_fan_speed = 75
+cool_fan_speed_0 = 0
+cool_fan_speed_max = 100
+cool_min_layer_time = 10
+cool_min_layer_time_fan_speed_max = 8
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = 250
+infill_sparse_density = 15
+material_final_print_temperature = =material_print_temperature - 5
+material_initial_print_temperature = =material_print_temperature - 5
+raft_airgap = =0.12 if extruder_nr == support_extruder_nr else 0
+raft_surface_speed = =speed_print * 3/4 if extruder_nr == support_extruder_nr else 50
+skin_overlap = 10
+speed_layer_0 = =speed_print * 7/24
+speed_prime_tower = =speed_print * 1/4
+speed_print = 120.0
+speed_roofing = =speed_print * 13/24
+speed_support = =speed_print * 5/6
+speed_support_bottom = 25
+speed_support_interface = =speed_print * 15/24
+speed_topbottom = =speed_print * 11/24
+speed_wall = =speed_print * 5/24
+speed_wall_0 = =speed_print * 1/6
+support_angle = 50
+support_bottom_angles = [135]
+support_bottom_density = 15
+support_bottom_distance = 0.1
+support_bottom_enable = True
+support_bottom_line_width = 0.6
+support_bottom_stair_step_height = 0
+support_infill_angles = [45,45,45,45,45,45,45,45,45,45,135,135,135,135,135,135,135,135,135,135]
+support_infill_rate = 15.0
+support_interface_density = 85
+support_interface_enable = True
+support_interface_pattern = zigzag
+support_line_width = 0.3
+support_material_flow = 95
+support_pattern = zigzag
+support_roof_density = 85
+support_roof_wall_count = 1
+support_supported_skin_fan_speed = 60.0
+support_top_distance = =support_z_distance
+support_xy_distance = 0.35
+support_xy_distance_overhang = 0.25
+support_xy_overrides_z = xy_overrides_z
+support_z_distance = 0.203
+top_skin_expand_distance = 2.4
+wall_overhang_angle = 30
+wall_overhang_speed_factor = 40
+


### PR DESCRIPTION
Added PC-ABS & PC-ABS-FR intent and quality files
for Method X & Method XL.  These materials pair with
1C, 1XA and Labs extruders.

Exclude PC-ABS and PC-ABS-FR from sketch printers
and Method.

PP-550

