### PR TITLE
PP-680 Remove gradual flow lines from high speed S-line prints

### DIFF
--- a/resources/definitions/ultimaker_s8.def.json
+++ b/resources/definitions/ultimaker_s8.def.json
@@ -236,7 +236,7 @@
         "flooring_layer_count": { "value": 1 },
         "flooring_material_flow": { "value": "skin_material_flow * 110/93" },
         "flooring_monotonic": { "value": false },
-        "gradual_flow_discretisation_step_size": { "value": 1 },
+        "gradual_flow_discretisation_step_size": { "value": 0.3 },
         "gradual_flow_enabled": { "value": true },
         "hole_xy_offset": { "value": 0.075 },
         "infill_material_flow": { "value": "material_flow if infill_sparse_density < 95 else 95" },


### PR DESCRIPTION
# Description

This removes the gradual flow lines from the outside walls of prints

## Type of change

- [x] Printer definition file(s)

# How Has This Been Tested?

- [x] Loaded into Cura
- [x] Printed on multiple high speed S-line printers

**Test Configuration**:
S6s, S8s

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
