### PR TITLE
Safeguard against decrease in number of extruders

### DIFF
--- a/cura/Settings/ExtruderManager.py
+++ b/cura/Settings/ExtruderManager.py
@@ -257,9 +257,10 @@ class ExtruderManager(QObject):
             painted_extruders = node.callDecoration("getPaintedExtruders")
             if painted_extruders is not None:
                 for extruder_nr in painted_extruders:
-                    if str(extruder_nr) not in self.extruderIds:
-                        extruder_nr = int(self._application.getMachineManager().defaultExtruderPosition)
-                    used_extruder_stack_ids.add(self.extruderIds[str(extruder_nr)])
+                    try:
+                        used_extruder_stack_ids.add(self.extruderIds[str(extruder_nr)])
+                    except KeyError:
+                        pass
 
         # Check limit to extruders
         limit_to_extruder_feature_list = ["wall_0_extruder_nr",


### PR DESCRIPTION
When the painted model goes from a machine with higher number of extruders to a lower number of extruders with painted data, adding the safeguard to prevent crash with a try-except

CURA-12800