### PR TITLE
Update fdmprinter.def.json Initial and Final print temperatures

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2728,7 +2728,7 @@
                 "material_initial_print_temperature":
                 {
                     "label": "Initial Printing Temperature",
-                    "description": "The minimal temperature while heating up to the Printing Temperature at which printing can already start.",
+                    "description": "A multi-extruder setting. The minimal temperature while heating up to the Printing Temperature at which printing can start.",
                     "unit": "\u00b0C",
                     "type": "float",
                     "default_value": 200,
@@ -2737,14 +2737,14 @@
                     "minimum_value_warning": "material_standby_temperature",
                     "maximum_value_warning": "material_print_temperature",
                     "maximum_value": "365",
-                    "enabled": "machine_nozzle_temp_enabled and not machine_extruders_share_heater",
+                    "enabled": "machine_nozzle_temp_enabled and not machine_extruders_share_heater and machine_extruder_count > 1",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
                 "material_final_print_temperature":
                 {
                     "label": "Final Printing Temperature",
-                    "description": "The temperature to which to already start cooling down just before the end of printing.",
+                    "description": "A multi-extruder setting. The temperature to use just before the end of printing.",
                     "unit": "\u00b0C",
                     "type": "float",
                     "default_value": 195,
@@ -2753,7 +2753,7 @@
                     "minimum_value_warning": "material_standby_temperature",
                     "maximum_value_warning": "material_print_temperature",
                     "maximum_value": "365",
-                    "enabled": "machine_nozzle_temp_enabled and not machine_extruders_share_heater",
+                    "enabled": "machine_nozzle_temp_enabled and not machine_extruders_share_heater and machine_extruder_count > 1",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
                 },
@@ -4819,7 +4819,7 @@
                 "retraction_combing_avoid_distance":
                 {
                     "label": "Inside Travel Avoid Distance",
-                    "description": "The distance between the nozzle and outer walls when travelling inside a model.",
+                    "description": "The distance between the nozzle and already printed outer walls when travelling inside a model.",
                     "unit": "mm",
                     "type": "float",
                     "default_value": 0.6,


### PR DESCRIPTION
# Description

The "Initial Print Temperature" and "Final Print Temperature" are not used by single extruder machines but both settings remain "enabled" and they can cause some confusion. This PR disables the settings when "machine_extruder_count == 1" so that they are not visible when a machine has a single extruder.

This PR also includes minor changes to the descriptions.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ X] Printer definition file(s)

## Note
I'll leave this as a Draft as it involves "fdmprinter.def.json".

**Test Configuration**:
* Operating System:
Win 10 Pro

# Checklist:
<!-- Check if relevant -->

- [ X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [ X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have uploaded any files required to test this change
