### PR TITLE
Issues #21521 and Fix applied to #21521

### DIFF
--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -189,8 +189,11 @@ class CuraEngineBackend(QObject, Backend):
         self._slicing_error_message = Message(
             text = catalog.i18nc("@message", "Oops! We encountered an unexpected error during your slicing process. "
                                              "Rest assured, we've automatically received the crash logs for analysis, "
-                                             "if you have not disabled data sharing in your preferences. To assist us "
-                                             "further, consider sharing your project details on our issue tracker."),
+                                             "if you have not disabled data sharing in your preferences. "
+                                             "If you use supports, ensure models and the build plate leave enough room "
+                                             "for support structures; packing models tightly or using Arrange All Models "
+                                             "can still leave no usable space, which may trigger this error. "
+                                             "To assist us further, consider sharing your project details on our issue tracker."),
             title = catalog.i18nc("@message:title", "Slicing failed"),
             message_type = Message.MessageType.ERROR
         )

--- a/resources/i18n/cura.pot
+++ b/resources/i18n/cura.pot
@@ -2755,7 +2755,7 @@ msgid "Only one G-code file can be loaded at a time. Skipped importing {0}"
 msgstr ""
 
 msgctxt "@message"
-msgid "Oops! We encountered an unexpected error during your slicing process. Rest assured, we've automatically received the crash logs for analysis, if you have not disabled data sharing in your preferences. To assist us further, consider sharing your project details on our issue tracker."
+msgid "Oops! We encountered an unexpected error during your slicing process. Rest assured, we've automatically received the crash logs for analysis, if you have not disabled data sharing in your preferences. If you use supports, ensure models and the build plate leave enough room for support structures; packing models tightly or using Arrange All Models can still leave no usable space, which may trigger this error. To assist us further, consider sharing your project details on our issue tracker."
 msgstr ""
 
 msgctxt "@action:button"


### PR DESCRIPTION
# Description

This improves the generic slicing failure message so users get a clearer hint when the failure may be related to **supports and model placement** (e.g. no room for supports after tight packing or **Arrange All Models**), as described in [#21521](https://github.com/Ultimaker/Cura/issues/21521).

**Changes:**
- `plugins/CuraEngineBackend/CuraEngineBackend.py` — extended the `_slicing_error_message` user-visible text (same `@message` context; existing crash-report / issue-tracker wording kept).
- `resources/i18n/cura.pot` — updated `msgid` for translators.

This improves user-facing diagnostics for a class of engine failures that previously only showed a generic "unexpected error" with no mention of supports or spacing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [x] Translations

# How Has This Been Tested?

- [x] **Manual / logical review** — verified the string is valid Python, wrapped in `catalog.i18nc("@message", ...)`, and that `cura.pot` matches the new source `msgid`.
- [ ] **In-app slice failure path** — recommend quickly triggering a known engine failure with supports enabled to confirm the message displays as expected.

**Test Configuration**:
* Operating System: Windows (change if you verified in-app on another OS)

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices) (string change only; no QML)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas (not needed for straightforward copy)
- [x] I have uploaded any files required to test this change (issue #21521 links a repro `.zip`)
