### PR TITLE
CURA-12761 Handle group selection as multi-selection w.r.t painting

### DIFF
--- a/plugins/PaintTool/PaintTool.qml
+++ b/plugins/PaintTool/PaintTool.qml
@@ -327,7 +327,7 @@ Item
         UM.Label
         {
             anchors.fill: parent
-            text: catalog.i18nc("@label", "Select a single model to start painting")
+            text: catalog.i18nc("@label", "Select a single ungrouped model to start painting")
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
         }

--- a/plugins/PaintTool/PaintTool.qml
+++ b/plugins/PaintTool/PaintTool.qml
@@ -327,7 +327,7 @@ Item
         UM.Label
         {
             anchors.fill: parent
-            text: catalog.i18nc("@label", "Select a single ungrouped model to start painting")
+            text: catalog.i18nc("@label", "Select a single model to start painting")
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
         }

--- a/plugins/PaintTool/PaintView.py
+++ b/plugins/PaintTool/PaintView.py
@@ -61,7 +61,7 @@ class PaintView(CuraView):
     canUndoChanged = pyqtSignal(bool)
     canRedoChanged = pyqtSignal(bool)
 
-    def setCurrentPaintedObject(self, current_painted_object: Optional[SceneNode]):
+    def setPaintedObject(self, painted_object: Optional[SceneNode]):
         if self._painted_object is not None:
             texture_changed_signal = self._painted_object.callDecoration("getPaintTextureChangedSignal")
             texture_changed_signal.disconnect(self._onCurrentPaintedObjectTextureChanged)
@@ -69,14 +69,22 @@ class PaintView(CuraView):
         self._paint_texture = None
         self._cursor_texture = None
 
-        self._painted_object = current_painted_object
+        self._painted_object = None
 
-        if self._painted_object is not None:
+        if painted_object is not None and painted_object.callDecoration("isSliceable"):
+            self._painted_object = painted_object
             texture_changed_signal = self._painted_object.callDecoration("getPaintTextureChangedSignal")
-            texture_changed_signal.connect(self._onCurrentPaintedObjectTextureChanged)
+            if texture_changed_signal is not None:
+                texture_changed_signal.connect(self._onCurrentPaintedObjectTextureChanged)
             self._onCurrentPaintedObjectTextureChanged()
 
         self._updateCurrentBitsRanges()
+
+    def getPaintedObject(self) -> Optional[SceneNode]:
+        return self._painted_object
+
+    def hasPaintedObject(self) -> bool:
+        return self._painted_object is not None
 
     def _onCurrentPaintedObjectTextureChanged(self) -> None:
         paint_texture = self._painted_object.callDecoration("getPaintTexture")


### PR DESCRIPTION
Fixes group handling, and disable painting for grouped objects. This is not really nice because it forces the user to ungroup objects to be able to paint them. However, the painting is currently designed to allow painting a single object at once, and selecting a group does select multiple objects. This should be improved later.

CURA-12761
Fixes https://github.com/Ultimaker/Cura/issues/21012