### PR TITLE
Dim settings when extruder is disabled

### DIFF
--- a/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml
+++ b/resources/qml/PrintSetupSelector/Custom/CustomPrintSetup.qml
@@ -258,6 +258,10 @@ Item
         border.width: UM.Theme.getSize("default_lining").width
 
         color: UM.Theme.getColor("main_background")
+        
+        // Reduce opacity of the settings when the selected extruder is disabled
+        opacity: Cura.MachineManager.activeStack != null && !Cura.MachineManager.activeStack.isEnabled ? 0.4 : 1.0
+        
         Cura.SettingView
         {
             anchors


### PR DESCRIPTION
# Description

Added logic to reduce the opacity of the settings panel when the selected extruder is disabled, providing a clearer visual indication of its inactive state.
The change is subtle enough not to conflict with the style, and is clear enough to notify the user.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Multi-extruder printer -> enable / disable extruder -> custom settings should recover
<img width="1773" height="889" alt="image" src="https://github.com/user-attachments/assets/6b636999-46b7-4d21-bba2-2f9a7138f3bb" />
<img width="1776" height="897" alt="image" src="https://github.com/user-attachments/assets/05b0b21a-da33-463d-b70b-91098d433976" />


- [x] Test in dark-mode & with  extruders

<img width="1798" height="909" alt="image" src="https://github.com/user-attachments/assets/2f7bf699-6985-4165-b1d2-4844c1c0ff69" />
<img width="1779" height="903" alt="image" src="https://github.com/user-attachments/assets/e3aae6ce-4262-4167-8187-e4cab31a1355" />
<img width="1778" height="897" alt="image" src="https://github.com/user-attachments/assets/2e782f37-1eb8-43ca-b923-f786597b2c0c" />


**Test Configuration**:
* Operating System:
Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
