### PR TITLE
Update IntentSelectionModel.py

### DIFF
--- a/cura/Machines/Models/IntentSelectionModel.py
+++ b/cura/Machines/Models/IntentSelectionModel.py
@@ -127,7 +127,7 @@ class IntentSelectionModel(ListModel):
                     "custom_icon": icon,
                     "icon": None,
                     "intent_category": category,
-                    "weight": 5,
+                    "weight": len(_default_intent_categories),
                 })
 
         result.sort(key=lambda k: k["weight"])

--- a/cura/Machines/Models/IntentSelectionModel.py
+++ b/cura/Machines/Models/IntentSelectionModel.py
@@ -127,7 +127,7 @@ class IntentSelectionModel(ListModel):
                     "custom_icon": icon,
                     "icon": None,
                     "intent_category": category,
-                    "weight": len(_default_intent_categories),
+                    "weight": len(self._default_intent_categories),
                 })
 
         result.sort(key=lambda k: k["weight"])


### PR DESCRIPTION
Weight of 5 is occupied by Solid intent, so any profiles added that don't exist in the _default_intent_categories there will have the same weight as Solid

Fixes the random order of the solid intents on Method X/XL (ABSR)
However if additional intents are added, their order is not always guaranteed between instances.
