### PR TITLE
[PP-593] Mark Nylon CF Slide as experimental on CC 0.4 cores

### DIFF
--- a/resources/intent/ultimaker_s3/um_s3_cc0.4_nylon-cf-slide_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s3/um_s3_cc0.4_nylon-cf-slide_0.2mm_engineering.inst.cfg
@@ -5,6 +5,7 @@ version = 4
 
 [metadata]
 intent_category = engineering
+is_experimental = True
 material = generic_nylon-cf-slide
 quality_type = draft
 setting_version = 25

--- a/resources/intent/ultimaker_s5/um_s5_cc0.4_nylon-cf-slide_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s5/um_s5_cc0.4_nylon-cf-slide_0.2mm_engineering.inst.cfg
@@ -5,6 +5,7 @@ version = 4
 
 [metadata]
 intent_category = engineering
+is_experimental = True
 material = generic_nylon-cf-slide
 quality_type = draft
 setting_version = 25

--- a/resources/quality/ultimaker_s3/um_s3_cc0.4_nylon-cf-slide_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_cc0.4_nylon-cf-slide_0.2mm.inst.cfg
@@ -1,9 +1,10 @@
 [general]
 definition = ultimaker_s3
-name = Fast
+name = Fast - Experimental
 version = 4
 
 [metadata]
+is_experimental = True
 material = generic_nylon-cf-slide
 quality_type = draft
 setting_version = 25

--- a/resources/quality/ultimaker_s5/um_s5_cc0.4_nylon-cf-slide_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_cc0.4_nylon-cf-slide_0.2mm.inst.cfg
@@ -1,9 +1,10 @@
 [general]
 definition = ultimaker_s5
-name = Fast
+name = Fast - Experimental
 version = 4
 
 [metadata]
+is_experimental = True
 material = generic_nylon-cf-slide
 quality_type = draft
 setting_version = 25


### PR DESCRIPTION
# Description
Nylon CF Slide still has some printing problems with the CC 0.4 print core on the S3/S5/S7. It prints a lot better with the CC 0.6 core. Let's mark the profiles as experimental on the CC 0.4 cores until we improve the quality to our standards.