### PR TITLE
CURA-12150 Add local preference to monitor use of USB writing

### DIFF
--- a/plugins/USBPrinting/USBPrinterOutputDevice.py
+++ b/plugins/USBPrinting/USBPrinterOutputDevice.py
@@ -97,6 +97,8 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
 
         CuraApplication.getInstance().getOnExitCallbackManager().addCallback(self._checkActivePrintingUponAppExit)
 
+        CuraApplication.getInstance().getPreferences().addPreference("usb_printing/enabled", False)
+
     # This is a callback function that checks if there is any printing in progress via USB when the application tries
     # to exit. If so, it will show a confirmation before
     def _checkActivePrintingUponAppExit(self) -> None:
@@ -143,6 +145,8 @@ class USBPrinterOutputDevice(PrinterOutputDevice):
         controller.stopPreheatTimers()
 
         CuraApplication.getInstance().getController().setActiveStage("MonitorStage")
+
+        CuraApplication.getInstance().getPreferences().setValue("usb_printing/enabled", True)
 
         #Find the g-code to print.
         gcode_textio = StringIO()


### PR DESCRIPTION
This is the first step of smartly enabling the USB printing: we add an internal preference, that is `False` by default, and will be set to `True` whenever the user actually prints something over USB. This will remain as is for Cura 5.10, in order to "log" users that are actually using it. In a future version, we will use this preference to enable USB printing or not. This way, all the users that have been actively using it on Cura 5.10 should have it still enabled without any action. Others will be prompted with a specific UI when adding a printer. This is not perfect, but should allow us to catch a large majority of users of USB printing.

CURA-12150