### PR TITLE
Cura 12678 sketch sprint profile update

### DIFF
--- a/resources/definitions/ultimaker_sketch_sprint.def.json
+++ b/resources/definitions/ultimaker_sketch_sprint.def.json
@@ -158,7 +158,7 @@
         "machine_max_feedrate_z": { "default_value": 40 },
         "machine_min_cool_heat_time_window": { "value": "15" },
         "machine_name": { "default_value": "MakerBot Sketch Sprint" },
-        "machine_start_gcode": { "default_value": "G28\nM132 X Y Z A B\nG1 Z50.000 F420\nG161 X Y F3300\nM7 T0\nM6 T0\nM651 S255\nG1 Z0.25 F6000\nG1 E-1.5 F800\nG1 E2 F800\nG1 X111 Y111 Z0.25 F4800\nG1 X111 Y-111 E25 F1200" },
+        "machine_start_gcode": { "default_value": "G28\nM132 X Y Z A B\nG1 Z50.000 F420\nG161 X Y F3300\nM7 T0\nM6 T0\nM651 S255\nSET_SERVO SERVO=my_servo ANGLE=180\nSET_FAN_SPEED FAN=external_fan SPEED=1\nSET_FAN_SPEED FAN=internal_fan SPEED=1\nG1 Z0.25 F6000\nG1 E-1.5 F800\nG1 E2 F800\nG1 X111 Y111 Z0.25 F4800\nG1 X111 Y-111 E25 F1200" },
         "machine_width": { "default_value": 221.5 },
         "material_bed_temp_wait": { "value": "False" },
         "material_bed_temperature":

--- a/resources/quality/ultimaker_sketch_sprint/um_sketch_sprint_0.4mm_um-pla-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_sketch_sprint/um_sketch_sprint_0.4mm_um-pla-175_0.2mm.inst.cfg
@@ -12,4 +12,8 @@ variant = 0.4mm
 weight = -2
 
 [values]
-
+bridge_wall_speed = 40
+cool_min_layer_time_overhang = 12
+cool_min_speed = 40
+wall_overhang_angle = 30
+wall_overhang_speed_factors = [60]

--- a/resources/quality/ultimaker_sketch_sprint/um_sketch_sprint_0.4mm_um-pla-175_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_sketch_sprint/um_sketch_sprint_0.4mm_um-pla-175_0.2mm.inst.cfg
@@ -17,3 +17,4 @@ cool_min_layer_time_overhang = 12
 cool_min_speed = 40
 wall_overhang_angle = 30
 wall_overhang_speed_factors = [60]
+


### PR DESCRIPTION
# Description
PR fixes low print quality on Sketch Sprint with PLA on pro models with bridging and overhang features as a result of having a large gap in machine settings between the speed of features.
PR also enables the fan system for all materials (PLA is excluded in FW and the chamber fan is set to internal circulation)

## Type of change
- [x] Printer definition file(s)

# How Has This Been Tested?
- Print validation on Y coupler and Y coupler extender (pro models)


CURA-12678