### PR TITLE
[CURA-12752] Fix prime-tower for multi-material painting

### DIFF
--- a/cura/BuildVolume.py
+++ b/cura/BuildVolume.py
@@ -117,6 +117,7 @@ class BuildVolume(SceneNode):
 
         self._has_errors = False
         self._application.getController().getScene().sceneChanged.connect(self._onSceneChanged)
+        self._application.getController().getScene().sceneChanged.connect(self._onStackChanged)
 
         # Objects loaded at the moment. We are connected to the property changed events of these objects.
         self._scene_objects = set()  # type: Set[SceneNode]
@@ -655,7 +656,7 @@ class BuildVolume(SceneNode):
                     extra_z = retraction_hop
         return extra_z
 
-    def _onStackChanged(self):
+    def _onStackChanged(self, *args) -> None:
         self._stack_change_timer.start()
 
     def _onStackChangeTimerFinished(self) -> None:

--- a/cura/Settings/ExtruderManager.py
+++ b/cura/Settings/ExtruderManager.py
@@ -210,7 +210,7 @@ class ExtruderManager(QObject):
             image_array = numpy.frombuffer(image_ptr, dtype=numpy.uint32).reshape(image_size)
 
             bit_range_start, bit_range_end = texture_data_mapping["extruder"]
-            image_array = (image_array << (32 - 1 - (bit_range_end - bit_range_start))) >> (32 - 1 - bit_range_end)
+            image_array = (image_array << (32 - 1 - bit_range_end)) >> (32 - 1 - (bit_range_end - bit_range_start))
 
             return numpy.unique(image_array).tolist()
         else:

--- a/plugins/CuraEngineBackend/StartSliceJob.py
+++ b/plugins/CuraEngineBackend/StartSliceJob.py
@@ -764,21 +764,7 @@ class StartSliceJob(Job):
 
     @staticmethod
     def _getUsedExtruders(node: SceneNode) -> List[int]:
-        used_extruders = []
-
-        # Look at extruders used in painted texture
-        node_texture = node.callDecoration("getPaintTexture")
-        texture_data_mapping = node.callDecoration("getTextureDataMapping")
-        if node_texture is not None and texture_data_mapping is not None and "extruder" in texture_data_mapping:
-            texture_image = node_texture.getImage().copy()
-            image_ptr = texture_image.bits()
-            image_ptr.setsize(texture_image.sizeInBytes())
-            image_size = texture_image.height(), texture_image.width()
-            image_array = numpy.frombuffer(image_ptr, dtype=numpy.uint32).reshape(image_size)
-
-            bit_range_start, bit_range_end = texture_data_mapping["extruder"]
-            image_array = (image_array << (32 - 1 - (bit_range_end - bit_range_start))) >> (32 - 1 - bit_range_end)
-            used_extruders = numpy.unique(image_array).tolist()
+        used_extruders = ExtruderManager.getInstance().getPaintedExtruders(node)
 
         # There is no relevant painting data, just take the extruder associated to the model
         if not used_extruders:

--- a/plugins/PaintTool/PaintTool.py
+++ b/plugins/PaintTool/PaintTool.py
@@ -455,7 +455,7 @@ class PaintTool(Tool):
                 Logger.logException("e", "Error when adding paint stroke")
 
             self._last_world_coords = world_coords
-            self._updateScene(node)
+            self._updateScene(node if event_caught else None)
             return event_caught
 
         return False


### PR DESCRIPTION
The prime-tower (w.r.t. the front-end, it was already working in-engine) didn't 'listen' to painted-on materials. Now it does.

I'm not _quite_ happy with the code, but this should be a good general direction.

I also managed to fix the 'if you first paint seams and _then_ materials something breaks' issue ... _unless_ there's some little vs. big-endian thing going on.