### PR TITLE
CURA-12386 G-Code replacement fails with single line code

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -265,6 +265,10 @@ pycharm_targets:
     module_name: Cura
     name: pytest in TestSettingVisibilityPresets.py
     script_name: tests/Settings/TestSettingVisibilityPresets.py
+  - jinja_path: .run_templates/pycharm_cura_test.run.xml.jinja
+    module_name: Cura
+    name: pytest in TestStartEndGCode.py
+    script_name: tests/Machines/TestStartEndGCode.py
 
 pip_requirements_core:
   any_os:

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -76,7 +76,7 @@ class GcodeStartEndFormatter:
     # will be used. Alternatively, if the expression is formatted as "{[expression], [extruder_nr]}",
     # then the expression will be evaluated with the extruder stack of the specified extruder_nr.
 
-    _instruction_regex = re.compile(r"{(?P<condition>if|else|elif|endif)?\s*(?P<expression>.*?)\s*(?:,\s*(?P<extruder_nr_expr>.*))?\s*}(?P<end_of_line>\n?)")
+    _instruction_regex = re.compile(r"{(?P<condition>if|else|elif|endif)?\s*(?P<expression>[^{}]*?)\s*(?:,\s*(?P<extruder_nr_expr>[^{}]*))?\s*}(?P<end_of_line>\n?)")
 
     def __init__(self, all_extruder_settings: Dict[str, Dict[str, Any]], default_extruder_nr: int = -1) -> None:
         super().__init__()

--- a/tests/Machines/TestStartEndGCode.py
+++ b/tests/Machines/TestStartEndGCode.py
@@ -7,12 +7,6 @@ from unittest.mock import MagicMock
 from plugins.CuraEngineBackend.StartSliceJob import GcodeStartEndFormatter
 
 
-# def createMockedInstanceContainer(container_id):
-#     result = MagicMock()
-#     result.getId = MagicMock(return_value=container_id)
-#     result.getMetaDataEntry = MagicMock(side_effect=getMetadataEntrySideEffect)
-#     return result
-
 class MockValueProvider:
     ##  Creates a mock value provider.
     #
@@ -259,7 +253,7 @@ Q2000
         ''
     ),
 
-(
+    (
         'Unexpected end character',
         None,
 '''{if material_temperature > 200, 0}}
@@ -269,6 +263,20 @@ S2000
 {endif}''',
 '''S2000
 '''
+    ),
+
+    (
+        'Multiple replaces on single line',
+        None,
+'''BT={bed_temperature} IE={initial_extruder}''',
+'''BT=50.0 IE=0'''
+    ),
+
+    (
+        'Multiple extruder replaces on single line',
+        None,
+'''MT0={material_temperature, 0} MT1={material_temperature, 1}''',
+'''MT0=190.0 MT1=210.0'''
     ),
 ]
 


### PR DESCRIPTION
The regex was not specific enough and would catch the rest of the line, now we force stopping as soon as we see a `{` or `}`

CURA-12386
Fixes [20183](https://github.com/Ultimaker/Cura/issues/20183)