### PR TITLE
Remove unused hack

### DIFF
--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -942,21 +942,4 @@ UM.MainWindow
         okButtonText: catalog.i18nc("@button", "Save new profile")
         onAccepted: CuraApplication.getQualityManagementModel().createQualityChanges(newName, true);
     }
-
-    /**
-     * Function to check whether a QML object has a certain type.
-     * Taken from StackOverflow: https://stackoverflow.com/a/28384228 and
-     * adapted to our code style.
-     * Licensed under CC BY-SA 3.0.
-     * \param obj The QtObject to get the name of.
-     * \param class_name (str) The name of the class to check against. Has to be
-     * the QtObject class name, not the QML entity name.
-     */
-    function qmlTypeOf(obj, class_name)
-    {
-        //className plus "(" is the class instance without modification.
-        //className plus "_QML" is the class instance with user-defined properties.
-        var str = obj.toString();
-        return str.indexOf(class_name + "(") == 0 || str.indexOf(class_name + "_QML") == 0;
-    }
 }


### PR DESCRIPTION
# Description

Introduced back in 798c1f198c48c0f3f590bca64f254c776befc0da and unused since 5992e66ed670c038f3a05a58840321686076fdee, this is no longer an appropriate way to perform type checks in QML by modern Qt standards. Just use instanceof operator instead, if needed; it works since Qt 5.10

Source: https://doc.qt.io/qt-6/qtqml-javascript-hostenvironment.html

## Type of change

- [x] Chore/cleanup

# How Has This Been Tested?

- [ ] Search for the function name in all project files, find none.

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
