### PR TITLE
Remove NSIS uninstall shortcut removal

### DIFF
--- a/packaging/NSIS/Ultimaker-Cura.nsi.jinja
+++ b/packaging/NSIS/Ultimaker-Cura.nsi.jinja
@@ -158,12 +158,10 @@ RmDir /r /REBOOTOK "$INSTDIR"
 
 !ifdef REG_START_MENU
 Delete "$SMPROGRAMS\${APP_NAME}.lnk"
-Delete "$SMPROGRAMS\Uninstall ${APP_NAME}.lnk"
 !endif
 
 !ifndef REG_START_MENU
 Delete "$SMPROGRAMS\${APP_NAME}.lnk"
-Delete "$SMPROGRAMS\Uninstall ${APP_NAME}.lnk"
 !endif
 
 !insertmacro APP_UNASSOCIATE "stl" "Cura.model"


### PR DESCRIPTION
# Description

Remove NSIS removal of uninstall Start Menu shortcut during uninstall, as it no longer exists. Accidentally left it behind. See #20446 / #20302

Windows specific.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Cleanup


# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
