### PR TITLE
PP-569-improve-top-surface-PPS-CF-on-F4

### DIFF
--- a/resources/quality/ultimaker_factor4/um_f4_ht0.6_cffpps_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_ht0.6_cffpps_0.2mm.inst.cfg
@@ -18,6 +18,7 @@ gradual_flow_enabled = True
 infill_wall_line_count = 1
 max_flow_acceleration = 1
 retraction_combing_max_distance = 2
+roofing_material_flow = =material_flow
 skin_material_flow = =material_flow * 0.93
 speed_print = 60
 xy_offset = =machine_nozzle_size * -0.25


### PR DESCRIPTION
# Description

PP-569 set top surface flow to material flow to reduce gaps in top surface. Overextrusion is preferred over gaps in the top surface.


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Printed on F4 to confirm that this does not lead to reliability issues

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
