### PR TITLE
Remove redundant settings from legacy variants

### DIFF
--- a/resources/variants/ultimaker_s6_aa025.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa025.inst.cfg
@@ -113,7 +113,6 @@ retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_min_travel = 5
 retraction_prime_speed = =retraction_speed
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s6_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa04.inst.cfg
@@ -111,9 +111,7 @@ retraction_hop = 2
 retraction_hop_after_extruder_switch_height = =retraction_hop
 retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_min_travel = 5
-retraction_prime_speed = 15
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s6_aa08.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa08.inst.cfg
@@ -121,10 +121,8 @@ retraction_hop_after_extruder_switch_height = =retraction_hop
 retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_hop_only_when_collides = True
 retraction_min_travel = 5
-retraction_prime_speed = 15
 retraction_speed = 25
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s6_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s6_cc04.inst.cfg
@@ -112,7 +112,6 @@ retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_min_travel = 5
 retraction_prime_speed = =retraction_speed
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s6_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s6_cc06.inst.cfg
@@ -112,7 +112,6 @@ retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_min_travel = 5
 retraction_prime_speed = =retraction_speed
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s8_aa025.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa025.inst.cfg
@@ -113,7 +113,6 @@ retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_min_travel = 5
 retraction_prime_speed = =retraction_speed
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s8_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa04.inst.cfg
@@ -111,9 +111,7 @@ retraction_hop = 2
 retraction_hop_after_extruder_switch_height = =retraction_hop
 retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_min_travel = 5
-retraction_prime_speed = 15
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s8_aa08.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa08.inst.cfg
@@ -121,10 +121,8 @@ retraction_hop_after_extruder_switch_height = =retraction_hop
 retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_hop_only_when_collides = True
 retraction_min_travel = 5
-retraction_prime_speed = 15
 retraction_speed = 25
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s8_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s8_cc04.inst.cfg
@@ -112,7 +112,6 @@ retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_min_travel = 5
 retraction_prime_speed = =retraction_speed
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0

--- a/resources/variants/ultimaker_s8_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s8_cc06.inst.cfg
@@ -112,7 +112,6 @@ retraction_hop_enabled = =extruders_enabled_count > 1
 retraction_min_travel = 5
 retraction_prime_speed = =retraction_speed
 roofing_expansion = 0
-roofing_monotonic = True
 roofing_pattern = =top_bottom_pattern
 seam_overhang_angle = =support_angle
 skin_edge_support_thickness = =4 * layer_height if infill_sparse_density < 30 else 0


### PR DESCRIPTION
Settings were removed from S8, so they should also not be in the legacy variants anymore.
See [18b83bf777b589125dd457a0dbda86be3f91537b](https://github.com/Ultimaker/Cura/commit/18b83bf777b589125dd457a0dbda86be3f91537b)

Legacy variants are generated with a Jinja template, that automatically reverts the overrides in the `ultimaker_s8` definition to the value of the `ultimaker_s5` (or lower) definition. So these with these settings removed from S8, they also automatically get erased from the legacy variant profiles.