### PR TITLE
CURA-12655 obsolete appimagetools

### DIFF
--- a/packaging/AppImage-builder/AppImageBuilder.yml.jinja
+++ b/packaging/AppImage-builder/AppImageBuilder.yml.jinja
@@ -77,4 +77,4 @@ AppImage:
   arch: {{ arch }}
   file_name: {{ file_name }}
   update-information: guess
-  comp: zlib
+  comp: gzip

--- a/packaging/AppImage-builder/AppImageBuilder.yml.jinja
+++ b/packaging/AppImage-builder/AppImageBuilder.yml.jinja
@@ -77,3 +77,4 @@ AppImage:
   arch: {{ arch }}
   file_name: {{ file_name }}
   update-information: guess
+  comp: zlib

--- a/packaging/AppImage-builder/AppImageBuilder.yml.jinja
+++ b/packaging/AppImage-builder/AppImageBuilder.yml.jinja
@@ -77,4 +77,4 @@ AppImage:
   arch: {{ arch }}
   file_name: {{ file_name }}
   update-information: guess
-  comp: lzma
+  comp: gzip

--- a/packaging/AppImage-builder/AppImageBuilder.yml.jinja
+++ b/packaging/AppImage-builder/AppImageBuilder.yml.jinja
@@ -77,4 +77,4 @@ AppImage:
   arch: {{ arch }}
   file_name: {{ file_name }}
   update-information: guess
-  comp: gzip
+  comp: lzma


### PR DESCRIPTION
Change compression level to gzip instead of xz, because xz is no more available in the AppImage toolkit.
* Pros:
  * It works (and we don't really have an other option)
  * It starts much faster
* Cons:
  * Output file is now 316MB instead of 268MB