### PR TITLE
Add outputs and notification step to workflow

### DIFF
--- a/.github/workflows/conan-package-resources.yml
+++ b/.github/workflows/conan-package-resources.yml
@@ -21,7 +21,19 @@ on:
       - '[0-9].[0-9][0-9]*'
 
 jobs:
+  get-conan-recipe-version:
+    uses: ./.github/workflows/get-conan-recipe-version.yml
+    with:
+      conan_recipe_root: "./resources/"
+      repository: ${{ github.repository }}
+      branch: ${{ github.ref_name }}
+      release: false
+      internal: false
+    secrets: inherit
+
   conan-package:
+    name: Create Conan Package
+    needs: get-conan-recipe-version
     uses: ultimaker/cura-workflows/.github/workflows/conan-package.yml@main
     with:
       conan_recipe_root: "./resources/"
@@ -30,27 +42,10 @@ jobs:
       install_system_dependencies: false
     secrets: inherit
 
-  extract-package-version:
-    runs-on: ubuntu-latest
-    needs: conan-package
-    outputs:
-      package_version: ${{ steps.get-package-version.outputs.package_version }}
-
-    steps:
-      - name: Extract Conan Package Version
-        id: get-package-version
-        run: |
-          # Replace this with your real logic to determine the package version
-          PACKAGE_VERSION=$(cat ./resources/conanfile.py | grep version | head -n 1 | cut -d '"' -f 2)
-          echo "Detected package version: $PACKAGE_VERSION"
-
-          # Set the package_version as an output for this job
-          echo "::set-output name=package_version::$PACKAGE_VERSION"
-
-  # Job 3: Notify the dependent repository
   notify-dependent-package:
+    name: Notify Dependent Repository
+    needs: [get-conan-recipe-version, conan-package]
     runs-on: ubuntu-latest
-    needs: extract-package-version  # This ensures that it runs after extract-package-version
 
     steps:
       - name: Notify Dependent Repository
@@ -60,4 +55,4 @@ jobs:
           curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/DEPENDENT_ORG/DEPENDENT_REPO/dispatches \
-          -d '{"event_type": "dependency-package-change", "client_payload": { "changed_dependency": "dependency-package", "version": "${{ needs.extract-package-version.outputs.package_version }}" }}'
+          -d '{"event_type": "dependency-version-update", "client_payload": { "version": "${{ needs.get-conan-recipe-version.outputs.version_base }}", "full_version": "${{ needs.get-conan-recipe-version.outputs.version_full }}", "package_name": "${{ needs.get-conan-recipe-version.outputs.package_name }}" }}'

--- a/.github/workflows/conan-package-resources.yml
+++ b/.github/workflows/conan-package-resources.yml
@@ -41,7 +41,7 @@ jobs:
         id: get-package-version
         run: |
           # Replace this with your real logic to determine the package version
-          PACKAGE_VERSION=$(cat ./conanfile.py | grep version | head -n 1 | cut -d '"' -f 2)
+          PACKAGE_VERSION=$(cat ./resources/conanfile.py | grep version | head -n 1 | cut -d '"' -f 2)
           echo "Detected package version: $PACKAGE_VERSION"
 
           # Set the package_version as an output for this job

--- a/.github/workflows/conan-package-resources.yml
+++ b/.github/workflows/conan-package-resources.yml
@@ -29,3 +29,32 @@ jobs:
       platform_mac: false
       install_system_dependencies: false
     secrets: inherit
+
+    outputs:
+      package_version: ${{ steps.get-package-version.outputs.package_version }}
+
+    steps:
+      - name: Extract Conan Package Version
+        id: get-package-version
+        run: |
+          # Replace this with your real logic to determine the package version
+          PACKAGE_VERSION=$(cat ./resources/conanfile.py | grep version | head -n 1 | cut -d '"' -f 2)
+          echo "Detected package version: $PACKAGE_VERSION"
+          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_ENV
+
+          # Set the package_version as an output
+          echo "::set-output name=package_version::$PACKAGE_VERSION"
+
+  notify-dependent-package:
+    runs-on: ubuntu-latest
+    needs: conan-package  # Ensures this job runs after conan-package completes!
+
+    steps:
+      - name: Notify Dependent Repository
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEPENDENT_REPO_TOKEN }}  # Ensure token has correct scopes
+        run: |
+          curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/DEPENDENT_ORG/DEPENDENT_REPO/dispatches \
+          -d '{"event_type": "dependency-package-change", "client_payload": { "changed_dependency": "dependency-package", "version": "{{ needs.conan-package.outputs.package_version }}" }}'

--- a/.github/workflows/conan-package-resources.yml
+++ b/.github/workflows/conan-package-resources.yml
@@ -1,4 +1,4 @@
-name: conan-package-resources
+name: conan-package-resources-and-notify
 
 on:
   push:
@@ -38,7 +38,7 @@ jobs:
         id: get-package-version
         run: |
           # Replace this with your real logic to determine the package version
-          PACKAGE_VERSION=$(cat ./resources/conanfile.py | grep version | head -n 1 | cut -d '"' -f 2)
+          PACKAGE_VERSION=$(cat ./conanfile.py | grep version | head -n 1 | cut -d '"' -f 2)
           echo "Detected package version: $PACKAGE_VERSION"
           echo "package_version=$PACKAGE_VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/conan-package-resources.yml
+++ b/.github/workflows/conan-package-resources.yml
@@ -21,19 +21,8 @@ on:
       - '[0-9].[0-9][0-9]*'
 
 jobs:
-  get-conan-recipe-version:
-    uses: ./.github/workflows/get-conan-recipe-version.yml
-    with:
-      conan_recipe_root: "./resources/"
-      repository: ${{ github.repository }}
-      branch: ${{ github.ref_name }}
-      release: false
-      internal: false
-    secrets: inherit
-
   conan-package:
     name: Create Conan Package
-    needs: get-conan-recipe-version
     uses: ultimaker/cura-workflows/.github/workflows/conan-package.yml@main
     with:
       conan_recipe_root: "./resources/"
@@ -44,7 +33,7 @@ jobs:
 
   notify-dependent-package:
     name: Notify Dependent Repository
-    needs: [get-conan-recipe-version, conan-package]
+    needs: conan-package
     runs-on: ubuntu-latest
 
     steps:
@@ -55,4 +44,4 @@ jobs:
           curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/DEPENDENT_ORG/DEPENDENT_REPO/dispatches \
-          -d '{"event_type": "dependency-version-update", "client_payload": { "version": "${{ needs.get-conan-recipe-version.outputs.version_base }}", "full_version": "${{ needs.get-conan-recipe-version.outputs.version_full }}", "package_name": "${{ needs.get-conan-recipe-version.outputs.package_name }}" }}'
+          -d '{"event_type": "dependency-version-update", "client_payload": { "version": "${{ needs.conan-package.outputs.version_base }}", "full_version": "${{ needs.conan-package.outputs.version_full }}", "package_name": "${{ needs.conan-package.outputs.package_name }}" }}'

--- a/.github/workflows/conan-package-resources.yml
+++ b/.github/workflows/conan-package-resources.yml
@@ -30,6 +30,9 @@ jobs:
       install_system_dependencies: false
     secrets: inherit
 
+  extract-package-version:
+    runs-on: ubuntu-latest
+    needs: conan-package
     outputs:
       package_version: ${{ steps.get-package-version.outputs.package_version }}
 
@@ -40,21 +43,21 @@ jobs:
           # Replace this with your real logic to determine the package version
           PACKAGE_VERSION=$(cat ./conanfile.py | grep version | head -n 1 | cut -d '"' -f 2)
           echo "Detected package version: $PACKAGE_VERSION"
-          echo "package_version=$PACKAGE_VERSION" >> $GITHUB_ENV
 
-          # Set the package_version as an output
+          # Set the package_version as an output for this job
           echo "::set-output name=package_version::$PACKAGE_VERSION"
 
+  # Job 3: Notify the dependent repository
   notify-dependent-package:
     runs-on: ubuntu-latest
-    needs: conan-package  # Ensures this job runs after conan-package completes!
+    needs: extract-package-version  # This ensures that it runs after extract-package-version
 
     steps:
       - name: Notify Dependent Repository
         env:
-          GITHUB_TOKEN: ${{ secrets.DEPENDENT_REPO_TOKEN }}  # Ensure token has correct scopes
+          GITHUB_TOKEN: ${{ secrets.DEPENDENT_REPO_TOKEN }}
         run: |
           curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/DEPENDENT_ORG/DEPENDENT_REPO/dispatches \
-          -d '{"event_type": "dependency-package-change", "client_payload": { "changed_dependency": "dependency-package", "version": "{{ needs.conan-package.outputs.package_version }}" }}'
+          -d '{"event_type": "dependency-package-change", "client_payload": { "changed_dependency": "dependency-package", "version": "${{ needs.extract-package-version.outputs.package_version }}" }}'


### PR DESCRIPTION
This update extracts the Conan package version as an output and adds a step to notify a dependent repository of changes.

NP-732

