### PR TITLE
Update to 'AddCoolingProfile.py'

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/AddCoolingProfile.py
+++ b/plugins/PostProcessingPlugin/scripts/AddCoolingProfile.py
@@ -15,11 +15,22 @@ Designed in January 2023 by GregValiant (Greg Foresi)
         01/05/24  (GV) Revised the regex replacements.
         12/11/24  (GV) Added 'off_fan_speed' for the idle nozzle layer cooling fan.  It does not have to go to 0%.
         03/22/25  (GV) Added 'Chamber Cooling Fan / Auxiliary Fan' control.
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
+=======
+        12/26/25  (GV) Added 'Enable Script' setting so it can be left installed, but not run.
+        12/26/25  (GV) Added 'Jump Start' option to get the fan spinning just before it is actually called.
+>>>>>>> Stashed changes
+=======
+        12/26/25  (GV) Added 'Enable Script' setting so it can be left installed, but not run.
+        12/26/25  (GV) Added 'Jump Start' option to get the fan spinning just before it is actually called.
+>>>>>>> Stashed changes
 """
 
 from ..Script import Script
 from UM.Application import Application
 import re
+from UM.Logger import Logger
 
 class AddCoolingProfile(Script):
 
@@ -31,6 +42,13 @@ class AddCoolingProfile(Script):
             "version": 2,
             "settings":
             {
+                "enable_cooling_profile":
+                {
+                    "label": "Enable Advanced Cooling",
+                    "description": "Enable the script so it will run.",
+                    "type": "bool",
+                    "enabled": true
+                },
                 "fan_layer_or_feature":
                 {
                     "label": "Cooling Control by:",
@@ -39,17 +57,26 @@ class AddCoolingProfile(Script):
                     "options": {
                         "by_layer": "Layer Numbers",
                         "by_feature": "Feature Types"},
-                    "default_value": "by_layer"
+                    "default_value": "by_layer",
+                    "enabled": "enable_cooling_profile"
                 },
                 "delete_existing_m106":
                 {
                     "label": "Remove M106 lines prior to inserting new.",
                     "description": "If you have 2 or more instances of 'Advanced Cooling Fan Control' running (to cool a portion of a print differently), then you must uncheck this box or the followup instances will remove all the lines inserted by the first instance.  Pay attention to the Start and Stop layers.  Regardless of this setting:  The script always removes M106 lines starting with the lowest layer number (when 'By Layer') or the starting layer number (when 'By Feature').  If you want to keep the M106 lines that Cura inserted up to the point where this post-processor will start making insertions, then un-check the box.",
                     "type": "bool",
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": true,
                     "value": true,
                     "default_value": true,
                     "read_only": true
+=======
+=======
+>>>>>>> Stashed changes
+                    "enabled": "enable_cooling_profile",
+                    "default_value": true
+>>>>>>> Stashed changes
                 },
                 "feature_fan_start_layer":
                 {
@@ -59,7 +86,7 @@ class AddCoolingProfile(Script):
                     "default_value": 5,
                     "minimum_value": 1,
                     "unit": "Lay#   ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_end_layer":
                 {
@@ -69,7 +96,7 @@ class AddCoolingProfile(Script):
                     "default_value": -1,
                     "minimum_value": -1,
                     "unit": "Lay#   ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "layer_fan_1":
                 {
@@ -78,7 +105,7 @@ class AddCoolingProfile(Script):
                     "type": "str",
                     "default_value": "5/30",
                     "unit": "L#/%    ",
-                    "enabled": "fan_layer_or_feature == 'by_layer'"
+                    "enabled": "fan_layer_or_feature == 'by_layer' and enable_cooling_profile"
                 },
                 "layer_fan_2":
                 {
@@ -87,7 +114,7 @@ class AddCoolingProfile(Script):
                     "type": "str",
                     "default_value": "",
                     "unit": "L#/%    ",
-                    "enabled": "fan_layer_or_feature == 'by_layer'"
+                    "enabled": "fan_layer_or_feature == 'by_layer' and enable_cooling_profile"
                 },
                 "layer_fan_3":
                 {
@@ -96,7 +123,7 @@ class AddCoolingProfile(Script):
                     "type": "str",
                     "default_value": "",
                     "unit": "L#/%    ",
-                    "enabled": "fan_layer_or_feature == 'by_layer'"
+                    "enabled": "fan_layer_or_feature == 'by_layer' and enable_cooling_profile"
                 },
                 "layer_fan_4":
                 {
@@ -105,7 +132,7 @@ class AddCoolingProfile(Script):
                     "type": "str",
                     "default_value": "",
                     "unit": "L#/%    ",
-                    "enabled": "fan_layer_or_feature == 'by_layer'"
+                    "enabled": "fan_layer_or_feature == 'by_layer' and enable_cooling_profile"
                 },
                 "layer_fan_5":
                 {
@@ -114,7 +141,7 @@ class AddCoolingProfile(Script):
                     "type": "str",
                     "default_value": "",
                     "unit": "L#/%    ",
-                    "enabled": "fan_layer_or_feature == 'by_layer'"
+                    "enabled": "fan_layer_or_feature == 'by_layer' and enable_cooling_profile"
                 },
                 "layer_fan_6":
                 {
@@ -123,7 +150,7 @@ class AddCoolingProfile(Script):
                     "type": "str",
                     "default_value": "",
                     "unit": "L#/%    ",
-                    "enabled": "fan_layer_or_feature == 'by_layer'"
+                    "enabled": "fan_layer_or_feature == 'by_layer' and enable_cooling_profile"
                 },
                 "layer_fan_7":
                 {
@@ -132,7 +159,7 @@ class AddCoolingProfile(Script):
                     "type": "str",
                     "default_value": "",
                     "unit": "L#/%    ",
-                    "enabled": "fan_layer_or_feature == 'by_layer'"
+                    "enabled": "fan_layer_or_feature == 'by_layer' and enable_cooling_profile"
                 },
                 "layer_fan_8":
                 {
@@ -141,7 +168,7 @@ class AddCoolingProfile(Script):
                     "type": "str",
                     "default_value": "",
                     "unit": "L#/%    ",
-                    "enabled": "fan_layer_or_feature == 'by_layer'"
+                    "enabled": "fan_layer_or_feature == 'by_layer' and enable_cooling_profile"
                 },
                 "feature_fan_skirt":
                 {
@@ -152,7 +179,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_wall_inner":
                 {
@@ -163,7 +190,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_wall_outer":
                 {
@@ -174,7 +201,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_fill":
                 {
@@ -185,7 +212,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_skin":
                 {
@@ -196,7 +223,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_support":
                 {
@@ -207,7 +234,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_support_interface":
                 {
@@ -218,7 +245,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_prime_tower":
                 {
@@ -229,7 +256,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_bridge":
                 {
@@ -240,14 +267,14 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "fan_layer_or_feature == 'by_feature'"
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
                 },
                 "feature_fan_combing":
                 {
                     "label": "Fan 'OFF' during Combing:",
                     "description": "When checked will set the fan to 0% for combing moves over 5 lines long in the gcode. When un-checked the fan speed during combing is whatever the previous speed is set to.",
                     "type": "bool",
-                    "enabled": "fan_layer_or_feature == 'by_feature'",
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile",
                     "default_value": true
                 },
                 "feature_fan_feature_final":
@@ -259,7 +286,7 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
-                    "enabled": "(int(feature_fan_end_layer) != -1) and (fan_layer_or_feature == 'by_feature')"
+                    "enabled": "(int(feature_fan_end_layer) != -1) and (fan_layer_or_feature == 'by_feature') and enable_cooling_profile"
                 },
                 "fan_enable_raft":
                 {
@@ -267,7 +294,7 @@ class AddCoolingProfile(Script):
                     "description": "Enable the fan for the raft layers.  When enabled the Raft Fan Speed will continue until another Layer or Feature setting over-rides it.",
                     "type": "bool",
                     "default_value": false,
-                    "enabled": true
+                    "enabled":  "enable_cooling_profile"
                 },
                 "fan_raft_percent":
                 {
@@ -278,7 +305,25 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": "fan_enable_raft"
+=======
+=======
+>>>>>>> Stashed changes
+                    "enabled": "fan_enable_raft and enable_cooling_profile"
+                },
+                "enable_off_fan_speed_enable":
+                {
+                    "label": "Hidden setting",
+                    "description": "For dual extruder printers, this enables 'enable_off_fan_speed'.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": false
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
                 },
                 "enable_off_fan_speed":
                 {
@@ -286,7 +331,15 @@ class AddCoolingProfile(Script):
                     "description": "For machines with independent layer cooling fans.  Leaving a fan running while the other nozzle is printing can help with oozing.  You can pick the speed % for the idle nozzle layer cooling fan to hold at.",
                     "type": "bool",
                     "default_value": false,
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": "enable_off_fan_speed_enable and self.extruder_count > 1"
+=======
+                    "enabled": "enable_off_fan_speed_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
+=======
+                    "enabled": "enable_off_fan_speed_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
                 },
                 "off_fan_speed":
                 {
@@ -297,6 +350,8 @@ class AddCoolingProfile(Script):
                     "minimum_value": 0,
                     "maximum_value": 100,
                     "unit": "%    ",
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": "enable_off_fan_speed_enable and enable_off_fan_speed and self.extruder_count > 1"
                 },
                 "enable_off_fan_speed_enable":
@@ -306,6 +361,12 @@ class AddCoolingProfile(Script):
                     "type": "bool",
                     "default_value": false,
                     "enabled": false
+=======
+                    "enabled": "enable_off_fan_speed_enable and enable_off_fan_speed and enable_cooling_profile"
+>>>>>>> Stashed changes
+=======
+                    "enabled": "enable_off_fan_speed_enable and enable_off_fan_speed and enable_cooling_profile"
+>>>>>>> Stashed changes
                 },
                 "bv_fan_speed_control_enable":
                 {
@@ -313,7 +374,15 @@ class AddCoolingProfile(Script):
                     "description": "Controls the 'Build Volume Fan' or an 'Auxiliary Fan' on printers with that hardware.  Provides: 'On' layer, 'Off' layer, and PWM speed control of a secondary fan.",
                     "type": "bool",
                     "default_value": false,
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": "enable_bv_fan"
+=======
+                    "enabled": "enable_bv_fan and enable_cooling_profile"
+>>>>>>> Stashed changes
+=======
+                    "enabled": "enable_bv_fan and enable_cooling_profile"
+>>>>>>> Stashed changes
                 },
                 "bv_fan_nr":
                 {
@@ -323,7 +392,15 @@ class AddCoolingProfile(Script):
                     "unit": "#    ",
                     "default_value": 0,
                     "minimum_value": 0,
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": "enable_bv_fan and bv_fan_speed_control_enable"
+=======
+                    "enabled": "enable_bv_fan and bv_fan_speed_control_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
+=======
+                    "enabled": "enable_bv_fan and bv_fan_speed_control_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
                 },
                 "bv_fan_speed":
                 {
@@ -334,7 +411,15 @@ class AddCoolingProfile(Script):
                     "default_value": 50,
                     "maximum_value": 100,
                     "minimum_value": 0,
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": "enable_bv_fan and bv_fan_speed_control_enable"
+=======
+                    "enabled": "enable_bv_fan and bv_fan_speed_control_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
+=======
+                    "enabled": "enable_bv_fan and bv_fan_speed_control_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
                 },
                 "bv_fan_start_layer":
                 {
@@ -344,7 +429,15 @@ class AddCoolingProfile(Script):
                     "unit": "Layer#    ",
                     "default_value": 1,
                     "minimum_value": 1,
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": "enable_bv_fan and bv_fan_speed_control_enable"
+=======
+                    "enabled": "enable_bv_fan and bv_fan_speed_control_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
+=======
+                    "enabled": "enable_bv_fan and bv_fan_speed_control_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
                 },
                 "bv_fan_end_layer":
                 {
@@ -354,7 +447,15 @@ class AddCoolingProfile(Script):
                     "unit": "Layer#    ",
                     "default_value": -1,
                     "minimum_value": -1,
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                     "enabled": "enable_bv_fan and bv_fan_speed_control_enable"
+=======
+                    "enabled": "enable_bv_fan and bv_fan_speed_control_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
+=======
+                    "enabled": "enable_bv_fan and bv_fan_speed_control_enable and enable_cooling_profile"
+>>>>>>> Stashed changes
                 },
                 "enable_bv_fan":
                 {
@@ -363,11 +464,29 @@ class AddCoolingProfile(Script):
                     "type": "bool",
                     "default_value": false,
                     "enabled": false
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
+=======
+=======
+>>>>>>> Stashed changes
+                },
+                "jump_start_enable":
+                {
+                    "label": "Enable Jump Starting",
+                    "description": "Some fans take a bit of time to get up to speed.  This option will enter a 75% fan speed line 5 lines before the M106 fan setting line.",
+                    "type": "bool",
+                    "default_value": false,
+                    "enabled": "fan_layer_or_feature == 'by_feature' and enable_cooling_profile"
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
                 }
             }
         }"""
 
     def initialize(self) -> None:
+
         super().initialize()
         self.global_stack = Application.getInstance().getGlobalContainerStack()
         self.extruder_list = self.global_stack.extruderList
@@ -404,12 +523,36 @@ class AddCoolingProfile(Script):
                 feature_fan_combing:  Whether or not to shut the cooling fan off during travel moves.
                 the_start_layer:  When in By Feature this is the user selected start of the fan changes.
                 the_end_layer:  When in By Feature this is the user selected end of the fan changes
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                 the_end_is_enabled:  When in By Feature, if the fan control ends before the print ends, then this will enable the Final Fan Speed to carry through to the print end.                
                 
+=======
+                the_end_is_enabled:  When in By Feature, if the fan control ends before the print ends, then this will enable the Final Fan Speed to carry through to the print end.
+
+>>>>>>> Stashed changes
+=======
+                the_end_is_enabled:  When in By Feature, if the fan control ends before the print ends, then this will enable the Final Fan Speed to carry through to the print end.
+
+>>>>>>> Stashed changes
         """
         # Exit if the gcode has been previously post-processed.
         if ";POSTPROCESSED" in data[0]:
             return data
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
+=======
+=======
+>>>>>>> Stashed changes
+
+        # Return if the script is not enabled.
+        if not bool(self.getSettingValueByKey("enable_cooling_profile")):
+            return data
+
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
         # Initialize variables that are buried in if statements.
         t0_fan = " P0"; t1_fan = " P0"; t2_fan = " P0"; t3_fan = " P0"; is_multi_extr_print = True
 
@@ -421,9 +564,19 @@ class AddCoolingProfile(Script):
         except AttributeError:
             pass
 
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
         bed_adhesion = (self.extruder_list[0].getProperty("adhesion_type", "value"))
         print_sequence = str(self.global_stack.getProperty("print_sequence", "value"))
 
+=======
+        bed_adhesion = self.extruder_list[0].getProperty("adhesion_type", "value")
+        print_sequence = str(self.global_stack.getProperty("print_sequence", "value"))
+>>>>>>> Stashed changes
+=======
+        bed_adhesion = self.extruder_list[0].getProperty("adhesion_type", "value")
+        print_sequence = str(self.global_stack.getProperty("print_sequence", "value"))
+>>>>>>> Stashed changes
         # Assign the fan numbers to the tools
         if self.extruder_count == 1:
             is_multi_fan = False
@@ -454,6 +607,8 @@ class AddCoolingProfile(Script):
         if  by_layer_or_feature == "by_layer":
             # By layer doesn't do any feature search so there is no need to look for combing moves
             feature_fan_combing = False
+            # Don't need to jump start fans when By Layer
+            self._jump_start = False
             fan_list[0] = self.getSettingValueByKey("layer_fan_1")
             fan_list[2] = self.getSettingValueByKey("layer_fan_2")
             fan_list[4] = self.getSettingValueByKey("layer_fan_3")
@@ -470,6 +625,7 @@ class AddCoolingProfile(Script):
 
         # Assign the variable values if "By Feature"
         elif by_layer_or_feature == "by_feature":
+            self._jump_start = self.getSettingValueByKey("jump_start_enable")
             the_start_layer = self.getSettingValueByKey("feature_fan_start_layer") - 1
             the_end_layer = self.getSettingValueByKey("feature_fan_end_layer")
             try:
@@ -693,6 +849,8 @@ class AddCoolingProfile(Script):
                         if layer_number == str(fan_list[num]):
                             layer = layer.replace(fan_lines[0],fan_lines[0] + "\n" + fan_list[num + 1] + str(t0_fan))
                             single_fan_data[l_index] = layer
+        if self._jump_start:
+            single_fan_data = self._jump_start_layer_cooling_fan(single_fan_data, layer_0_index)
         return single_fan_data
 
     # Multi-Fan "By Layer"
@@ -761,6 +919,16 @@ class AddCoolingProfile(Script):
         # Insure the fans get shut off if 'off_fan_speed' was enabled
         if self.extruder_count > 1 and self.getSettingValueByKey("enable_off_fan_speed"):
             multi_fan_data[-1] += "M106 S0 P1\nM106 S0 P0\n"
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
+=======
+        if self._jump_start:
+            multi_fan_data = self._jump_start_layer_cooling_fan(multi_fan_data, layer_0_index)
+>>>>>>> Stashed changes
+=======
+        if self._jump_start:
+            multi_fan_data = self._jump_start_layer_cooling_fan(multi_fan_data, layer_0_index)
+>>>>>>> Stashed changes
         return multi_fan_data
 
     # Single fan by feature
@@ -788,12 +956,22 @@ class AddCoolingProfile(Script):
                         if feature_fan_combing == True:
                             modified_data += "M106 S0" + t0_fan + "\n"
                 modified_data += line + "\n"
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
                 
+=======
+
+>>>>>>> Stashed changes
+=======
+
+>>>>>>> Stashed changes
                 # If an End Layer is defined and is less than the last layer then insert the Final Speed
                 if line == ";LAYER:" + str(the_end_layer) and the_end_is_enabled == True:
                     modified_data += feature_speed_list[len(feature_speed_list) - 1] + t0_fan + "\n"
             if modified_data.endswith("\n"): modified_data = modified_data[0: - 1]
             single_fan_data[l_index] = modified_data
+        if self._jump_start:
+            single_fan_data = self._jump_start_layer_cooling_fan(single_fan_data, layer_0_index)
         return single_fan_data
 
     # Multi-fan by feature
@@ -892,6 +1070,16 @@ class AddCoolingProfile(Script):
         # Insure the fans get shut off if 'off_fan_speed' was enabled
         if self.extruder_count > 1 and self.getSettingValueByKey("enable_off_fan_speed"):
             multi_fan_data[-1] += "M106 S0 P1\nM106 S0 P0\n"
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
+=======
+        if self._jump_start:
+            multi_fan_data = self._jump_start_layer_cooling_fan(multi_fan_data, layer_0_index)
+>>>>>>> Stashed changes
+=======
+        if self._jump_start:
+            multi_fan_data = self._jump_start_layer_cooling_fan(multi_fan_data, layer_0_index)
+>>>>>>> Stashed changes
         return multi_fan_data
 
     # Try to catch layer input errors, set the minimum speed to 12%, and put the strings together
@@ -1007,4 +1195,39 @@ class AddCoolingProfile(Script):
                             lines[fdex] = f"M106 S0 P{bv_fan_nr}\n" + line
                     bv_data[index] = "\n".join(lines)
                     break
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
         return bv_data
+=======
+=======
+>>>>>>> Stashed changes
+        return bv_data
+
+    def _jump_start_layer_cooling_fan(self, data: str, layer_0_index: int):
+        """
+        If the fan is off - run the speed up to ~70% prior to setting the actual speed to insure the fan starts spinning.
+        """
+        fan_mode = not bool(self.extruder_list[0].getProperty("machine_scale_fan_speed_zero_to_one", "value"))
+        fan_is_on = False
+        for lay_index, layer in enumerate(data):
+            if lay_index < layer_0_index:
+                continue
+            lines = layer.split("\n")
+            for index, line in enumerate(lines):
+                if line.startswith("M106 S0") or line.startswith("M107"):
+                    fan_is_on = False
+                elif line.startswith("M106 S") and f"{float(self.getValue(line, 'S'))}" != "0":
+                    try:
+                        if not fan_is_on:
+                            lines[index - 5] += "\nM106 S179 ; Jump start" if fan_mode else "\nM106 S0.7 ; Jump start"
+                            fan_is_on = True
+                    except:# IndexError:
+                        lines[0] += "\nM106 S179 ; Junp start" if fan_mode else "\nM106 S0.7 ; Jump start"
+                        fan_is_on = True
+                        continue
+            data[lay_index] = "\n".join(lines)
+        return data
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes


### PR DESCRIPTION
# Description

Added "Enabled" setting.
Added "Jump Start" option to get the fans spinning just before they are actually called when "By Feature" is selected.

## Type of change

- [ X] New feature (non-breaking change which adds functionality)

* Operating System:  Windows 10 Pro

# Checklist:
<!-- Check if relevant -->

- [ X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have uploaded any files required to test this change
