### PR TITLE
[PP-609] Update travel speed settings for Ultimaker S8 

### DIFF
--- a/resources/definitions/ultimaker_s8.def.json
+++ b/resources/definitions/ultimaker_s8.def.json
@@ -500,8 +500,8 @@
         "speed_travel":
         {
             "maximum_value": 500,
-            "maximum_value_warning": 300,
-            "value": 300
+            "maximum_value_warning": 500,
+            "value": 500
         },
         "speed_travel_layer_0":
         {


### PR DESCRIPTION
Back to 500mm/s now that the edge case bug in the motion planner has been fixed in the latest firmware.

PP-609