### PR TITLE
[CURA-12389][PP-535] Add pressure advance setting

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -3232,6 +3232,19 @@
                     "minimum_value": 0.01,
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
+                },
+                "material_pressure_advance_factor":
+                {
+                    "enabled": false,
+                    "label": "Pressure advance factor",
+                    "description": "Tuning factor for pressure advance, which is meant to synchronize extrusion with motion",
+                    "default_value": 0.05,
+                    "maximum_value_warning": 1.0,
+                    "minimum_value": 0,
+                    "type": "float",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": true,
+                    "settable_per_meshgroup": false
                 }
             }
         },


### PR DESCRIPTION
# [CURA-12389] / [PP-535] Add pressure advance setting
## Description
Add `material_pressure_advance_factor` setting. This is a machine setting and not exposed to the user.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Printer definition file(s)
- [ ] Translations

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change


[CURA-12389]: https://ultimaker.atlassian.net/browse/CURA-12389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PP-535]: https://ultimaker.atlassian.net/browse/PP-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ