### PR TITLE
[CURA-12442] Same cache as other setting-lists to reduce slowness on scroll.

### DIFF
--- a/resources/qml/Preferences/SettingVisibilityPage.qml
+++ b/resources/qml/Preferences/SettingVisibilityPage.qml
@@ -164,6 +164,7 @@ UM.PreferencesPage
                 expanded: ["*"]
                 visibilityHandler: UM.SettingPreferenceVisibilityHandler {}
             }
+            cacheBuffer: 1000000   // Set a large cache to effectively just cache every list item.
 
             property Component settingVisibilityCategory: Cura.SettingVisibilityCategory {}
             property Component settingVisibilityItem: Cura.SettingVisibilityItem {}


### PR DESCRIPTION
This does incur a cost on the first load of the list though.