### PR TITLE
[CURA-12512] Add speed settings for auxilary ('build volume') fan.

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4887,13 +4887,12 @@
                 "build_volume_fan_speed_0":
                 {
                     "label": "Initial Layers Build Volume Fan Speed",
-                    "description": "Build-volume fan speed until 'Build Volume Fan Speed at Layer'.",
+                    "description": "The fan speed (as a percentage) for the auxiliary or build-volume fan, that is set until the layer specified at 'Build Volume Fan Speed at Layer' is reached. After that, the speed is set by 'Build Volume Fan Speed' instead (so not this 'Initial Layers' one).",
                     "unit": "%",
                     "type": "float",
                     "minimum_value": "0",
                     "maximum_value": "100",
                     "default_value": 0,
-                    "value": "0.0",
                     "enabled": "build_volume_fan_nr != 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,
@@ -4902,13 +4901,12 @@
                 "build_volume_fan_speed":
                 {
                     "label": "Build Volume Fan Speed",
-                    "description": "Build-volume fan speed starting from 'Build Volume Fan Speed at Layer'.",
+                    "description": "The fan speed (as a percentage) for the auxiliary or build-volume fan, that is set from the moment that the layer specified at 'Build Volume Fan Speed at Layer' is reached and onwards. Before that, the speed is set by 'Initial Layers Build Volume Fan Speed' instead.",
                     "unit": "%",
                     "type": "float",
                     "minimum_value": "0",
                     "maximum_value": "100",
                     "default_value": 100,
-                    "value": "100.0",
                     "enabled": "build_volume_fan_nr != 0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": false,

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4855,7 +4855,7 @@
                 },
                 "build_fan_full_at_height":
                 {
-                    "label": "Build Fan Speed at Height",
+                    "label": "Build Volume Fan Speed at Height",
                     "description": "The height at which the fans spin on regular fan speed. At the layers below the fan speed gradually increases from Initial Fan Speed to Regular Fan Speed.",
                     "unit": "mm",
                     "type": "float",
@@ -4870,8 +4870,8 @@
                     {
                         "build_fan_full_layer":
                         {
-                            "label": "Build Fan Speed at Layer",
-                            "description": "The layer at which the build fans spin on full fan speed. This value is calculated and rounded to a whole number.",
+                            "label": "Build Volume Fan Speed at Layer",
+                            "description": "The layer at which the build-volume fans spin on full fan speed. This value is calculated and rounded to a whole number.",
                             "type": "int",
                             "default_value": 0,
                             "minimum_value": "0",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4884,6 +4884,36 @@
                         }
                     }
                 },
+                "build_volume_fan_speed_0":
+                {
+                    "label": "Initial Layers Build Volume Fan Speed",
+                    "description": "Build-volume fan speed until 'Build Volume Fan Speed at Layer'.",
+                    "unit": "%",
+                    "type": "float",
+                    "minimum_value": "0",
+                    "maximum_value": "100",
+                    "default_value": 0,
+                    "value": "0.0",
+                    "enabled": "build_volume_fan_nr != 0",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false
+                },
+                "build_volume_fan_speed":
+                {
+                    "label": "Build Volume Fan Speed",
+                    "description": "Build-volume fan speed starting from 'Build Volume Fan Speed at Layer'.",
+                    "unit": "%",
+                    "type": "float",
+                    "minimum_value": "0",
+                    "maximum_value": "100",
+                    "default_value": 100,
+                    "value": "100.0",
+                    "enabled": "build_volume_fan_nr != 0",
+                    "settable_per_mesh": false,
+                    "settable_per_extruder": false,
+                    "settable_per_meshgroup": false
+                },
                 "cool_fan_speed":
                 {
                     "label": "Fan Speed",


### PR DESCRIPTION
Previously you could only set on/off starting on a certain layer.

Backend PR: https://github.com/Ultimaker/CuraEngine/pull/2226

