### PR TITLE
PP-632 Release visual profiles for S8

### DIFF
--- a/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.15mm_visual.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA+ 0.4
+
+[values]
+material_print_temperature = =default_material_print_temperature - 5
+speed_print = 100
+speed_wall = 75
+top_bottom_thickness = =round(layer_height*6,3)
+

--- a/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_tough-pla_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_tough-pla_0.15mm_visual.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_tough_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA+ 0.4
+
+[values]
+material_print_temperature = =default_material_print_temperature - 5
+speed_print = 100
+speed_wall = 75
+top_bottom_thickness = =round(layer_height*6,3)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.15mm.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA+ 0.4
+weight = -1
+
+[values]
+material_final_print_temperature = =material_print_temperature - 15
+material_initial_print_temperature = =material_print_temperature - 15
+retraction_prime_speed = =retraction_speed
+support_structure = tree
+

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_tough-pla_0.15mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA+ 0.4
+weight = -1
+
+[values]
+retraction_prime_speed = =retraction_speed
+retraction_speed = 25
+support_structure = tree
+


### PR DESCRIPTION
# Description
PP-632 Release visual profiles for S8
Added print profiles for 0.15mm layer height with a visual intent for PLA and Tough PLA. Profiles are still faster than S7 profiles.

This fixes... OR This improves... -->

## Type of change

- [ ] Added print profiles

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Tested on multiple printers with multiple materials, including dual extrusion and dual material capabilities


# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
