### PR TITLE
CURA-11810 fix mac dialogs

### DIFF
--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -9,7 +9,7 @@ import QtQuick.Window 2.2
 import UM 1.5 as UM
 import Cura 1.6 as Cura
 
-Window
+UM.Dialog
 {
     id: marketplaceDialog
     property variant catalog: UM.I18nCatalog { name: "cura" }
@@ -25,293 +25,289 @@ Window
     width: minimumWidth
     height: minimumHeight
 
-    onVisibleChanged:
-    {
-        while(contextStack.depth > 1)
-        {
-            contextStack.pop(); //Do NOT use the StackView.Immediate transition here, since it causes the window to stay empty. Seemingly a Qt bug: https://bugreports.qt.io/browse/QTBUG-60670?
-        }
-    }
-
-    Connections
-    {
-        target: Cura.API.account
-        function onLoginStateChanged()
-        {
-            close();
-        }
-    }
-
     title: "Marketplace" //Seen by Ultimaker as a brand name, so this doesn't get translated.
-    modality: Qt.NonModal
 
     // Background color
     Rectangle
     {
         anchors.fill: parent
         color: UM.Theme.getColor("main_background")
-    }
-    //The Marketplace can have a page in front of everything with package details. The stack view controls its visibility.
-    StackView
-    {
-        id: contextStack
-        anchors.fill: parent
 
-        initialItem: packageBrowse
-
-        ColumnLayout
+        //The Marketplace can have a page in front of everything with package details. The stack view controls its visibility.
+        StackView
         {
-            id: packageBrowse
+            id: contextStack
+            anchors.fill: parent
 
-            spacing: UM.Theme.getSize("narrow_margin").height
+            initialItem: packageBrowse
 
-            // Page title.
-            Item
+            ColumnLayout
             {
-                Layout.preferredWidth: parent.width
-                Layout.preferredHeight: childrenRect.height + UM.Theme.getSize("default_margin").height
+                id: packageBrowse
 
-                UM.Label
+                spacing: UM.Theme.getSize("narrow_margin").height
+
+                // Page title.
+                Item
                 {
-                    id: pageTitle
-                    anchors
-                    {
-                        left: parent.left
-                        leftMargin: UM.Theme.getSize("default_margin").width
-                        right: parent.right
-                        rightMargin: UM.Theme.getSize("default_margin").width
-                        bottom: parent.bottom
-                    }
+                    Layout.preferredWidth: parent.width
+                    Layout.preferredHeight: childrenRect.height + UM.Theme.getSize("default_margin").height
 
-                    font: UM.Theme.getFont("large")
-                    text: content.item ? content.item.pageTitle: catalog.i18nc("@title", "Loading...")
+                    UM.Label
+                    {
+                        id: pageTitle
+                        anchors
+                        {
+                            left: parent.left
+                            leftMargin: UM.Theme.getSize("default_margin").width
+                            right: parent.right
+                            rightMargin: UM.Theme.getSize("default_margin").width
+                            bottom: parent.bottom
+                        }
+
+                        font: UM.Theme.getFont("large")
+                        text: content.item ? content.item.pageTitle : catalog.i18nc("@title", "Loading...")
+                    }
                 }
-            }
 
-            OnboardBanner
-            {
-                id: onBoardBanner
-                visible: content.item && content.item.bannerVisible
-                text: content.item && content.item.bannerText
-                icon: content.item && content.item.bannerIcon
-                onRemove: content.item && content.item.onRemoveBanner
-                readMoreUrl: content.item && content.item.bannerReadMoreUrl
-
-                Layout.fillWidth: true
-                Layout.leftMargin: UM.Theme.getSize("default_margin").width
-                Layout.rightMargin: UM.Theme.getSize("default_margin").width
-            }
-
-            // Search & Top-Level Tabs
-            Item
-            {
-                id: searchHeader
-                implicitHeight: childrenRect.height
-                implicitWidth: parent.width - 2 * UM.Theme.getSize("default_margin").width
-                Layout.alignment: Qt.AlignHCenter
-                RowLayout
+                OnboardBanner
                 {
-                    width: parent.width
-                    height: UM.Theme.getSize("button_icon").height + UM.Theme.getSize("default_margin").height
-                    spacing: UM.Theme.getSize("thin_margin").width
+                    id: onBoardBanner
+                    visible: content.item && content.item.bannerVisible
+                    text: content.item && content.item.bannerText
+                    icon: content.item && content.item.bannerIcon
+                    onRemove: content.item && content.item.onRemoveBanner
+                    readMoreUrl: content.item && content.item.bannerReadMoreUrl
 
-                    Cura.SearchBar
+                    Layout.fillWidth: true
+                    Layout.leftMargin: UM.Theme.getSize("default_margin").width
+                    Layout.rightMargin: UM.Theme.getSize("default_margin").width
+                }
+
+                // Search & Top-Level Tabs
+                Item
+                {
+                    id: searchHeader
+                    implicitHeight: childrenRect.height
+                    implicitWidth: parent.width - 2 * UM.Theme.getSize("default_margin").width
+                    Layout.alignment: Qt.AlignHCenter
+                    RowLayout
                     {
-                        id: searchBar
-                        implicitHeight: UM.Theme.getSize("button_icon").height
-                        Layout.fillWidth: true
-                        onTextEdited: searchStringChanged(text)
-                    }
+                        width: parent.width
+                        height: UM.Theme.getSize("button_icon").height + UM.Theme.getSize("default_margin").height
+                        spacing: UM.Theme.getSize("thin_margin").width
 
-                    // Page selection.
-                    TabBar
-                    {
-                        id: pageSelectionTabBar
-                        Layout.alignment: Qt.AlignRight
-                        height: UM.Theme.getSize("button_icon").height
-                        spacing: 0
-                        background: Rectangle { color: "transparent" }
-                        currentIndex: manager.tabShown
-
-                        onCurrentIndexChanged:
+                        Cura.SearchBar
                         {
-                            manager.tabShown = currentIndex
-                            searchBar.text = "";
-                            searchBar.visible = currentItem.hasSearch;
-                            content.source = currentItem.sourcePage;
+                            id: searchBar
+                            implicitHeight: UM.Theme.getSize("button_icon").height
+                            Layout.fillWidth: true
+                            onTextEdited: searchStringChanged(text)
                         }
 
-                        PackageTypeTab
+                        // Page selection.
+                        TabBar
                         {
-                            id: pluginTabText
-                            width: implicitWidth
-                            text: catalog.i18nc("@button", "Plugins")
-                            property string sourcePage: "Plugins.qml"
-                            property bool hasSearch: true
-                        }
-                        PackageTypeTab
-                        {
-                            id: materialsTabText
-                            width: implicitWidth
-                            text: catalog.i18nc("@button", "Materials")
-                            property string sourcePage: "Materials.qml"
-                            property bool hasSearch: true
-                        }
-                        ManagePackagesButton
-                        {
-                            property string sourcePage: "ManagedPackages.qml"
-                            property bool hasSearch: false
+                            id: pageSelectionTabBar
+                            Layout.alignment: Qt.AlignRight
+                            height: UM.Theme.getSize("button_icon").height
+                            spacing: 0
+                            background: Rectangle {
+                                color: "transparent"
+                            }
+                            currentIndex: manager.tabShown
 
-                            Cura.NotificationIcon
+                            onCurrentIndexChanged:
                             {
-                                anchors
-                                {
-                                    horizontalCenter: parent.right
-                                    verticalCenter: parent.top
-                                }
-                                visible: CuraApplication.getPackageManager().packagesWithUpdate.length > 0
+                                manager.tabShown = currentIndex
+                                searchBar.text = "";
+                                searchBar.visible = currentItem.hasSearch;
+                                content.source = currentItem.sourcePage;
+                            }
 
-                                labelText:
+                            PackageTypeTab
+                            {
+                                id: pluginTabText
+                                width: implicitWidth
+                                text: catalog.i18nc("@button", "Plugins")
+                                property string sourcePage: "Plugins.qml"
+                                property bool hasSearch: true
+                            }
+                            PackageTypeTab
+                            {
+                                id: materialsTabText
+                                width: implicitWidth
+                                text: catalog.i18nc("@button", "Materials")
+                                property string sourcePage: "Materials.qml"
+                                property bool hasSearch: true
+                            }
+                            ManagePackagesButton
+                            {
+                                property string sourcePage: "ManagedPackages.qml"
+                                property bool hasSearch: false
+
+                                Cura.NotificationIcon
                                 {
-                                    const itemCount = CuraApplication.getPackageManager().packagesWithUpdate.length
-                                    return itemCount > 9 ? "9+" : itemCount
+                                    anchors
+                                    {
+                                        horizontalCenter: parent.right
+                                        verticalCenter: parent.top
+                                    }
+                                    visible: CuraApplication.getPackageManager().packagesWithUpdate.length > 0
+
+                                    labelText:
+                                    {
+                                        const itemCount = CuraApplication.getPackageManager().packagesWithUpdate.length
+                                        return itemCount > 9 ? "9+" : itemCount
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
 
-            FontMetrics
-            {
-                id: fontMetrics
-                font: UM.Theme.getFont("default")
-            }
+                FontMetrics
+                {
+                    id: fontMetrics
+                    font: UM.Theme.getFont("default")
+                }
 
-            Cura.TertiaryButton
-            {
-                text: catalog.i18nc("@info", "Search in the browser")
-                iconSource: UM.Theme.getIcon("LinkExternal")
-                visible: pageSelectionTabBar.currentItem.hasSearch && searchHeader.visible
-                isIconOnRightSide: true
-                height: fontMetrics.height
-                textFont: fontMetrics.font
-                textColor: UM.Theme.getColor("text")
+                Cura.TertiaryButton
+                {
+                    text: catalog.i18nc("@info", "Search in the browser")
+                    iconSource: UM.Theme.getIcon("LinkExternal")
+                    visible: pageSelectionTabBar.currentItem.hasSearch && searchHeader.visible
+                    isIconOnRightSide: true
+                    height: fontMetrics.height
+                    textFont: fontMetrics.font
+                    textColor: UM.Theme.getColor("text")
 
-                onClicked: content.item && Qt.openUrlExternally(content.item.searchInBrowserUrl)
-            }
-
-            // Page contents.
-            Rectangle
-            {
-                Layout.preferredWidth: parent.width
-                Layout.fillHeight: true
-                color: UM.Theme.getColor("detail_background")
+                    onClicked: content.item && Qt.openUrlExternally(content.item.searchInBrowserUrl)
+                }
 
                 // Page contents.
-                Loader
+                Rectangle
                 {
-                    id: content
-                    anchors.fill: parent
-                    anchors.margins: UM.Theme.getSize("default_margin").width
-                    source: "Plugins.qml"
+                    Layout.preferredWidth: parent.width
+                    Layout.fillHeight: true
+                    color: UM.Theme.getColor("detail_background")
 
-                    Connections
+                    // Page contents.
+                    Loader
                     {
-                        target: content
-                        function onLoaded()
+                        id: content
+                        anchors.fill: parent
+                        anchors.margins: UM.Theme.getSize("default_margin").width
+                        source: "Plugins.qml"
+
+                        Connections
                         {
-                            pageTitle.text = content.item.pageTitle
-                            searchStringChanged.connect(handleSearchStringChanged)
-                        }
-                        function handleSearchStringChanged(new_search)
-                        {
-                            content.item.model.searchString = new_search
+                            target: content
+
+                            function onLoaded()
+                            {
+                                pageTitle.text = content.item.pageTitle
+                                searchStringChanged.connect(handleSearchStringChanged)
+                            }
+
+                            function handleSearchStringChanged(new_search)
+                            {
+                                content.item.model.searchString = new_search
+                            }
                         }
                     }
                 }
             }
         }
-    }
 
-    Rectangle
-    {
-        height: quitButton.height + 2 * UM.Theme.getSize("default_margin").width
-        color: UM.Theme.getColor("primary")
-        visible: manager.showRestartNotification
-        anchors
+        Rectangle
         {
-            left: parent.left
-            right: parent.right
-            bottom: parent.bottom
-        }
-
-        RowLayout
-        {
+            height: quitButton.height + 2 * UM.Theme.getSize("default_margin").width
+            color: UM.Theme.getColor("primary")
+            visible: manager.showRestartNotification
             anchors
             {
                 left: parent.left
                 right: parent.right
-                verticalCenter: parent.verticalCenter
-                margins: UM.Theme.getSize("default_margin").width
+                bottom: parent.bottom
             }
-            spacing: UM.Theme.getSize("default_margin").width
-            UM.ColorImage
-            {
-                id: bannerIcon
-                source: UM.Theme.getIcon("Plugin")
 
-                color: UM.Theme.getColor("primary_button_text")
-                implicitWidth: UM.Theme.getSize("banner_icon_size").width
-                implicitHeight: UM.Theme.getSize("banner_icon_size").height
-            }
-            Text
+            RowLayout
             {
-                color: UM.Theme.getColor("primary_button_text")
-                text: catalog.i18nc("@button", "In order to use the package you will need to restart Cura")
-                font: UM.Theme.getFont("default")
-                renderType: Text.NativeRendering
-                Layout.fillWidth: true
-            }
-            Cura.SecondaryButton
-            {
-                id: quitButton
-                text: catalog.i18nc("@info:button, %1 is the application name", "Quit %1").arg(CuraApplication.applicationDisplayName)
-                onClicked:
+                anchors
                 {
-                    marketplaceDialog.hide();
-                    CuraApplication.checkAndExitApplication();
+                    left: parent.left
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                    margins: UM.Theme.getSize("default_margin").width
+                }
+                spacing: UM.Theme.getSize("default_margin").width
+                UM.ColorImage
+                {
+                    id: bannerIcon
+                    source: UM.Theme.getIcon("Plugin")
+
+                    color: UM.Theme.getColor("primary_button_text")
+                    implicitWidth: UM.Theme.getSize("banner_icon_size").width
+                    implicitHeight: UM.Theme.getSize("banner_icon_size").height
+                }
+                Text
+                {
+                    color: UM.Theme.getColor("primary_button_text")
+                    text: catalog.i18nc("@button", "In order to use the package you will need to restart Cura")
+                    font: UM.Theme.getFont("default")
+                    renderType: Text.NativeRendering
+                    Layout.fillWidth: true
+                }
+                Cura.SecondaryButton
+                {
+                    id: quitButton
+                    text: catalog.i18nc("@info:button, %1 is the application name", "Quit %1").arg(CuraApplication.applicationDisplayName)
+                    onClicked:
+                    {
+                        marketplaceDialog.hide();
+                        CuraApplication.checkAndExitApplication();
+                    }
                 }
             }
         }
-    }
 
-    Rectangle
-    {
-        color: UM.Theme.getColor("main_background")
-        anchors.fill: parent
-        visible: !Cura.API.account.isLoggedIn && CuraApplication.isEnterprise
-
-        UM.Label
+        Rectangle
         {
-            id: signInLabel
-            anchors.centerIn: parent
-            width: Math.round(UM.Theme.getSize("modal_window_minimum").width / 2.5)
-            text: catalog.i18nc("@description","Please sign in to get verified plugins and materials for UltiMaker Cura Enterprise")
-            horizontalAlignment: Text.AlignHCenter
+            color: UM.Theme.getColor("main_background")
+            anchors.fill: parent
+            visible: !Cura.API.account.isLoggedIn && CuraApplication.isEnterprise
+
+            UM.Label
+            {
+                id: signInLabel
+                anchors.centerIn: parent
+                width: Math.round(UM.Theme.getSize("modal_window_minimum").width / 2.5)
+                text: catalog.i18nc("@description", "Please sign in to get verified plugins and materials for UltiMaker Cura Enterprise")
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            Cura.PrimaryButton
+            {
+                id: loginButton
+                width: UM.Theme.getSize("account_button").width
+                height: UM.Theme.getSize("account_button").height
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: signInLabel.bottom
+                anchors.topMargin: UM.Theme.getSize("default_margin").height * 2
+                text: catalog.i18nc("@button", "Sign in")
+                fixedWidthMode: true
+                onClicked: Cura.API.account.login()
+            }
         }
 
-        Cura.PrimaryButton
+        Connections
         {
-            id: loginButton
-            width: UM.Theme.getSize("account_button").width
-            height: UM.Theme.getSize("account_button").height
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.top: signInLabel.bottom
-            anchors.topMargin: UM.Theme.getSize("default_margin").height * 2
-            text: catalog.i18nc("@button", "Sign in")
-            fixedWidthMode: true
-            onClicked: Cura.API.account.login()
+            target: Cura.API.account
+            function onLoginStateChanged()
+            {
+                reject();
+            }
         }
     }
 }

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -456,45 +456,32 @@ UM.MainWindow
         }
     }
 
-    UM.PreferencesDialog
+    Component
     {
-        id: preferences
-
-        Component.onCompleted:
+        id: preferencesDialogComponent
+        Cura.PreferencesDialog
         {
-            //; Remove & re-add the general page as we want to use our own instead of uranium standard.
-            removePage(0);
-            insertPage(0, catalog.i18nc("@title:tab","General"), Qt.resolvedUrl("Preferences/GeneralPage.qml"));
-
-            removePage(1);
-            insertPage(1, catalog.i18nc("@title:tab","Settings"), Qt.resolvedUrl("Preferences/SettingVisibilityPage.qml"));
-
-            insertPage(2, catalog.i18nc("@title:tab", "Printers"), Qt.resolvedUrl("Preferences/MachinesPage.qml"));
-
-            insertPage(3, catalog.i18nc("@title:tab", "Materials"), Qt.resolvedUrl("Preferences/Materials/MaterialsPage.qml"));
-
-            insertPage(4, catalog.i18nc("@title:tab", "Profiles"), Qt.resolvedUrl("Preferences/ProfilesPage.qml"));
-            currentPage = 0;
+            selfDestroy: true
         }
+    }
 
-        onVisibleChanged:
-        {
-            // When the dialog closes, switch to the General page.
-            // This prevents us from having a heavy page like Setting Visibility active in the background.
-            setPage(0);
-        }
+    function showPreferencesDialog()
+    {
+        var dialog = preferencesDialogComponent.createObject(base)
+        dialog.show()
+        return dialog
     }
 
     Connections
     {
         target: Cura.Actions.preferences
-        function onTriggered() { preferences.visible = true }
+        function onTriggered() { showPreferencesDialog() }
     }
 
     Connections
     {
         target: CuraApplication
-        function onShowPreferencesWindow() { preferences.visible = true }
+        function onShowPreferencesWindow() { showPreferencesDialog() }
     }
 
     Connections
@@ -511,8 +498,8 @@ UM.MainWindow
         target: Cura.Actions.configureMachines
         function onTriggered()
         {
-            preferences.visible = true;
-            preferences.setPage(2);
+            var dialog = showPreferencesDialog()
+            dialog.currentPage = 2;
         }
     }
 
@@ -521,8 +508,8 @@ UM.MainWindow
         target: Cura.Actions.manageProfiles
         function onTriggered()
         {
-            preferences.visible = true;
-            preferences.setPage(4);
+            var dialog = showPreferencesDialog()
+            dialog.currentPage = 4;
         }
     }
 
@@ -531,8 +518,8 @@ UM.MainWindow
         target: Cura.Actions.manageMaterials
         function onTriggered()
         {
-            preferences.visible = true;
-            preferences.setPage(3)
+            var dialog = showPreferencesDialog()
+            dialog.currentPage = 3;
         }
     }
 
@@ -541,11 +528,11 @@ UM.MainWindow
         target: Cura.Actions.configureSettingVisibility
         function onTriggered(source)
         {
-            preferences.visible = true;
-            preferences.setPage(1);
+            var dialog = showPreferencesDialog()
+            dialog.currentPage = 1;
             if(source && source.key)
             {
-                preferences.getCurrentItem().scrollToSection(source.key);
+                dialog.currentItem.scrollToSection(source.key);
             }
         }
     }

--- a/resources/qml/Preferences/PreferencesDialog.qml
+++ b/resources/qml/Preferences/PreferencesDialog.qml
@@ -1,0 +1,136 @@
+// Copyright (c) 2022 Ultimaker B.V.
+// Uranium is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.1
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.1
+import QtQuick.Window 2.1
+
+import ".."
+
+import UM 1.6 as UM
+
+UM.Dialog
+{
+    id: base
+
+    title: catalog.i18nc("@title:window", "Preferences")
+    minimumWidth: UM.Theme.getSize("modal_window_minimum").width
+    minimumHeight: UM.Theme.getSize("modal_window_minimum").height
+    width: minimumWidth
+    height: minimumHeight
+
+    property alias currentPage: pagesList.currentIndex
+    property alias currentItem: pagesList.currentItem
+
+    Rectangle
+    {
+        anchors.fill: parent
+        color: UM.Theme.getColor("background_2")
+    }
+
+    Item
+    {
+        id: test
+        anchors.fill: parent
+        anchors.margins: UM.Theme.getSize("default_margin").width
+
+        ListView
+        {
+            id: pagesList
+            width: UM.Theme.getSize("preferences_page_list_item").width
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+
+            ScrollBar.vertical: UM.ScrollBar {}
+            clip: true
+            model: [
+                {
+                    name: catalog.i18nc("@title:tab","General"),
+                    item: Qt.resolvedUrl("GeneralPage.qml")
+                },
+                {
+                    name: catalog.i18nc("@title:tab","Settings"),
+                    item: Qt.resolvedUrl("SettingVisibilityPage.qml")
+                },
+                {
+                    name: catalog.i18nc("@title:tab","Printers"),
+                    item: Qt.resolvedUrl("MachinesPage.qml")
+                },
+                {
+                    name: catalog.i18nc("@title:tab","Materials"),
+                    item: Qt.resolvedUrl("Materials/MaterialsPage.qml")
+                },
+                {
+                    name: catalog.i18nc("@title:tab","Profiles"),
+                    item: Qt.resolvedUrl("ProfilesPage.qml")
+                }
+            ]
+
+            delegate: Rectangle
+            {
+                width: parent ? parent.width : 0
+                height: pageLabel.height
+
+                color: ListView.isCurrentItem ? UM.Theme.getColor("background_3") : UM.Theme.getColor("main_background")
+
+                UM.Label
+                {
+                    id: pageLabel
+                    anchors.centerIn: parent
+                    verticalAlignment: Text.AlignVCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    width: parent.width
+                    height: UM.Theme.getSize("preferences_page_list_item").height
+                    color: UM.Theme.getColor("text_default")
+                    text: modelData.name
+                }
+                MouseArea
+                {
+                    anchors.fill: parent
+                    onClicked: pagesList.currentIndex = index
+                }
+            }
+
+            onCurrentIndexChanged: stackView.replace(model[currentIndex].item)
+        }
+
+        StackView
+        {
+            id: stackView
+            anchors
+            {
+                left: pagesList.right
+                leftMargin: UM.Theme.getSize("narrow_margin").width
+                top: parent.top
+                bottom: parent.bottom
+                right: parent.right
+            }
+
+            initialItem: Item { property bool resetEnabled: false }
+
+            replaceEnter: Transition
+            {
+                NumberAnimation
+                {
+                    properties: "opacity"
+                    from: 0
+                    to: 1
+                    duration: 100
+                }
+            }
+            replaceExit: Transition
+            {
+                NumberAnimation
+                {
+                    properties: "opacity"
+                    from: 1
+                    to: 0
+                    duration: 100
+                }
+            }
+        }
+
+        UM.I18nCatalog { id: catalog; name: "uranium"; }
+    }
+}

--- a/resources/qml/Preferences/PreferencesDialog.qml
+++ b/resources/qml/Preferences/PreferencesDialog.qml
@@ -19,21 +19,15 @@ UM.Dialog
     minimumHeight: UM.Theme.getSize("modal_window_minimum").height
     width: minimumWidth
     height: minimumHeight
+    backgroundColor: UM.Theme.getColor("background_2")
 
     property alias currentPage: pagesList.currentIndex
     property alias currentItem: pagesList.currentItem
-
-    Rectangle
-    {
-        anchors.fill: parent
-        color: UM.Theme.getColor("background_2")
-    }
 
     Item
     {
         id: test
         anchors.fill: parent
-        anchors.margins: UM.Theme.getSize("default_margin").width
 
         ListView
         {
@@ -46,23 +40,23 @@ UM.Dialog
             clip: true
             model: [
                 {
-                    name: catalog.i18nc("@title:tab","General"),
+                    name: catalog.i18nc("@title:tab", "General"),
                     item: Qt.resolvedUrl("GeneralPage.qml")
                 },
                 {
-                    name: catalog.i18nc("@title:tab","Settings"),
+                    name: catalog.i18nc("@title:tab", "Settings"),
                     item: Qt.resolvedUrl("SettingVisibilityPage.qml")
                 },
                 {
-                    name: catalog.i18nc("@title:tab","Printers"),
+                    name: catalog.i18nc("@title:tab", "Printers"),
                     item: Qt.resolvedUrl("MachinesPage.qml")
                 },
                 {
-                    name: catalog.i18nc("@title:tab","Materials"),
+                    name: catalog.i18nc("@title:tab", "Materials"),
                     item: Qt.resolvedUrl("Materials/MaterialsPage.qml")
                 },
                 {
-                    name: catalog.i18nc("@title:tab","Profiles"),
+                    name: catalog.i18nc("@title:tab", "Profiles"),
                     item: Qt.resolvedUrl("ProfilesPage.qml")
                 }
             ]

--- a/resources/qml/qmldir
+++ b/resources/qml/qmldir
@@ -52,3 +52,7 @@ NumericTextFieldWithUnit    1.0 NumericTextFieldWithUnit.qml
 PrintHeadMinMaxTextField    1.0 PrintHeadMinMaxTextField.qml
 SimpleCheckBox              1.0 SimpleCheckBox.qml
 RenameDialog                1.0 RenameDialog.qml
+
+# Cura/Preferences
+
+PreferencesDialog 1.0 PreferencesDialog.qml


### PR DESCRIPTION
The Marketplace and the Preferences dialog are having display issues in Mac environment. In order to fix this, I have applied some sanity changes:
* Set the proper `transientParent` to dialogs created by Python code
* Set them as modal so that they sould always appear in front of the main window
* Instanciate them only when required, then delete them as soon as we don't need them, then create a new one if we need to re-display

As a bonus, I also removed some unused QML components and simplified the creation logic of the preferences dialog.

CURA-11810
Requires https://github.com/Ultimaker/Uranium/pull/1004