### PR TITLE
PP-655: S8 legacy cores

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -8808,7 +8808,7 @@
                     "value": "line_width + support_xy_distance + 1.0",
                     "enabled": "bridge_settings_enabled",
                     "settable_per_mesh": true,
-                    "settable_per_extruder": false
+                    "settable_per_extruder": true
                 },
                 "bridge_skin_support_threshold":
                 {

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.06mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_abs
+quality_type = high
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_abs
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.15mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_abs
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_abs
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.1mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_abs
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_abs_0.2mm_quick.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = generic_abs
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_sparse_density = 15
+jerk_print = 6000
+speed_infill = =speed_print
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = 0.8
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_cpe_plus
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_cpe_plus
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_cpe_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_cpe_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_cpe
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_cpe_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_cpe_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_cpe
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_nylon_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_nylon_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_nylon
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_nylon_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_nylon_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_nylon
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pc_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pc_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_pc
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pc_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pc_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_pc
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_petg_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_petg_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_petg
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_petg_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_petg_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_petg
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.06mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_pla
+quality_type = high
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.15mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_pla
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.1mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_pla
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.2mm_quick.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = generic_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_sparse_density = 15
+jerk_print = 6000
+speed_infill = =speed_print
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = 0.8
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_pla_0.3mm_quick.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+is_experimental = True
+material = generic_pla
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 4000
+acceleration_wall = 2000
+acceleration_wall_0 = 2000
+infill_sparse_density = 10
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 50
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = 0.8
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.06mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_tough_pla
+quality_type = high
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_tough_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.15mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_tough_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.1mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_tough_pla
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.1mm_visual.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = generic_tough_pla
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+speed_infill = 50
+top_bottom_thickness = 1.05
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.2mm_quick.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = generic_tough_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_sparse_density = 15
+jerk_print = 6000
+speed_infill = =speed_print
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = 0.8
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_tough-pla_0.3mm_quick.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+is_experimental = True
+material = generic_tough_pla
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 4000
+acceleration_wall = 2000
+acceleration_wall_0 = 2000
+infill_sparse_density = 10
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 50
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = 0.8
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.06mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = high
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.15mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.15mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.1mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.1mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-abs_0.3mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.06mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = high
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.15mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.15mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.1mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.1mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-petg_0.3mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.06mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_pla
+quality_type = high
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.15mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.15mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.1mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_pla
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.1mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_pla
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-pla_0.3mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_pla
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.06mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.06mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_tough_pla
+quality_type = high
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.15mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_tough_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.15mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.15mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_tough_pla
+quality_type = fast
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.1mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.1mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_tough_pla
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.1mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.1mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_tough_pla
+quality_type = normal
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_tough_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_tough_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_tough_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.3mm_quick.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_tough_pla
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_print = 150
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =2 * line_width
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_abs
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_abs
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.3mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.4mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-abs_0.4mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_abs
+quality_type = superdraft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_petg
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_petg
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.3mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.4mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-petg_0.4mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_petg
+quality_type = superdraft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.3mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_pla
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.4mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-pla_0.4mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_pla
+quality_type = superdraft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm_engineering.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = ultimaker_tough_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+jerk_print = 6000
+max_flow_acceleration = 1
+speed_infill = =speed_print
+speed_print = 35
+speed_roofing = =speed_topbottom
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_tough_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm_visual.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm_visual.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Visual
+version = 4
+
+[metadata]
+intent_category = visual
+material = ultimaker_tough_pla
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_print = 2500
+acceleration_wall_0 = 1000
+inset_direction = inside_out
+jerk_wall_0 = 4000
+max_flow_acceleration = 0.5
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(35/50))
+speed_wall_0 = =math.ceil(speed_wall*(20/50))
+speed_wall_x = =math.ceil(speed_wall*(35/50))
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+z_seam_type = back
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.3mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.3mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_tough_pla
+quality_type = verydraft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.4mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.4mm_quick.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Quick
+version = 4
+
+[metadata]
+intent_category = quick
+material = ultimaker_tough_pla
+quality_type = superdraft
+setting_version = 25
+type = intent
+variant = AA 0.8
+
+[values]
+acceleration_wall_0 = 2000
+gradual_flow_enabled = False
+gradual_infill_step_height = =4 * layer_height
+gradual_infill_steps = 3
+infill_sparse_density = 40
+jerk_print = 6000
+jerk_wall_0 = 6000
+speed_wall = =speed_print
+speed_wall_0 = 40
+top_bottom_thickness = =4 * layer_height
+wall_thickness = =wall_line_width_0
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.4_nylon-cf-slide_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.4_nylon-cf-slide_0.2mm_engineering.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+is_experimental = True
+material = generic_nylon-cf-slide
+quality_type = draft
+setting_version = 25
+type = intent
+variant = CC 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.4_petcf_0.15mm_annealing.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.4_petcf_0.15mm_annealing.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Annealing
+version = 4
+
+[metadata]
+intent_category = annealing
+material = generic_petcf
+quality_type = fast
+setting_version = 25
+type = intent
+variant = CC 0.4
+
+[values]
+infill_sparse_density = 100
+jerk_print = 6000
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.9
+speed_infill = =speed_print
+speed_layer_0 = 20
+speed_print = 25
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_enable = True
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.4_petcf_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.4_petcf_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_petcf
+quality_type = fast
+setting_version = 25
+type = intent
+variant = CC 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 25
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.4_petcf_0.2mm_annealing.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.4_petcf_0.2mm_annealing.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Annealing
+version = 4
+
+[metadata]
+intent_category = annealing
+material = generic_petcf
+quality_type = draft
+setting_version = 25
+type = intent
+variant = CC 0.4
+
+[values]
+infill_sparse_density = 100
+jerk_print = 6000
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.9
+speed_infill = =speed_print
+speed_layer_0 = 20
+speed_print = 20
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_enable = True
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.4_petcf_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.4_petcf_0.2mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_petcf
+quality_type = draft
+setting_version = 25
+type = intent
+variant = CC 0.4
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 20
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.6_nylon-cf-slide_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.6_nylon-cf-slide_0.2mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_nylon-cf-slide
+quality_type = draft
+setting_version = 25
+type = intent
+variant = CC 0.6
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.6_petcf_0.15mm_annealing.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.6_petcf_0.15mm_annealing.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Annealing
+version = 4
+
+[metadata]
+intent_category = annealing
+material = generic_petcf
+quality_type = fast
+setting_version = 25
+type = intent
+variant = CC 0.6
+
+[values]
+infill_sparse_density = 100
+jerk_print = 6000
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.9
+speed_infill = =speed_print
+speed_layer_0 = 20
+speed_print = 25
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_enable = True
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.6_petcf_0.15mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.6_petcf_0.15mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_petcf
+quality_type = fast
+setting_version = 25
+type = intent
+variant = CC 0.6
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 25
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.6_petcf_0.2mm_annealing.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.6_petcf_0.2mm_annealing.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Annealing
+version = 4
+
+[metadata]
+intent_category = annealing
+material = generic_petcf
+quality_type = draft
+setting_version = 25
+type = intent
+variant = CC 0.6
+
+[values]
+infill_sparse_density = 100
+jerk_print = 6000
+material_shrinkage_percentage_xy = 100.3
+material_shrinkage_percentage_z = 100.9
+speed_infill = =speed_print
+speed_layer_0 = 20
+speed_print = 25
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_enable = True
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/intent/ultimaker_s8/um_s8_cc0.6_petcf_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_cc0.6_petcf_0.2mm_engineering.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_petcf
+quality_type = draft
+setting_version = 25
+type = intent
+variant = CC 0.6
+
+[values]
+jerk_print = 6000
+speed_infill = =speed_print
+speed_print = 25
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+top_bottom_thickness = =wall_thickness
+wall_thickness = =line_width * 3
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_abs_0.1mm.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_abs
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+cool_fan_speed_0 = 0
+material_print_temperature = =default_material_print_temperature - 20
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_cpe_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_cpe_0.1mm.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_cpe
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+material_print_temperature = =default_material_print_temperature - 15
+speed_infill = =math.ceil(speed_print * 40 / 55)
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.8
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_nylon_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_nylon_0.1mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_nylon
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 20
+ooze_shield_angle = 40
+raft_airgap = 0.4
+speed_print = 70
+speed_topbottom = =math.ceil(speed_print * 30 / 70)
+speed_wall = =math.ceil(speed_print * 30 / 70)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 30
+switch_extruder_retraction_amount = 30
+switch_extruder_retraction_speeds = 40
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_pc_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_pc_0.1mm.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_s8
+name = Fine - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pc
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+brim_width = 20
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+material_print_temperature = =default_material_print_temperature - 10
+multiple_mesh_overlap = 0
+ooze_shield_angle = 40
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+raft_airgap = 0.25
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 40)
+support_bottom_distance = =support_z_distance
+support_interface_density = 87.5
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_petg_0.1mm.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_petg
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+material_print_temperature = =default_material_print_temperature - 15
+speed_infill = =math.ceil(speed_print * 40 / 55)
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.8
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_pla_0.1mm.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+brim_width = 8
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 10
+retraction_hop = 0.2
+speed_print = 30
+speed_wall = =math.ceil(speed_print * 25 / 30)
+speed_wall_0 = =math.ceil(speed_print * 20 / 30)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.72
+travel_avoid_distance = 0.4
+wall_0_inset = 0.015
+wall_0_wipe_dist = 0.25
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_pp_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_pp_0.1mm.inst.cfg
@@ -1,0 +1,46 @@
+[general]
+definition = ultimaker_s8
+name = Fine - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pp
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+brim_width = 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'tetrahedral'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+material_final_print_temperature = =material_print_temperature - 10
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature - 2
+multiple_mesh_overlap = 0
+prime_tower_enable = False
+prime_tower_size = 16
+prime_tower_wipe_enabled = True
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.2
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+retraction_prime_speed = 15
+speed_print = 25
+speed_wall = =math.ceil(speed_print * 25 / 25)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
+support_angle = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+top_bottom_thickness = 1
+travel_avoid_distance = 3
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_tough-pla_0.1mm.inst.cfg
@@ -1,0 +1,31 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+brim_width = 8
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 5
+speed_print = 30
+speed_topbottom = =math.ceil(speed_print * 20 / 30)
+speed_wall = =math.ceil(speed_print * 25 / 30)
+speed_wall_0 = =math.ceil(speed_print * 20 / 30)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.72
+wall_0_inset = 0.015
+wall_0_wipe_dist = 0.25
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_um-abs_0.1mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_fan_speed_0 = 0
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_um-petg_0.1mm.inst.cfg
@@ -1,0 +1,70 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_um-pla_0.1mm.inst.cfg
@@ -1,0 +1,70 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_um-tough-pla_0.1mm.inst.cfg
@@ -1,0 +1,71 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.25
+weight = 0
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.06mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_abs
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+machine_nozzle_cool_down_speed = 0.8
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature - 10
+prime_tower_enable = False
+raft_airgap = 0.15
+speed_infill = =math.ceil(speed_print * 40 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 30 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.15mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_abs
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+prime_tower_enable = False
+raft_airgap = 0.15
+speed_infill = =math.ceil(speed_print * 45 / 60)
+speed_print = 60
+speed_topbottom = =math.ceil(speed_print * 30 / 60)
+speed_wall = =math.ceil(speed_print * 40 / 60)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.1mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_abs
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = False
+raft_airgap = 0.15
+speed_infill = =math.ceil(speed_print * 40 / 55)
+speed_print = 55
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+speed_wall = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.2mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_abs
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature + 5
+prime_tower_enable = False
+raft_airgap = 0.15
+speed_infill = =math.ceil(speed_print * 50 / 60)
+speed_print = 60
+speed_topbottom = =math.ceil(speed_print * 35 / 60)
+speed_wall = =math.ceil(speed_print * 45 / 60)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_abs_0.3mm.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_abs
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 20
+material_print_temperature = =default_material_print_temperature + 7
+prime_tower_enable = False
+raft_airgap = 0.15
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_bam_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_bam_0.15mm.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_bam
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+brim_replaces_support = False
+build_volume_temperature = =50 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 24
+default_material_bed_temperature = =0 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 60
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
+speed_print = 80
+speed_topbottom = =math.ceil(speed_print * 30 / 80)
+speed_wall = =math.ceil(speed_print * 40 / 80)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+support_angle = 45
+support_bottom_distance = =math.ceil(min(extruderValues('material_adhesion_tendency')) / 2) * layer_height
+support_infill_sparse_thickness = =2 * layer_height
+support_interface_density = =min(extruderValues('material_surface_energy'))
+support_interface_enable = True
+support_top_distance = =math.ceil(min(extruderValues('material_adhesion_tendency')) / 1) * layer_height
+top_bottom_thickness = 1
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_bam_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_bam_0.1mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_bam
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+brim_replaces_support = False
+build_volume_temperature = =50 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 24
+default_material_bed_temperature = =0 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 60
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
+support_angle = 45
+support_bottom_distance = =math.ceil(min(extruderValues('material_adhesion_tendency')) / 2) * layer_height
+support_infill_sparse_thickness = =2 * layer_height
+support_interface_density = =min(extruderValues('material_surface_energy'))
+support_interface_enable = True
+support_top_distance = =math.ceil(min(extruderValues('material_adhesion_tendency')) / 1) * layer_height
+top_bottom_thickness = 1
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_bam_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_bam_0.2mm.inst.cfg
@@ -1,0 +1,31 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_bam
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+brim_replaces_support = False
+build_volume_temperature = =50 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 24
+default_material_bed_temperature = =0 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 60
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 5
+prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
+speed_topbottom = =math.ceil(speed_print * 35 / 70)
+speed_wall = =math.ceil(speed_print * 50 / 70)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 50)
+support_angle = 45
+support_bottom_distance = =math.ceil(min(extruderValues('material_adhesion_tendency')) / 2) * layer_height
+support_interface_density = =min(extruderValues('material_surface_energy'))
+support_interface_enable = True
+support_top_distance = =math.ceil(min(extruderValues('material_adhesion_tendency')) / 2) * layer_height
+top_bottom_thickness = 1
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_bam_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_bam_0.3mm.inst.cfg
@@ -1,0 +1,32 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_bam
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+brim_replaces_support = False
+build_volume_temperature = =50 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 24
+default_material_bed_temperature = =0 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 60
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 5
+prime_tower_enable = =min(extruderValues('material_surface_energy')) < 100
+speed_topbottom = =math.ceil(speed_print * 35 / 70)
+speed_wall = =math.ceil(speed_print * 50 / 70)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 50)
+support_angle = 45
+support_bottom_distance = 0.3
+support_interface_density = =min(extruderValues('material_surface_energy'))
+support_interface_enable = True
+support_top_distance = 0.3
+top_bottom_thickness = 1
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.06mm.inst.cfg
@@ -1,0 +1,36 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_cpe_plus
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+infill_wipe_dist = 0
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 8
+multiple_mesh_overlap = 0
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+retraction_hop = 0.2
+retraction_hop_enabled = False
+retraction_hop_only_when_collides = True
+retraction_prime_speed = =retraction_speed
+speed_print = 40
+speed_topbottom = =math.ceil(speed_print * 30 / 35)
+speed_wall = =math.ceil(speed_print * 35 / 40)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 35)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.4/layer_height)*layer_height
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.15mm.inst.cfg
@@ -1,0 +1,33 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_cpe_plus
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+infill_wipe_dist = 0
+machine_min_cool_heat_time_window = 15
+multiple_mesh_overlap = 0
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+retraction_hop = 0.2
+retraction_hop_enabled = False
+retraction_hop_only_when_collides = True
+retraction_prime_speed = =retraction_speed
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 45 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.4/layer_height)*layer_height
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.1mm.inst.cfg
@@ -1,0 +1,36 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_cpe_plus
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+infill_wipe_dist = 0
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 5
+multiple_mesh_overlap = 0
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+retraction_hop = 0.2
+retraction_hop_enabled = False
+retraction_hop_only_when_collides = True
+retraction_prime_speed = =retraction_speed
+speed_print = 40
+speed_topbottom = =math.ceil(speed_print * 30 / 35)
+speed_wall = =math.ceil(speed_print * 35 / 40)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 35)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.4/layer_height)*layer_height
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe-plus_0.2mm.inst.cfg
@@ -1,0 +1,33 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_cpe_plus
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+infill_wipe_dist = 0
+machine_min_cool_heat_time_window = 15
+multiple_mesh_overlap = 0
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+retraction_hop = 0.2
+retraction_hop_enabled = False
+retraction_hop_only_when_collides = True
+retraction_prime_speed = =retraction_speed
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 40 / 50)
+speed_wall = =math.ceil(speed_print * 50 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 40 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.4/layer_height)*layer_height
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe_0.06mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_cpe
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 10
+retraction_prime_speed = =retraction_speed
+speed_infill = =math.ceil(speed_print * 40 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 30 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe_0.15mm.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_cpe
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+retraction_prime_speed = =retraction_speed
+speed_infill = =math.ceil(speed_print * 50 / 60)
+speed_print = 60
+speed_topbottom = =math.ceil(speed_print * 30 / 60)
+speed_wall = =math.ceil(speed_print * 40 / 60)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe_0.1mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_cpe
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 5
+retraction_prime_speed = =retraction_speed
+speed_infill = =math.ceil(speed_print * 45 / 55)
+speed_print = 55
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+speed_wall = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_cpe_0.2mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_cpe
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+material_print_temperature = =default_material_print_temperature + 5
+retraction_prime_speed = =retraction_speed
+speed_infill = =math.ceil(speed_print * 50 / 60)
+speed_print = 60
+speed_topbottom = =math.ceil(speed_print * 35 / 60)
+speed_wall = =math.ceil(speed_print * 45 / 60)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_nylon_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_nylon_0.06mm.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_nylon
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+material_print_temperature = =default_material_print_temperature - 5
+ooze_shield_angle = 40
+raft_airgap = 0.4
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 30
+switch_extruder_retraction_amount = 30
+switch_extruder_retraction_speeds = 40
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_nylon_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_nylon_0.15mm.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_nylon
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+ooze_shield_angle = 40
+raft_airgap = 0.4
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 30
+switch_extruder_retraction_amount = 30
+switch_extruder_retraction_speeds = 40
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_nylon_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_nylon_0.1mm.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_nylon
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+material_print_temperature = =default_material_print_temperature - 5
+ooze_shield_angle = 40
+raft_airgap = 0.4
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 30
+switch_extruder_retraction_amount = 30
+switch_extruder_retraction_speeds = 40
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_nylon_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_nylon_0.2mm.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_nylon
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+material_print_temperature = =default_material_print_temperature + 5
+ooze_shield_angle = 40
+raft_airgap = 0.4
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 30
+switch_extruder_retraction_amount = 30
+switch_extruder_retraction_speeds = 40
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pc_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pc_0.06mm.inst.cfg
@@ -1,0 +1,42 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_pc
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+brim_width = 20
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 20
+multiple_mesh_overlap = 0
+ooze_shield_angle = 40
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+raft_airgap = 0.25
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 40)
+support_bottom_distance = =support_z_distance
+support_interface_density = 87.5
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pc_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pc_0.15mm.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pc
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+brim_width = 20
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+multiple_mesh_overlap = 0
+ooze_shield_angle = 40
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+raft_airgap = 0.25
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 40)
+support_bottom_distance = =support_z_distance
+support_interface_density = 87.5
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pc_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pc_0.1mm.inst.cfg
@@ -1,0 +1,42 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pc
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+brim_width = 20
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 10
+multiple_mesh_overlap = 0
+ooze_shield_angle = 40
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+raft_airgap = 0.25
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 40)
+support_bottom_distance = =support_z_distance
+support_interface_density = 87.5
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pc_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pc_0.2mm.inst.cfg
@@ -1,0 +1,41 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pc
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+brim_width = 20
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+multiple_mesh_overlap = 0
+ooze_shield_angle = 40
+prime_tower_enable = True
+prime_tower_wipe_enabled = True
+raft_airgap = 0.25
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 40)
+support_bottom_distance = =support_z_distance
+support_interface_density = 87.5
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.06mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_petg
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 10
+speed_infill = =math.ceil(speed_print * 40 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 30 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.15mm.inst.cfg
@@ -1,0 +1,25 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_petg
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+speed_infill = =math.ceil(speed_print * 50 / 60)
+speed_print = 60
+speed_topbottom = =math.ceil(speed_print * 30 / 60)
+speed_wall = =math.ceil(speed_print * 40 / 60)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.1mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_petg
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_print_temperature = =default_material_print_temperature - 5
+speed_infill = =math.ceil(speed_print * 45 / 55)
+speed_print = 55
+speed_topbottom = =math.ceil(speed_print * 30 / 55)
+speed_wall = =math.ceil(speed_print * 30 / 55)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.2mm.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_petg
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+material_print_temperature = =default_material_print_temperature + 5
+speed_infill = =math.ceil(speed_print * 50 / 60)
+speed_print = 60
+speed_topbottom = =math.ceil(speed_print * 35 / 60)
+speed_wall = =math.ceil(speed_print * 45 / 60)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_petg_0.3mm.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_petg
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+material_print_temperature = =default_material_print_temperature + 5
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.06mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature - 5
+raft_airgap = 0.25
+retraction_prime_speed = =retraction_speed
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 35 / 50)
+speed_wall = =math.ceil(speed_print * 35 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.15mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+raft_airgap = 0.25
+retraction_prime_speed = =retraction_speed
+speed_print = 70
+speed_topbottom = =math.ceil(speed_print * 35 / 70)
+speed_wall = =math.ceil(speed_print * 45 / 70)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 70)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.1mm.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+raft_airgap = 0.25
+retraction_prime_speed = =retraction_speed
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.2mm.inst.cfg
@@ -1,0 +1,31 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+acceleration_wall = 2000
+acceleration_wall_0 = 2000
+infill_sparse_density = 15
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 5
+raft_airgap = 0.25
+retraction_prime_speed = =retraction_speed
+speed_topbottom = =math.ceil(speed_print * 40 / 70)
+speed_wall = =math.ceil(speed_print * 55 / 70)
+speed_wall_0 = =math.ceil(speed_wall * 45 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.8
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pla_0.3mm.inst.cfg
@@ -1,0 +1,35 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pla
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+acceleration_print = 2000
+acceleration_topbottom = 1000
+acceleration_wall = 1500
+acceleration_wall_0 = 1000
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 15
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+raft_airgap = 0.25
+retraction_prime_speed = =retraction_speed
+speed_print = 50
+speed_wall = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.9
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pp_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pp_0.15mm.inst.cfg
@@ -1,0 +1,45 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_pp
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+brim_width = 20
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'tetrahedral'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 10
+material_initial_print_temperature = =material_print_temperature - 10
+multiple_mesh_overlap = 0
+prime_tower_enable = False
+prime_tower_size = 16
+prime_tower_wipe_enabled = True
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.8
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+speed_print = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 25)
+speed_wall = =math.ceil(speed_print * 25 / 25)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
+support_angle = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+top_bottom_thickness = 1.1
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pp_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pp_0.1mm.inst.cfg
@@ -1,0 +1,46 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_pp
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+brim_width = 20
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'tetrahedral'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 10
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature - 2
+multiple_mesh_overlap = 0
+prime_tower_enable = False
+prime_tower_size = 16
+prime_tower_wipe_enabled = True
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.8
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+speed_print = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 25)
+speed_wall = =math.ceil(speed_print * 25 / 25)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
+support_angle = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+top_bottom_thickness = 1
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_pp_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_pp_0.2mm.inst.cfg
@@ -1,0 +1,45 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pp
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+brim_width = 20
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'tetrahedral'
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+material_final_print_temperature = =material_print_temperature - 10
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature + 8
+multiple_mesh_overlap = 0
+prime_tower_enable = False
+prime_tower_size = 16
+prime_tower_wipe_enabled = True
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.8
+retraction_hop = 2
+retraction_hop_only_when_collides = True
+speed_print = 25
+speed_topbottom = =math.ceil(speed_print * 25 / 25)
+speed_wall = =math.ceil(speed_print * 25 / 25)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
+support_angle = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.06mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = False
+retraction_prime_speed = =retraction_speed
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.15mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+prime_tower_enable = False
+retraction_prime_speed = =retraction_speed
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.1mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = False
+retraction_prime_speed = =retraction_speed
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 45)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.2mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+prime_tower_enable = False
+retraction_prime_speed = =retraction_speed
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall * 20 / 24)
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 36 / 50)
+speed_wall_0 = =math.ceil(speed_print * 26 / 50)
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tough-pla_0.3mm.inst.cfg
@@ -1,0 +1,36 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_tough_pla
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+acceleration_print = 2000
+acceleration_topbottom = 1000
+acceleration_wall = 1500
+acceleration_wall_0 = 1000
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 15
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 5
+prime_tower_enable = False
+raft_airgap = 0.25
+retraction_prime_speed = =retraction_speed
+speed_print = 50
+speed_wall = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1.2
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.15mm.inst.cfg
@@ -1,0 +1,52 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_tpu
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = =bridge_skin_material_flow
+bridge_wall_speed = 10
+brim_width = 8.75
+gradual_infill_step_height = =5 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
+infill_sparse_density = 10
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.5
+machine_nozzle_heat_up_speed = 2.5
+material_final_print_temperature = =material_print_temperature - 10
+material_flow = 106
+material_initial_print_temperature = =material_print_temperature - 10
+multiple_mesh_overlap = 0
+prime_tower_wipe_enabled = True
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.8
+retraction_hop_only_when_collides = True
+skin_line_width = =round(line_width / 0.8, 2)
+speed_print = 25
+speed_topbottom = =math.ceil(speed_print * 0.8)
+speed_wall = =math.ceil(speed_print * 25 / 25)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
+support_angle = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+top_bottom_thickness = =layer_height * 6
+travel_avoid_distance = 1.5
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.1mm.inst.cfg
@@ -1,0 +1,53 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = generic_tpu
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = =bridge_skin_material_flow
+bridge_wall_speed = 10
+brim_width = 8.75
+gradual_infill_step_height = =5 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
+infill_sparse_density = 10
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.5
+machine_nozzle_heat_up_speed = 2.5
+material_final_print_temperature = =material_print_temperature - 10
+material_flow = 106
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature - 2
+multiple_mesh_overlap = 0
+prime_tower_wipe_enabled = True
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.8
+retraction_hop_only_when_collides = True
+skin_line_width = =round(line_width / 0.8, 2)
+speed_print = 25
+speed_topbottom = =math.ceil(speed_print * 0.8)
+speed_wall = =math.ceil(speed_print * 25 / 25)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
+support_angle = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+top_bottom_thickness = =layer_height * 6
+travel_avoid_distance = 1.5
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.2mm.inst.cfg
@@ -1,0 +1,52 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_tpu
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = =bridge_skin_material_flow
+bridge_wall_speed = 10
+brim_width = 8.75
+gradual_infill_step_height = =5 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
+infill_sparse_density = 10
+infill_wipe_dist = 0.1
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.5
+machine_nozzle_heat_up_speed = 2.5
+material_final_print_temperature = =material_print_temperature - 10
+material_flow = 106
+material_initial_print_temperature = =material_print_temperature - 10
+multiple_mesh_overlap = 0
+prime_tower_wipe_enabled = True
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.8
+retraction_hop_only_when_collides = True
+skin_line_width = =round(line_width / 0.8, 2)
+speed_print = 25
+speed_topbottom = =math.ceil(speed_print * 0.8)
+speed_wall = =math.ceil(speed_print * 25 / 25)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 25)
+support_angle = 50
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 35
+top_bottom_thickness = =layer_height * 6
+travel_avoid_distance = 1.5
+wall_0_inset = 0
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.06mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.15mm.inst.cfg
@@ -1,0 +1,73 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+max_flow_acceleration = 1
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.1mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm.inst.cfg
@@ -1,0 +1,78 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_material_flow = =1.05 * material_flow
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+max_flow_acceleration = 1
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_material_flow = =material_flow
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_x_material_flow = =1.05 * wall_material_flow
+wall_x_material_flow_roofing = =wall_material_flow
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.3mm.inst.cfg
@@ -1,0 +1,75 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 7
+max_flow_acceleration = 1
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.15
+retraction_amount = 6.5
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.4
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.06mm.inst.cfg
@@ -1,0 +1,71 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.15mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+max_flow_acceleration = 1
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.1mm.inst.cfg
@@ -1,0 +1,71 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm.inst.cfg
@@ -1,0 +1,77 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_material_flow = =1.1 * material_flow
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+max_flow_acceleration = 1
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+skin_material_flow = =1.05 * material_flow
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_x_material_flow = =1.1 * wall_material_flow
+wall_x_material_flow_roofing = =wall_material_flow
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.3mm.inst.cfg
@@ -1,0 +1,74 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 20
+material_print_temperature = =default_material_print_temperature + 5
+max_flow_acceleration = 1
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+retraction_amount = 8
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.4
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.06mm.inst.cfg
@@ -1,0 +1,71 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 12
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.15mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 12
+max_flow_acceleration = 2
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.1mm.inst.cfg
@@ -1,0 +1,71 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 12
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm.inst.cfg
@@ -1,0 +1,77 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_material_flow = =1.1 * material_flow
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 12
+material_print_temperature = =default_material_print_temperature + 5
+max_flow_acceleration = 2
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+skin_material_flow = =1.05 * material_flow
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+wall_x_material_flow = =1.1 * wall_material_flow
+wall_x_material_flow_roofing = =wall_material_flow
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.3mm.inst.cfg
@@ -1,0 +1,74 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 12
+material_print_temperature = =default_material_print_temperature + 10
+max_flow_acceleration = 2
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.06mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = high
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 1
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 14
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -1,0 +1,73 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -1
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 14
+max_flow_acceleration = 2
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.35
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.1mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Fine
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = normal
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = 0
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 14
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(20/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.3
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -1,0 +1,77 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_material_flow = =1.1 * material_flow
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 14
+max_flow_acceleration = 2
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+skin_material_flow = =1.05 * material_flow
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.35
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+wall_x_material_flow = =1.1 * wall_material_flow
+wall_x_material_flow_roofing = =wall_material_flow
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -1,0 +1,75 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -3
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_max_flowrate = 14
+material_print_temperature = =default_material_print_temperature + 5
+max_flow_acceleration = 2
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = False
+raft_airgap = 0.25
+retraction_amount = 6.5
+retraction_prime_speed = =retraction_speed
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_structure = tree
+support_top_distance = =support_z_distance
+support_z_distance = 0.4
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_abs_0.2mm.inst.cfg
@@ -1,0 +1,20 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_abs
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+material_print_temperature = =default_material_print_temperature + 5
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_abs_0.3mm.inst.cfg
@@ -1,0 +1,20 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_abs
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+material_print_temperature = =default_material_print_temperature + 7
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_abs_0.4mm.inst.cfg
@@ -1,0 +1,21 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_abs
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+material_print_temperature = =default_material_print_temperature + 10
+speed_infill = =math.ceil(speed_print * 37 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 30 / 50)
+speed_wall = =math.ceil(speed_print * 37 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe-plus_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe-plus_0.2mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_cpe_plus
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+brim_width = 14
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 20
+prime_tower_enable = True
+retraction_hop = 0.1
+retraction_hop_enabled = False
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 35 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+support_z_distance = =layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe-plus_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe-plus_0.3mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_cpe_plus
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+brim_width = 14
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 17
+prime_tower_enable = True
+retraction_hop = 0.1
+retraction_hop_enabled = False
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 35 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+support_z_distance = =layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe-plus_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe-plus_0.4mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_s8
+name = Sprint - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_cpe_plus
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+brim_width = 14
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 15
+prime_tower_enable = True
+retraction_hop = 0.1
+retraction_hop_enabled = False
+speed_infill = =math.ceil(speed_print * 40 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 35 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+support_z_distance = =layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe_0.2mm.inst.cfg
@@ -1,0 +1,21 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_cpe
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+brim_width = 15
+material_print_temperature = =default_material_print_temperature + 10
+prime_tower_enable = True
+speed_print = 40
+speed_topbottom = =math.ceil(speed_print * 25 / 40)
+speed_wall = =math.ceil(speed_print * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe_0.3mm.inst.cfg
@@ -1,0 +1,21 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_cpe
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+brim_width = 15
+material_print_temperature = =default_material_print_temperature + 12
+prime_tower_enable = True
+speed_print = 40
+speed_topbottom = =math.ceil(speed_print * 25 / 40)
+speed_wall = =math.ceil(speed_print * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_cpe_0.4mm.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_cpe
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+brim_width = 15
+material_print_temperature = =default_material_print_temperature + 15
+prime_tower_enable = True
+speed_infill = =math.ceil(speed_print * 33 / 45)
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 30 / 45)
+speed_wall = =math.ceil(speed_print * 33 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_nylon_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_nylon_0.2mm.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_nylon
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+brim_width = 5.6
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 5
+ooze_shield_angle = 40
+prime_tower_enable = True
+raft_airgap = 0.45
+support_angle = 70
+switch_extruder_prime_speed = 30
+switch_extruder_retraction_amount = 30
+switch_extruder_retraction_speeds = 40
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_nylon_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_nylon_0.3mm.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_nylon
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+brim_width = 5.6
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 5
+ooze_shield_angle = 40
+prime_tower_enable = True
+raft_airgap = 0.45
+support_angle = 70
+switch_extruder_prime_speed = 30
+switch_extruder_retraction_amount = 30
+switch_extruder_retraction_speeds = 40
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_nylon_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_nylon_0.4mm.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_nylon
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+brim_width = 5.6
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
+material_print_temperature = =default_material_print_temperature - 5
+ooze_shield_angle = 40
+prime_tower_enable = True
+raft_airgap = 0.45
+support_angle = 70
+switch_extruder_prime_speed = 30
+switch_extruder_retraction_amount = 30
+switch_extruder_retraction_speeds = 40
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pc_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pc_0.2mm.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s8
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pc
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+brim_width = 14
+material_print_temperature = =default_material_print_temperature - 15
+raft_airgap = 0.5
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pc_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pc_0.3mm.inst.cfg
@@ -1,0 +1,23 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pc
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+brim_width = 14
+material_print_temperature = =default_material_print_temperature - 12
+raft_airgap = 0.5
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 40 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pc_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pc_0.4mm.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Sprint - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pc
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+brim_width = 14
+material_print_temperature = =default_material_print_temperature - 10
+raft_airgap = 0.5
+speed_infill = =math.ceil(speed_print * 37 / 50)
+speed_print = 50
+speed_topbottom = =math.ceil(speed_print * 25 / 50)
+speed_wall = =math.ceil(speed_print * 37 / 50)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_petg_0.2mm.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_petg
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+brim_width = 7
+cool_fan_speed = 20
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = True
+speed_print = 40
+speed_topbottom = =math.ceil(speed_print * 25 / 40)
+speed_wall = =math.ceil(speed_print * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_petg_0.3mm.inst.cfg
@@ -1,0 +1,22 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_petg
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+brim_width = 7
+cool_fan_speed = 20
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = True
+speed_print = 40
+speed_topbottom = =math.ceil(speed_print * 25 / 40)
+speed_wall = =math.ceil(speed_print * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_petg_0.4mm.inst.cfg
@@ -1,0 +1,24 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_petg
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+brim_width = 7
+cool_fan_speed = 20
+material_print_temperature = =default_material_print_temperature - 5
+prime_tower_enable = True
+speed_infill = =math.ceil(speed_print * 33 / 45)
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 30 / 45)
+speed_wall = =math.ceil(speed_print * 33 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 30 / 40)
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pla_0.2mm.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pla_0.3mm.inst.cfg
@@ -1,0 +1,26 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pla_0.4mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_pla
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 15
+speed_infill = =math.ceil(speed_print * 35 / 45)
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 35 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pp_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pp_0.2mm.inst.cfg
@@ -1,0 +1,35 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pp
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+brim_width = 25
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'tetrahedral'
+material_final_print_temperature = =material_print_temperature - 10
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature + 11
+multiple_mesh_overlap = 0.2
+prime_tower_enable = True
+prime_tower_flow = 100
+prime_tower_min_volume = 10
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.5
+retraction_hop = 0.5
+retraction_prime_speed = 15
+speed_wall_x = =math.ceil(speed_wall * 30 / 30)
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 45
+top_bottom_thickness = 1.6
+top_skin_expand_distance = =line_width * 2
+wall_0_wipe_dist = =line_width * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pp_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pp_0.3mm.inst.cfg
@@ -1,0 +1,35 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_pp
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+brim_width = 25
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'tetrahedral'
+material_final_print_temperature = =material_print_temperature - 10
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature + 13
+multiple_mesh_overlap = 0.2
+prime_tower_enable = True
+prime_tower_flow = 100
+prime_tower_min_volume = 15
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.5
+retraction_hop = 0.5
+retraction_prime_speed = 15
+speed_wall_x = =math.ceil(speed_wall * 30 / 30)
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 45
+top_bottom_thickness = 1.6
+top_skin_expand_distance = =line_width * 2
+wall_0_wipe_dist = =line_width * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_pp_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_pp_0.4mm.inst.cfg
@@ -1,0 +1,36 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_pp
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+brim_width = 25
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'tetrahedral'
+material_final_print_temperature = =material_print_temperature - 10
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature + 15
+multiple_mesh_overlap = 0.2
+prime_tower_enable = True
+prime_tower_flow = 100
+prime_tower_min_volume = 20
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.5
+retraction_hop = 0.5
+retraction_prime_speed = 15
+speed_infill = =math.ceil(speed_wall * 30 / 30)
+speed_wall_x = =math.ceil(speed_wall * 30 / 30)
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 45
+top_bottom_thickness = 1.6
+top_skin_expand_distance = =line_width * 2
+wall_0_wipe_dist = =line_width * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tough-pla_0.2mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cubic'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+prime_tower_enable = False
+speed_print = 45
+speed_topbottom = =round(speed_print * 35 / 45)
+speed_wall = =round(speed_print * 40 / 45)
+speed_wall_0 = =round(speed_print * 35 / 45)
+support_angle = 70
+top_bottom_thickness = =layer_height * 6
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tough-pla_0.3mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cubic'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 15
+prime_tower_enable = False
+speed_infill = =math.ceil(speed_print * 30 / 35)
+speed_print = 35
+speed_topbottom = =math.ceil(speed_print * 20 / 35)
+speed_wall = =math.ceil(speed_print * 25 / 35)
+speed_wall_0 = =math.ceil(speed_print * 20 / 35)
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tough-pla_0.4mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_tough_pla
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cubic'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 15
+prime_tower_enable = False
+speed_infill = =math.ceil(speed_print * 30 / 30)
+speed_print = 30
+speed_topbottom = =math.ceil(speed_print * 20 / 30)
+speed_wall = =math.ceil(speed_print * 25 / 30)
+speed_wall_0 = =math.ceil(speed_print * 20 / 30)
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.2mm.inst.cfg
@@ -1,0 +1,48 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_tpu
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = =bridge_skin_material_flow
+bridge_wall_speed = 10
+brim_width = 8.75
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
+machine_nozzle_cool_down_speed = 0.5
+machine_nozzle_heat_up_speed = 2.5
+material_final_print_temperature = =material_print_temperature - 10
+material_flow = 105
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature - 4
+multiple_mesh_overlap = 0.2
+prime_tower_enable = True
+prime_tower_flow = 100
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.5
+retraction_hop = 1.5
+retraction_hop_only_when_collides = False
+retraction_prime_speed = 15
+speed_print = 30
+speed_topbottom = =math.ceil(speed_print * 25 / 30)
+speed_wall = =math.ceil(speed_print * 30 / 30)
+speed_wall_x = =math.ceil(speed_wall * 30 / 30)
+support_angle = 50
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 45
+top_bottom_thickness = =layer_height * 6
+top_skin_expand_distance = =line_width * 2
+travel_avoid_distance = 1.5
+wall_0_wipe_dist = =line_width * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.3mm.inst.cfg
@@ -1,0 +1,49 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_tpu
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = =bridge_skin_material_flow
+bridge_wall_speed = 10
+brim_width = 8.75
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
+infill_sparse_density = 15
+machine_nozzle_cool_down_speed = 0.5
+machine_nozzle_heat_up_speed = 2.5
+material_final_print_temperature = =material_print_temperature - 10
+material_flow = 105
+material_initial_print_temperature = =material_print_temperature - 10
+material_print_temperature = =default_material_print_temperature - 2
+multiple_mesh_overlap = 0.2
+prime_tower_enable = True
+prime_tower_flow = 100
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.5
+retraction_hop = 1.5
+retraction_hop_only_when_collides = False
+retraction_prime_speed = 15
+speed_print = 30
+speed_topbottom = =math.ceil(speed_print * 23 / 30)
+speed_wall = =math.ceil(speed_print * 30 / 30)
+speed_wall_x = =math.ceil(speed_wall * 30 / 30)
+support_angle = 50
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 45
+top_bottom_thickness = =layer_height * 6
+top_skin_expand_distance = =line_width * 2
+travel_avoid_distance = 1.5
+wall_0_wipe_dist = =line_width * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.4mm.inst.cfg
@@ -1,0 +1,48 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_tpu
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = =bridge_skin_material_flow
+bridge_wall_speed = 10
+brim_width = 8.75
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
+infill_sparse_density = 15
+machine_nozzle_cool_down_speed = 0.5
+machine_nozzle_heat_up_speed = 2.5
+material_final_print_temperature = =material_print_temperature - 10
+material_flow = 105
+material_initial_print_temperature = =material_print_temperature - 10
+multiple_mesh_overlap = 0.2
+prime_tower_enable = True
+prime_tower_flow = 100
+retraction_count_max = 15
+retraction_extra_prime_amount = 0.5
+retraction_hop = 1.5
+retraction_hop_only_when_collides = False
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =math.ceil(speed_print * 20 / 30)
+speed_wall = =speed_print
+speed_wall_x = =speed_print
+support_angle = 50
+switch_extruder_prime_speed = 15
+switch_extruder_retraction_amount = 20
+switch_extruder_retraction_speeds = 45
+top_bottom_thickness = =layer_height * 6
+top_skin_expand_distance = =line_width * 2
+travel_avoid_distance = 1.5
+wall_0_wipe_dist = =line_width * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm.inst.cfg
@@ -1,0 +1,75 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = 200
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 5
+max_flow_acceleration = 1
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 4
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.3mm.inst.cfg
@@ -1,0 +1,73 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 7
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 4
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 75
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/75))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.4mm.inst.cfg
@@ -1,0 +1,73 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = ultimaker_abs
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.8
+material_flow = 93
+material_max_flowrate = 22
+material_print_temperature = =default_material_print_temperature + 10
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.15
+retraction_amount = 4
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/50))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm.inst.cfg
@@ -1,0 +1,74 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = 200
+bridge_wall_speed = 20
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+max_flow_acceleration = 1
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 3.5
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.3mm.inst.cfg
@@ -1,0 +1,74 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 100
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = 100
+bridge_wall_speed = 20
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 3.5
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 75
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/75))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.4mm.inst.cfg
@@ -1,0 +1,74 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = ultimaker_petg
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 100
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = 100
+bridge_wall_speed = 20
+cool_min_layer_time = 4
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.4
+machine_nozzle_heat_up_speed = 1.7
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 23
+material_print_temperature = =default_material_print_temperature - 5
+max_flow_acceleration = 1
+optimize_wall_printing_order = False
+prime_tower_enable = True
+retraction_amount = 3.5
+retraction_prime_speed = 15
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 50
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/50))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1.2 , layer_height * 6)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm.inst.cfg
@@ -1,0 +1,74 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = 200
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 15
+material_print_temperature = =default_material_print_temperature + 10
+max_flow_acceleration = 2
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 4
+retraction_prime_speed = 22
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.3mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 15
+material_print_temperature = =default_material_print_temperature + 10
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 4
+retraction_prime_speed = 22
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 65
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/65))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.4mm.inst.cfg
@@ -1,0 +1,72 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = ultimaker_pla
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 15
+material_print_temperature = =default_material_print_temperature + 15
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+raft_airgap = 0.25
+retraction_amount = 4
+retraction_prime_speed = 22
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 30
+speed_prime_tower = =speed_wall_0
+speed_print = 45
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/45))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -1,0 +1,75 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -2
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_material_flow = 200
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_material_flow = 200
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 17
+material_print_temperature = =default_material_print_temperature + 10
+max_flow_acceleration = 2
+meshfix_maximum_resolution = 0.7
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.25
+retraction_amount = 4
+retraction_prime_speed = 22
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 100
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/100))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -1,0 +1,73 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -3
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 17
+material_print_temperature = =default_material_print_temperature + 15
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.25
+retraction_amount = 4
+retraction_prime_speed = 22
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 65
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/65))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -1,0 +1,73 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = ultimaker_tough_pla
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = AA 0.8
+weight = -4
+
+[values]
+acceleration_infill = =acceleration_print
+acceleration_ironing = 1000
+acceleration_layer_0 = =acceleration_wall_0
+acceleration_print = 3500
+acceleration_roofing = =acceleration_wall_0
+acceleration_topbottom = =acceleration_wall
+acceleration_wall = =acceleration_infill
+acceleration_wall_0 = 1500
+acceleration_wall_x = =acceleration_wall
+bridge_skin_speed = =bridge_wall_speed
+bridge_sparse_infill_max_density = 50
+bridge_wall_speed = 30
+cool_min_layer_time = 6
+gradual_flow_discretisation_step_size = 0.2
+gradual_flow_enabled = True
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'grid'
+infill_sparse_density = 15
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_wall_0
+jerk_print = =max(30, speed_print/2) * 200
+jerk_roofing = =jerk_wall_0
+jerk_topbottom = =jerk_wall
+jerk_wall = =jerk_infill
+jerk_wall_0 = =max(30, speed_wall_0/2) * 200
+machine_nozzle_cool_down_speed = 1.3
+machine_nozzle_heat_up_speed = 1.9
+material_extrusion_cool_down_speed = 0.7
+material_flow = 93
+material_max_flowrate = 17
+material_print_temperature = =default_material_print_temperature + 15
+max_flow_acceleration = 2
+optimize_wall_printing_order = False
+prime_tower_enable = True
+raft_airgap = 0.25
+retraction_amount = 4
+retraction_prime_speed = 22
+retraction_speed = 45
+small_skin_on_surface = False
+small_skin_width = 4
+speed_infill = =speed_print
+speed_ironing = 20
+speed_layer_0 = 26
+speed_prime_tower = =speed_wall_0
+speed_print = 45
+speed_roofing = =math.ceil(speed_wall*(45/100))
+speed_support_interface = =speed_wall_0
+speed_topbottom = =speed_print
+speed_wall = =speed_infill
+speed_wall_0 = =math.ceil(speed_wall*(30/45))
+speed_wall_x = =speed_wall
+speed_wall_x_roofing = =speed_roofing
+support_angle = 70
+support_interface_enable = False
+support_structure = tree
+top_bottom_thickness = =max(1 , layer_height * 5)
+wall_0_wipe_dist = 0.8
+wall_line_width_0 = =line_width * (1 + magic_spiralize * 0.25)
+zig_zaggify_infill = True
+

--- a/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_bb0.4_pva_0.06mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fine
+version = 4
+
+[metadata]
+material = generic_pva
+quality_type = high
+setting_version = 25
+type = quality
+variant = BB 0.4
+weight = 1
+
+[values]
+acceleration_prime_tower = 1500
+brim_replaces_support = False
+build_volume_temperature = =70 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 35
+cool_fan_enabled = =not (support_enable and (extruder_nr == support_infill_extruder_nr))
+default_material_bed_temperature = =0 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 60
+initial_layer_line_width_factor = 150
+material_print_temperature = =default_material_print_temperature - 5
+minimum_support_area = 4
+retraction_count_max = 5
+skirt_brim_minimal_length = =min(2000, 175 / (layer_height * line_width))
+speed_prime_tower = 25
+speed_support = 50
+support_infill_sparse_thickness = =3 * layer_height
+support_interface_enable = True
+

--- a/resources/quality/ultimaker_s8/um_s8_bb0.8_pva_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_bb0.8_pva_0.2mm.inst.cfg
@@ -1,0 +1,27 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_pva
+quality_type = draft
+setting_version = 25
+type = quality
+variant = BB 0.8
+weight = -2
+
+[values]
+acceleration_prime_tower = 1500
+brim_replaces_support = False
+build_volume_temperature = =70 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 35
+cool_fan_enabled = =not (support_enable and (extruder_nr == support_infill_extruder_nr))
+default_material_bed_temperature = =0 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 60
+initial_layer_line_width_factor = 150
+minimum_support_area = 4
+retraction_count_max = 5
+skirt_brim_minimal_length = =min(2000, 175 / (layer_height * line_width))
+speed_prime_tower = 25
+speed_support = 50
+support_interface_enable = True
+

--- a/resources/quality/ultimaker_s8/um_s8_bb0.8_pva_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_bb0.8_pva_0.3mm.inst.cfg
@@ -1,0 +1,29 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_pva
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = BB 0.8
+weight = -3
+
+[values]
+acceleration_prime_tower = 1500
+brim_replaces_support = False
+build_volume_temperature = =70 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 35
+cool_fan_enabled = =not (support_enable and (extruder_nr == support_infill_extruder_nr))
+default_material_bed_temperature = =0 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 60
+initial_layer_line_width_factor = 150
+material_print_temperature = =default_material_print_temperature + 5
+minimum_support_area = 4
+retraction_count_max = 5
+skirt_brim_minimal_length = =min(2000, 175 / (layer_height * line_width))
+speed_prime_tower = 25
+speed_support = 50
+support_infill_sparse_thickness = 0.3
+support_interface_enable = True
+

--- a/resources/quality/ultimaker_s8/um_s8_bb0.8_pva_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_bb0.8_pva_0.4mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Sprint
+version = 4
+
+[metadata]
+material = generic_pva
+quality_type = superdraft
+setting_version = 25
+type = quality
+variant = BB 0.8
+weight = -4
+
+[values]
+acceleration_prime_tower = 1500
+brim_replaces_support = False
+build_volume_temperature = =70 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 35
+cool_fan_enabled = =not (support_enable and (extruder_nr == support_infill_extruder_nr))
+default_material_bed_temperature = =0 if extruders_enabled_count > 1 and (not support_enable or extruder_nr != support_extruder_nr) else 60
+initial_layer_line_width_factor = 150
+material_print_temperature = =default_material_print_temperature + 5
+minimum_support_area = 4
+retraction_count_max = 5
+skirt_brim_minimal_length = =min(2000, 175 / (layer_height * line_width))
+speed_prime_tower = 25
+speed_support = 50
+support_interface_enable = True
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_cffcpe_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_cffcpe_0.15mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_cffcpe
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -1
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_cffcpe_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_cffcpe_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_cffcpe
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_cffpa_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_cffpa_0.15mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_cffpa
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -1
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_cffpa_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_cffpa_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_cffpa
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_gffcpe_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_gffcpe_0.15mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_gffcpe
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -1
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_gffcpe_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_gffcpe_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_gffcpe
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_gffpa_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_gffpa_0.15mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_gffpa
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -1
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_gffpa_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_gffpa_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_gffpa
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_nylon-cf-slide_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_nylon-cf-slide_0.2mm.inst.cfg
@@ -1,0 +1,19 @@
+[general]
+definition = ultimaker_s8
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_nylon-cf-slide
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_petcf_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_petcf_0.15mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_petcf
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -1
+
+[values]
+cool_fan_speed_max = =cool_fan_speed
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+raft_airgap = =layer_height * 2
+skin_overlap = 20
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.8
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_petcf_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_petcf_0.2mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_petcf
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -2
+
+[values]
+cool_fan_speed_max = =cool_fan_speed
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+raft_airgap = =layer_height * 2
+skin_overlap = 20
+speed_infill = =speed_print
+speed_print = 25
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 0.8
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_pla_0.15mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Normal - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -1
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_pla_0.2mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -2
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_um-pla_0.15mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Normal - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = ultimaker_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -1
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.4_um-pla_0.2mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.4
+weight = -2
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_cffcpe_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_cffcpe_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_cffcpe
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_cffpa_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_cffpa_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_cffpa
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_gffcpe_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_gffcpe_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_gffcpe
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_gffpa_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_gffpa_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_gffpa
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_nylon-cf-slide_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_nylon-cf-slide_0.2mm.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_nylon-cf-slide
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -2
+
+[values]
+support_bottom_distance = =support_z_distance / 2
+support_top_distance = =support_z_distance
+support_z_distance = =layer_height * 2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_petcf_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_petcf_0.15mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_s8
+name = Normal
+version = 4
+
+[metadata]
+material = generic_petcf
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -1
+
+[values]
+cool_fan_speed_max = =cool_fan_speed
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+raft_airgap = =layer_height * 2
+skin_overlap = 20
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_petcf_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_petcf_0.2mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_s8
+name = Fast
+version = 4
+
+[metadata]
+material = generic_petcf
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -2
+
+[values]
+cool_fan_speed_max = =cool_fan_speed
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+raft_airgap = =layer_height * 2
+skin_overlap = 20
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_petcf_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_petcf_0.3mm.inst.cfg
@@ -1,0 +1,30 @@
+[general]
+definition = ultimaker_s8
+name = Extra Fast
+version = 4
+
+[metadata]
+material = generic_petcf
+quality_type = verydraft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -3
+
+[values]
+cool_fan_speed_max = =cool_fan_speed
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+raft_airgap = =layer_height * 2
+skin_overlap = 20
+speed_infill = =speed_print
+speed_print = 30
+speed_topbottom = =speed_print
+speed_wall = =speed_print
+speed_wall_0 = =speed_wall
+speed_wall_x = =speed_wall
+support_bottom_distance = =support_z_distance
+support_interface_enable = True
+support_top_distance = =support_z_distance
+support_z_distance = =math.ceil(0.3/layer_height)*layer_height
+top_bottom_thickness = 1.2
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_pla_0.15mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Normal - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -1
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_pla_0.2mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = generic_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -2
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_um-pla_0.15mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Normal - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = ultimaker_pla
+quality_type = fast
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -1
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/quality/ultimaker_s8/um_s8_cc0.6_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc0.6_um-pla_0.2mm.inst.cfg
@@ -1,0 +1,28 @@
+[general]
+definition = ultimaker_s8
+name = Fast - Experimental
+version = 4
+
+[metadata]
+is_experimental = True
+material = ultimaker_pla
+quality_type = draft
+setting_version = 25
+type = quality
+variant = CC 0.6
+weight = -2
+
+[values]
+gradual_infill_step_height = =3 * layer_height
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+machine_nozzle_cool_down_speed = 0.75
+machine_nozzle_heat_up_speed = 1.6
+material_print_temperature = =default_material_print_temperature + 10
+speed_print = 45
+speed_topbottom = =math.ceil(speed_print * 35 / 45)
+speed_wall = =math.ceil(speed_print * 40 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 35 / 40)
+speed_wall_x = =speed_wall
+support_angle = 70
+top_bottom_thickness = =layer_height * 4
+

--- a/resources/variants/ultimaker_s6_aa025.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa025.inst.cfg
@@ -1,0 +1,188 @@
+[general]
+definition = ultimaker_s6
+name = AA 0.25
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_min_layer_time = 0
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 4000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+machine_nozzle_id = AA 0.25
+machine_nozzle_size = 0.25
+machine_nozzle_tip_outer_diameter = 0.65
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_min_volume = 6
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_min_travel = 5
+retraction_prime_speed = =retraction_speed
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 55
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_wall_0
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = 20
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 55)
+speed_wall_0 = =math.ceil(speed_wall * 20 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = =switch_extruder_retraction_speeds
+switch_extruder_retraction_amount = =machine_heat_zone_length
+top_bottom_thickness = 1.2
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_thickness = =wall_line_width_0 + wall_line_width_x * 2
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+xy_offset_layer_0 = =(-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s6_aa025.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa025.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_min_layer_time = 0
 cool_min_layer_time_overhang = =cool_min_layer_time
 cool_min_layer_time_overhang_min_segment_length = 5
@@ -77,6 +76,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -99,7 +99,6 @@ max_skin_angle_for_expansion = 90
 meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_min_volume = 6
 retraction_amount = 6.5
 retraction_combing_avoid_distance = =machine_nozzle_size * 1.5

--- a/resources/variants/ultimaker_s6_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa04.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = =cool_min_layer_time
 cool_min_layer_time_overhang_min_segment_length = 5
@@ -77,6 +76,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -86,6 +86,7 @@ jerk_wall_x = =jerk_wall
 jerk_wall_x_flooring = =jerk_wall_x
 jerk_wall_x_roofing = =jerk_wall_x
 machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
 machine_nozzle_id = AA 0.4
 machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
@@ -98,7 +99,6 @@ max_skin_angle_for_expansion = 90
 meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_min_volume = 6
 retraction_amount = 6.5
 retraction_combing_avoid_distance = =machine_nozzle_size * 1.5

--- a/resources/variants/ultimaker_s6_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa04.inst.cfg
@@ -1,0 +1,185 @@
+[general]
+definition = ultimaker_s6
+name = AA 0.4
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_min_layer_time = 6
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 4000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_id = AA 0.4
+machine_nozzle_size = 0.4
+machine_nozzle_tip_outer_diameter = 1.0
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_min_volume = 6
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_min_travel = 5
+retraction_prime_speed = 15
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 70
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_wall_0
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = =math.ceil(speed_print * 30 / 70)
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 70)
+speed_wall_0 = =math.ceil(speed_wall * 20 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = =switch_extruder_retraction_speeds
+switch_extruder_retraction_amount = =machine_heat_zone_length
+top_bottom_thickness = 1.2
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s6_aa08.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa08.inst.cfg
@@ -1,0 +1,197 @@
+[general]
+definition = ultimaker_s6
+name = AA 0.8
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_fan_speed = 7
+cool_min_layer_time = 6
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+default_material_print_temperature = 200
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+infill_wipe_dist = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 5000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+layer_height = 0.2
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+machine_nozzle_id = AA 0.8
+machine_nozzle_size = 0.8
+machine_nozzle_tip_outer_diameter = 2.0
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+multiple_mesh_overlap = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_enable = False
+prime_tower_min_volume = 6
+prime_tower_wipe_enabled = True
+raft_surface_layers = 1
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_hop_only_when_collides = True
+retraction_min_travel = 5
+retraction_prime_speed = 15
+retraction_speed = 25
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 35
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_wall_0
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = =math.ceil(speed_print * 25 / 35)
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 35)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = 20
+switch_extruder_retraction_amount = 16.5
+top_bottom_thickness = 1.4
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s6_aa08.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa08.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_fan_speed = 7
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = =cool_min_layer_time
@@ -80,6 +79,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -105,7 +105,6 @@ meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 multiple_mesh_overlap = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_enable = False
 prime_tower_min_volume = 6
 prime_tower_wipe_enabled = True

--- a/resources/variants/ultimaker_s6_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s6_cc04.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = =cool_min_layer_time
 cool_min_layer_time_overhang_min_segment_length = 5
@@ -77,6 +76,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -86,6 +86,7 @@ jerk_wall_x = =jerk_wall
 jerk_wall_x_flooring = =jerk_wall_x
 jerk_wall_x_roofing = =jerk_wall_x
 machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
 machine_nozzle_id = CC 0.4
 machine_nozzle_size = 0.4
 material_extrusion_cool_down_speed = 0.7
@@ -97,7 +98,6 @@ max_skin_angle_for_expansion = 90
 meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_min_volume = 6
 retraction_amount = 6.5
 retraction_combing_avoid_distance = =machine_nozzle_size * 1.5

--- a/resources/variants/ultimaker_s6_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s6_cc04.inst.cfg
@@ -1,0 +1,184 @@
+[general]
+definition = ultimaker_s6
+name = CC 0.4
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_min_layer_time = 6
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 4000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_id = CC 0.4
+machine_nozzle_size = 0.4
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_min_volume = 6
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_min_travel = 5
+retraction_prime_speed = =retraction_speed
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 45
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_topbottom
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = =switch_extruder_retraction_speeds
+switch_extruder_retraction_amount = =machine_heat_zone_length
+top_bottom_thickness = =layer_height * 6
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s6_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s6_cc06.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = =cool_min_layer_time
 cool_min_layer_time_overhang_min_segment_length = 5
@@ -77,6 +76,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -86,6 +86,7 @@ jerk_wall_x = =jerk_wall
 jerk_wall_x_flooring = =jerk_wall_x
 jerk_wall_x_roofing = =jerk_wall_x
 machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
 machine_nozzle_id = CC 0.6
 machine_nozzle_size = 0.6
 material_extrusion_cool_down_speed = 0.7
@@ -97,7 +98,6 @@ max_skin_angle_for_expansion = 90
 meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_min_volume = 6
 retraction_amount = 6.5
 retraction_combing_avoid_distance = =machine_nozzle_size * 1.5

--- a/resources/variants/ultimaker_s6_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s6_cc06.inst.cfg
@@ -1,0 +1,184 @@
+[general]
+definition = ultimaker_s6
+name = CC 0.6
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_min_layer_time = 6
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 4000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_id = CC 0.6
+machine_nozzle_size = 0.6
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_min_volume = 6
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_min_travel = 5
+retraction_prime_speed = =retraction_speed
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 45
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_topbottom
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = =switch_extruder_retraction_speeds
+switch_extruder_retraction_amount = =machine_heat_zone_length
+top_bottom_thickness = =layer_height * 6
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s8_aa025.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa025.inst.cfg
@@ -1,0 +1,188 @@
+[general]
+definition = ultimaker_s8
+name = AA 0.25
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_min_layer_time = 0
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 4000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+machine_nozzle_id = AA 0.25
+machine_nozzle_size = 0.25
+machine_nozzle_tip_outer_diameter = 0.65
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_min_volume = 6
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_min_travel = 5
+retraction_prime_speed = =retraction_speed
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 55
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_wall_0
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = 20
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 55)
+speed_wall_0 = =math.ceil(speed_wall * 20 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = =switch_extruder_retraction_speeds
+switch_extruder_retraction_amount = =machine_heat_zone_length
+top_bottom_thickness = 1.2
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_thickness = =wall_line_width_0 + wall_line_width_x * 2
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+xy_offset_layer_0 = =(-0.2 if adhesion_type == "skirt" or adhesion_type == "none" else 0) + xy_offset
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s8_aa025.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa025.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_min_layer_time = 0
 cool_min_layer_time_overhang = =cool_min_layer_time
 cool_min_layer_time_overhang_min_segment_length = 5
@@ -77,6 +76,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -99,7 +99,6 @@ max_skin_angle_for_expansion = 90
 meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_min_volume = 6
 retraction_amount = 6.5
 retraction_combing_avoid_distance = =machine_nozzle_size * 1.5

--- a/resources/variants/ultimaker_s8_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa04.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = =cool_min_layer_time
 cool_min_layer_time_overhang_min_segment_length = 5
@@ -77,6 +76,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -86,6 +86,7 @@ jerk_wall_x = =jerk_wall
 jerk_wall_x_flooring = =jerk_wall_x
 jerk_wall_x_roofing = =jerk_wall_x
 machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
 machine_nozzle_id = AA 0.4
 machine_nozzle_size = 0.4
 machine_nozzle_tip_outer_diameter = 1.0
@@ -98,7 +99,6 @@ max_skin_angle_for_expansion = 90
 meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_min_volume = 6
 retraction_amount = 6.5
 retraction_combing_avoid_distance = =machine_nozzle_size * 1.5

--- a/resources/variants/ultimaker_s8_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa04.inst.cfg
@@ -1,0 +1,185 @@
+[general]
+definition = ultimaker_s8
+name = AA 0.4
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_min_layer_time = 6
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 4000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_id = AA 0.4
+machine_nozzle_size = 0.4
+machine_nozzle_tip_outer_diameter = 1.0
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_min_volume = 6
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_min_travel = 5
+retraction_prime_speed = 15
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 70
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_wall_0
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = =math.ceil(speed_print * 30 / 70)
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 70)
+speed_wall_0 = =math.ceil(speed_wall * 20 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = =switch_extruder_retraction_speeds
+switch_extruder_retraction_amount = =machine_heat_zone_length
+top_bottom_thickness = 1.2
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s8_aa08.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa08.inst.cfg
@@ -1,0 +1,197 @@
+[general]
+definition = ultimaker_s8
+name = AA 0.8
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_fan_speed = 7
+cool_min_layer_time = 6
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+default_material_print_temperature = 200
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+infill_wipe_dist = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 5000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+layer_height = 0.2
+machine_min_cool_heat_time_window = 15
+machine_nozzle_cool_down_speed = 0.85
+machine_nozzle_heat_up_speed = 1.5
+machine_nozzle_id = AA 0.8
+machine_nozzle_size = 0.8
+machine_nozzle_tip_outer_diameter = 2.0
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+multiple_mesh_overlap = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_enable = False
+prime_tower_min_volume = 6
+prime_tower_wipe_enabled = True
+raft_surface_layers = 1
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_hop_only_when_collides = True
+retraction_min_travel = 5
+retraction_prime_speed = 15
+retraction_speed = 25
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 35
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_wall_0
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = =math.ceil(speed_print * 25 / 35)
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 35)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = 20
+switch_extruder_retraction_amount = 16.5
+top_bottom_thickness = 1.4
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s8_aa08.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa08.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_fan_speed = 7
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = =cool_min_layer_time
@@ -80,6 +79,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -105,7 +105,6 @@ meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 multiple_mesh_overlap = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_enable = False
 prime_tower_min_volume = 6
 prime_tower_wipe_enabled = True

--- a/resources/variants/ultimaker_s8_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s8_cc04.inst.cfg
@@ -1,0 +1,184 @@
+[general]
+definition = ultimaker_s8
+name = CC 0.4
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_min_layer_time = 6
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 4000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_id = CC 0.4
+machine_nozzle_size = 0.4
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_min_volume = 6
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_min_travel = 5
+retraction_prime_speed = =retraction_speed
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 45
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_topbottom
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = =switch_extruder_retraction_speeds
+switch_extruder_retraction_amount = =machine_heat_zone_length
+top_bottom_thickness = =layer_height * 6
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+

--- a/resources/variants/ultimaker_s8_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s8_cc04.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = =cool_min_layer_time
 cool_min_layer_time_overhang_min_segment_length = 5
@@ -77,6 +76,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -86,6 +86,7 @@ jerk_wall_x = =jerk_wall
 jerk_wall_x_flooring = =jerk_wall_x
 jerk_wall_x_roofing = =jerk_wall_x
 machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
 machine_nozzle_id = CC 0.4
 machine_nozzle_size = 0.4
 material_extrusion_cool_down_speed = 0.7
@@ -97,7 +98,6 @@ max_skin_angle_for_expansion = 90
 meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_min_volume = 6
 retraction_amount = 6.5
 retraction_combing_avoid_distance = =machine_nozzle_size * 1.5

--- a/resources/variants/ultimaker_s8_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s8_cc06.inst.cfg
@@ -46,7 +46,6 @@ bridge_wall_material_flow = =wall_material_flow
 bridge_wall_min_length = =line_width + support_xy_distance + 1.0
 bridge_wall_speed = =bridge_skin_speed
 brim_width = 7
-cool_during_extruder_switch = unchanged
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = =cool_min_layer_time
 cool_min_layer_time_overhang_min_segment_length = 5
@@ -77,6 +76,7 @@ jerk_support_interface = =jerk_support
 jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
 jerk_topbottom = =jerk_print
 jerk_travel = =jerk_print
+jerk_travel_enabled = False
 jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
 jerk_wall = =jerk_print
 jerk_wall_0 = =jerk_wall
@@ -86,6 +86,7 @@ jerk_wall_x = =jerk_wall
 jerk_wall_x_flooring = =jerk_wall_x
 jerk_wall_x_roofing = =jerk_wall_x
 machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_heat_up_speed = 1.4
 machine_nozzle_id = CC 0.6
 machine_nozzle_size = 0.6
 material_extrusion_cool_down_speed = 0.7
@@ -97,7 +98,6 @@ max_skin_angle_for_expansion = 90
 meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
 min_infill_area = 0
 optimize_wall_printing_order = True
-prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
 prime_tower_min_volume = 6
 retraction_amount = 6.5
 retraction_combing_avoid_distance = =machine_nozzle_size * 1.5

--- a/resources/variants/ultimaker_s8_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s8_cc06.inst.cfg
@@ -1,0 +1,184 @@
+[general]
+definition = ultimaker_s8
+name = CC 0.6
+version = 4
+
+[metadata]
+hardware_type = nozzle
+setting_version = 25
+type = variant
+
+[values]
+acceleration_flooring = =acceleration_topbottom
+acceleration_infill = =acceleration_print
+acceleration_layer_0 = =acceleration_topbottom
+acceleration_prime_tower = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_print = 3500
+acceleration_print_layer_0 = =acceleration_layer_0
+acceleration_roofing = =acceleration_topbottom
+acceleration_skirt_brim = =acceleration_layer_0
+acceleration_support = =math.ceil(acceleration_print * 2000 / 3500)
+acceleration_support_bottom = =extruderValue(support_bottom_extruder_nr, 'acceleration_support_interface')
+acceleration_support_infill = =acceleration_support
+acceleration_support_interface = =acceleration_topbottom
+acceleration_support_roof = =extruderValue(support_roof_extruder_nr, 'acceleration_support_interface')
+acceleration_topbottom = =math.ceil(acceleration_print * 1000 / 3500)
+acceleration_travel = =acceleration_print if magic_spiralize else 5000
+acceleration_travel_enabled = False
+acceleration_travel_layer_0 = =acceleration_layer_0 * acceleration_travel / acceleration_print
+acceleration_wall = =math.ceil(acceleration_print * 1500 / 3500)
+acceleration_wall_0 = =math.ceil(acceleration_wall * 1000 / 1000)
+acceleration_wall_0_flooring = =acceleration_wall_0
+acceleration_wall_0_roofing = =acceleration_wall_0
+acceleration_wall_x = =acceleration_wall
+acceleration_wall_x_flooring = =acceleration_wall_x
+acceleration_wall_x_roofing = =acceleration_wall_x
+adhesion_type = brim
+bottom_thickness = =top_bottom_thickness
+bridge_enable_more_layers = False
+bridge_skin_density = 80
+bridge_skin_material_flow = =skin_material_flow
+bridge_skin_material_flow_2 = =skin_material_flow
+bridge_skin_speed = =speed_topbottom
+bridge_skin_speed_2 = =speed_topbottom
+bridge_sparse_infill_max_density = 0
+bridge_wall_material_flow = =wall_material_flow
+bridge_wall_min_length = =line_width + support_xy_distance + 1.0
+bridge_wall_speed = =bridge_skin_speed
+brim_width = 7
+cool_during_extruder_switch = unchanged
+cool_min_layer_time = 6
+cool_min_layer_time_overhang = =cool_min_layer_time
+cool_min_layer_time_overhang_min_segment_length = 5
+cool_min_speed = =round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)
+cool_min_temperature = =max([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])
+extra_infill_lines_to_support_skins = none
+flooring_layer_count = 0
+gradual_flow_enabled = False
+hole_xy_offset = 0
+infill_material_flow = =(1.95-infill_sparse_density / 100 if infill_sparse_density > 95 else 1) * material_flow
+infill_overlap = =0 if infill_sparse_density > 80 else 10
+infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'triangles'
+infill_sparse_density = 20
+infill_wall_line_count = 0
+initial_bottom_layers = =bottom_layers
+jerk_flooring = =jerk_topbottom
+jerk_infill = =jerk_print
+jerk_layer_0 = =jerk_print
+jerk_prime_tower = =jerk_print
+jerk_print = 4000
+jerk_print_layer_0 = =max(4000, jerk_wall_0)
+jerk_roofing = =jerk_topbottom
+jerk_skirt_brim = =jerk_layer_0
+jerk_support = =jerk_print
+jerk_support_bottom = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_support_infill = =jerk_support
+jerk_support_interface = =jerk_support
+jerk_support_roof = =extruderValue(support_roof_extruder_nr, 'jerk_support_interface')
+jerk_topbottom = =jerk_print
+jerk_travel = =jerk_print
+jerk_travel_layer_0 = =jerk_layer_0 * jerk_travel / jerk_print
+jerk_wall = =jerk_print
+jerk_wall_0 = =jerk_wall
+jerk_wall_0_flooring = =jerk_wall_0
+jerk_wall_0_roofing = =jerk_wall_0
+jerk_wall_x = =jerk_wall
+jerk_wall_x_flooring = =jerk_wall_x
+jerk_wall_x_roofing = =jerk_wall_x
+machine_nozzle_cool_down_speed = 0.9
+machine_nozzle_id = CC 0.6
+machine_nozzle_size = 0.6
+material_extrusion_cool_down_speed = 0.7
+material_final_print_temperature = =max(-273.15, material_print_temperature - 15)
+material_initial_print_temperature = =max(-273.15, material_print_temperature - 10)
+material_pressure_advance_factor = 0.05
+max_flow_acceleration = 1
+max_skin_angle_for_expansion = 90
+meshfix_maximum_resolution = =max(speed_wall_0 / 75, 0.5)
+min_infill_area = 0
+optimize_wall_printing_order = True
+prime_tower_brim_enable = =resolveOrValue('adhesion_type') in ['raft', 'brim']
+prime_tower_min_volume = 6
+retraction_amount = 6.5
+retraction_combing_avoid_distance = =machine_nozzle_size * 1.5
+retraction_combing_max_distance = 15
+retraction_hop = 2
+retraction_hop_after_extruder_switch_height = =retraction_hop
+retraction_hop_enabled = =extruders_enabled_count > 1
+retraction_min_travel = 5
+retraction_prime_speed = =retraction_speed
+skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0
+skin_material_flow = =0.95 * material_flow
+skin_outline_count = =0 if top_bottom_pattern == 'concentric' and top_bottom_pattern_0 == 'concentric' and roofing_layer_count <= 0 else 1
+skin_overlap = 20
+skin_preshrink = =wall_line_width_0 + (wall_line_count - 1) * wall_line_width_x
+skirt_brim_minimal_length = 250
+skirt_brim_speed = =speed_layer_0
+skirt_line_count = 1
+small_skin_on_surface = False
+small_skin_width = =skin_line_width * 2
+speed_flooring = =speed_topbottom
+speed_infill = =speed_print
+speed_ironing = =speed_topbottom * 20 / 30
+speed_layer_0 = =min(30, layer_height / layer_height_0 * speed_wall_0)
+speed_prime_tower = =speed_topbottom
+speed_print = 45
+speed_print_layer_0 = =speed_layer_0
+speed_roofing = =speed_topbottom
+speed_support = =speed_topbottom
+speed_support_bottom = =extruderValue(support_bottom_extruder_nr, 'speed_support_interface')
+speed_support_infill = =speed_support
+speed_support_interface = =speed_topbottom
+speed_support_roof = =extruderValue(support_roof_extruder_nr, 'speed_support_interface')
+speed_topbottom = =math.ceil(speed_print * 25 / 45)
+speed_travel = 150
+speed_travel_layer_0 = =speed_travel
+speed_wall = =math.ceil(speed_print * 30 / 45)
+speed_wall_0 = =math.ceil(speed_wall * 25 / 30)
+speed_wall_0_flooring = =speed_wall_0
+speed_wall_0_roofing = =speed_wall_0
+speed_wall_x = =speed_wall
+speed_wall_x_flooring = =speed_wall_x
+speed_wall_x_roofing = =speed_wall_x
+support_angle = 60
+support_bottom_distance = =support_z_distance / 2
+support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
+support_interface_enable = False
+support_interface_offset = =support_offset
+support_line_width = =line_width
+support_offset = =support_line_width + 0.4 if support_structure == 'normal' else 0.0
+support_pattern = zigzag
+support_structure = normal
+support_top_distance = =support_z_distance
+support_tree_angle = =max(min(support_angle, 85), 20)
+support_tree_angle_slow = =support_tree_angle * 2 / 3
+support_tree_bp_diameter = 7.5
+support_tree_branch_diameter = 5
+support_tree_branch_diameter_angle = 7
+support_tree_max_diameter = 25
+support_tree_tip_diameter = =support_line_width * 2
+support_tree_top_rate = =30 if support_roof_enable else 10
+support_xy_distance = 0.7
+support_xy_distance_overhang = 0.2
+support_z_distance = =layer_height * 2
+switch_extruder_prime_speed = =switch_extruder_retraction_speeds
+switch_extruder_retraction_amount = =machine_heat_zone_length
+top_bottom_thickness = =layer_height * 6
+travel_avoid_other_parts = True
+travel_avoid_supports = False
+wall_0_acceleration = 20.0
+wall_0_deceleration = 20.0
+wall_0_end_speed_ratio = 100.0
+wall_0_inset = 0
+wall_0_speed_split_distance = 1.0
+wall_0_start_speed_ratio = 100.0
+wall_0_wipe_dist = =machine_nozzle_size / 2
+wall_material_flow = =material_flow
+wall_overhang_angle = 90
+wall_x_material_flow = =wall_material_flow
+xy_offset = =-layer_height * 0.1
+z_seam_corner = z_seam_corner_weighted
+z_seam_position = back
+z_seam_type = sharpest_corner
+


### PR DESCRIPTION
# Description
Merge together with Ultimaker/fdm_materials#366

Except for some explainable differences, a flatpack of the S5 results in the same settings as a flatpack of the S8 legacy core profiles. The differences are:
- `machine_name`, `machine_start_gcode`, `machine_gcode_flavor`, ...
- 2 settings that are not settable per extruder (and no resolve): `cool_during_extruder_switch`, `prime_tower_mode`
- Some small differences that are caused by the layer height being scaled with the material Z shrinkage factor on the S8, but not on the S5.
- Differences of <= 0.1% are ignored

See also Ultimaker/autogenerate_print_profiles#296

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
- Ran test print for PLA 0.2mm Balanced on AA 0.4
- Compared flatpacks between S5 and S8

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
