### PR TITLE
PP-658 Fix BVT temperature limits based on thermal model F4

### DIFF
--- a/resources/definitions/ultimaker_factor4.def.json
+++ b/resources/definitions/ultimaker_factor4.def.json
@@ -74,8 +74,8 @@
         {
             "maximum_value": "max(35, min((material_bed_temperature + 20) / 2, 70))",
             "maximum_value_warning": "max(30, min((material_bed_temperature + 10) / 2, 70))",
-            "minimum_value": "max((material_bed_temperature - 30) / 2, 30)",
-            "minimum_value_warning": "max((material_bed_temperature - 20) / 2, 30)"
+            "minimum_value": "max((material_bed_temperature - 40) / 1.5, 30)",
+            "minimum_value_warning": "max((material_bed_temperature - 35) / 1.5, 30)"
         },
         "cool_min_layer_time": { "value": 3 },
         "cool_min_layer_time_fan_speed_max": { "value": "cool_min_layer_time + 12" },


### PR DESCRIPTION
# Description

Updates the thermal model for the build volume temperature, so the limit includes the cases where the set build plate temperature can't be reached due to too much build volume cooling.

## Type of change

- [ ] Printer definition file(s)

# How Has This Been Tested?

- [ ] Tried to slice with PC + PLA -> blocks slice as intented
- [ ] Tried to slice with PC + PVA -> blocks slice as intented
- [ ] Tried to slice with PC + ABS -> slices as intented


# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
