### PR TITLE
For consistency we want to allow “Any Color” profiles for the S3

### DIFF
--- a/resources/definitions/ultimaker_s3.def.json
+++ b/resources/definitions/ultimaker_s3.def.json
@@ -48,6 +48,7 @@
         "preferred_quality_type": "draft",
         "preferred_variant_name": "AA 0.4",
         "supported_actions": [ "DiscoverUM3Action" ],
+        "supports_abstract_color": true,
         "supports_material_export": true,
         "supports_usb_connection": false,
         "variants_name": "Print Core",


### PR DESCRIPTION
For consistency we want to allow “Any Color” profiles for the S3.

Although the S3 does not support a material station (rendering the “Any Color” option a bit useless), it is still good to offer it in the color list to be consistent with the other S line printers. 

PP-610