### PR TITLE
[CURA-12485] This name wasn't the same as in the complete settings list.

### DIFF
--- a/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
+++ b/resources/qml/PrintSetupSelector/Recommended/RecommendedSupportSelector.qml
@@ -46,7 +46,7 @@ RecommendedSettingSection
     contents: [
         RecommendedSettingItem
         {
-            settingName: catalog.i18nc("@action:label", "Support Type")
+            settingName: catalog.i18nc("@action:label", "Support Structure")
             tooltipText: catalog.i18nc("@label", "Chooses between the techniques available to generate support. \n\n\"Normal\" support creates a support structure directly below the overhanging parts and drops those areas straight down. \n\n\"Tree\" support creates branches towards the overhanging areas that support the model on the tips of those branches, and allows the branches to crawl around the model to support it from the build plate as much as possible.")
             isCompressed: enableSupportRow.isCompressed
 


### PR DESCRIPTION
Even worse, support type there already means something else. Done in main for supposedly 5.11 instead of 5.10 since the translations might not work since they have a different context/label here.