### PR TITLE
CURA-12970 Messages stack over when sending a print over DF

### DIFF
--- a/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
+++ b/plugins/UM3NetworkPrinting/src/Cloud/CloudOutputDevice.py
@@ -297,6 +297,7 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
 
         :param response: The response from the cloud API.
         """
+        self._uploader_handle = None
         self._uploaded_print_job = self._pre_upload_print_job
         self._progress.hide()
 
@@ -349,6 +350,7 @@ class CloudOutputDevice(UltimakerNetworkedPrinterOutputDevice):
         self._progress.hide()
         self._pre_upload_print_job = None
         self._uploaded_print_job = None
+        self._uploader_handle = None
         self._cancelInProgressJobs()
         PrintJobUploadErrorMessage(message).show()
         self.writeError.emit()


### PR DESCRIPTION
In some cases of the upload sequence, the `_uploader_handle` of the `CloudOutputDevice` would not be cleared after the sequence is over, which results in upload error message displayed when subsequently changing the scene.

CURA-12970