### PR TITLE
CURA-12055 fix load ufp then stl

### DIFF
--- a/plugins/GCodeReader/FlavorParser.py
+++ b/plugins/GCodeReader/FlavorParser.py
@@ -527,6 +527,6 @@ class FlavorParser:
 
         # The "save/print" button's state is bound to the backend state.
         backend = CuraApplication.getInstance().getBackend()
-        backend.backendStateChange.emit(Backend.BackendState.Disabled)
+        backend.setState(Backend.BackendState.Disabled)
 
         return scene_node


### PR DESCRIPTION
Instead of just emitting the signal for the state change, actually set the state so that the UI and the model don't end up with inconsistent values

CURA-12055

:thought_balloon: There is also a similar signal emission on https://github.com/Ultimaker/Cura/blob/3c6400823d05b73ea689a631cf51eeed66c58302/plugins/CuraEngineBackend/CuraEngineBackend.py#L405
It should not be necessary and I actually tried to remove it and everything seems fine. In this case however, there should be no state inconsistency, and it does not seem to create a bug, so I let it as is.