### PR TITLE
[PP-605] Add missing machine_nozzle_size to S6 BB 0.4

### DIFF
--- a/resources/variants/ultimaker_s6_bb04.inst.cfg
+++ b/resources/variants/ultimaker_s6_bb04.inst.cfg
@@ -11,6 +11,7 @@ type = variant
 [values]
 machine_nozzle_heat_up_speed = 1.5
 machine_nozzle_id = BB 0.4
+machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
 retraction_amount = 4.5
 support_bottom_height = =layer_height * 2


### PR DESCRIPTION
Same as https://github.com/Ultimaker/Cura/pull/20463.

With the new S6 BB 0.4 variant, it was also missing. We've now switched to templates for the variants, so now they are all correct