### PR TITLE
CURA-13110 gcode analyzer workflow

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -9892,6 +9892,14 @@
                     "type": "str",
                     "default_value": "[[1,0,0], [0,1,0], [0,0,1]]",
                     "enabled": false
+                },
+                "initial_extruder_nr":
+                 {
+                    "label": "Initial Extruder Number",
+                    "description": "Extruder that should be used first when printing.",
+                    "type": "extruder",
+                    "default_value": 0,
+                    "enabled": false
                 }
             }
         }

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -9723,7 +9723,8 @@
                     "settable_per_extruder": true,
                     "settable_per_mesh": true
                 },
-                "minimum_infill_line_length": {
+                "minimum_infill_line_length":
+                {
                     "label": "Minimum Infill Line Length",
                     "description": "When an infill area generates lines with a total length lower than this value, they will be discarded to avoid printing lots of tiny useless lines. It can help reduce travel moves, retractions and unretractions.",
                     "type": "float",
@@ -9894,7 +9895,7 @@
                     "enabled": false
                 },
                 "initial_extruder_nr":
-                 {
+                {
                     "label": "Initial Extruder Number",
                     "description": "Extruder that should be used first when printing.",
                     "type": "extruder",


### PR DESCRIPTION
This PR adds the `initial_extruder_nr` pseudo-setting to the command-line settings, so that the engine can retrieve a proper value when started from the command-line, which includes running the GCodeAnalyzer

CURA-13110
Comes with https://github.com/Ultimaker/CuraEngine/pull/2326