### PR TITLE
Enable more retraction settings to be set per-model

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4553,7 +4553,7 @@
                     "minimum_value_warning": "-0.0001",
                     "maximum_value_warning": "10.0",
                     "enabled": "retraction_enable and machine_gcode_flavor != \"UltiGCode\"",
-                    "settable_per_mesh": false,
+                    "settable_per_mesh": true,
                     "settable_per_extruder": true
                 },
                 "retraction_speed":
@@ -4643,7 +4643,7 @@
                     "maximum_value": 999999999,
                     "type": "int",
                     "enabled": "retraction_enable",
-                    "settable_per_mesh": false,
+                    "settable_per_mesh": true,
                     "settable_per_extruder": true
                 },
                 "retraction_extrusion_window":
@@ -4657,7 +4657,7 @@
                     "maximum_value_warning": "retraction_amount * 2",
                     "value": "retraction_amount",
                     "enabled": "retraction_enable",
-                    "settable_per_mesh": false,
+                    "settable_per_mesh": true,
                     "settable_per_extruder": true
                 },
                 "retraction_combing":


### PR DESCRIPTION
# Description
This allows more retraction settings to be set per-object.  These retraction settings were already supported on a per-object basis on the backend by https://github.com/Ultimaker/CuraEngine/pull/1769, but were not enabled by the corresponding frontend PR at the time.

This helps get incrementally closer to exposing per-model settings https://github.com/Ultimaker/Cura/issues/3193

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested the g-code output after changing per-object settings.  (e.g. add two objects, set retraction distance do something different on one of them, check that this modifies the output g-code by diffing the g code before and after the change.)

**Test Configuration**:
* Operating System: Debian

# Checklist:

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have uploaded any files required to test this change
