### PR TITLE
Duplicate (import/export) Processing Scripts

### DIFF
--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.py
@@ -4,12 +4,13 @@
 import configparser  # The script lists are stored in metadata as serialised config files.
 import importlib.util
 import io  # To allow configparser to write to a string.
+import json
 import os.path
 import pkgutil
 import sys
-from typing import Dict, Type, TYPE_CHECKING, List, Optional, cast
+from typing import Any, Dict, Type, TYPE_CHECKING, List, Optional, cast
 
-from PyQt6.QtCore import QObject, pyqtProperty, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import QObject, QUrl, pyqtProperty, pyqtSignal, pyqtSlot
 
 from UM.Application import Application
 from UM.Extension import Extension
@@ -256,6 +257,99 @@ class PostProcessingPlugin(QObject, Extension):
         self.scriptListChanged.emit()
         self._propertyChanged()
 
+    @pyqtSlot()
+    def clearScripts(self) -> None:
+        """Remove all scripts from the active script list."""
+        self._script_list.clear()
+        self.setSelectedScriptIndex(-1)
+        self.scriptListChanged.emit()
+        self._propertyChanged()
+
+    @pyqtSlot(QUrl)
+    def exportScripts(self, file_url: QUrl) -> None:
+        """Export the current script list to a JSON file.
+
+        :param file_url: The URL of the file to export to.
+        """
+        file_path = file_url.toLocalFile()
+        if not file_path:
+            Logger.log("w", "exportScripts called with empty file path.")
+            return
+
+        scripts_data = []  # type: List[Dict[str, Any]]
+        for script in self._script_list:
+            script_key = script.getSettingData()["key"]
+            settings = {}  # type: Dict[str, str]
+            for setting_key in script.getSettingData()["settings"]:
+                settings[setting_key] = str(script.getSettingValueByKey(setting_key))
+            scripts_data.append({"key": script_key, "settings": settings})
+
+        export_dict = {
+            "version": 1,
+            "type": "postprocessing-script-config",
+            "scripts": scripts_data,
+        }
+
+        try:
+            with open(file_path, "w", encoding = "utf-8") as f:
+                json.dump(export_dict, f, indent = 2)
+            Logger.log("d", "Exported {count} post-processing script(s) to {path}".format(
+                count = len(scripts_data), path = file_path))
+        except OSError as e:
+            Logger.logException("e", "Failed to export post-processing scripts to {path}: {err}".format(
+                path = file_path, err = str(e)))
+
+    @pyqtSlot(QUrl)
+    def importScripts(self, file_url: QUrl) -> None:
+        """Import a script list from a previously exported JSON file.
+
+        :param file_url: The URL of the file to import from.
+        """
+        file_path = file_url.toLocalFile()
+        if not file_path:
+            Logger.log("w", "importScripts called with empty file path.")
+            return
+
+        try:
+            with open(file_path, "r", encoding = "utf-8") as f:
+                import_dict = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            Logger.logException("e", "Failed to read post-processing scripts from {path}: {err}".format(
+                path = file_path, err = str(e)))
+            return
+
+        if import_dict.get("type") != "postprocessing-script-config":
+            Logger.log("e", "File {path} is not a valid post-processing script configuration (wrong type).".format(
+                path = file_path))
+            return
+
+        scripts_data = import_dict.get("scripts", [])
+        self.loadAllScripts()
+        new_scripts = []  # type: List[Script]
+        for entry in scripts_data:
+            script_key = entry.get("key")
+            if script_key not in self._loaded_scripts:
+                Logger.log("e", "Unknown post-processing script '{key}' encountered during import; skipping.".format(
+                    key = script_key))
+                continue
+            new_script = self._loaded_scripts[script_key]()
+            new_script.initialize()
+            for setting_key, setting_value in entry.get("settings", {}).items():
+                if new_script._instance is not None:
+                    new_script._instance.setProperty(setting_key, "value", setting_value)
+            new_scripts.append(new_script)
+
+        if not new_scripts:
+            Logger.log("w", "No valid scripts found in {path}.".format(path = file_path))
+            return
+
+        self._script_list.clear()
+        self._script_list.extend(new_scripts)
+        self.setSelectedScriptIndex(0)
+        self.scriptListChanged.emit()
+        self._propertyChanged()
+        Logger.log("d", "Imported {count} post-processing script(s) from {path}".format(
+            count = len(new_scripts), path = file_path))
     @pyqtSlot(int)
     def duplicateScriptByIndex(self, index: int) -> None:
         if index < 0 or index >= len(self._script_list):

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.py
@@ -256,6 +256,27 @@ class PostProcessingPlugin(QObject, Extension):
         self.scriptListChanged.emit()
         self._propertyChanged()
 
+    @pyqtSlot(int)
+    def duplicateScriptByIndex(self, index: int) -> None:
+        if index < 0 or index >= len(self._script_list):
+            return
+
+        original_script = self._script_list[index]
+        script_key = original_script.getSettingData()["key"]
+
+        new_script = self._loaded_scripts[script_key]()
+        new_script.initialize()
+
+        for setting_key in original_script.getSettingData()["settings"]:
+            setting_value = original_script.getSettingValueByKey(setting_key)
+            if new_script._instance is not None:
+                new_script._instance.setProperty(setting_key, "value", setting_value)
+
+        self._script_list.append(new_script)
+        self.setSelectedScriptIndex(len(self._script_list) - 1)
+        self.scriptListChanged.emit()
+        self._propertyChanged()
+
     def _restoreScriptInforFromMetadata(self):
         self.loadAllScripts()
         new_stack = self._global_container_stack

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -88,14 +88,29 @@ UM.Dialog
 
             spacing: base.textMargin
 
-            UM.Label
+            RowLayout
             {
                 id: activeScriptsHeader
-                text: catalog.i18nc("@label", "Post Processing Scripts")
                 anchors.left: parent.left
                 anchors.right: parent.right
-                font: UM.Theme.getFont("large_bold")
-                elide: Text.ElideRight
+                spacing: UM.Theme.getSize("narrow_margin").width
+
+                Cura.SecondaryButton
+                {
+                    id: scriptOptionsButton
+                    Layout.preferredWidth: height
+                    iconSource: UM.Theme.getIcon("Hamburger")
+                    tooltip: catalog.i18nc("@info:tooltip", "Import, export or clear scripts")
+                    onClicked: scriptOptionsMenu.open()
+                }
+
+                UM.Label
+                {
+                    Layout.fillWidth: true
+                    text: catalog.i18nc("@label", "Post Processing Scripts")
+                    font: UM.Theme.getFont("large_bold")
+                    elide: Text.ElideRight
+                }
             }
             ListView
             {
@@ -271,28 +286,13 @@ UM.Dialog
                     }
                 }
             }
-            RowLayout
+            Cura.SecondaryButton
             {
+                id: addButton
                 anchors.left: parent.left
                 anchors.right: parent.right
-                spacing: UM.Theme.getSize("narrow_margin").width
-
-                Cura.SecondaryButton
-                {
-                    id: addButton
-                    Layout.fillWidth: true
-                    text: catalog.i18nc("@action", "Add a script")
-                    onClicked: scriptsMenu.open()
-                }
-
-                Cura.SecondaryButton
-                {
-                    id: scriptOptionsButton
-                    Layout.preferredWidth: height
-                    iconSource: UM.Theme.getIcon("Hamburger")
-                    tooltip: catalog.i18nc("@info:tooltip", "Import, export or clear scripts")
-                    onClicked: scriptOptionsMenu.open()
-                }
+                text: catalog.i18nc("@action", "Add a script")
+                onClicked: scriptsMenu.open()
             }
         }
 
@@ -336,7 +336,7 @@ UM.Dialog
             Cura.MenuItem
             {
                 text: catalog.i18nc("@action:inmenu", "Clear scripts")
-                onTriggered: manager.clearScripts()
+                onTriggered: confirmClearScriptsDialog.open()
             }
         }
 
@@ -357,6 +357,15 @@ UM.Dialog
             fileMode: FileDialog.OpenFile
             nameFilters: [ catalog.i18nc("@filter:file", "Post Processing Scripts (*.postprocessing)"), catalog.i18nc("@filter:file", "All files (*)") ]
             onAccepted: manager.importScripts(selectedFile)
+        }
+
+        Cura.MessageDialog
+        {
+            id: confirmClearScriptsDialog
+            title: catalog.i18nc("@dialog:title", "Clear Post-Processing Scripts")
+            text: catalog.i18nc("@dialog:info", "Are you sure you want to clear all Post-Processing Scripts?")
+            standardButtons: Dialog.Yes | Dialog.No
+            onAccepted: manager.clearScripts()
         }
 
         Rectangle

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -15,7 +15,7 @@ UM.Dialog
 {
     id: dialog
 
-    title: catalog.i18nc("@title:window", "Post Processing Plugin")
+    title: catalog.i18nc("@title:window", "Post-Processing Scripts")
     width: 700 * screenScaleFactor
     height: 500 * screenScaleFactor
     minimumWidth: 400 * screenScaleFactor
@@ -24,6 +24,7 @@ UM.Dialog
     onVisibleChanged:
     {
         // Whenever the window is closed (either via the "Close" button or the X on the window frame), we want to update it in the stack.
+				
         if (!visible)
         {
             manager.writeScriptsToStack()
@@ -34,6 +35,7 @@ UM.Dialog
     {
         UM.I18nCatalog{id: catalog; name: "cura"}
         id: base
+				
         property int columnWidth: Math.round((base.width / 2) - UM.Theme.getSize("default_margin").width)
         property int textMargin: UM.Theme.getSize("narrow_margin").width
         property string activeScriptName
@@ -42,6 +44,7 @@ UM.Dialog
 
         // Helper function to check if a setting should use multiline text area
         // Supports "multiline" or "@[multiline]" or "@[multiline, other] comment"
+				
         function isMultilineSetting(definition)
         {
             if (!definition || !definition.comments)
@@ -52,12 +55,14 @@ UM.Dialog
             var commentsLower = definition.comments.toLowerCase();
             
             // Simple format: exact match
+						
             if (commentsLower === "multiline")
             {
                 return true;
             }
             
             // Directive format: parse @[...] and check if multiline is in the list
+						
             var directiveStart = commentsLower.indexOf("@[");
             var directiveEnd = commentsLower.indexOf("]", directiveStart);
             if (directiveStart >= 0 && directiveEnd > directiveStart)
@@ -83,6 +88,7 @@ UM.Dialog
         Column
         {
             id: activeScripts
+						
             width: base.columnWidth
             height: parent.height
 
@@ -90,37 +96,42 @@ UM.Dialog
 
             RowLayout
             {
-                id: activeScriptsHeader
                 anchors.left: parent.left
                 anchors.right: parent.right
                 spacing: UM.Theme.getSize("narrow_margin").width
+							
+								UM.BurgerButton
+								{
+									id: scriptOptionsMenuIcon
 
-                Cura.SecondaryButton
-                {
-                    id: scriptOptionsButton
-                    Layout.preferredWidth: height
-                    iconSource: UM.Theme.getIcon("Hamburger")
-                    tooltip: catalog.i18nc("@info:tooltip", "Import, export or clear scripts")
-                    onClicked: scriptOptionsMenu.open()
-                }
-
-                UM.Label
-                {
-                    Layout.fillWidth: true
-                    text: catalog.i18nc("@label", "Post Processing Scripts")
-                    font: UM.Theme.getFont("large_bold")
-                    elide: Text.ElideRight
-                }
+									onClicked:
+									{
+											scriptOptionsMenu.open()
+									}
+								}
+		
+								UM.Label
+								{
+										id: activeScriptsHeader
+										
+										text: catalog.i18nc("@label", "Post-Processing Scripts")
+										anchors.left: scriptOptionsMenuIcon.right
+										font: UM.Theme.getFont("large_bold")
+										elide: Text.ElideRight
+								}
             }
+						
             ListView
             {
                 id: activeScriptsList
+								
                 anchors
                 {
                     left: parent.left
                     right: parent.right
                     rightMargin: base.textMargin
                 }
+								
                 height: Math.min(contentHeight, parent.height - parent.spacing * 2 - activeScriptsHeader.height - addButton.height) //At the window height, start scrolling this one.
 
                 clip: true
@@ -128,6 +139,7 @@ UM.Dialog
                 {
                     id: activeScriptsScrollBar
                 }
+								
                 model: manager.scriptList
 
                 delegate: Button
@@ -180,6 +192,7 @@ UM.Dialog
                         Item
                         {
                             id: duplicateButton
+														
                             Layout.preferredWidth: height
                             Layout.fillHeight: true
 
@@ -203,6 +216,7 @@ UM.Dialog
                         Item
                         {
                             id: downButton
+														
                             Layout.preferredWidth: height
                             Layout.fillHeight: true
                             enabled: index != manager.scriptList.length - 1
@@ -216,6 +230,7 @@ UM.Dialog
                                     {
                                         manager.setSelectedScriptIndex(index + 1)
                                     }
+																		
                                     return manager.moveScript(index, index + 1)
                                 }
                             }
@@ -230,9 +245,11 @@ UM.Dialog
                                 source: UM.Theme.getIcon("ChevronSingleDown")
                             }
                         }
+												
                         Item
                         {
                             id: upButton
+														
                             Layout.preferredWidth: height
                             Layout.fillHeight: true
                             enabled: index != 0
@@ -246,6 +263,7 @@ UM.Dialog
                                     {
                                         manager.setSelectedScriptIndex(index - 1)
                                     }
+																		
                                     return manager.moveScript(index, index - 1)
                                 }
                             }
@@ -264,6 +282,7 @@ UM.Dialog
                         Item
                         {
                             id: removeButton
+														
                             Layout.preferredWidth: height
                             Layout.fillHeight: true
 
@@ -286,12 +305,12 @@ UM.Dialog
                     }
                 }
             }
+						
             Cura.SecondaryButton
             {
                 id: addButton
-                anchors.left: parent.left
-                anchors.right: parent.right
-                text: catalog.i18nc("@action", "Add a script")
+								
+								text: catalog.i18nc("@action", "Add Post-Processing Script")
                 onClicked: scriptsMenu.open()
             }
         }
@@ -321,13 +340,13 @@ UM.Dialog
 
             Cura.MenuItem
             {
-                text: catalog.i18nc("@action:inmenu", "Export scripts")
+                text: catalog.i18nc("@action:inmenu", "Export Scripts")
                 onTriggered: exportScriptsDialog.open()
             }
 
             Cura.MenuItem
             {
-                text: catalog.i18nc("@action:inmenu", "Import scripts")
+                text: catalog.i18nc("@action:inmenu", "Import Scripts")
                 onTriggered: importScriptsDialog.open()
             }
 
@@ -335,17 +354,77 @@ UM.Dialog
 
             Cura.MenuItem
             {
-                text: catalog.i18nc("@action:inmenu", "Clear scripts")
-                onTriggered: confirmClearScriptsDialog.open()
+                text: catalog.i18nc("@action:inmenu", "Clear Scripts")
+                //onTriggered: manager.clearScripts()
+								onTriggered: confirmRemoveScriptsDialog.open()
             }
         }
 
+				// Dialogs
+				
+				UM.Dialog
+				{
+						id: confirmRemoveScriptsDialog
+
+						title: catalog.i18nc("@title:window", "Confirm Script Removal")
+						width: 400 * screenScaleFactor
+						height: 100 * screenScaleFactor
+						minimumWidth: 400 * screenScaleFactor
+						minimumHeight: 100 * screenScaleFactor
+						backgroundColor: UM.Theme.getColor("main_background")
+
+						UM.Label
+						{
+								id: confirmPrompt
+								
+								text: catalog.i18nc("@label", "Are you sure you want to remove ALL Post-Processing Scripts?")
+								anchors.left: parent.left
+								font: UM.Theme.getFont("medium")
+						}
+
+						Item
+						{
+								ButtonGroup 
+								{
+										buttons: [yesButton, noButton]
+										checkedButton: noButton
+								}
+						}
+
+						rightButtons: 
+						[
+								Cura.SecondaryButton
+								{
+										id: yesButton
+										
+										text: catalog.i18nc("@action:button","Yes")
+										onClicked: 										
+										{
+												manager.clearScripts()
+												confirmRemoveScriptsDialog.close()
+										}
+								},
+								
+								Cura.PrimaryButton
+								{
+										id: noButton
+										
+										text: catalog.i18nc("@action:button", "No")
+										onClicked: 										
+										{
+											confirmRemoveScriptsDialog.close()
+										}
+								}
+						]
+				}
+				
         FileDialog
         {
             id: exportScriptsDialog
-            title: catalog.i18nc("@title:window", "Export Post Processing Scripts")
+						
+            title: catalog.i18nc("@title:window", "Export Post-Processing Scripts")
             fileMode: FileDialog.SaveFile
-            nameFilters: [ catalog.i18nc("@filter:file", "Post Processing Scripts (*.postprocessing)"), catalog.i18nc("@filter:file", "All files (*)") ]
+            nameFilters: [ catalog.i18nc("@filter:file", "Post-Processing Scripts (*.postprocessing)"), catalog.i18nc("@filter:file", "All files (*)") ]
             defaultSuffix: "postprocessing"
             onAccepted: manager.exportScripts(selectedFile)
         }
@@ -353,33 +432,27 @@ UM.Dialog
         FileDialog
         {
             id: importScriptsDialog
-            title: catalog.i18nc("@title:window", "Import Post Processing Scripts")
+						
+            title: catalog.i18nc("@title:window", "Import Post-Processing Scripts")
             fileMode: FileDialog.OpenFile
-            nameFilters: [ catalog.i18nc("@filter:file", "Post Processing Scripts (*.postprocessing)"), catalog.i18nc("@filter:file", "All files (*)") ]
+            nameFilters: [ catalog.i18nc("@filter:file", "Post-Processing Scripts (*.postprocessing)"), catalog.i18nc("@filter:file", "All files (*)") ]
             onAccepted: manager.importScripts(selectedFile)
-        }
-
-        Cura.MessageDialog
-        {
-            id: confirmClearScriptsDialog
-            title: catalog.i18nc("@dialog:title", "Clear Post-Processing Scripts")
-            text: catalog.i18nc("@dialog:info", "Are you sure you want to clear all Post-Processing Scripts?")
-            standardButtons: Dialog.Yes | Dialog.No
-            onAccepted: manager.clearScripts()
         }
 
         Rectangle
         {
+				    id: settingsPanel
+
             color: UM.Theme.getColor("main_background")
             anchors.left: activeScripts.right
             anchors.leftMargin: UM.Theme.getSize("default_margin").width
             anchors.right: parent.right
             height: parent.height
-            id: settingsPanel
 
             UM.Label
             {
                 id: scriptSpecsHeader
+								
                 text: manager.selectedScriptIndex == -1 ? catalog.i18nc("@label", "Settings") : base.activeScriptName
                 anchors
                 {
@@ -399,6 +472,7 @@ UM.Dialog
             ListView
             {
                 id: listview
+								
                 anchors
                 {
                     top: scriptSpecsHeader.bottom
@@ -417,6 +491,7 @@ UM.Dialog
                 model: UM.SettingDefinitionsModel
                 {
                     id: definitionsModel
+										
                     containerId: manager.selectedScriptDefinitionId
                     onContainerIdChanged: definitionsModel.setAllVisible(true)
                     showAll: true
@@ -425,7 +500,7 @@ UM.Dialog
                 delegate: Loader
                 {
                     id: settingLoader
-
+										
                     width: listview.width
                     height:
                     {
@@ -435,6 +510,7 @@ UM.Dialog
                             {
                                 return UM.Theme.getSize("standard_list_lineheight").height + UM.Theme.getSize("narrow_margin").height + (UM.Theme.getSize("setting_control").height * 3);
                             }
+														
                             return UM.Theme.getSize("section").height;
                         }
                         else
@@ -442,6 +518,7 @@ UM.Dialog
                             return 0
                         }
                     }
+										
                     Behavior on height { NumberAnimation { duration: 100 } }
                     opacity: provider.properties.enabled == "True" ? 1 : 0
 
@@ -456,6 +533,7 @@ UM.Dialog
                     //Qt5.4.2 and earlier has a bug where this causes a crash: https://bugreports.qt.io/browse/QTBUG-35989
                     //In addition, while it works for 5.5 and higher, the ordering of the actual combo box drop down changes,
                     //causing nasty issues when selecting different options. So disable asynchronous loading of enum type completely.
+										
                     asynchronous: model.type != "enum" && model.type != "extruder"
 
                     onLoaded:
@@ -465,16 +543,21 @@ UM.Dialog
                         settingLoader.item.showLinkedSettingIcon = false
                         settingLoader.item.doDepthIndentation = false
                         settingLoader.item.doQualityUserSettingEmphasis = false
+												
                         // Pass properties explicitly to custom components that don't extend SettingItem
+												
                         if (settingLoader.item.hasOwnProperty("definition")) {
                             settingLoader.item.definition = settingLoader.definition
                         }
+												
                         if (settingLoader.item.hasOwnProperty("settingDefinitionsModel")) {
                             settingLoader.item.settingDefinitionsModel = settingLoader.settingDefinitionsModel
                         }
+												
                         if (settingLoader.item.hasOwnProperty("propertyProvider")) {
                             settingLoader.item.propertyProvider = settingLoader.propertyProvider
                         }
+												
                         if (settingLoader.item.hasOwnProperty("globalPropertyProvider")) {
                             settingLoader.item.globalPropertyProvider = settingLoader.globalPropertyProvider
                         }
@@ -506,6 +589,7 @@ UM.Dialog
                     UM.SettingPropertyProvider
                     {
                         id: provider
+												
                         containerStackId: manager.selectedScriptStackId
                         key: model.key ? model.key : "None"
                         watchedProperties: [ "value", "enabled", "state", "validationState" ]
@@ -514,9 +598,11 @@ UM.Dialog
 
                     // Specialty provider that only watches global_inherits (we can't filter on what property changed we get events
                     // so we bypass that to make a dedicated provider).
+										
                     UM.SettingPropertyProvider
                     {
                         id: inheritStackProvider
+												
                         containerStack: Cura.MachineManager.activeMachine
                         key: model.key ? model.key : "None"
                         watchedProperties: [ "limit_to_extruder" ]
@@ -548,49 +634,49 @@ UM.Dialog
         Component
         {
             id: settingTextField;
-
+						
             Cura.SettingTextField { }
         }
 
         Component
         {
             id: settingTextArea;
-
+						
             SettingTextArea { }
         }
 
         Component
         {
             id: settingComboBox;
-
+						
             Cura.SettingComboBox { }
         }
 
         Component
         {
             id: settingExtruder;
-
+						
             Cura.SettingExtruder { }
         }
 
         Component
         {
             id: settingCheckBox;
-
+						
             Cura.SettingCheckBox { }
         }
 
         Component
         {
             id: settingCategory;
-
+						
             Cura.SettingCategory { }
         }
 
         Component
         {
             id: settingUnknown;
-
+						
             Cura.SettingUnknown { }
         }
     }
@@ -625,10 +711,13 @@ UM.Dialog
                     {
                         tipText += "<li>" + manager.getScriptLabelByKey(manager.scriptList[i]) + "</li>";
                     }
+										
                     tipText += "</ul>";
                 }
+								
                 return tipText
             }
+						
             toolTipContentAlignment: UM.Enums.ContentAlignment.AlignLeft
             onClicked: dialog.show()
             iconSource: Qt.resolvedUrl("Script.svg")
@@ -638,6 +727,7 @@ UM.Dialog
         Cura.NotificationIcon
         {
             id: activeScriptCountIcon
+						
             visible: activeScriptsList.count > 0
             anchors
             {

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -163,6 +163,29 @@ UM.Dialog
 
                         Item
                         {
+                            id: duplicateButton
+                            Layout.preferredWidth: height
+                            Layout.fillHeight: true
+
+                            MouseArea
+                            {
+                                anchors.fill: parent
+                                onClicked: manager.duplicateScriptByIndex(index)
+                            }
+
+                            UM.ColorImage
+                            {
+                                anchors.verticalCenter: parent.verticalCenter
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                width: UM.Theme.getSize("standard_arrow").width
+                                height: UM.Theme.getSize("standard_arrow").height
+                                color: UM.Theme.getColor("text")
+                                source: UM.Theme.getIcon("DuplicateScript")
+                            }
+                        }
+
+                        Item
+                        {
                             id: downButton
                             Layout.preferredWidth: height
                             Layout.fillHeight: true

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -6,6 +6,7 @@ import QtQuick.Controls 2.15
 import QtQml.Models 2.15 as Models
 import QtQuick.Layouts 1.1
 import QtQuick.Window 2.2
+import QtQuick.Dialogs
 
 import UM 1.5 as UM
 import Cura 1.0 as Cura
@@ -270,11 +271,28 @@ UM.Dialog
                     }
                 }
             }
-            Cura.SecondaryButton
+            RowLayout
             {
-                id: addButton
-                text: catalog.i18nc("@action", "Add a script")
-                onClicked: scriptsMenu.open()
+                anchors.left: parent.left
+                anchors.right: parent.right
+                spacing: UM.Theme.getSize("narrow_margin").width
+
+                Cura.SecondaryButton
+                {
+                    id: addButton
+                    Layout.fillWidth: true
+                    text: catalog.i18nc("@action", "Add a script")
+                    onClicked: scriptsMenu.open()
+                }
+
+                Cura.SecondaryButton
+                {
+                    id: scriptOptionsButton
+                    Layout.preferredWidth: height
+                    iconSource: UM.Theme.getIcon("Hamburger")
+                    tooltip: catalog.i18nc("@info:tooltip", "Import, export or clear scripts")
+                    onClicked: scriptOptionsMenu.open()
+                }
             }
         }
 
@@ -295,6 +313,50 @@ UM.Dialog
                 onObjectAdded: function(index, object) { scriptsMenu.insertItem(index, object)}
                 onObjectRemoved: function(index, object) {  scriptsMenu.removeItem(object) }
             }
+        }
+
+        Cura.Menu
+        {
+            id: scriptOptionsMenu
+
+            Cura.MenuItem
+            {
+                text: catalog.i18nc("@action:inmenu", "Export scripts")
+                onTriggered: exportScriptsDialog.open()
+            }
+
+            Cura.MenuItem
+            {
+                text: catalog.i18nc("@action:inmenu", "Import scripts")
+                onTriggered: importScriptsDialog.open()
+            }
+
+            Cura.MenuSeparator {}
+
+            Cura.MenuItem
+            {
+                text: catalog.i18nc("@action:inmenu", "Clear scripts")
+                onTriggered: manager.clearScripts()
+            }
+        }
+
+        FileDialog
+        {
+            id: exportScriptsDialog
+            title: catalog.i18nc("@title:window", "Export Post Processing Scripts")
+            fileMode: FileDialog.SaveFile
+            nameFilters: [ catalog.i18nc("@filter:file", "Post Processing Scripts (*.postprocessing)"), catalog.i18nc("@filter:file", "All files (*)") ]
+            defaultSuffix: "postprocessing"
+            onAccepted: manager.exportScripts(selectedFile)
+        }
+
+        FileDialog
+        {
+            id: importScriptsDialog
+            title: catalog.i18nc("@title:window", "Import Post Processing Scripts")
+            fileMode: FileDialog.OpenFile
+            nameFilters: [ catalog.i18nc("@filter:file", "Post Processing Scripts (*.postprocessing)"), catalog.i18nc("@filter:file", "All files (*)") ]
+            onAccepted: manager.importScripts(selectedFile)
         }
 
         Rectangle

--- a/plugins/PostProcessingPlugin/tests/TestPostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/tests/TestPostProcessingPlugin.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2020 Ultimaker B.V.
 # Cura is released under the terms of the LGPLv3 or higher.
 
+import json
 import os
 import sys
+import tempfile
+
 from typing import Any, Dict, List
 from unittest.mock import patch, MagicMock
 
@@ -143,3 +146,179 @@ def _bundled_file_path():
     return os.path.join(
         Resources.getStoragePath(Resources.Resources) + "scripts/blaat.py"
     )
+
+
+def _make_plugin_instance():
+    """Create a PostProcessingPlugin instance with all Qt/Application dependencies mocked."""
+    mock_app = MagicMock()
+    mock_stack = MagicMock()
+    mock_stack.getMetaDataEntry = MagicMock(return_value=None)
+    mock_app.getGlobalContainerStack = MagicMock(return_value=mock_stack)
+    mock_app.getOutputDeviceManager = MagicMock(return_value=MagicMock())
+    mock_app.globalContainerStackChanged = MagicMock()
+    mock_app.mainWindowChanged = MagicMock()
+
+    with patch("plugins.PostProcessingPlugin.PostProcessingPlugin.Application") as mock_application_cls, \
+         patch("plugins.PostProcessingPlugin.PostProcessingPlugin.CuraApplication") as mock_cura_app_cls, \
+         patch("PyQt6.QtCore.QObject.__init__", return_value=None), \
+         patch("UM.Extension.Extension.__init__", return_value=None):
+        mock_application_cls.getInstance = MagicMock(return_value=mock_app)
+        mock_cura_app_cls.getInstance = MagicMock(return_value=mock_app)
+        plugin = PostProcessingPlugin.__new__(PostProcessingPlugin)
+        plugin._loaded_scripts = {}
+        plugin._script_labels = {}
+        plugin._script_list = []
+        plugin._selected_script_index = -1
+        plugin._global_container_stack = mock_stack
+        plugin._view = None
+        return plugin
+
+
+def test_export_scripts_writes_valid_json():
+    """exportScripts should write a valid JSON file with the correct structure."""
+    plugin = _make_plugin_instance()
+
+    mock_script = MagicMock()
+    mock_script.getSettingData = MagicMock(return_value={"key": "PauseAtHeight", "settings": {"pause_at": "10"}})
+    mock_script.getSettingValueByKey = MagicMock(return_value="10")
+    plugin._script_list = [mock_script]
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".postprocessing", delete=False) as f:
+        tmp_path = f.name
+
+    try:
+        mock_url = MagicMock()
+        mock_url.toLocalFile = MagicMock(return_value=tmp_path)
+        plugin.exportScripts(mock_url)
+
+        with open(tmp_path, "r") as f:
+            data = json.load(f)
+
+        assert data["type"] == "postprocessing-script-config"
+        assert data["version"] == 1
+        assert len(data["scripts"]) == 1
+        assert data["scripts"][0]["key"] == "PauseAtHeight"
+        assert data["scripts"][0]["settings"]["pause_at"] == "10"
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_export_scripts_empty_list():
+    """exportScripts with an empty script list should write a JSON with an empty scripts array."""
+    plugin = _make_plugin_instance()
+    plugin._script_list = []
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".postprocessing", delete=False) as f:
+        tmp_path = f.name
+
+    try:
+        mock_url = MagicMock()
+        mock_url.toLocalFile = MagicMock(return_value=tmp_path)
+        plugin.exportScripts(mock_url)
+
+        with open(tmp_path, "r") as f:
+            data = json.load(f)
+
+        assert data["type"] == "postprocessing-script-config"
+        assert data["scripts"] == []
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_import_scripts_loads_scripts():
+    """importScripts should populate _script_list from the JSON file."""
+    plugin = _make_plugin_instance()
+
+    mock_script_class = MagicMock()
+    mock_script_instance = MagicMock()
+    mock_script_instance._instance = MagicMock()
+    mock_script_class.return_value = mock_script_instance
+    plugin._loaded_scripts = {"PauseAtHeight": mock_script_class}
+
+    export_data = {
+        "version": 1,
+        "type": "postprocessing-script-config",
+        "scripts": [{"key": "PauseAtHeight", "settings": {"pause_at": "10"}}],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".postprocessing", delete=False) as f:
+        json.dump(export_data, f)
+        tmp_path = f.name
+
+    try:
+        mock_url = MagicMock()
+        mock_url.toLocalFile = MagicMock(return_value=tmp_path)
+
+        with patch.object(plugin, "loadAllScripts"), \
+             patch.object(plugin, "setSelectedScriptIndex") as mock_set_idx, \
+             patch.object(plugin, "scriptListChanged") as mock_signal, \
+             patch.object(plugin, "_propertyChanged"):
+            plugin.importScripts(mock_url)
+
+        assert len(plugin._script_list) == 1
+        assert plugin._script_list[0] is mock_script_instance
+        mock_script_instance.initialize.assert_called_once()
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_import_scripts_wrong_type_ignored():
+    """importScripts should skip files that do not have the correct type field."""
+    plugin = _make_plugin_instance()
+
+    bad_data = {"version": 1, "type": "something-else", "scripts": []}
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".postprocessing", delete=False) as f:
+        json.dump(bad_data, f)
+        tmp_path = f.name
+
+    try:
+        mock_url = MagicMock()
+        mock_url.toLocalFile = MagicMock(return_value=tmp_path)
+        plugin.importScripts(mock_url)
+        assert plugin._script_list == []
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_import_scripts_unknown_key_skipped():
+    """importScripts should skip entries whose script key is not in _loaded_scripts."""
+    plugin = _make_plugin_instance()
+    plugin._loaded_scripts = {}
+
+    export_data = {
+        "version": 1,
+        "type": "postprocessing-script-config",
+        "scripts": [{"key": "UnknownScript", "settings": {}}],
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".postprocessing", delete=False) as f:
+        json.dump(export_data, f)
+        tmp_path = f.name
+
+    try:
+        mock_url = MagicMock()
+        mock_url.toLocalFile = MagicMock(return_value=tmp_path)
+
+        with patch.object(plugin, "loadAllScripts"):
+            plugin.importScripts(mock_url)
+
+        assert plugin._script_list == []
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_clear_scripts_empties_list():
+    """clearScripts should remove all scripts from _script_list."""
+    plugin = _make_plugin_instance()
+
+    mock_script = MagicMock()
+    plugin._script_list = [mock_script]
+
+    with patch.object(plugin, "setSelectedScriptIndex") as mock_set_idx, \
+         patch.object(plugin, "scriptListChanged") as mock_signal, \
+         patch.object(plugin, "_propertyChanged"):
+        plugin.clearScripts()
+
+    assert plugin._script_list == []
+

--- a/plugins/PostProcessingPlugin/tests/TestPostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/tests/TestPostProcessingPlugin.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+from typing import Any, Dict, List
 from unittest.mock import patch, MagicMock
 
 from UM.PluginRegistry import PluginRegistry
@@ -55,6 +56,87 @@ def test_enterprise_signed_user_script_allowed(plugin_registry):
 @patch("cura.ApplicationMetadata.IsEnterpriseVersion", False)
 def test_enterprise_bundled_script_allowed():
     assert PostProcessingPlugin._isScriptAllowed(_bundled_file_path())
+
+
+def _create_plugin_with_scripts(scripts: List[Any]) -> MagicMock:
+    plugin = MagicMock(spec=PostProcessingPlugin)
+    plugin._script_list = scripts
+    plugin._loaded_scripts = {}
+    plugin._selected_script_index = len(scripts) - 1 if scripts else -1
+    plugin.setSelectedScriptIndex = lambda index: setattr(plugin, "_selected_script_index", index)
+    plugin.duplicateScriptByIndex = lambda index: PostProcessingPlugin.duplicateScriptByIndex(plugin, index)
+    return plugin
+
+
+def _create_mock_script(key: str, settings: Dict[str, Any], values: Dict[str, Any]) -> MagicMock:
+    script = MagicMock()
+    script.getSettingData = MagicMock(return_value={"key": key, "settings": settings})
+    script.getSettingValueByKey = MagicMock(side_effect=lambda k: values.get(k))
+    script._instance = MagicMock()
+    return script
+
+
+def test_duplicate_script_appends_copy() -> None:
+    original_script = _create_mock_script("PauseAtHeight", {"pause_height": None}, {"pause_height": 10})
+
+    new_script = MagicMock()
+    new_script._instance = MagicMock()
+    new_script_class = MagicMock(return_value=new_script)
+
+    plugin = _create_plugin_with_scripts([original_script])
+    plugin._loaded_scripts = {"PauseAtHeight": new_script_class}
+
+    plugin.duplicateScriptByIndex(0)
+
+    assert len(plugin._script_list) == 2
+    new_script.initialize.assert_called_once()
+    new_script._instance.setProperty.assert_called_once_with("pause_height", "value", 10)
+    assert plugin._selected_script_index == 1
+
+
+def test_duplicate_script_invalid_index_below_range() -> None:
+    original_script = _create_mock_script("PauseAtHeight", {}, {})
+    plugin = _create_plugin_with_scripts([original_script])
+
+    plugin.duplicateScriptByIndex(-1)
+
+    assert len(plugin._script_list) == 1
+
+
+def test_duplicate_script_invalid_index_above_range() -> None:
+    original_script = _create_mock_script("PauseAtHeight", {}, {})
+    plugin = _create_plugin_with_scripts([original_script])
+
+    plugin.duplicateScriptByIndex(5)
+
+    assert len(plugin._script_list) == 1
+
+
+def test_duplicate_script_empty_list() -> None:
+    plugin = _create_plugin_with_scripts([])
+
+    plugin.duplicateScriptByIndex(0)
+
+    assert len(plugin._script_list) == 0
+
+
+def test_duplicate_script_copies_all_settings() -> None:
+    settings = {"layer": None, "speed": None, "temp": None}
+    values = {"layer": 5, "speed": 50, "temp": 210}
+    original_script = _create_mock_script("PauseAtHeight", settings, values)
+
+    new_script = MagicMock()
+    new_script._instance = MagicMock()
+    new_script_class = MagicMock(return_value=new_script)
+
+    plugin = _create_plugin_with_scripts([original_script])
+    plugin._loaded_scripts = {"PauseAtHeight": new_script_class}
+
+    plugin.duplicateScriptByIndex(0)
+
+    calls = new_script._instance.setProperty.call_args_list
+    called_keys = {call.args[0]: call.args[2] for call in calls}
+    assert called_keys == {"layer": 5, "speed": 50, "temp": 210}
 
 
 def _bundled_file_path():

--- a/resources/themes/cura-light/icons/default/DuplicateScript.svg
+++ b/resources/themes/cura-light/icons/default/DuplicateScript.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+<path d="M17,7V3H6C4.3,3,3,4.3,3,6v11h4v4h11c1.7,0,3-1.3,3-3V7H17z M7,15H5V5h10v2H7V15z M15,9v6H9V9H15z M19,19H9v-2h8V9h2V19z" />
+</svg>


### PR DESCRIPTION
# Description

Added the ability to duplicate Processing Scripts and their content.

Also snuck in the ability to export/import the script configuration, instead of having to do this from scratch.  Just a nicety to have since I have to setup a bunch of pauses at different layers for different prints in order to change filament.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I'll be completely honest, ran this through Copilot and let Jesus take the wheel  I've been trying to get Cura running locally for the last two days with no luck, so at this point hopefully someone else can verify it or just close it.   I appreciate how ridiculous seems, but even following the instructions I just can't get things running locally (keep getting stuck up on UM and pyArcus versioning).

**Test Configuration**:
Windows 11

# Checklist:

Verified that Copilot had all the best practices and contributing content resolved.

- [X] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [X] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have uploaded any files required to test this change

> No specific files, should just be able to duplicate and import/export the Script config.