### PR TITLE
CURA-12224 handle loooong setting names

### DIFF
--- a/resources/qml/Settings/SettingItem.qml
+++ b/resources/qml/Settings/SettingItem.qml
@@ -13,7 +13,7 @@ import "."
 Item
 {
     id: base
-    height: enabled ? UM.Theme.getSize("section").height + UM.Theme.getSize("narrow_margin").height : 0
+    height: enabled ? Math.max(UM.Theme.getSize("section").height, label.height) + UM.Theme.getSize("narrow_margin").height : 0
     anchors.left: parent.left
     anchors.right: parent.right
 

--- a/resources/themes/cura-light/theme.json
+++ b/resources/themes/cura-light/theme.json
@@ -567,7 +567,7 @@
         "section_icon_column": [2.5, 2.5],
 
         "setting": [25.0, 1.8],
-        "setting_control": [11.0, 2.0],
+        "setting_control": [9.0, 2.0],
         "setting_control_radius": [0.15, 0.15],
         "setting_control_depth_margin": [1.4, 0.0],
         "setting_unit_margin": [0.5, 0.5],


### PR DESCRIPTION
This PR has 2 changes:
* Give some less space to the settings input fields, so that we have more for the text. It also makes the values closer to their units, and in the vast majority of cases the input fields are mostly empty
* Make the field higher when the text doesn't fit in, so that it properly resizes with multi-line names

![image](https://github.com/user-attachments/assets/a7bf42d1-57cf-480c-8b5c-8e0b04e22583)
