### PR TITLE
[CURA-13015] Supress the keep/discard dialog when opening files.

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -773,7 +773,10 @@ class CuraApplication(QtApplication):
     def discardOrKeepProfileChanges(self) -> bool:
         has_user_interaction = False
         choice = self.getPreferences().getValue("cura/choice_on_profile_override")
-        if choice == "always_discard":
+        if not self._currently_loading_files:
+            # opening from a file; don't show dialog and KEEP the profile
+            self.discardOrKeepProfileChangesClosed("keep")
+        elif choice == "always_discard":
             # don't show dialog and DISCARD the profile
             self.discardOrKeepProfileChangesClosed("discard")
         elif choice == "always_keep":


### PR DESCRIPTION
Otherwise the user might be asked (with incorrect values even, based on the profile, not the current changes they made) for all setting-changes that are both a user change (so no default) _and_ changed in the file to a different value to keep/discard. This 'popped up' (pun intended) after some refactoring of 3mf loading.
