### PR TITLE
CURA-12976 Fix Inside Travel Avoid Distance description

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -4819,7 +4819,7 @@
                 "retraction_combing_avoid_distance":
                 {
                     "label": "Inside Travel Avoid Distance",
-                    "description": "The distance between the nozzle and already printed outer walls when travelling inside a model.",
+                    "description": "The distance between the nozzle and outer walls when travelling inside a model.",
                     "unit": "mm",
                     "type": "float",
                     "default_value": 0.6,


### PR DESCRIPTION
The "Inside Travel Avoid Distance" is applied based on the outer walls of the current layer, whether they are already printed or not yet. This PR fixes the description so that it matches the expected/implemented behavior.

CURA-12976

:information_source: Since this is not a critical change and it breaks the strings, it is applied on `main`.