### PR TITLE
CURA-12169 fix autoarrange for disallowed areas

### DIFF
--- a/cura/Arranging/ArrangeObjectsJob.py
+++ b/cura/Arranging/ArrangeObjectsJob.py
@@ -40,7 +40,7 @@ class ArrangeObjectsJob(Job):
 
         found_solution_for_all = False
         try:
-            found_solution_for_all = arranger.arrange()
+            found_solution_for_all = arranger.arrange(only_if_full_success = True)
         except:  # If the thread crashes, the message should still close
             Logger.logException("e",
                                 "Unable to arrange the objects on the buildplate. The arrange algorithm has crashed.")

--- a/cura/Arranging/Arranger.py
+++ b/cura/Arranging/Arranger.py
@@ -16,12 +16,16 @@ class Arranger:
         """
         raise NotImplementedError
 
-    def arrange(self, add_new_nodes_in_scene: bool = False) -> bool:
+    def arrange(self, add_new_nodes_in_scene: bool = False, only_if_full_success: bool = False) -> bool:
         """
         Find placement for a set of scene nodes, and move them by using a single grouped operation.
         :param add_new_nodes_in_scene: Whether to create new scene nodes before applying the transformations and rotations
         :return: found_solution_for_all: Whether the algorithm found a place on the buildplate for all the objects
         """
         grouped_operation, not_fit_count = self.createGroupOperationForArrange(add_new_nodes_in_scene)
-        grouped_operation.push()
-        return not_fit_count == 0
+        full_success = not_fit_count == 0
+
+        if full_success or not only_if_full_success:
+            grouped_operation.push()
+
+        return full_success

--- a/cura/Arranging/Nest2DArrange.py
+++ b/cura/Arranging/Nest2DArrange.py
@@ -54,63 +54,73 @@ class Nest2DArrange(Arranger):
         machine_depth = self._build_volume.getDepth() - (edge_disallowed_size * 2)
         build_plate_bounding_box = Box(int(machine_width * self._factor), int(machine_depth * self._factor))
 
+        # Use a tiny margin for the build_plate_polygon (the nesting doesn't like overlapping disallowed areas)
+        half_machine_width = 0.5 * machine_width - 1
+        half_machine_depth = 0.5 * machine_depth - 1
+        build_plate_polygon = Polygon(numpy.array([
+            [half_machine_width, -half_machine_depth],
+            [-half_machine_width, -half_machine_depth],
+            [-half_machine_width, half_machine_depth],
+            [half_machine_width, half_machine_depth]
+        ], numpy.float32))
+
+        def _convert_points(points):
+            if points is not None and len(points) > 2:  # numpy array has to be explicitly checked against None
+                converted_points = []
+                for point in points:
+                    converted_points.append(Point(int(point[0] * self._factor), int(point[1] * self._factor)))
+                return [converted_points]
+            else:
+                return []
+
+        polygons_nodes_to_arrange = []
+        for node in self._nodes_to_arrange:
+            hull_polygon = node.callDecoration("getConvexHull")
+            if not hull_polygon or hull_polygon.getPoints is None:
+                Logger.log("w", "Object {} cannot be arranged because it has no convex hull.".format(node.getName()))
+                continue
+
+            polygons_nodes_to_arrange += _convert_points(hull_polygon.getPoints())
+
+        polygons_disallowed_areas = []
+        for area in self._build_volume.getDisallowedAreas():
+            # Clip the disallowed areas so that they don't overlap the bounding box (The arranger chokes otherwise)
+            clipped_area = area.intersectionConvexHulls(build_plate_polygon)
+
+            polygons_disallowed_areas += _convert_points(clipped_area.getPoints())
+
+        polygons_fixed_nodes = []
         if self._fixed_nodes is None:
             self._fixed_nodes = []
+        for node in self._fixed_nodes:
+            hull_polygon = node.callDecoration("getConvexHull")
 
-        strategies = [NfpConfig.Alignment.CENTER] * 3 + [NfpConfig.Alignment.BOTTOM_LEFT] * 3
+            if hull_polygon is not None:
+                polygons_fixed_nodes += _convert_points(hull_polygon.getPoints())
+
+        strategies = [NfpConfig.Alignment.CENTER,
+                      NfpConfig.Alignment.BOTTOM_LEFT,
+                      NfpConfig.Alignment.BOTTOM_RIGHT,
+                      NfpConfig.Alignment.TOP_LEFT,
+                      NfpConfig.Alignment.TOP_RIGHT,
+                      NfpConfig.Alignment.DONT_ALIGN]
         found_solution_for_all = False
         while not found_solution_for_all and len(strategies) > 0:
 
             # Add all the items we want to arrange
             node_items = []
-            for node in self._nodes_to_arrange:
-                hull_polygon = node.callDecoration("getConvexHull")
-                if not hull_polygon or hull_polygon.getPoints is None:
-                    Logger.log("w", "Object {} cannot be arranged because it has no convex hull.".format(node.getName()))
-                    continue
-                converted_points = []
-                for point in hull_polygon.getPoints():
-                    converted_points.append(Point(int(point[0] * self._factor), int(point[1] * self._factor)))
-                item = Item(converted_points)
+            for polygon in polygons_nodes_to_arrange:
+                node_items.append(Item(polygon))
+
+            for polygon in polygons_disallowed_areas:
+                disallowed_area = Item(polygon)
+                disallowed_area.markAsDisallowedAreaInBin(0)
+                node_items.append(disallowed_area)
+
+            for polygon in polygons_fixed_nodes:
+                item = Item(polygon)
+                item.markAsFixedInBin(0)
                 node_items.append(item)
-
-            # Use a tiny margin for the build_plate_polygon (the nesting doesn't like overlapping disallowed areas)
-            half_machine_width = 0.5 * machine_width - 1
-            half_machine_depth = 0.5 * machine_depth - 1
-            build_plate_polygon = Polygon(numpy.array([
-                [half_machine_width, -half_machine_depth],
-                [-half_machine_width, -half_machine_depth],
-                [-half_machine_width, half_machine_depth],
-                [half_machine_width, half_machine_depth]
-            ], numpy.float32))
-
-            disallowed_areas = self._build_volume.getDisallowedAreas()
-            for area in disallowed_areas:
-                converted_points = []
-
-                # Clip the disallowed areas so that they don't overlap the bounding box (The arranger chokes otherwise)
-                clipped_area = area.intersectionConvexHulls(build_plate_polygon)
-
-                if clipped_area.getPoints() is not None and len(
-                        clipped_area.getPoints()) > 2:  # numpy array has to be explicitly checked against None
-                    for point in clipped_area.getPoints():
-                        converted_points.append(Point(int(point[0] * self._factor), int(point[1] * self._factor)))
-
-                    disallowed_area = Item(converted_points)
-                    disallowed_area.markAsDisallowedAreaInBin(0)
-                    node_items.append(disallowed_area)
-
-            for node in self._fixed_nodes:
-                converted_points = []
-                hull_polygon = node.callDecoration("getConvexHull")
-
-                if hull_polygon is not None and hull_polygon.getPoints() is not None and len(
-                        hull_polygon.getPoints()) > 2:  # numpy array has to be explicitly checked against None
-                    for point in hull_polygon.getPoints():
-                        converted_points.append(Point(int(point[0] * self._factor), int(point[1] * self._factor)))
-                    item = Item(converted_points)
-                    item.markAsFixedInBin(0)
-                    node_items.append(item)
 
             config = NfpConfig()
             config.accuracy = 1.0

--- a/cura/MultiplyObjectsJob.py
+++ b/cura/MultiplyObjectsJob.py
@@ -84,6 +84,7 @@ class MultiplyObjectsJob(Job):
                 arranger = Nest2DArrange(nodes, Application.getInstance().getBuildVolume(), fixed_nodes, factor=1000)
 
             group_operation, not_fit_count = arranger.createGroupOperationForArrange(add_new_nodes_in_scene=True)
+            found_solution_for_all = not_fit_count == 0
 
         if nodes_to_add_without_arrange:
             for nested_node in nodes_to_add_without_arrange:


### PR DESCRIPTION
1. Initial bug was caused by trying multiple placement strategies but not reconstructing the items between iterations, which caused inconsistencies in data given to libnest2d.
2. Changed the UI behavior to not display a partial re-arrange which is often worse than the current situation
3. Add more strategies to test to increase the likeliness of finding an arrangement