### PR TITLE
[CURA-12835] Fix UX performance drop for some abstract printers.

### DIFF
--- a/cura/PrinterOutput/Models/PrinterConfigurationModel.py
+++ b/cura/PrinterOutput/Models/PrinterConfigurationModel.py
@@ -76,6 +76,8 @@ class PrinterConfigurationModel(QObject):
         printers = ContainerRegistry.getInstance().findContainersMetadata(
             ignore_case=True, type="machine", name=self._printer_type, container_type=DefinitionContainer)
         id = printers[0]["id"] if len(printers) > 0 and "id" in printers[0] else ""
+        if id == "":
+            return []
         definitions = ContainerRegistry.getInstance().findContainersMetadata(
             ignore_case=True, type="variant", definition=id+"*")
         return [x["name"] for x in definitions]


### PR DESCRIPTION
Early-out when printer-type hasn't any printers.

This would otherwise search in, and process the result of, _all_ variants, since the 'id' would be empty. This could actually happen w.r.t. searching dealing with abstract printers, which could slow down the process enough that the entire UI becomes very stuttery for users.

1st (and hopefully last) attempt at fixing CURA-12835 (and if we're lucky, some other seemingly related issues).