### PR TITLE
conanfile.py: correct quotes in f-string

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -338,7 +338,7 @@ class CuraConan(ConanFile):
 
         if extra_build_identifiers:
             separator = "+" if not cura_version.build else "."
-            cura_version = Version(f"{cura_version}{separator}{".".join(extra_build_identifiers)}")
+            cura_version = Version(f"{cura_version}{separator}{'.'.join(extra_build_identifiers)}")
 
         self.output.info(f"Write CuraVersion.py to {self.recipe_folder}")
 


### PR DESCRIPTION
# Description

The outer quotes are double quotes (`"`) but so are the inner quotes of the `join()` method, which results in the string being terminated too soon and thus a syntax error. This is fixed by replacing the inner quotes with single-quotes (`'`)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Before the change the build process stopped immediately because of this error. Afterwards... well, I still haven't managed to get it to build because of broken Conan dependencies (verified on multiple machines and OS's), but at least this (rather obvious) syntax error doesn't pop-up any longer.

**Test Configuration**:
* Operating System: tested on both Arch Linux and Ubuntu 24.04.

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have uploaded any files required to test this change
