### PR TITLE
Update PurgeLinesAndUnload.py

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/PurgeLinesAndUnload.py
+++ b/plugins/PostProcessingPlugin/scripts/PurgeLinesAndUnload.py
@@ -497,7 +497,7 @@ class PurgeLinesAndUnload(Script):
                 "G92 E0 ; Reset extruder\n"
             ]
             return "\n".join(gcode_lines)
-        
+
         purge_location = self.getSettingValueByKey("purge_line_location")
         purge_extrusion_full = True if self.getSettingValueByKey("purge_line_length") == "purge_full" else False
         purge_str = ";---------------------[Purge Lines]\nG0 F600 Z2 ; Move up\nG92 E0 ; Reset extruder\n"


### PR DESCRIPTION
# Description

An extremely minor bug fix.
The GcodeReader did not like ";TYPE:CUSTOM" which was being added to the purge paragraph.  It was causing a "WARNNG" to be added to the log file.  This change addresses that.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ X] Bug fix (non-breaking change which fixes an issue)

# Checklist:
<!-- Check if relevant -->

- [ X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have uploaded any files required to test this change
