### PR TITLE
PP-573 Sprint Tree Supports Update

### DIFF
--- a/resources/definitions/ultimaker_sketch_sprint.def.json
+++ b/resources/definitions/ultimaker_sketch_sprint.def.json
@@ -342,10 +342,12 @@
             "value": 20
         },
         "support_angle": { "value": "60" },
-        "support_bottom_density": { "value": "support_infill_rate" },
-        "support_bottom_distance": { "value": "layer_height" },
+        "support_bottom_density": { "value": "80 if support_structure == 'tree' else support_infill_rate" },
+        "support_bottom_distance": { "value": 0.2 },
         "support_bottom_enable": { "value": true },
-        "support_bottom_height": { "value": "layer_height * 2" },
+        "support_bottom_height": { "value": "layer_height if support_structure == 'tree' else layer_height * 2" },
+        "support_bottom_offset": { "value": "0 if support_structure == 'tree' else support_interface_offset" },
+        "support_bottom_wall_count": { "value": "1 if support_structure == 'tree' else 0" },
         "support_brim_line_count": { "value": 5 },
         "support_infill_angles":
         {
@@ -371,7 +373,7 @@
         "support_use_towers": { "value": false },
         "support_xy_distance": { "value": 0.3 },
         "support_xy_overrides_z": { "value": "'xy_overrides_z'" },
-        "support_z_distance": { "value": "layer_height if support_structure == 'tree' else 0.25" },
+        "support_z_distance": { "value": "0.2 if support_structure == 'tree' else 0.25" },
         "top_bottom_thickness": { "value": "5 * layer_height" },
         "top_layers": { "value": 5 },
         "travel_avoid_distance": { "value": 0.625 },


### PR DESCRIPTION
The Sprint tree supports inherited settings that
were tuned for Normal Support.  The support floor
connection to model roofs was weak, and causing
some trees to detach (depending on the model
geometry).  Sometimes the nozzle to collided
with the broken support, and resulted in XY shifts, and
the fan cover disconnecting while printing.

Additionally, I adjusted the support Z distance
values for layers heights > 0.2.

The new settings allow for better tree support
adhesion, improving the print success rate.

PP-573

Using the updated Sprint definition file, I completed test prints for the following configurations:

PLA Balanced Fast
PLA Balanced Extra Fast
PLA Draft
TPLA Balanced Fast
TPLA Balanced Extra Fast
TPLA Draft
MPLA Balanced