### PR TITLE
PP-599 slower unretracts to reduce extrusion issues

### DIFF
--- a/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_nylon-cf-slide_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_nylon-cf-slide_0.2mm.inst.cfg
@@ -13,4 +13,5 @@ weight = -2
 
 [values]
 cool_min_layer_time_fan_speed_max = 11
+retraction_prime_speed = 15
 


### PR DESCRIPTION
# Description
Based on customer feedback, we reduced extrusion issues in the S8 profiles for the CC+04 with Nylon CF Slide by reducing the retraction amount and the retraction prime speed. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Replicated customer issue
- [x] Printed same parts with these new settings


