### PR TITLE
[PP-647] Revert "Remove unused global qualties"

### DIFF
--- a/resources/quality/ultimaker_s8/um_s8_global_High_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_global_High_Quality.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+global_quality = True
+quality_type = high
+setting_version = 25
+type = quality
+weight = 1
+
+[values]
+layer_height = =round(0.06 * material_shrinkage_percentage_z / 100, 5)
+

--- a/resources/quality/ultimaker_s8/um_s8_global_Superdraft_Quality.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_global_Superdraft_Quality.inst.cfg
@@ -1,0 +1,15 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+global_quality = True
+quality_type = superdraft
+setting_version = 25
+type = quality
+weight = -4
+
+[values]
+layer_height = =round(0.4 * material_shrinkage_percentage_z / 100, 5)
+


### PR DESCRIPTION
Reverts Ultimaker/Cura#20657

These qualities are necessary for 3rd party materials. The qualities should be filtered out by neoprep, just like Cura does, because even with these global qualities removed, some materials do not have profiles for all the qualities.

@casperlamboo 