### PR TITLE
PP-664 Reduce z-resonances in F4 print process

### DIFF
--- a/resources/definitions/ultimaker_factor4.def.json
+++ b/resources/definitions/ultimaker_factor4.def.json
@@ -86,6 +86,7 @@
         "gantry_height": { "value": 35 },
         "gradual_support_infill_steps": { "value": "3 if support_interface_enable and support_structure != 'tree' else 0" },
         "group_outer_walls": { "value": "False" },
+        "infill_angles": { "value": "[-40, 50] if infill_pattern in ('grid', 'lines', 'zigzag')  else [ ]" },
         "infill_before_walls": { "value": "False if infill_sparse_density > 50 else True" },
         "infill_enable_travel_optimization": { "value": "True" },
         "infill_material_flow":
@@ -94,7 +95,7 @@
             "value": "(1 + (skin_material_flow-infill_sparse_density) / 100 if infill_sparse_density > skin_material_flow else 1) * material_flow"
         },
         "infill_overlap": { "value": "0" },
-        "infill_pattern": { "value": "'zigzag' if infill_sparse_density > 50 else 'triangles'" },
+        "infill_pattern": { "value": "'zigzag' if infill_sparse_density > 50 else 'gyroid' if 15 < speed_infill / ( infill_line_width * 300 / infill_sparse_density ) < 25 else 'triangles'" },
         "infill_sparse_density": { "maximum_value": "100" },
         "infill_wipe_dist": { "value": "0" },
         "inset_direction": { "value": "'inside_out'" },
@@ -199,6 +200,7 @@
             "value": "skin_material_flow"
         },
         "roofing_monotonic": { "value": "True" },
+        "skin_angles": { "value": "[-40, 50]" },
         "skin_material_flow":
         {
             "maximum_value": "100",


### PR DESCRIPTION
# Description

This reduces resonances in the print process, leading to less ringing in top/bottom skin and in infill.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Printer definition file(s)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Printed on different Factor 4 printers
- [ ] Deployed changes in 5.11 alpha and tested how values changed with different infill percentages

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [ ] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ ] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change
