### PR TITLE
S6/S8: cool_during_extruder_switch to “all fans” (reduce oozing on pr…

### DIFF
--- a/resources/definitions/ultimaker_s8.def.json
+++ b/resources/definitions/ultimaker_s8.def.json
@@ -203,6 +203,7 @@
             "unit": "mm/s",
             "value": 50
         },
+        "cool_during_extruder_switch": { "value": "'all_fans'" },
         "cool_min_layer_time": { "value": 5 },
         "cool_min_layer_time_overhang": { "value": 9 },
         "cool_min_layer_time_overhang_min_segment_length": { "value": 2 },
@@ -397,6 +398,7 @@
             "enabled": true,
             "value": 0.5
         },
+        "material_print_temperature": { "maximum_value_warning": 320 },
         "material_print_temperature_layer_0": { "maximum_value_warning": 320 },
         "max_flow_acceleration": { "value": 8.0 },
         "max_skin_angle_for_expansion": { "value": 45 },
@@ -445,7 +447,7 @@
         "speed_layer_0":
         {
             "maximum_value_warning": 300,
-            "value": "speed_wall"
+            "value": "min(speed_wall,50)"
         },
         "speed_prime_tower":
         {
@@ -500,13 +502,13 @@
         "speed_travel":
         {
             "maximum_value": 500,
-            "maximum_value_warning": 300,
-            "value": 300
+            "maximum_value_warning": 500,
+            "value": 500
         },
         "speed_travel_layer_0":
         {
             "maximum_value": 500,
-            "maximum_value_warning": 300,
+            "maximum_value_warning": 500,
             "value": 150
         },
         "speed_wall":
@@ -573,6 +575,7 @@
         "wall_material_flow": { "value": 95 },
         "wall_overhang_angle": { "value": 45 },
         "wall_x_material_flow": { "value": 100 },
+        "xy_offset": { "value": 0.05 },
         "z_seam_corner": { "value": "'z_seam_corner_weighted'" },
         "z_seam_position": { "value": "'backright'" },
         "z_seam_type": { "value": "'sharpest_corner'" }

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_petg_0.2mm.inst.cfg
@@ -14,4 +14,5 @@ weight = -2
 [values]
 cool_min_layer_time = 4
 material_print_temperature = =default_material_print_temperature + 5
+retraction_prime_speed = 15
 

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.1mm.inst.cfg
@@ -12,6 +12,8 @@ variant = AA+ 0.4
 weight = 0
 
 [values]
+material_final_print_temperature = =material_print_temperature - 15
+material_initial_print_temperature = =material_print_temperature - 15
 retraction_prime_speed = =retraction_speed
 support_structure = tree
 

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.2mm.inst.cfg
@@ -12,6 +12,8 @@ variant = AA+ 0.4
 weight = -2
 
 [values]
+material_final_print_temperature = =material_print_temperature - 15
+material_initial_print_temperature = =material_print_temperature - 15
 retraction_prime_speed = =retraction_speed
 support_structure = tree
 

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.6_petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.6_petg_0.2mm.inst.cfg
@@ -16,5 +16,6 @@ bridge_skin_material_flow = 200
 bridge_wall_material_flow = 200
 cool_min_layer_time = 4
 material_print_temperature = =default_material_print_temperature + 5
+retraction_prime_speed = 15
 support_interface_enable = False
 

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.6_petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.6_petg_0.3mm.inst.cfg
@@ -16,6 +16,7 @@ bridge_skin_material_flow = 200
 bridge_wall_material_flow = 200
 cool_min_layer_time = 4
 material_print_temperature = =default_material_print_temperature + 10
+retraction_prime_speed = 15
 support_interface_enable = False
 wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
 

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.6_pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.6_pla_0.2mm.inst.cfg
@@ -14,6 +14,8 @@ weight = -2
 [values]
 bridge_skin_material_flow = 200
 bridge_wall_material_flow = 200
+material_final_print_temperature = =material_print_temperature - 15
+material_initial_print_temperature = =material_print_temperature - 15
 retraction_prime_speed = =retraction_speed
 support_interface_enable = False
 support_structure = tree

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.6_pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.6_pla_0.3mm.inst.cfg
@@ -14,6 +14,8 @@ weight = -3
 [values]
 bridge_skin_material_flow = 200
 bridge_wall_material_flow = 200
+material_final_print_temperature = =material_print_temperature - 15
+material_initial_print_temperature = =material_print_temperature - 15
 material_print_temperature = =default_material_print_temperature + 20
 retraction_prime_speed = =retraction_speed
 support_interface_enable = False

--- a/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.15mm.inst.cfg
@@ -22,6 +22,7 @@ initial_layer_line_width_factor = 150
 jerk_prime_tower = 4000
 jerk_support = 4000
 minimum_support_area = 4
+prime_tower_min_volume = 20
 retraction_amount = 6.5
 retraction_count_max = 5
 skirt_brim_minimal_length = =min(2000, 175 / (layer_height * line_width))

--- a/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.1mm.inst.cfg
@@ -23,6 +23,7 @@ jerk_prime_tower = 4000
 jerk_support = 4000
 material_print_temperature = =default_material_print_temperature - 5
 minimum_support_area = 4
+prime_tower_min_volume = 20
 retraction_amount = 6.5
 retraction_count_max = 5
 skirt_brim_minimal_length = =min(2000, 175 / (layer_height * line_width))

--- a/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.2mm.inst.cfg
@@ -23,6 +23,7 @@ jerk_prime_tower = 4000
 jerk_support = 4000
 material_print_temperature = =default_material_print_temperature + 5
 minimum_support_area = 4
+prime_tower_min_volume = 20
 retraction_amount = 6.5
 retraction_count_max = 5
 skirt_brim_minimal_length = =min(2000, 175 / (layer_height * line_width))

--- a/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.3mm.inst.cfg
@@ -23,6 +23,7 @@ jerk_prime_tower = 4000
 jerk_support = 4000
 material_print_temperature = =default_material_print_temperature - 5
 minimum_support_area = 4
+prime_tower_min_volume = 20
 retraction_amount = 6.5
 retraction_count_max = 5
 skirt_brim_minimal_length = =min(2000, 175 / (layer_height * line_width))

--- a/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_cpe-plus_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_cpe-plus_0.2mm.inst.cfg
@@ -12,4 +12,7 @@ variant = CC+ 0.4
 weight = -2
 
 [values]
+material_alternate_walls = True
+material_final_print_temperature = =material_print_temperature - 15
+material_initial_print_temperature = =material_print_temperature - 15
 

--- a/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_pc_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_pc_0.2mm.inst.cfg
@@ -15,7 +15,10 @@ weight = -2
 cool_min_layer_time = 6
 cool_min_layer_time_fan_speed_max = 12
 inset_direction = inside_out
+material_alternate_walls = True
+material_final_print_temperature = =material_print_temperature - 15
 material_flow = 95
+material_initial_print_temperature = =material_print_temperature - 15
 retraction_prime_speed = 15
 speed_wall_x = =speed_wall_0
 


### PR DESCRIPTION
…ints)

S6/S8: Set xy_offset to 0.1mm to compensate (cyclinder outer walls 0.2mm to small) S6/S8: Travel speed to 500mm/s (this is PP-606)
S6/S8: Maximum first layer speed is 50mm/s to improve adhesion reliability and bottom layer quality PLA: Reduce intial and final nozzle temperature with 10C (195C) to reduce oozing on model PETG: Unretract speed from 45mm/s to 15mm/s to reduce bubbles in the walls PVA: Increase prime tower purge volume from 10.0mm3 to 20mm3 to improve tower stability (esp in combi with high temp model materials) PC and CPE+: Reduce warping
        - Alternating wall
        - 10C higher nozzle temperature (PC:290C, CPE+: 280C) to remelt the line below
              -  Keep initial and final temperature the same
        - 5C higher bed temperature (PC:115C, CPE+: 280C) to increase bed adhesion
        - Chamber temperature 50C (max value S line)

PP-625
