### PR TITLE
Trigger machine error checking during startup. Otherwise slicing will keep failing until selected printer is changed.

### DIFF
--- a/cura/Machines/MachineErrorChecker.py
+++ b/cura/Machines/MachineErrorChecker.py
@@ -61,6 +61,7 @@ class MachineErrorChecker(QObject):
         self._machine_manager.globalContainerChanged.connect(self.startErrorCheck)
 
         self._onMachineChanged()
+        self.startErrorCheck()
 
     def _setCheckTimer(self) -> None:
         """A QTimer to regulate error check frequency


### PR DESCRIPTION
See the original PR here; https://github.com/Ultimaker/Cura/pull/19318

New PR made because we don't usually, if the PR is not to `main`, accept external PR's after a release is out, to the release branches (though this may in certain circumstances be acceptable when we're in, or before, the beta period) -- and this was genuinely the easiest way to change this to main.

See also internal ticket CURA-12615
