### PR TITLE
[SEM-608] Revert the capital M

### DIFF
--- a/resources/definitions/ultimaker_s6.def.json
+++ b/resources/definitions/ultimaker_s6.def.json
@@ -48,6 +48,6 @@
     "overrides":
     {
         "adhesion_type": { "value": "'brim'" },
-        "machine_name": { "default_value": "UltiMaker S6" }
+        "machine_name": { "default_value": "Ultimaker S6" }
     }
 }

--- a/resources/definitions/ultimaker_s7.def.json
+++ b/resources/definitions/ultimaker_s7.def.json
@@ -47,7 +47,7 @@
     "overrides":
     {
         "default_material_print_temperature": { "maximum_value_warning": "320" },
-        "machine_name": { "default_value": "UltiMaker S7" },
+        "machine_name": { "default_value": "Ultimaker S7" },
         "material_print_temperature_layer_0": { "maximum_value_warning": "320" }
     }
 }

--- a/resources/definitions/ultimaker_s8.def.json
+++ b/resources/definitions/ultimaker_s8.def.json
@@ -385,7 +385,7 @@
             "unit": "m/s\u00b3",
             "value": "20000 if machine_gcode_flavor == 'Cheetah' else 100"
         },
-        "machine_name": { "default_value": "UltiMaker S8" },
+        "machine_name": { "default_value": "Ultimaker S8" },
         "machine_nozzle_cool_down_speed": { "default_value": 1.3 },
         "machine_nozzle_heat_up_speed": { "default_value": 0.6 },
         "machine_start_gcode": { "default_value": "M213 U0.1 ;undercut 0.1mm" },


### PR DESCRIPTION
# Description

The machine_name setting is not user-facing. This is only used to paste into the gcode header. Opinicus expects a lower-case m (`Ultimaker`) for all the machines. With an upper-case, the job fails to start

I'll bring the cookies next week 🍪 
