### PR TITLE
PP-600: Reduce S8 travel speed

### DIFF
--- a/resources/definitions/ultimaker_s8.def.json
+++ b/resources/definitions/ultimaker_s8.def.json
@@ -500,13 +500,13 @@
         "speed_travel":
         {
             "maximum_value": 500,
-            "maximum_value_warning": 400,
-            "value": 400
+            "maximum_value_warning": 300,
+            "value": 300
         },
         "speed_travel_layer_0":
         {
             "maximum_value": 500,
-            "maximum_value_warning": 400,
+            "maximum_value_warning": 300,
             "value": 150
         },
         "speed_wall":


### PR DESCRIPTION
# Description
We see some occasional layer shifts with the S8 caused by the 400mm/s travel speed and potentially a bug in Cheetah. Reduce the travel speed to 300mm/s until this issue is resolved.

# How Has This Been Tested?
Ran test prints with 300mm/s and found no issues in the XCP logging

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
