### PR TITLE
Correct calculation of initial bottom layers & clean up

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -1736,7 +1736,7 @@
                                     "maximum_value": "999999",
                                     "default_value": 6,
                                     "type": "int",
-                                    "value": "math.ceil(round((bottom_thickness - layer_height_0) / resolveOrValue('layer_height'), 4)) + 1",
+                                    "value": "bottom_layers",
                                     "limit_to_extruder": "top_bottom_extruder_nr",
                                     "settable_per_mesh": true
                                 }


### PR DESCRIPTION
# Explanation
These changes are intended to calculate the correct number of layers when slicing a model before printing. This only works in specific scenario where the `Initial Layer Height` is different than the `Layer Height`. In addition to the correct calculation, we obtain the correct layers result on the slider.

> [!NOTE]
> Most users don't notice the issue because `Initial Bottom Layers` is not shown by default (even in Expert settings) and even fewer users check these values.

> [!IMPORTANT]
> Please note that the calculation of the number of layers is always based on the layer thickness value.

# Description of changes
<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 
This fixes... OR This improves... -->
Line 1739: The formula for calculating the number of `Initial Bottom Layers` shows the correct values finally.
Line 3766: the formula "* 30 / 60" is easier to write as "/ 2"
Line 7269: the formula "/ 60 * 30" is easier to write as "/ 2"

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Printer definition file(s)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Cleanup

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested with Cura version 5.11.0 and previous. Working well.