### PR TITLE
Update FilamentChange.py

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/FilamentChange.py
+++ b/plugins/PostProcessingPlugin/scripts/FilamentChange.py
@@ -92,7 +92,7 @@ class FilamentChange(Script):
                     "type": "float",
                     "default_value": 0,
                     "minimum_value": 0,
-                    "enabled": "enabled"
+                    "enabled": "enabled and not firmware_config"
                 },
                 "retract_method":
                 {


### PR DESCRIPTION
Hide the "Z-Move" when in "use firmware configuration" mode.
It appears it was missed when the manual configuration was added.

# Description

This fixes... OR This improves... -->

Bug fix.

<!-- Please delete options that are not relevant. -->

- [ X] Bug fix (non-breaking change which fixes an issue)

# Checklist:
<!-- Check if relevant -->

- [ X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X ] I have uploaded any files required to test this change
