### PR TITLE
[PP-605] Add machine_nozzle_size to variants

### DIFF
--- a/resources/variants/ultimaker_s3_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s3_aa04.inst.cfg
@@ -12,6 +12,7 @@ type = variant
 brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = AA 0.4
+machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 6.5
 speed_print = 70

--- a/resources/variants/ultimaker_s3_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s3_bb04.inst.cfg
@@ -15,6 +15,7 @@ acceleration_support_bottom = =math.ceil(acceleration_support_interface * 100 / 
 acceleration_support_interface = =math.ceil(acceleration_support * 1500 / 2000)
 machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = BB 0.4
+machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)

--- a/resources/variants/ultimaker_s5_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s5_aa04.inst.cfg
@@ -12,6 +12,7 @@ type = variant
 brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = AA 0.4
+machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 6.5
 speed_print = 70

--- a/resources/variants/ultimaker_s5_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s5_bb04.inst.cfg
@@ -15,6 +15,7 @@ acceleration_support_bottom = =math.ceil(acceleration_support_interface * 100 / 
 acceleration_support_interface = =math.ceil(acceleration_support * 1500 / 2000)
 machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = BB 0.4
+machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)
 speed_support = =math.ceil(speed_print * 25 / 35)

--- a/resources/variants/ultimaker_s7_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s7_aa04.inst.cfg
@@ -12,6 +12,7 @@ type = variant
 brim_width = 7
 machine_nozzle_cool_down_speed = 0.9
 machine_nozzle_id = AA 0.4
+machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 6.5
 speed_print = 70

--- a/resources/variants/ultimaker_s7_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s7_bb04.inst.cfg
@@ -15,6 +15,7 @@ acceleration_support_bottom = =math.ceil(acceleration_support_interface * 100 / 
 acceleration_support_interface = =math.ceil(acceleration_support * 1500 / 2000)
 machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = BB 0.4
+machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 4.5
 speed_prime_tower = =math.ceil(speed_print * 10 / 35)

--- a/resources/variants/ultimaker_s8_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s8_bb04.inst.cfg
@@ -11,6 +11,7 @@ type = variant
 [values]
 machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = BB 0.4
+machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 4.5
 support_bottom_height = =layer_height * 2


### PR DESCRIPTION
# Description
This PR adds the `machine_nozzle_size` to the S-line variants that did not have them yet. This makes our jinja templates a lot cleaner and easier.

This does not change any setting trees, as fdmprinter already defines the nozzle size as 0.4 as default. However, the nozzle size is strictly a property of the variant, so it's good to explicitly set it there.

The CC 0.4 variants already defined the `machine_nozzle_size` as 0.4, so only the AA and BB cores are affected.