### PR TITLE
CURA-13108 Anchor warning text between icon and button

### DIFF
--- a/resources/qml/PrintSetupSelector/ProfileWarningReset.qml
+++ b/resources/qml/PrintSetupSelector/ProfileWarningReset.qml
@@ -52,7 +52,6 @@ Item
             rightMargin: UM.Theme.getSize("thin_margin").width
         }
 
-
         states: [
             State
             {

--- a/resources/qml/PrintSetupSelector/ProfileWarningReset.qml
+++ b/resources/qml/PrintSetupSelector/ProfileWarningReset.qml
@@ -42,15 +42,16 @@ Item
     {
         id: warning
         visible: fullWarning
-        width: visible ? parent.width - warningIcon.width - (compareAndSaveButton.width + resetToDefaultQualityButton.width) : 0
+        wrapMode: Text.WordWrap
         anchors
         {
             left: warningIcon.right
+            right: resetToDefaultQualityButton.left
             verticalCenter: parent.verticalCenter
             leftMargin: visible ? UM.Theme.getSize("thin_margin").width : 0
+            rightMargin: UM.Theme.getSize("thin_margin").width
         }
 
-        wrapMode: Text.WordWrap
 
         states: [
             State


### PR DESCRIPTION
Replace the hard-coded width calculation for the warning text with left/right anchors to tie it between the warning icon and the reset button. Add a right anchor and symmetric thin margins, and ensure Text.WordWrap is set. This makes the warning label layout responsive and avoids manual width arithmetic.

CURA-13108
