### PR TITLE
Clean up Windows Start Menu

### DIFF
--- a/packaging/NSIS/Ultimaker-Cura.nsi.jinja
+++ b/packaging/NSIS/Ultimaker-Cura.nsi.jinja
@@ -16,12 +16,10 @@
 !define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_NAME}-${VERSION}"
 !define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}-${VERSION}"
 
-!define REG_START_MENU "Start Menu Folder"
+!define REG_START_MENU "Start Menu Shortcut"
 
 ;Require administrator access
 RequestExecutionLevel admin
-
-var SM_Folder
 
 ######################################################################
 
@@ -68,7 +66,6 @@ InstallDir "$PROGRAMFILES64\${APP_NAME}"
 !define MUI_STARTMENUPAGE_REGISTRY_ROOT "${REG_ROOT}"
 !define MUI_STARTMENUPAGE_REGISTRY_KEY "${UNINSTALL_PATH}"
 !define MUI_STARTMENUPAGE_REGISTRY_VALUENAME "${REG_START_MENU}"
-!insertmacro MUI_PAGE_STARTMENU Application $SM_Folder
 !endif
 
 !insertmacro MUI_PAGE_INSTFILES
@@ -108,25 +105,21 @@ WriteUninstaller "$INSTDIR\uninstall.exe"
 
 !ifdef REG_START_MENU
 !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
-CreateDirectory "$SMPROGRAMS\$SM_Folder"
-CreateShortCut "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}"
-CreateShortCut "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe"
+CreateShortCut "$SMPROGRAMS\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}"
 
 !ifdef WEB_SITE
 WriteIniStr "$INSTDIR\UltiMaker Cura website.url" "InternetShortcut" "URL" "${WEB_SITE}"
-CreateShortCut "$SMPROGRAMS\$SM_Folder\UltiMaker Cura website.lnk" "$INSTDIR\UltiMaker Cura website.url"
+CreateShortCut "$SMPROGRAMS\UltiMaker Cura website.lnk" "$INSTDIR\UltiMaker Cura website.url"
 !endif
 !insertmacro MUI_STARTMENU_WRITE_END
 !endif
 
 !ifndef REG_START_MENU
-CreateDirectory "$SMPROGRAMS\{{ app_name }}"
-CreateShortCut "$SMPROGRAMS\{{ app_name }}\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}"
-CreateShortCut "$SMPROGRAMS\{{ app_name }}\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe"
+CreateShortCut "$SMPROGRAMS\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}"
 
 !ifdef WEB_SITE
 WriteIniStr "$INSTDIR\UltiMaker Cura website.url" "InternetShortcut" "URL" "${WEB_SITE}"
-CreateShortCut "$SMPROGRAMS\{{ app_name }}\UltiMaker Cura website.lnk" "$INSTDIR\UltiMaker Cura website.url"
+CreateShortCut "$SMPROGRAMS\UltiMaker Cura website.lnk" "$INSTDIR\UltiMaker Cura website.url"
 !endif
 !endif
 
@@ -184,22 +177,19 @@ Delete "$INSTDIR\${APP_NAME} website.url"
 RmDir /r /REBOOTOK "$INSTDIR"
 
 !ifdef REG_START_MENU
-!insertmacro MUI_STARTMENU_GETFOLDER "Application" $SM_Folder
-Delete "$SMPROGRAMS\$SM_Folder\${APP_NAME}.lnk"
-Delete "$SMPROGRAMS\$SM_Folder\Uninstall ${APP_NAME}.lnk"
+Delete "$SMPROGRAMS\${APP_NAME}.lnk"
+Delete "$SMPROGRAMS\Uninstall ${APP_NAME}.lnk"
 !ifdef WEB_SITE
-Delete "$SMPROGRAMS\$SM_Folder\UltiMaker Cura website.lnk"
+Delete "$SMPROGRAMS\UltiMaker Cura website.lnk"
 !endif
-RmDir "$SMPROGRAMS\$SM_Folder"
 !endif
 
 !ifndef REG_START_MENU
-Delete "$SMPROGRAMS\{{ app_name }}\${APP_NAME}.lnk"
-Delete "$SMPROGRAMS\{{ app_name }}\Uninstall ${APP_NAME}.lnk"
+Delete "$SMPROGRAMS\${APP_NAME}.lnk"
+Delete "$SMPROGRAMS\Uninstall ${APP_NAME}.lnk"
 !ifdef WEB_SITE
-Delete "$SMPROGRAMS\{{ app_name }}\UltiMaker Cura website.lnk"
+Delete "$SMPROGRAMS\UltiMaker Cura website.lnk"
 !endif
-RmDir "$SMPROGRAMS\{{ app_name }}"
 !endif
 
 !insertmacro APP_UNASSOCIATE "stl" "Cura.model"


### PR DESCRIPTION
# Description

Cleans up the Windows Start Menu entry by removing the uninstall shortcut (which is no longer created since at least Windows 10 anyways), and placing the Cura shortcut directly in the Start Menu without creating any folder, which is the recommenced practice for a clean appearance and saves the click needed for expanding a folder.

I have left the ability to create a website link in the Start Menu, although this not the right place and I consider it unclean. I would recommend removing that too.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Cleanup (non-breaking UX improvement)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Not tested, minor change. Will set up a build environment if requested

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
