### PR TITLE
[CURA-12441] Margin wasn't wide enough to see that it's a tree.

### DIFF
--- a/resources/qml/Preferences/SettingVisibilityItem.qml
+++ b/resources/qml/Preferences/SettingVisibilityItem.qml
@@ -11,7 +11,7 @@ Item
     // Use the depth of the model to move the item, but also leave space for the visibility / enabled exclamation mark.
 
     // Align checkbox with SettingVisibilityCategory icon with + 5
-    x: definition ? definition.depth * UM.Theme.getSize("narrow_margin").width : UM.Theme.getSize("default_margin").width
+    x: definition ? definition.depth * UM.Theme.getSize("wide_margin").width : UM.Theme.getSize("default_margin").width
 
     UM.TooltipArea
     {


### PR DESCRIPTION
Reduce apparent visual clutter by making the supposed meaningful margin actually meaningful visually.