### PR TITLE
PP-704 Add ASA Generic for Factor Line

### DIFF
--- a/resources/intent/ultimaker_factor4/um_f4_aa0.4_asa_0.2mm_engineering.inst.cfg
+++ b/resources/intent/ultimaker_factor4/um_f4_aa0.4_asa_0.2mm_engineering.inst.cfg
@@ -1,0 +1,18 @@
+[general]
+definition = ultimaker_factor4
+name = Accurate
+version = 4
+
+[metadata]
+intent_category = engineering
+material = generic_asa
+quality_type = draft
+setting_version = 25
+type = intent
+variant = AA 0.4
+
+[values]
+jerk_print = 30
+speed_print = 80
+wall_thickness = =wall_line_width_0 + wall_line_width_x * 2
+

--- a/resources/quality/ultimaker_factor4/um_f4_aa0.4_asa_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_factor4/um_f4_aa0.4_asa_0.2mm.inst.cfg
@@ -1,0 +1,21 @@
+[general]
+definition = ultimaker_factor4
+name = Fast
+version = 4
+
+[metadata]
+material = generic_asa
+quality_type = draft
+setting_version = 25
+type = quality
+variant = AA 0.4
+weight = -2
+
+[values]
+gradual_flow_discretisation_step_size = 0.1
+gradual_flow_enabled = True
+inset_direction = outside_in
+max_flow_acceleration = 1
+skin_material_flow = =material_flow * 0.93
+speed_print = 60
+


### PR DESCRIPTION
# Description

<!-- Please include a summary of which issue is fixed or feature was added. Please also include relevant motivation and context. 
If this pull request adds settings definitions for machines/materials, list them here. 

This adds a Generic ASA profile for Factor 4 printers, to assist users in setting up the print process for this material.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Quality and Intent profile

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Deployed in Cura 5.12 master builds
- [x] Printed multiple prints on Factor 4 with different ASA grades, including testing of deprimes

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
