### PR TITLE
[PP-607] Improve CPE and PC surface quality

### DIFF
--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_cpe_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_cpe_0.2mm.inst.cfg
@@ -13,8 +13,10 @@ weight = -2
 
 [values]
 infill_overlap = 20
-infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'gyroid'
-speed_print = 100
-speed_wall_0 = =speed_print
+infill_pattern = lines
+speed_print = 40
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
 support_interface_enable = True
+wall_thickness = =wall_line_width_0 + 2*wall_line_width_x
 

--- a/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_pc_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_pc_0.2mm.inst.cfg
@@ -14,6 +14,8 @@ weight = -2
 [values]
 cool_min_layer_time = 6
 cool_min_layer_time_fan_speed_max = 12
-retraction_amount = 8
+inset_direction = inside_out
+material_flow = 95
 retraction_prime_speed = 15
+speed_wall_x = =speed_wall_0
 


### PR DESCRIPTION
PC: Prevent holes in outside wall of PC prints due to air capture during unretracts:
Reduce retract length, inner wall before outer wall, inner wall speed equal to outer wall. We also lowered the flow rate to 95% for PC because we noticed that it was over extruding.

CPE: CPE is VERY fragile to printer over itself or bumps. Lower all speeds to 40mm/s, goto 'lines' infill type to prevent crossing over lines, 3 walls to prevent issues with infill to reach the outer wall.

PP-607
