### PR TITLE
[CURA-12254] Don't lose text-field focus when scrolling.

### DIFF
--- a/resources/qml/Settings/SettingItem.qml
+++ b/resources/qml/Settings/SettingItem.qml
@@ -53,6 +53,7 @@ Item
     signal showTooltip(string text)
     signal hideTooltip()
     signal showAllHiddenInheritedSettings(string category_id)
+    signal setScrollPositionChangeLoseFocus(bool lose_focus)
 
     function createTooltipText()
     {

--- a/resources/qml/Settings/SettingTextField.qml
+++ b/resources/qml/Settings/SettingTextField.qml
@@ -148,6 +148,11 @@ SettingItem
                 if(activeFocus)
                 {
                     base.focusReceived();
+                    setScrollPositionChangeLoseFocus(false);
+                }
+                else
+                {
+                    setScrollPositionChangeLoseFocus(true);
                 }
                 base.focusGainedByClick = false;
             }

--- a/resources/qml/Settings/SettingView.qml
+++ b/resources/qml/Settings/SettingView.qml
@@ -15,6 +15,7 @@ Item
 
     property QtObject settingVisibilityPresetsModel: CuraApplication.getSettingVisibilityPresetsModel()
     property bool findingSettings
+    property bool loseFocusOnScrollPositionChange: true
 
     Item
     {
@@ -195,7 +196,7 @@ Item
             onPositionChanged: {
                 // This removes focus from items when scrolling.
                 // This fixes comboboxes staying open and scrolling container
-                if (!activeFocus && !filter.activeFocus) {
+                if (!activeFocus && !filter.activeFocus && loseFocusOnScrollPositionChange) {
                     forceActiveFocus();
                 }
             }
@@ -377,6 +378,10 @@ Item
                             contents.currentItem.item.focusItem.forceActiveFocus()
                         }
                     }
+                }
+                function onSetScrollPositionChangeLoseFocus(lose_focus)
+                {
+                    loseFocusOnScrollPositionChange = lose_focus;
                 }
             }
         }


### PR DESCRIPTION
When scrolling to settings, we might want to collapse the opened pop-ups (from extruder choses and the like) ... but that shouldn't come at the expense of losing focus on text-field settings occasionally (most notably of course if the scroll-bar changes length due to what you just changed).