### PR TITLE
Preserve original filename when opening cura:// URLs

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -1875,11 +1875,16 @@ class CuraApplication(QtApplication):
                             if content_disposition_match is not None:
                                 filename = content_disposition_match.group("filename").strip("\"")
 
-                        tmp = tempfile.NamedTemporaryFile(suffix=filename, delete=False)
-                        with open(tmp.name, "wb") as f:
+                        # Write the download to a fresh temp directory under
+                        # its real filename, so the file shown in Cura keeps
+                        # the original name. Using NamedTemporaryFile(suffix=…)
+                        # would produce `tmpXXXXXX<filename>` instead.
+                        tmp_dir = tempfile.mkdtemp(prefix="cura-open-")
+                        tmp_path = os.path.join(tmp_dir, filename)
+                        with open(tmp_path, "wb") as f:
                             f.write(response.readAll())
 
-                        self.readLocalFile(QUrl.fromLocalFile(tmp.name), add_to_recent_files=False)
+                        self.readLocalFile(QUrl.fromLocalFile(tmp_path), add_to_recent_files=False)
                     except Exception as ex:
                         Logger.warning(f"Exception {str(ex)}")
                         on_error()


### PR DESCRIPTION
When a model is opened via a `cura://open?file=…` URL (e.g. Thingiverse's "Send to Cura" button), the downloaded file is shown in Cura with a name like `tmpAbC123model.stl` instead of `model.stl`.

The handler in `CuraApplication._openUrl` already does the work to recover the real filename — it parses the `Content-Disposition` header, and falls back to the last URL path segment. But it then passes that name as the `suffix` argument to `tempfile.NamedTemporaryFile`, which produces `tmpXXXXXX<suffix>`. So the careful filename extraction is effectively wasted.

This PR writes the download to a fresh temp directory under its real filename instead. The temp file is still disposable, but the name Cura displays (and suggests on save) is now the original model name.

## Before / after

- **Before:** `tmpAbC123thingiverse_123456_model.stl`
- **After:** `thingiverse_123456_model.stl`