### PR TITLE
CURA-12754 dynamic dialogs

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -283,6 +283,8 @@ class CuraApplication(QtApplication):
 
         self._supported_url_schemes: List[str] = ["cura", "slicer"]
 
+        self._confirm_exit_dialog_callback: Optional[Callable[[bool], None]] = None
+
     @pyqtProperty(str, constant=True)
     def ultimakerCloudApiRootUrl(self) -> str:
         return UltimakerCloudConstants.CuraCloudAPIRoot
@@ -717,12 +719,13 @@ class CuraApplication(QtApplication):
 
     showConfirmExitDialog = pyqtSignal(str, arguments = ["message"])
 
-    def setConfirmExitDialogCallback(self, callback: Callable) -> None:
+    def setConfirmExitDialogCallback(self, callback: Optional[Callable[[bool], None]]) -> None:
         self._confirm_exit_dialog_callback = callback
 
     @pyqtSlot(bool)
     def callConfirmExitDialogCallback(self, yes_or_no: bool) -> None:
-        self._confirm_exit_dialog_callback(yes_or_no)
+        if self._confirm_exit_dialog_callback is not None:
+            self._confirm_exit_dialog_callback(yes_or_no)
 
     showPreferencesWindow = pyqtSignal()
     """Signal to connect preferences action in QML"""

--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -115,6 +115,7 @@ from cura.UI.RecommendedMode import RecommendedMode
 from cura.UI.TextManager import TextManager
 from cura.UI.WelcomePagesModel import WelcomePagesModel
 from cura.UI.WhatsNewPagesModel import WhatsNewPagesModel
+from cura.UI.WhatsNewSubPagesModel import WhatsNewSubPagesModel
 from cura.UltimakerCloud import UltimakerCloudConstants
 from cura.Utils.NetworkingUtil import NetworkingUtil
 from . import BuildVolume
@@ -228,10 +229,6 @@ class CuraApplication(QtApplication):
         self._discovered_printer_model = DiscoveredPrintersModel(self, parent = self)
         self._discovered_cloud_printers_model = DiscoveredCloudPrintersModel(self, parent = self)
         self._first_start_machine_actions_model = None
-        self._welcome_pages_model = WelcomePagesModel(self, parent = self)
-        self._add_printer_pages_model = AddPrinterPagesModel(self, parent = self)
-        self._add_printer_pages_model_without_cancel = AddPrinterPagesModel(self, parent = self)
-        self._whats_new_pages_model = WhatsNewPagesModel(self, parent = self)
         self._text_manager = TextManager(parent = self)
 
         self._quality_profile_drop_down_menu_model = None
@@ -928,10 +925,6 @@ class CuraApplication(QtApplication):
         self._cura_API.initialize()
         self.processEvents()
         self._output_device_manager.start()
-        self._welcome_pages_model.initialize()
-        self._add_printer_pages_model.initialize()
-        self._add_printer_pages_model_without_cancel.initialize(cancellable = False)
-        self._whats_new_pages_model.initialize()
 
         # Initialize the FileProviderModel
         self._file_provider_model.initialize(self._onFileProviderEnabledChanged)
@@ -1067,21 +1060,25 @@ class CuraApplication(QtApplication):
     def getSettingVisibilityPresetsModel(self, *args) -> SettingVisibilityPresetsModel:
         return self._setting_visibility_presets_model
 
+    @deprecated("This should no more be called, you should directly create a new model instead", since="5.14.0")
     @pyqtSlot(result = QObject)
     def getWelcomePagesModel(self, *args) -> "WelcomePagesModel":
-        return self._welcome_pages_model
+        return WelcomePagesModel()
 
+    @deprecated("This should no more be called, you should directly create a new model instead", since="5.14.0")
     @pyqtSlot(result = QObject)
     def getAddPrinterPagesModel(self, *args) -> "AddPrinterPagesModel":
-        return self._add_printer_pages_model
+        return AddPrinterPagesModel()
 
+    @deprecated("This should no more be called, you should directly create a new model instead", since="5.14.0")
     @pyqtSlot(result = QObject)
     def getAddPrinterPagesModelWithoutCancel(self, *args) -> "AddPrinterPagesModel":
-        return self._add_printer_pages_model_without_cancel
+        return AddPrinterPagesModel()
 
+    @deprecated("This should no more be called, you should directly create a new model instead", since="5.14.0")
     @pyqtSlot(result = QObject)
     def getWhatsNewPagesModel(self, *args) -> "WhatsNewPagesModel":
-        return self._whats_new_pages_model
+        return WhatsNewPagesModel()
 
     @pyqtSlot(result = QObject)
     def getMachineSettingsManager(self, *args) -> "MachineSettingsManager":
@@ -1313,6 +1310,7 @@ class CuraApplication(QtApplication):
         qmlRegisterType(NetworkingUtil, "Cura", 1, 5, "NetworkingUtil")
         qmlRegisterType(WelcomePagesModel, "Cura", 1, 0, "WelcomePagesModel")
         qmlRegisterType(WhatsNewPagesModel, "Cura", 1, 0, "WhatsNewPagesModel")
+        qmlRegisterType(WhatsNewSubPagesModel, "Cura", 1, 0, "WhatsNewSubPagesModel")
         qmlRegisterType(AddPrinterPagesModel, "Cura", 1, 0, "AddPrinterPagesModel")
         qmlRegisterType(TextManager, "Cura", 1, 0, "TextManager")
         qmlRegisterType(RecommendedMode, "Cura", 1, 0, "RecommendedMode")

--- a/cura/UI/AddPrinterPagesModel.py
+++ b/cura/UI/AddPrinterPagesModel.py
@@ -3,7 +3,7 @@
 
 from .WelcomePagesModel import WelcomePagesModel
 
-from UM.Decorators import deprecated
+from UM.Decorators import deprecated_argument
 
 
 #
@@ -12,7 +12,7 @@ from UM.Decorators import deprecated
 #
 class AddPrinterPagesModel(WelcomePagesModel):
 
-    @deprecated("Argument 'cancellable' is unused and will be removed. It was actually effectless already since many versions.", since="5.14.0")
+    @deprecated_argument(1, "cancellable", "Argument 'cancellable' is unused and will be removed. It was actually effectless already since many versions.", since="5.14.0")
     def initialize(self, cancellable: bool = True) -> None:
         self._pages.append({"id": "add_network_or_local_printer",
                             "page_url": self._getBuiltinWelcomePagePath("AddUltimakerOrThirdPartyPrinterStack.qml"),

--- a/cura/UI/AddPrinterPagesModel.py
+++ b/cura/UI/AddPrinterPagesModel.py
@@ -3,6 +3,8 @@
 
 from .WelcomePagesModel import WelcomePagesModel
 
+from UM.Decorators import deprecated
+
 
 #
 # This Qt ListModel is more or less the same the WelcomePagesModel, except that this model is only for adding a printer,
@@ -10,6 +12,7 @@ from .WelcomePagesModel import WelcomePagesModel
 #
 class AddPrinterPagesModel(WelcomePagesModel):
 
+    @deprecated("Argument 'cancellable' is unused and will be removed. It was actually effectless already since many versions.", since="5.14.0")
     def initialize(self, cancellable: bool = True) -> None:
         self._pages.append({"id": "add_network_or_local_printer",
                             "page_url": self._getBuiltinWelcomePagePath("AddUltimakerOrThirdPartyPrinterStack.qml"),
@@ -29,8 +32,6 @@ class AddPrinterPagesModel(WelcomePagesModel):
                             "page_url": self._getBuiltinWelcomePagePath("FirstStartMachineActionsContent.qml"),
                             "should_show_function": self.shouldShowMachineActions,
                             })
-        if cancellable:
-            self._pages[0]["previous_page_button_text"] = self._catalog.i18nc("@action:button", "Cancel")
 
         self.setItems(self._pages)
 

--- a/cura/UI/WelcomePagesModel.py
+++ b/cura/UI/WelcomePagesModel.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional, List, Dict, Any
 
 from PyQt6.QtCore import QUrl, Qt, pyqtSlot, pyqtProperty, pyqtSignal
 
-from UM.Decorators import deprecated
+from UM.Decorators import deprecated, deprecated_argument
 from UM.i18n import i18nCatalog
 from UM.Logger import Logger
 from UM.Qt.ListModel import ListModel
@@ -43,7 +43,7 @@ class WelcomePagesModel(ListModel):
     NextPageButtonTextRole = Qt.ItemDataRole.UserRole + 4  # The text for the next page button
     PreviousPageButtonTextRole = Qt.ItemDataRole.UserRole + 5  # The text for the previous page button
 
-    @deprecated("Argument 'application' is unused and will be removed", since="5.14.0")
+    @deprecated_argument(1, "application", "It is unused and will be removed", since="5.14.0")
     def __init__(self, application: "CuraApplication" = None, parent: Optional["QObject"] = None) -> None:
         super().__init__(parent)
 

--- a/cura/UI/WelcomePagesModel.py
+++ b/cura/UI/WelcomePagesModel.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional, List, Dict, Any
 
 from PyQt6.QtCore import QUrl, Qt, pyqtSlot, pyqtProperty, pyqtSignal
 
+from UM.Decorators import deprecated
 from UM.i18n import i18nCatalog
 from UM.Logger import Logger
 from UM.Qt.ListModel import ListModel
@@ -42,7 +43,8 @@ class WelcomePagesModel(ListModel):
     NextPageButtonTextRole = Qt.ItemDataRole.UserRole + 4  # The text for the next page button
     PreviousPageButtonTextRole = Qt.ItemDataRole.UserRole + 5  # The text for the previous page button
 
-    def __init__(self, application: "CuraApplication", parent: Optional["QObject"] = None) -> None:
+    @deprecated("Argument 'application' is unused and will be removed", since="5.14.0")
+    def __init__(self, application: "CuraApplication" = None, parent: Optional["QObject"] = None) -> None:
         super().__init__(parent)
 
         self.addRoleName(self.IdRole, "id")
@@ -51,7 +53,8 @@ class WelcomePagesModel(ListModel):
         self.addRoleName(self.NextPageButtonTextRole, "next_page_button_text")
         self.addRoleName(self.PreviousPageButtonTextRole, "previous_page_button_text")
 
-        self._application = application
+        from cura.CuraApplication import CuraApplication
+        self._application: "CuraApplication" = CuraApplication.getInstance()
         self._catalog = i18nCatalog("cura")
 
         self._default_next_button_text = self._catalog.i18nc("@action:button", "Next")
@@ -65,6 +68,8 @@ class WelcomePagesModel(ListModel):
         # If the welcome flow should be shown. It can show the complete flow or just the changelog depending on the
         # specific case. See initialize() for how this variable is set.
         self._should_show_welcome_flow = False
+
+        self.initialize()
 
     allFinished = pyqtSignal()  # emitted when all steps have been finished
     currentPageIndexChanged = pyqtSignal()
@@ -102,7 +107,6 @@ class WelcomePagesModel(ListModel):
         Ends the Welcome-Pages. Put as a separate function for cases like the 'decline' in the User-Agreement.
         """
         self.allFinished.emit()
-        self.resetState()
 
     @pyqtSlot()
     def goToNextPage(self, from_index: Optional[int] = None) -> None:
@@ -186,6 +190,7 @@ class WelcomePagesModel(ListModel):
         should_show_function = next_page_item.get("should_show_function", lambda: True)
         return should_show_function()
 
+    @deprecated("This should no more be called, you should create a new model for each view instead", since = "5.14.0")
     @pyqtSlot()
     def resetState(self) -> None:
         """

--- a/cura/UI/WhatsNewPagesModel.py
+++ b/cura/UI/WhatsNewPagesModel.py
@@ -2,12 +2,12 @@
 # Cura is released under the terms of the LGPLv3 or higher.
 
 import os
-from typing import Optional, Dict, List, Tuple, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from PyQt6.QtCore import pyqtProperty, pyqtSlot
 
+from UM.Decorators import deprecated
 from UM.Logger import Logger
-from UM.Resources import Resources
 
 from cura.UI.WelcomePagesModel import WelcomePagesModel
 
@@ -22,43 +22,10 @@ class WhatsNewPagesModel(WelcomePagesModel):
     "what's new" page. This is also used in the "Help" menu to show the changes log.
     """
 
-    image_formats = [".png", ".jpg", ".jpeg", ".gif", ".svg"]
-    text_formats = [".txt", ".htm", ".html"]
-    image_key = "image"
-    text_key = "text"
-
-    def __init__(self, application: "CuraApplication", parent: Optional["QObject"] = None) -> None:
+    @deprecated("Argument 'application' is unused and will be removed", since="5.14.0")
+    def __init__(self, application: "CuraApplication" = None, parent: Optional["QObject"] = None) -> None:
         super().__init__(application, parent)
-        self._subpages: List[Dict[str, Optional[str]]] = []
-
-    @staticmethod
-    def _collectOrdinalFiles(resource_type: int, include: List[str]) -> Tuple[Dict[int, str], int]:
-        result = {}  # type: Dict[int, str]
-        highest = -1
-        try:
-            folder_path = Resources.getPath(resource_type, "whats_new")
-            for _, _, files in os.walk(folder_path):
-                for filename in files:
-                    basename = os.path.basename(filename)
-                    base, ext = os.path.splitext(basename)
-                    if ext.lower() not in include or not base.isdigit():
-                        continue
-                    page_no = int(base)
-                    highest = max(highest, page_no)
-                    result[page_no] = os.path.join(folder_path, filename)
-        except FileNotFoundError:
-            Logger.logException("w", "Could not find 'whats_new' folder for resource-type {0}".format(resource_type))
-        return result, highest
-
-    @staticmethod
-    def _loadText(filename: str) -> str:
-        result = ""
-        try:
-            with open(filename, "r", encoding="utf-8") as file:
-                result = file.read()
-        except OSError:
-            Logger.logException("w", "Could not open {0}".format(filename))
-        return result
+        self.initialize()
 
     def initialize(self) -> None:
         self._pages = []
@@ -78,36 +45,3 @@ class WhatsNewPagesModel(WelcomePagesModel):
         except FileNotFoundError:
             Logger.warning("Unable to find changelog page")
         self.setItems(self._pages)
-
-        images, max_image = WhatsNewPagesModel._collectOrdinalFiles(Resources.Images, WhatsNewPagesModel.image_formats)
-        texts, max_text = WhatsNewPagesModel._collectOrdinalFiles(Resources.Texts, WhatsNewPagesModel.text_formats)
-        highest = max(max_image, max_text)
-
-        self._subpages = []
-        for n in range(0, highest + 1):
-            self._subpages.append({
-                WhatsNewPagesModel.image_key: None if n not in images else images[n],
-                WhatsNewPagesModel.text_key: None if n not in texts else self._loadText(texts[n])
-            })
-        if len(self._subpages) == 0:
-            self._subpages.append({WhatsNewPagesModel.text_key: "~ There Is Nothing New Under The Sun ~"})
-
-    def _getSubpageItem(self, page: int, item: str) -> Optional[str]:
-        if 0 <= page < self.subpageCount and item in self._subpages[page]:
-            return self._subpages[page][item]
-        else:
-            return None
-
-    @pyqtProperty(int, constant = True)
-    def subpageCount(self) -> int:
-        return len(self._subpages)
-
-    @pyqtSlot(int, result = str)
-    def getSubpageImageSource(self, page: int) -> str:
-        result = self._getSubpageItem(page, WhatsNewPagesModel.image_key)
-        return "file:///" + (result if result else Resources.getPath(Resources.Images, "cura-icon.png"))
-
-    @pyqtSlot(int, result = str)
-    def getSubpageText(self, page: int) -> str:
-        result = self._getSubpageItem(page, WhatsNewPagesModel.text_key)
-        return result if result else "* * *"

--- a/cura/UI/WhatsNewSubPagesModel.py
+++ b/cura/UI/WhatsNewSubPagesModel.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Ultimaker B.V.
+# Cura is released under the terms of the LGPLv3 or higher.
+
+import os
+from typing import Optional, Dict, List, Tuple
+
+from PyQt6.QtCore import QObject, pyqtProperty, pyqtSlot
+
+from UM.Logger import Logger
+from UM.Resources import Resources
+
+
+class WhatsNewSubPagesModel(QObject):
+    """
+    This model loads the sub-pages of the what's new screen according to the text/html pages available
+    in the resources folder.
+    """
+
+    image_formats = [".png", ".jpg", ".jpeg", ".gif", ".svg"]
+    text_formats = [".txt", ".htm", ".html"]
+    image_key = "image"
+    text_key = "text"
+
+    def __init__(self, parent: Optional["QObject"] = None) -> None:
+        super().__init__(parent)
+
+        images, max_image = WhatsNewSubPagesModel._collectOrdinalFiles(Resources.Images, WhatsNewSubPagesModel.image_formats)
+        texts, max_text = WhatsNewSubPagesModel._collectOrdinalFiles(Resources.Texts, WhatsNewSubPagesModel.text_formats)
+        highest = max(max_image, max_text)
+
+        self._subpages: List[Dict[str, Optional[str]]] = []
+        for n in range(0, highest + 1):
+            self._subpages.append({
+                WhatsNewSubPagesModel.image_key: None if n not in images else images[n],
+                WhatsNewSubPagesModel.text_key: None if n not in texts else self._loadText(texts[n])
+            })
+        if len(self._subpages) == 0:
+            self._subpages.append({WhatsNewSubPagesModel.text_key: "~ There Is Nothing New Under The Sun ~"})
+
+    @staticmethod
+    def _collectOrdinalFiles(resource_type: int, include: List[str]) -> Tuple[Dict[int, str], int]:
+        result = {}  # type: Dict[int, str]
+        highest = -1
+        try:
+            folder_path = Resources.getPath(resource_type, "whats_new")
+            for _, _, files in os.walk(folder_path):
+                for filename in files:
+                    basename = os.path.basename(filename)
+                    base, ext = os.path.splitext(basename)
+                    if ext.lower() not in include or not base.isdigit():
+                        continue
+                    page_no = int(base)
+                    highest = max(highest, page_no)
+                    result[page_no] = os.path.join(folder_path, filename)
+        except FileNotFoundError:
+            Logger.logException("w", "Could not find 'whats_new' folder for resource-type {0}".format(resource_type))
+        return result, highest
+
+    @staticmethod
+    def _loadText(filename: str) -> str:
+        result = ""
+        try:
+            with open(filename, "r", encoding="utf-8") as file:
+                result = file.read()
+        except OSError:
+            Logger.logException("w", "Could not open {0}".format(filename))
+        return result
+
+    def _getSubpageItem(self, page: int, item: str) -> Optional[str]:
+        if 0 <= page < self.subpageCount and item in self._subpages[page]:
+            return self._subpages[page][item]
+        else:
+            return None
+
+    @pyqtProperty(int, constant = True)
+    def subpageCount(self) -> int:
+        return len(self._subpages)
+
+    @pyqtSlot(int, result = str)
+    def getSubpageImageSource(self, page: int) -> str:
+        result = self._getSubpageItem(page, WhatsNewSubPagesModel.image_key)
+        return "file:///" + (result if result else Resources.getPath(Resources.Images, "cura-icon.png"))
+
+    @pyqtSlot(int, result = str)
+    def getSubpageText(self, page: int) -> str:
+        result = self._getSubpageItem(page, WhatsNewSubPagesModel.text_key)
+        return result if result else "* * *"

--- a/cura/UI/WhatsNewSubPagesModel.py
+++ b/cura/UI/WhatsNewSubPagesModel.py
@@ -39,7 +39,7 @@ class WhatsNewSubPagesModel(QObject):
 
     @staticmethod
     def _collectOrdinalFiles(resource_type: int, include: List[str]) -> Tuple[Dict[int, str], int]:
-        result = {}  # type: Dict[int, str]
+        result: Dict[int, str] = {}
         highest = -1
         try:
             folder_path = Resources.getPath(resource_type, "whats_new")

--- a/plugins/3MFReader/ThreeMFWorkspaceReader.py
+++ b/plugins/3MFReader/ThreeMFWorkspaceReader.py
@@ -6,6 +6,7 @@ import zipfile
 import os
 import json
 import re
+import threading
 from typing import cast, Dict, List, Optional, Tuple, Any, Set
 
 import xml.etree.ElementTree as ET
@@ -116,7 +117,6 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
         super().__init__()
 
         self._supported_extensions = [".3mf"]
-        self._dialog = WorkspaceDialog()
         self._3mf_mesh_reader = None
         self._is_ucp = None
         self._container_registry = ContainerRegistry.getInstance()
@@ -147,6 +147,10 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
 
         self._user_settings: Dict[str, Dict[str, Any]] = {}
         self._deferred_node_file_name: Optional[str] = None
+
+        self._updatable_machines_count: int = 0
+        self._machine_to_override: str = ""
+        self._missing_packages: List[Dict[str, str]] = []
 
     def _clearState(self):
         self._id_mapping = {}
@@ -615,23 +619,23 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
         missing_package_metadata = self._filter_missing_package_metadata(package_metadata)
 
         # Load the user specifically exported settings
-        self._dialog.exportedSettingModel.clear()
-        self._dialog.setCurrentMachineName("")
+        dialog_closed_event = threading.Event()
+        dialog = self.makePreReadDialog(dialog_closed_event)
         if self._is_ucp:
             try:
                 self._user_settings = json.loads(archive.open("Cura/user-settings.json").read().decode("utf-8"))
                 any_extruder_stack = ExtruderManager.getInstance().getExtruderStack(0)
                 actual_global_stack = CuraApplication.getInstance().getGlobalContainerStack()
-                self._dialog.setCurrentMachineName(actual_global_stack.id)
+                dialog.setCurrentMachineName(actual_global_stack.id)
 
                 for stack_name, settings in self._user_settings.items():
                     if stack_name == 'global':
-                        self._dialog.exportedSettingModel.addSettingsFromStack(actual_global_stack, i18n_catalog.i18nc("@label", "Global"), settings)
+                        dialog.exportedSettingModel.addSettingsFromStack(actual_global_stack, i18n_catalog.i18nc("@label", "Global"), settings)
                     else:
                         extruder_match = re.fullmatch('extruder_([0-9]+)', stack_name)
                         if extruder_match is not None:
                             extruder_nr = int(extruder_match.group(1))
-                            self._dialog.exportedSettingModel.addSettingsFromStack(any_extruder_stack,
+                            dialog.exportedSettingModel.addSettingsFromStack(any_extruder_stack,
                                                                                    i18n_catalog.i18nc("@label",
                                                                                                       "Extruder {0}", extruder_nr + 1),
                                                                                    settings)
@@ -648,28 +652,27 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
                 return WorkspaceReader.PreReadResult.failed
 
         # Show the dialog, informing the user what is about to happen.
-        self._dialog.setMachineConflict(machine_conflict)
-        self._dialog.setIsPrinterGroup(is_printer_group)
-        self._dialog.setQualityChangesConflict(quality_changes_conflict)
-        self._dialog.setMaterialConflict(material_conflict)
-        self._dialog.setHasVisibleSettingsField(has_visible_settings_string)
-        self._dialog.setNumVisibleSettings(num_visible_settings)
-        self._dialog.setQualityName(quality_name)
-        self._dialog.setQualityType(quality_type)
-        self._dialog.setIntentName(intent_category)
-        self._dialog.setNumSettingsOverriddenByQualityChanges(num_settings_overridden_by_quality_changes)
-        self._dialog.setNumUserSettings(num_user_settings)
-        self._dialog.setActiveMode(active_mode)
-        self._dialog.setUpdatableMachines(updatable_machines)
-        self._dialog.setMaterialLabels(material_labels)
-        self._dialog.setMachineType(machine_type)
-        self._dialog.setExtruders(extruders)
-        self._dialog.setVariantType(variant_type_name)
-        self._dialog.setHasObjectsOnPlate(Application.getInstance().platformActivity)
-        self._dialog.setMissingPackagesMetadata(missing_package_metadata)
-        self._dialog.setAllowCreatemachine(not self._is_ucp)
-        self._dialog.setIsUcp(self._is_ucp)
-        self._dialog.show()
+        dialog.setMachineConflict(machine_conflict)
+        dialog.setIsPrinterGroup(is_printer_group)
+        dialog.setQualityChangesConflict(quality_changes_conflict)
+        dialog.setMaterialConflict(material_conflict)
+        dialog.setHasVisibleSettingsField(has_visible_settings_string)
+        dialog.setNumVisibleSettings(num_visible_settings)
+        dialog.setQualityName(quality_name)
+        dialog.setQualityType(quality_type)
+        dialog.setIntentName(intent_category)
+        dialog.setNumSettingsOverriddenByQualityChanges(num_settings_overridden_by_quality_changes)
+        dialog.setNumUserSettings(num_user_settings)
+        dialog.setActiveMode(active_mode)
+        dialog.setUpdatableMachines(updatable_machines)
+        dialog.setMaterialLabels(material_labels)
+        dialog.setMachineType(machine_type)
+        dialog.setExtruders(extruders)
+        dialog.setVariantType(variant_type_name)
+        dialog.setHasObjectsOnPlate(Application.getInstance().platformActivity)
+        dialog.setMissingPackagesMetadata(missing_package_metadata)
+        dialog.setAllowCreatemachine(not self._is_ucp)
+        dialog.setIsUcp(self._is_ucp)
 
 
         # Choosing the initially selected printer in MachineSelector
@@ -679,37 +682,40 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
             # The machine included in the project file exists locally already, no need to change selected printers.
             is_networked_machine = global_stack.hasNetworkedConnection()
             is_abstract_machine = parseBool(existing_global_stack.getMetaDataEntry("is_abstract_machine", False))
-            self._dialog.setMachineToOverride(global_stack.getId())
-            self._dialog.setResolveStrategy("machine", "override")
-        elif self._dialog.updatableMachinesModel.count > 0:
+            dialog.setMachineToOverride(global_stack.getId())
+            dialog.setResolveStrategy("machine", "override")
+        elif dialog.updatableMachinesModel.count > 0:
             # The machine included in the project file does not exist. There is another machine of the same type.
             # This will always default to an abstract machine first.
-            machine = self._dialog.updatableMachinesModel.getItem(self._dialog.currentMachinePositionIndex)
+            machine = dialog.updatableMachinesModel.getItem(dialog.currentMachinePositionIndex)
             machine_name = machine["name"]
             is_networked_machine = machine["isNetworked"]
             is_abstract_machine = machine["isAbstractMachine"]
-            self._dialog.setMachineToOverride(machine["id"])
-            self._dialog.setResolveStrategy("machine", "override")
+            dialog.setMachineToOverride(machine["id"])
+            dialog.setResolveStrategy("machine", "override")
         else:
             # The machine included in the project file does not exist. There are no other printers of the same type. Default to "Create New".
             machine_name = i18n_catalog.i18nc("@button", "Create new")
             is_networked_machine = False
             is_abstract_machine = False
-            self._dialog.setMachineToOverride(None)
-            self._dialog.setResolveStrategy("machine", "new")
+            dialog.setMachineToOverride(None)
+            dialog.setResolveStrategy("machine", "new")
 
-        self._dialog.setIsNetworkedMachine(is_networked_machine)
-        self._dialog.setIsAbstractMachine(is_abstract_machine)
-        self._dialog.setMachineName(machine_name)
-        self._dialog.updateCompatibleMachine()
+        dialog.setIsNetworkedMachine(is_networked_machine)
+        dialog.setIsAbstractMachine(is_abstract_machine)
+        dialog.setMachineName(machine_name)
+        dialog.updateCompatibleMachine()
 
         # Block until the dialog is closed.
-        self._dialog.waitForClose()
+        dialog_closed_event.wait()
 
-        if self._dialog.getResult() == {}:
+        if dialog.getResult() == {}:
             return WorkspaceReader.PreReadResult.cancelled
 
-        self._resolve_strategies = self._dialog.getResult()
+        self._updatable_machines_count = dialog.updatableMachinesModel.count
+        self._machine_to_override = dialog.getMachineToOverride()
+        self._missing_packages = dialog.missingPackages
+        self._resolve_strategies = dialog.getResult()
         #
         # There can be 3 resolve strategies coming from the dialog:
         #  - new:       create a new container
@@ -724,6 +730,10 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
                 continue
             self._resolve_strategies[key] = "override" if containers_found_dict[key] else "new"
         return WorkspaceReader.PreReadResult.accepted
+
+    @call_on_qt_thread
+    def makePreReadDialog(self, dialog_closed_event: threading.Event):
+        return WorkspaceDialog(dialog_closed_event)
 
     @call_on_qt_thread
     def read(self, file_name):
@@ -796,7 +806,7 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
         application.expandedCategoriesChanged.emit()  # Notify the GUI of the change
 
         # If there are no machines of the same type, create a new machine.
-        if self._resolve_strategies["machine"] != "override" or self._dialog.updatableMachinesModel.count == 0:
+        if self._resolve_strategies["machine"] != "override" or self._updatable_machines_count == 0:
             # We need to create a new machine
             machine_name = self._container_registry.uniqueName(self._machine_info.name)
 
@@ -812,7 +822,7 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
                 self._container_registry.addContainer(global_stack)
         else:
             # Find the machine which will be overridden
-            global_stacks = self._container_registry.findContainerStacks(id = self._dialog.getMachineToOverride(), type = "machine")
+            global_stacks = self._container_registry.findContainerStacks(id = self._machine_to_override, type = "machine")
             if not global_stacks:
                 message = Message(i18n_catalog.i18nc("@info:error Don't translate the XML tag <filename>!",
                                                      "Project file <filename>{0}</filename> is made using profiles that are unknown to this version of UltiMaker Cura.", file_name),
@@ -1368,7 +1378,7 @@ class ThreeMFWorkspaceReader(WorkspaceReader):
 
     def _settingIsFromMissingPackage(self, key, value):
         # Check if the key and value pair is from the missing package
-        for package in self._dialog.missingPackages:
+        for package in self._missing_packages:
             if value.startswith("PLUGIN::"):
                 if (package['id'] + "@" + package['package_version']) in value:
                     Logger.warning(f"Ignoring {key} value {value} from missing package")

--- a/plugins/3MFReader/WorkspaceDialog.py
+++ b/plugins/3MFReader/WorkspaceDialog.py
@@ -28,15 +28,12 @@ i18n_catalog = i18nCatalog("cura")
 
 
 class WorkspaceDialog(QObject):
-    showDialogSignal = pyqtSignal()
 
-    def __init__(self, parent = None) -> None:
+    def __init__(self, dialog_closed_event: threading.Event, parent = None) -> None:
         super().__init__(parent)
         self._component = None
         self._context = None
         self._view = None
-        self._qml_url = "WorkspaceDialog.qml"
-        self._lock = threading.Lock()
         self._default_strategy = None
         self._result = {
             "machine": self._default_strategy,
@@ -45,8 +42,7 @@ class WorkspaceDialog(QObject):
             "material": self._default_strategy,
         }
         self._override_machine = None
-        self._visible = False
-        self.showDialogSignal.connect(self.__show)
+        self._dialog_closed_event = dialog_closed_event
 
         self._has_quality_changes_conflict = False
         self._has_definition_changes_conflict = False
@@ -80,6 +76,12 @@ class WorkspaceDialog(QObject):
         self._exported_settings_model.modelChanged.connect(self.exportedSettingModelChanged.emit)
         self._current_machine_pos_index = 0
         self._is_ucp = False
+
+        three_mf_reader_path = PluginRegistry.getInstance().getPluginPath("3MFReader")
+        if three_mf_reader_path:
+            path = os.path.join(three_mf_reader_path, "WorkspaceDialog.qml")
+            self._view = CuraApplication.getInstance().createQmlComponent(path, initial_properties = {"manager": self})
+            self._view.show()
 
     machineConflictChanged = pyqtSignal()
     qualityChangesConflictChanged = pyqtSignal()
@@ -369,6 +371,7 @@ class WorkspaceDialog(QObject):
     @pyqtProperty(int, notify=exportedSettingModelChanged)
     def exportedSettingModelRowCount(self):
         return self._exported_settings_model.rowCount()
+
     @pyqtSlot()
     def closeBackend(self) -> None:
         """Close the backend: otherwise one could end up with "Slicing..."""
@@ -422,76 +425,21 @@ class WorkspaceDialog(QObject):
 
         return self._result
 
-    def _createViewFromQML(self) -> None:
-        three_mf_reader_path = PluginRegistry.getInstance().getPluginPath("3MFReader")
-        if three_mf_reader_path:
-            path = os.path.join(three_mf_reader_path, self._qml_url)
-            self._view = CuraApplication.getInstance().createQmlComponent(path, {"manager": self})
-
-    def show(self) -> None:
-        # Emit signal so the right thread actually shows the view.
-        if threading.current_thread() != threading.main_thread():
-            self._lock.acquire()
-        # Reset the result
-        self._result = {
-            "machine": self._default_strategy,
-            "quality_changes": self._default_strategy,
-            "definition_changes": self._default_strategy,
-            "material": self._default_strategy,
-        }
-        self._visible = True
-        self.showDialogSignal.emit()
-
     @pyqtSlot()
     def notifyClosed(self) -> None:
         """Used to notify the dialog so the lock can be released."""
-
-        self._result = {} # The result should be cleared before hide, because after it is released the main thread lock
-        self._visible = False
-        try:
-            self._lock.release()
-        except:
-            pass
-
-    def hide(self) -> None:
-        self._visible = False
-        self._view.hide()
-        try:
-            self._lock.release()
-        except:
-            pass
-
-    @pyqtSlot(bool)
-    def _onVisibilityChanged(self, visible: bool) -> None:
-        if not visible:
-            try:
-                self._lock.release()
-            except:
-                pass
+        self.onCancelButtonClicked()
 
     @pyqtSlot()
     def onOkButtonClicked(self) -> None:
         self._view.hide()
-        self.hide()
+        self._dialog_closed_event.set()
 
     @pyqtSlot()
     def onCancelButtonClicked(self) -> None:
         self._result = {}
         self._view.hide()
-        self.hide()
-
-    def waitForClose(self) -> None:
-        """Block thread until the dialog is closed."""
-
-        if self._visible:
-            if threading.current_thread() != threading.main_thread():
-                self._lock.acquire()
-                self._lock.release()
-            else:
-                # If this is not run from a separate thread, we need to ensure that the events are still processed.
-                while self._visible:
-                    time.sleep(1 / 50)
-                    QCoreApplication.processEvents()  # Ensure that the GUI does not freeze.
+        self._dialog_closed_event.set()
 
     @pyqtSlot()
     def showMissingMaterialsWarning(self) -> None:
@@ -527,10 +475,3 @@ class WorkspaceDialog(QObject):
             message.hide()
         elif sync_message_action == "learn_more":
             QDesktopServices.openUrl(QUrl("https://support.ultimaker.com/hc/en-us/articles/360011968360-Using-the-Ultimaker-Marketplace"))
-
-
-    def __show(self) -> None:
-        if self._view is None:
-            self._createViewFromQML()
-        if self._view:
-            self._view.show()

--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -11,6 +11,8 @@ import Cura 1.1 as Cura
 
 UM.Dialog
 {
+    property var manager
+
     id: workspaceDialog
     title: manager.isUcp? catalog.i18nc("@title:window Don't translate 'Universal Cura Project'", "Open Universal Cura Project (UCP)"): catalog.i18nc("@title:window", "Open Project")
 
@@ -75,13 +77,19 @@ UM.Dialog
             ListModel
             {
                 id: resolveStrategiesModel
+
+                signal initialized()
+
                 // Instead of directly adding the list elements, we add them afterwards.
                 // This is because it's impossible to use setting function results to be bound to listElement properties directly.
                 // See http://stackoverflow.com/questions/7659442/listelement-fields-as-properties
                 Component.onCompleted:
                 {
+                    console.log("init list")
                     append({"key": "override", "label": catalog.i18nc("@action:ComboBox Update/override existing profile", "Update existing")});
                     append({"key": "new", "label": catalog.i18nc("@action:ComboBox Save settings in a new profile", "Create new")});
+
+                    initialized();
                 }
             }
 
@@ -248,10 +256,13 @@ UM.Dialog
                             radius: UM.Theme.getSize("default_radius").width
                         }
 
-                        // This is a hack. This will trigger onCurrentIndexChanged and set the index when this component in loaded
-                        currentIndex:
-                        {
-                            currentIndex = 0
+                         Connections
+                         {
+                            target: resolveStrategiesModel
+                            function onInitialized()
+                            {
+                                currentIndex = 0;
+                            }
                         }
 
                         onCurrentIndexChanged:
@@ -343,10 +354,13 @@ UM.Dialog
                             radius: UM.Theme.getSize("default_radius").width
                         }
 
-                        // This is a hack. This will trigger onCurrentIndexChanged and set the index when this component in loaded
-                        currentIndex:
-                        {
-                            currentIndex = 0
+                        Connections
+                         {
+                            target: resolveStrategiesModel
+                            function onInitialized()
+                            {
+                                currentIndex = 0;
+                            }
                         }
 
                         onCurrentIndexChanged:

--- a/plugins/3MFReader/WorkspaceDialog.qml
+++ b/plugins/3MFReader/WorkspaceDialog.qml
@@ -85,7 +85,6 @@ UM.Dialog
                 // See http://stackoverflow.com/questions/7659442/listelement-fields-as-properties
                 Component.onCompleted:
                 {
-                    console.log("init list")
                     append({"key": "override", "label": catalog.i18nc("@action:ComboBox Update/override existing profile", "Update existing")});
                     append({"key": "new", "label": catalog.i18nc("@action:ComboBox Save settings in a new profile", "Create new")});
 

--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -422,7 +422,7 @@ Item
 
             onClicked:
             {
-                settingPickDialog.visible = true;
+                var settingPickDialog = settingPickDialogComponent.createObject(base)
                 if (currentMeshType === "support_mesh")
                 {
                     settingPickDialog.additional_excluded_settings = base.allCategoriesExceptSupport;
@@ -431,14 +431,16 @@ Item
                 {
                     settingPickDialog.additional_excluded_settings = [];
                 }
+                settingPickDialog.show();
             }
         }
 
     }
 
-    SettingPickDialog
+    Component
     {
-        id: settingPickDialog
+        id: settingPickDialogComponent
+        SettingPickDialog { selfDestroy: true; }
     }
 
     UM.SettingPropertyProvider

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.py
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.py
@@ -34,7 +34,7 @@ class PostProcessingPlugin(QObject, Extension):
         Extension.__init__(self)
         self.setMenuName(i18n_catalog.i18nc("@item:inmenu", "Post Processing"))
         self.addMenuItem(i18n_catalog.i18nc("@item:inmenu", "Modify G-Code"), self.showPopup)
-        self._view = None
+        self._dialog = None
 
         # Loaded scripts are all scripts that can be used
         self._loaded_scripts = {}  # type: Dict[str, Type[Script]]
@@ -50,7 +50,7 @@ class PostProcessingPlugin(QObject, Extension):
 
         Application.getInstance().getOutputDeviceManager().writeStarted.connect(self.execute)
         Application.getInstance().globalContainerStackChanged.connect(self._onGlobalContainerStackChanged)  # When the current printer changes, update the list of scripts.
-        CuraApplication.getInstance().mainWindowChanged.connect(self._createView)  # When the main window is created, create the view so that we can display the post-processing icon if necessary.
+        CuraApplication.getInstance().mainWindowChanged.connect(self._createSaveAreaButton)  # When the main window is created, create the view so that we can display the post-processing icon if necessary.
 
     selectedIndexChanged = pyqtSignal()
 
@@ -346,36 +346,36 @@ class PostProcessingPlugin(QObject, Extension):
         # We do want to listen to other events.
         self._global_container_stack.metaDataChanged.connect(self._restoreScriptInforFromMetadata)
 
-    def _createView(self) -> None:
-        """Creates the view used by show popup.
-
-        The view is saved because of the fairly aggressive garbage collection.
-        """
-
-        Logger.log("d", "Creating post processing plugin view.")
+    def _createSaveAreaButton(self) -> None:
+        """Creates the permanently displayed button on the bottom-right area."""
 
         self.loadAllScripts()
 
         # Create the plugin dialog component
-        path = os.path.join(cast(str, PluginRegistry.getInstance().getPluginPath("PostProcessingPlugin")), "PostProcessingPlugin.qml")
-        self._view = CuraApplication.getInstance().createQmlComponent(path, {"manager": self})
-        if self._view is None:
+        path = os.path.join(cast(str, PluginRegistry.getInstance().getPluginPath("PostProcessingPlugin")), "SaveAreaButton.qml")
+        button = CuraApplication.getInstance().createQmlComponent(path, {"manager": self})
+        if button is None:
             Logger.log("e", "Not creating PostProcessing button near save button because the QML component failed to be created.")
             return
-        Logger.log("d", "Post processing view created.")
 
-        # Create the save button component
-        CuraApplication.getInstance().addAdditionalComponent("saveButton", self._view.findChild(QObject, "postProcessingSaveAreaButton"))
+        # Register the component in the main view
+        CuraApplication.getInstance().addAdditionalComponent("saveButton", button)
+
+        button.clicked.connect(self.showPopup)
 
     def showPopup(self) -> None:
         """Show the (GUI) popup of the post processing plugin."""
 
-        if self._view is None:
-            self._createView()
-            if self._view is None:
-                Logger.log("e", "Not creating PostProcessing window since the QML component failed to be created.")
-                return
-        self._view.show()
+        self.loadAllScripts()
+
+        # Create the plugin dialog component
+        path = os.path.join(cast(str, PluginRegistry.getInstance().getPluginPath("PostProcessingPlugin")),
+                            "PostProcessingPlugin.qml")
+        self._dialog = CuraApplication.getInstance().createQmlComponent(path, {"manager": self})
+        if self._dialog is None:
+            return
+
+        self._dialog.show()
 
     def _propertyChanged(self) -> None:
         """Property changed: trigger re-slice

--- a/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
+++ b/plugins/PostProcessingPlugin/PostProcessingPlugin.qml
@@ -20,6 +20,7 @@ UM.Dialog
     minimumWidth: 400 * screenScaleFactor
     minimumHeight: 250 * screenScaleFactor
     backgroundColor: UM.Theme.getColor("main_background")
+    selfDestroy: true
     onVisibleChanged:
     {
         // Whenever the window is closed (either via the "Close" button or the X on the window frame), we want to update it in the stack.
@@ -505,53 +506,5 @@ UM.Dialog
     {
         text: catalog.i18nc("@action:button", "Close")
         onClicked: dialog.accept()
-    }
-
-    Item
-    {
-        objectName: "postProcessingSaveAreaButton"
-        visible: activeScriptsList.count > 0
-        height: UM.Theme.getSize("action_button").height
-        width: height
-
-        Cura.SecondaryButton
-        {
-            height: UM.Theme.getSize("action_button").height
-            tooltip:
-            {
-                var tipText = catalog.i18nc("@info:tooltip", "Change active post-processing scripts.");
-                if (activeScriptsList.count > 0)
-                {
-                    tipText += "<br><br>" + catalog.i18ncp("@info:tooltip",
-                        "The following script is active:",
-                        "The following scripts are active:",
-                        activeScriptsList.count
-                    ) + "<ul>";
-                    for(var i = 0; i < activeScriptsList.count; i++)
-                    {
-                        tipText += "<li>" + manager.getScriptLabelByKey(manager.scriptList[i]) + "</li>";
-                    }
-                    tipText += "</ul>";
-                }
-                return tipText
-            }
-            toolTipContentAlignment: UM.Enums.ContentAlignment.AlignLeft
-            onClicked: dialog.show()
-            iconSource: Qt.resolvedUrl("Script.svg")
-            fixedWidthMode: false
-        }
-
-        Cura.NotificationIcon
-        {
-            id: activeScriptCountIcon
-            visible: activeScriptsList.count > 0
-            anchors
-            {
-                horizontalCenter: parent.right
-                verticalCenter: parent.top
-            }
-
-            labelText: activeScriptsList.count
-        }
     }
 }

--- a/plugins/PostProcessingPlugin/SaveAreaButton.qml
+++ b/plugins/PostProcessingPlugin/SaveAreaButton.qml
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 UltiMaker
+// The PostProcessingPlugin is released under the terms of the LGPLv3 or higher.
+
+import QtQuick 2.2
+import QtQuick.Controls 2.15
+import QtQml.Models 2.15 as Models
+import QtQuick.Layouts 1.1
+import QtQuick.Window 2.2
+
+import UM 1.5 as UM
+import Cura 1.0 as Cura
+
+Item
+{
+    id: base
+    objectName: "postProcessingSaveAreaButton"
+    visible: manager.scriptList.length > 0
+    height: UM.Theme.getSize("action_button").height
+    width: height
+
+    signal clicked
+
+    Cura.SecondaryButton
+    {
+        height: UM.Theme.getSize("action_button").height
+        tooltip:
+        {
+            var tipText = catalog.i18nc("@info:tooltip", "Change active post-processing scripts.");
+            if (manager.scriptList.length > 0)
+            {
+                tipText += "<br><br>" + catalog.i18ncp("@info:tooltip",
+                    "The following script is active:",
+                    "The following scripts are active:",
+                    manager.scriptList.length
+                ) + "<ul>";
+                for(var i = 0; i < manager.scriptList.length; i++)
+                {
+                    tipText += "<li>" + manager.getScriptLabelByKey(manager.scriptList[i]) + "</li>";
+                }
+                tipText += "</ul>";
+            }
+            return tipText
+        }
+        toolTipContentAlignment: UM.Enums.ContentAlignment.AlignLeft
+        onClicked: base.clicked()
+        iconSource: Qt.resolvedUrl("Script.svg")
+        fixedWidthMode: false
+    }
+
+    Cura.NotificationIcon
+    {
+        id: activeScriptCountIcon
+        visible: manager.scriptList.length > 0
+        anchors
+        {
+            horizontalCenter: parent.right
+            verticalCenter: parent.top
+        }
+
+        labelText: manager.scriptList.length
+    }
+}

--- a/plugins/SliceInfoPlugin/SliceInfo.py
+++ b/plugins/SliceInfoPlugin/SliceInfo.py
@@ -61,14 +61,6 @@ class SliceInfo(QObject, Extension):
         self._more_info_dialog = None
         self._example_data_content = None
 
-        self._application.initializationFinished.connect(self._onAppInitialized)
-
-    def _onAppInitialized(self):
-        # DO NOT read any preferences values in the constructor because at the time plugins are created, no version
-        # upgrade has been performed yet because version upgrades are plugins too!
-        if self._more_info_dialog is None:
-            self._more_info_dialog = self._createDialog("MoreInfoWindow.qml")
-
     def messageActionTriggered(self, message_id, action_id):
         """Perform action based on user input.
 

--- a/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
+++ b/plugins/UM3NetworkPrinting/resources/qml/MonitorPrinterCard.qml
@@ -451,7 +451,13 @@ Item
             }
             text: catalog.i18nc("@action:button", "Details")
             visible: printer && printer.activePrintJob && printer.activePrintJob.configurationChanges.length > 0 && !printerStatus.visible
-            onClicked: base.enabled ? overrideConfirmationDialog.open() : {}
+            onClicked:
+            {
+                if(base.enabled)
+                {
+                    overrideConfirmationDialogComponent.createObject(base).open();
+                }
+            }
             enabled: OutputDevice.supportsPrintJobActions
         }
 
@@ -474,9 +480,13 @@ Item
         }
     }
 
-    MonitorConfigOverrideDialog
+    Component
     {
-        id: overrideConfirmationDialog
-        printer: base.printer
+        id: overrideConfirmationDialogComponent
+        MonitorConfigOverrideDialog
+        {
+            printer: base.printer
+            selfDestroy: true
+        }
     }
 }

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -71,30 +71,33 @@ UM.MainWindow
 
     }
 
-    Rectangle
+    Component
     {
-        id: greyOutBackground
-        anchors.fill: parent
-        visible: welcomeDialogItem.visible
-        color: UM.Theme.getColor("window_disabled_background")
-        opacity: 0.7
-        z: stageMenu.z + 1
+        id: welcomeDialogComponent
 
-        MouseArea
+        WelcomeDialogItem { model: WelcomePagesModel{} }
+    }
+
+    Component
+    {
+        id: whatsNewModalComponent
+
+        WelcomeDialogItem
         {
-            // Prevent all mouse events from passing through.
-            enabled: parent.visible
-            anchors.fill: parent
-            hoverEnabled: true
-            acceptedButtons: Qt.AllButtons
+            model: WhatsNewPagesModel{}
+            progressBarVisible: false
         }
     }
 
-    WelcomeDialogItem
+    Component
     {
-        id: welcomeDialogItem
-        visible: false
-        z: greyOutBackground.z + 1
+        id: addPrinterModalModalComponent
+
+        WelcomeDialogItem
+        {
+            model: AddPrinterPagesModel{}
+            progressBarVisible: false
+        }
     }
 
     Component.onCompleted:
@@ -112,9 +115,7 @@ UM.MainWindow
             Cura.Actions.parent = backgroundItem
 
             // Reuse the welcome dialog item to show "Add a printer" only.
-            welcomeDialogItem.model = CuraApplication.getAddPrinterPagesModelWithoutCancel()
-            welcomeDialogItem.progressBarVisible = false
-            welcomeDialogItem.visible = true
+            addPrinterModalModalComponent.createObject(base);
         }
     }
 
@@ -137,28 +138,21 @@ UM.MainWindow
 
             if (CuraApplication.shouldShowWelcomeDialog())
             {
-                welcomeDialogItem.visible = true
-            }
-            else
-            {
-                welcomeDialogItem.visible = false
-            }
-
-            // Reuse the welcome dialog item to show "What's New" only.
-            if (CuraApplication.shouldShowWhatsNewDialog())
-            {
-                welcomeDialogItem.model = CuraApplication.getWhatsNewPagesModel()
-                welcomeDialogItem.progressBarVisible = false
-                welcomeDialogItem.visible = true
-            }
-
-            // Reuse the welcome dialog item to show the "Add printers" dialog. Triggered when there is no active
-            // machine and the user is logged in.
-            if (!Cura.MachineManager.activeMachine && Cura.API.account.isLoggedIn)
-            {
-                welcomeDialogItem.model = CuraApplication.getAddPrinterPagesModelWithoutCancel()
-                welcomeDialogItem.progressBarVisible = false
-                welcomeDialogItem.visible = true
+                if (CuraApplication.shouldShowWhatsNewDialog())
+                {
+                    // Reuse the welcome dialog item to show "What's New" only.
+                    whatsNewModalComponent.createObject(base);
+                }
+                else if (!Cura.MachineManager.activeMachine && Cura.API.account.isLoggedIn)
+                {
+                    // Reuse the welcome dialog item to show the "Add printers" dialog. Triggered when there is no active
+                    // machine and the user is logged in.
+                    addPrinterModalModalComponent.createObject(base);
+                }
+                else
+                {
+                    welcomeDialogComponent.createObject(base);
+                }
             }
         }
     }
@@ -831,7 +825,6 @@ UM.MainWindow
         }
     }
 
-    property var wizardDialog
     Component
     {
         id: addMachineDialogLoader
@@ -841,34 +834,42 @@ UM.MainWindow
             title: catalog.i18nc("@title:window", "Add Printer")
             maximumWidth: Screen.width * 2
             maximumHeight: Screen.height * 2
-            model: CuraApplication.getAddPrinterPagesModel()
+            model: AddPrinterPagesModel{}
             progressBarVisible: false
+
             onVisibleChanged:
             {
                 if(!visible)
                 {
-                    wizardDialog = null
                     Cura.API.account.startSyncing()
                 }
             }
         }
     }
 
-    Cura.WizardDialog
+    Component
     {
-        id: whatsNewDialog
-        title: catalog.i18nc("@title:window", "What's New")
-        minimumWidth: UM.Theme.getSize("welcome_wizard_window").width
-        minimumHeight: UM.Theme.getSize("welcome_wizard_window").height
-        model: CuraApplication.getWhatsNewPagesModel()
-        progressBarVisible: false
-        visible: false
+        id: whatsNewDialogLoader
+
+        Cura.WizardDialog
+        {
+            id: whatsNewDialog
+            title: catalog.i18nc("@title:window", "What's New")
+            minimumWidth: UM.Theme.getSize("welcome_wizard_window").width
+            minimumHeight: UM.Theme.getSize("welcome_wizard_window").height
+            model: Cura.WhatsNewPagesModel{}
+            progressBarVisible: false
+            visible: false
+        }
     }
 
     Connections
     {
         target: Cura.Actions.whatsNew
-        function onTriggered() { whatsNewDialog.show() }
+        function onTriggered()
+        {
+            whatsNewDialogLoader.createObject(base).show();
+        }
     }
 
     Connections
@@ -876,9 +877,8 @@ UM.MainWindow
         target: Cura.Actions.addMachine
         function onTriggered()
         {
-            Cura.API.account.stopSyncing()
-            wizardDialog = addMachineDialogLoader.createObject()
-            wizardDialog.show()
+            Cura.API.account.stopSyncing();
+            addMachineDialogLoader.createObject(base).show();
         }
     }
 

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -247,8 +247,7 @@ UM.MainWindow
                             {
                                 // Try to install plugin & close.
                                 CuraApplication.installPackageViaDragAndDrop(filename);
-                                packageInstallDialog.text = catalog.i18nc("@label", "This package will be installed after restarting.");
-                                packageInstallDialog.open();
+                                packageInstallDialogComponent.createObject(base).open();
                             }
                             else
                             {
@@ -556,20 +555,25 @@ UM.MainWindow
         }
     }
 
-    Cura.MessageDialog
+    Component
     {
-        id: exitConfirmationDialog
-        title: catalog.i18nc("@title:window %1 is the application name", "Closing %1").arg(CuraApplication.applicationDisplayName)
-        text: catalog.i18nc("@label %1 is the application name", "Are you sure you want to exit %1?").arg(CuraApplication.applicationDisplayName)
-        standardButtons: Dialog.Yes | Dialog.No
-        onAccepted: CuraApplication.callConfirmExitDialogCallback(true)
-        onRejected: CuraApplication.callConfirmExitDialogCallback(false)
-        onClosed:
+        id: exitConfirmationDialogComponent
+
+        Cura.MessageDialog
         {
-            if (!visible)
+            id: exitConfirmationDialog
+            title: catalog.i18nc("@title:window %1 is the application name", "Closing %1").arg(CuraApplication.applicationDisplayName)
+            standardButtons: Dialog.Yes | Dialog.No
+            onAccepted: CuraApplication.callConfirmExitDialogCallback(true)
+            onRejected: CuraApplication.callConfirmExitDialogCallback(false)
+            selfDestroy: true
+            onClosed:
             {
-                // reset the text to default because other modules may change the message text.
-                text = catalog.i18nc("@label %1 is the application name", "Are you sure you want to exit %1?").arg(CuraApplication.applicationDisplayName);
+                if (!visible)
+                {
+                    // reset the text to default because other modules may change the message text.
+                    text = catalog.i18nc("@label %1 is the application name", "Are you sure you want to exit %1?").arg(CuraApplication.applicationDisplayName);
+                }
             }
         }
     }
@@ -579,6 +583,7 @@ UM.MainWindow
         target: CuraApplication
         function onShowConfirmExitDialog(message)
         {
+            var exitConfirmationDialog = exitConfirmationDialogComponent.createObject(base);
             exitConfirmationDialog.text = message;
             exitConfirmationDialog.open();
         }
@@ -655,6 +660,7 @@ UM.MainWindow
             var selectedMultipleFiles = fileUrlList.length > 1;
             if (selectedMultipleFiles && hasGcode)
             {
+                var infoMultipleFilesWithGcodeDialog = infoMultipleFilesWithGcodeDialogComponent.createObject(base)
                 infoMultipleFilesWithGcodeDialog.selectedMultipleFiles = selectedMultipleFiles;
                 infoMultipleFilesWithGcodeDialog.hasProjectFile = hasProjectFile;
                 infoMultipleFilesWithGcodeDialog.fileUrls = nonGcodeFileList.slice();
@@ -709,28 +715,39 @@ UM.MainWindow
         }
     }
 
-    Cura.MessageDialog
+    Component
     {
-        id: packageInstallDialog
-        title: catalog.i18nc("@window:title", "Install Package")
-        standardButtons: Dialog.Ok
+        id: packageInstallDialogComponent
+
+        Cura.MessageDialog
+        {
+            title: catalog.i18nc("@window:title", "Install Package")
+            text: catalog.i18nc("@label", "This package will be installed after restarting.")
+            standardButtons: Dialog.Ok
+            selfDestroy: true
+        }
     }
 
-    Cura.MessageDialog
+    Component
     {
-        id: infoMultipleFilesWithGcodeDialog
-        title: catalog.i18nc("@title:window", "Open File(s)")
-        standardButtons: Dialog.Ok
-        text: catalog.i18nc("@text:window", "We have found one or more G-Code files within the files you have selected. You can only open one G-Code file at a time. If you want to open a G-Code file, please just select only one.")
+        id: infoMultipleFilesWithGcodeDialogComponent
 
-        property var selectedMultipleFiles
-        property var hasProjectFile
-        property var fileUrls
-        property var projectFileUrlList
-
-        onAccepted:
+        Cura.MessageDialog
         {
-            openDialog.handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrls, projectFileUrlList);
+            title: catalog.i18nc("@title:window", "Open File(s)")
+            standardButtons: Dialog.Ok
+            text: catalog.i18nc("@text:window", "We have found one or more G-Code files within the files you have selected. You can only open one G-Code file at a time. If you want to open a G-Code file, please just select only one.")
+            selfDestroy: true
+
+            property var selectedMultipleFiles
+            property var hasProjectFile
+            property var fileUrls
+            property var projectFileUrlList
+
+            onAccepted:
+            {
+                openDialog.handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrls, projectFileUrlList);
+            }
         }
     }
 

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -673,41 +673,46 @@ UM.MainWindow
         function handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrlList, projectFileUrlList)
         {
             // Make sure the files opened through the openFilesIncludingProjectDialog are added to the recent files list
-            openFilesIncludingProjectsDialog.addToRecent = true;
-
-            // we only allow opening one project file
-            if (selectedMultipleFiles && hasProjectFile)
-            {
-                openFilesIncludingProjectsDialog.fileUrls = fileUrlList.slice();
-                openFilesIncludingProjectsDialog.show();
-                return;
-            }
+            const addToRecent = true;
 
             if (hasProjectFile)
             {
-                var projectFile = projectFileUrlList[0]
-                // check preference
-                var choice = UM.Preferences.getValue("cura/choice_on_open_project");
-                if (choice == "open_as_project")
+                if (selectedMultipleFiles)
                 {
-                    openFilesIncludingProjectsDialog.loadProjectFile(projectFile);
+                    var openFilesIncludingProjectsDialog = openFilesIncludingProjectsDialogComponent.createObject(base,
+                        {"fileUrls": fileUrlList.slice(), "addToRecent": addToRecent});
+                    openFilesIncludingProjectsDialog.show();
                 }
-                else if (choice == "open_as_model")
+                else
                 {
-                    openFilesIncludingProjectsDialog.loadModelFiles([projectFile].slice());
-                }
-                else    // always ask
-                {
-                    // ask whether to open as project or as models
-                    askOpenAsProjectOrModelsDialog.is_ucp = CuraApplication.isProjectUcp(projectFile);
-                    askOpenAsProjectOrModelsDialog.fileUrl = projectFile;
-                    askOpenAsProjectOrModelsDialog.addToRecent = true;
-                    askOpenAsProjectOrModelsDialog.show();
+                    var projectFile = projectFileUrlList[0];
+
+                    // check preference
+                    var choice = UM.Preferences.getValue("cura/choice_on_open_project");
+                    if (choice == "open_as_project")
+                    {
+                        loadProjectFile(projectFile, addToRecent);
+                    }
+                    else if (choice == "open_as_model")
+                    {
+                        loadModelFiles([projectFile].slice(), addToRecent);
+                    }
+                    else // always ask
+                    {
+                        var askOpenAsProjectOrModelsDialog =
+                            askOpenAsProjectOrModelsDialogComponent.createObject(base,
+                                {
+                                    "is_ucp": CuraApplication.isProjectUcp(projectFile),
+                                    "fileUrl": projectFile,
+                                    "addToRecent": addToRecent
+                                });
+                        askOpenAsProjectOrModelsDialog.show();
+                    }
                 }
             }
             else
             {
-                openFilesIncludingProjectsDialog.loadModelFiles(fileUrlList.slice());
+                loadModelFiles(fileUrlList.slice(), addToRecent);
             }
         }
     }
@@ -754,14 +759,20 @@ UM.MainWindow
         function onTriggered() { openDialog.open() }
     }
 
-    OpenFilesIncludingProjectsDialog
+    Component
     {
-        id: openFilesIncludingProjectsDialog
+        id: openFilesIncludingProjectsDialogComponent
+        OpenFilesIncludingProjectsDialog
+        {
+            selfDestroy: true
+            onAccepted: base.loadModelFiles(fileUrls, addToRecent)
+        }
     }
 
-    AskOpenAsProjectOrModelsDialog
+    Component
     {
-        id: askOpenAsProjectOrModelsDialog
+        id: askOpenAsProjectOrModelsDialogComponent
+        AskOpenAsProjectOrModelsDialog { selfDestroy: true }
     }
 
     Connections
@@ -769,10 +780,25 @@ UM.MainWindow
         target: CuraApplication
         function onOpenProjectFile(project_file, add_to_recent_files)
         {
-            askOpenAsProjectOrModelsDialog.is_ucp = CuraApplication.isProjectUcp(project_file);
-            askOpenAsProjectOrModelsDialog.fileUrl = project_file;
-            askOpenAsProjectOrModelsDialog.addToRecent = add_to_recent_files;
+            var askOpenAsProjectOrModelsDialog =
+                askOpenAsProjectOrModelsDialogComponent.createObject(base,
+                    {"is_ucp": CuraApplication.isProjectUcp(project_file),
+                              "fileUrl": project_file,
+                              "addToRecent": add_to_recent_files});
             askOpenAsProjectOrModelsDialog.show();
+        }
+    }
+
+    function loadProjectFile(projectFile, addToRecent)
+    {
+        UM.WorkspaceFileHandler.readLocalFile(projectFile, addToRecent);
+    }
+
+    function loadModelFiles(fileUrls, addToRecent)
+    {
+        for (var i in fileUrls)
+        {
+            CuraApplication.readLocalFile(fileUrls[i], "open_as_model", addToRecent);
         }
     }
 

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -254,7 +254,7 @@ UM.MainWindow
                                 nonPackages.push(filename);
                             }
                         }
-                        openDialog.handleOpenFileUrls(nonPackages);
+                        base.handleOpenFileUrls(nonPackages);
                     }
                 }
             }
@@ -604,115 +604,28 @@ UM.MainWindow
         function onTriggered() { base.exitFullscreen() }
     }
 
-    FileDialog
+    Component
     {
-        id: openDialog;
+        id: openDialogComponent
 
-        //: File open dialog title
-        title: catalog.i18nc("@title:window","Open file(s)")
-        modality: Qt.WindowModal
-        fileMode: FileDialog.FileMode.OpenFiles
-        nameFilters: UM.MeshFileHandler.supportedReadFileTypes;
-        currentFolder: CuraApplication.getDefaultPath("dialog_load_path")
-        onAccepted:
+        FileDialog
         {
-            // Because several implementations of the file dialog only update the folder
-            // when it is explicitly set.
-            var f = currentFolder;
-            currentFolder = f;
-
-            CuraApplication.setDefaultPath("dialog_load_path", currentFolder);
-
-            handleOpenFileUrls(selectedFiles);
-        }
-
-        // Yeah... I know... it is a mess to put all those things here.
-        // There are lots of user interactions in this part of the logic, such as showing a warning dialog here and there,
-        // etc. This means it will come back and forth from time to time between QML and Python. So, separating the logic
-        // and view here may require more effort but make things more difficult to understand.
-        function handleOpenFileUrls(fileUrlList)
-        {
-            // look for valid project files
-            var projectFileUrlList = [];
-            var hasGcode = false;
-            var nonGcodeFileList = [];
-            for (var i in fileUrlList)
+            //: File open dialog title
+            title: catalog.i18nc("@title:window", "Open file(s)")
+            modality: Qt.WindowModal
+            fileMode: FileDialog.FileMode.OpenFiles
+            nameFilters: UM.MeshFileHandler.supportedReadFileTypes;
+            currentFolder: CuraApplication.getDefaultPath("dialog_load_path")
+            onAccepted:
             {
-                var endsWithG = /\.g$/;
-                var endsWithGcode = /\.gcode$/;
-                if (endsWithG.test(fileUrlList[i]) || endsWithGcode.test(fileUrlList[i]))
-                {
-                    continue;
-                }
-                else if (CuraApplication.checkIsValidProjectFile(fileUrlList[i]))
-                {
-                    projectFileUrlList.push(fileUrlList[i]);
-                }
-                nonGcodeFileList.push(fileUrlList[i]);
-            }
-            hasGcode = nonGcodeFileList.length < fileUrlList.length;
+                // Because several implementations of the file dialog only update the folder
+                // when it is explicitly set.
+                var f = currentFolder;
+                currentFolder = f;
 
-            // show a warning if selected multiple files together with Gcode
-            var hasProjectFile = projectFileUrlList.length > 0;
-            var selectedMultipleFiles = fileUrlList.length > 1;
-            if (selectedMultipleFiles && hasGcode)
-            {
-                var infoMultipleFilesWithGcodeDialog = infoMultipleFilesWithGcodeDialogComponent.createObject(base)
-                infoMultipleFilesWithGcodeDialog.selectedMultipleFiles = selectedMultipleFiles;
-                infoMultipleFilesWithGcodeDialog.hasProjectFile = hasProjectFile;
-                infoMultipleFilesWithGcodeDialog.fileUrls = nonGcodeFileList.slice();
-                infoMultipleFilesWithGcodeDialog.projectFileUrlList = projectFileUrlList.slice();
-                infoMultipleFilesWithGcodeDialog.open();
-            }
-            else
-            {
-                handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrlList, projectFileUrlList);
-            }
-        }
+                CuraApplication.setDefaultPath("dialog_load_path", currentFolder);
 
-        function handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrlList, projectFileUrlList)
-        {
-            // Make sure the files opened through the openFilesIncludingProjectDialog are added to the recent files list
-            const addToRecent = true;
-
-            if (hasProjectFile)
-            {
-                if (selectedMultipleFiles)
-                {
-                    var openFilesIncludingProjectsDialog = openFilesIncludingProjectsDialogComponent.createObject(base,
-                        {"fileUrls": fileUrlList.slice(), "addToRecent": addToRecent});
-                    openFilesIncludingProjectsDialog.show();
-                }
-                else
-                {
-                    var projectFile = projectFileUrlList[0];
-
-                    // check preference
-                    var choice = UM.Preferences.getValue("cura/choice_on_open_project");
-                    if (choice == "open_as_project")
-                    {
-                        loadProjectFile(projectFile, addToRecent);
-                    }
-                    else if (choice == "open_as_model")
-                    {
-                        loadModelFiles([projectFile].slice(), addToRecent);
-                    }
-                    else // always ask
-                    {
-                        var askOpenAsProjectOrModelsDialog =
-                            askOpenAsProjectOrModelsDialogComponent.createObject(base,
-                                {
-                                    "is_ucp": CuraApplication.isProjectUcp(projectFile),
-                                    "fileUrl": projectFile,
-                                    "addToRecent": addToRecent
-                                });
-                        askOpenAsProjectOrModelsDialog.show();
-                    }
-                }
-            }
-            else
-            {
-                loadModelFiles(fileUrlList.slice(), addToRecent);
+                base.handleOpenFileUrls(selectedFiles);
             }
         }
     }
@@ -748,7 +661,7 @@ UM.MainWindow
 
             onAccepted:
             {
-                openDialog.handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrls, projectFileUrlList);
+                base.handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrls, projectFileUrlList);
             }
         }
     }
@@ -756,7 +669,7 @@ UM.MainWindow
     Connections
     {
         target: Cura.Actions.open
-        function onTriggered() { openDialog.open() }
+        function onTriggered() { openDialogComponent.createObject(base).open() }
     }
 
     Component
@@ -799,6 +712,96 @@ UM.MainWindow
         for (var i in fileUrls)
         {
             CuraApplication.readLocalFile(fileUrls[i], "open_as_model", addToRecent);
+        }
+    }
+
+    // Yeah... I know... it is a mess to put all those things here.
+    // There are lots of user interactions in this part of the logic, such as showing a warning dialog here and there,
+    // etc. This means it will come back and forth from time to time between QML and Python. So, separating the logic
+    // and view here may require more effort but make things more difficult to understand.
+    function handleOpenFileUrls(fileUrlList)
+    {
+        // look for valid project files
+        var projectFileUrlList = [];
+        var hasGcode = false;
+        var nonGcodeFileList = [];
+        for (var i in fileUrlList)
+        {
+            var endsWithG = /\.g$/;
+            var endsWithGcode = /\.gcode$/;
+            if (endsWithG.test(fileUrlList[i]) || endsWithGcode.test(fileUrlList[i]))
+            {
+                continue;
+            }
+            else if (CuraApplication.checkIsValidProjectFile(fileUrlList[i]))
+            {
+                projectFileUrlList.push(fileUrlList[i]);
+            }
+            nonGcodeFileList.push(fileUrlList[i]);
+        }
+        hasGcode = nonGcodeFileList.length < fileUrlList.length;
+
+        // show a warning if selected multiple files together with Gcode
+        var hasProjectFile = projectFileUrlList.length > 0;
+        var selectedMultipleFiles = fileUrlList.length > 1;
+        if (selectedMultipleFiles && hasGcode)
+        {
+            var infoMultipleFilesWithGcodeDialog = infoMultipleFilesWithGcodeDialogComponent.createObject(base)
+            infoMultipleFilesWithGcodeDialog.selectedMultipleFiles = selectedMultipleFiles;
+            infoMultipleFilesWithGcodeDialog.hasProjectFile = hasProjectFile;
+            infoMultipleFilesWithGcodeDialog.fileUrls = nonGcodeFileList.slice();
+            infoMultipleFilesWithGcodeDialog.projectFileUrlList = projectFileUrlList.slice();
+            infoMultipleFilesWithGcodeDialog.open();
+        }
+        else
+        {
+            base.handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrlList, projectFileUrlList);
+        }
+    }
+
+    function handleOpenFiles(selectedMultipleFiles, hasProjectFile, fileUrlList, projectFileUrlList)
+    {
+        // Make sure the files opened through the openFilesIncludingProjectDialog are added to the recent files list
+        const addToRecent = true;
+
+        if (hasProjectFile)
+        {
+            if (selectedMultipleFiles)
+            {
+                var openFilesIncludingProjectsDialog = openFilesIncludingProjectsDialogComponent.createObject(base,
+                    {"fileUrls": fileUrlList.slice(), "addToRecent": addToRecent});
+                openFilesIncludingProjectsDialog.show();
+            }
+            else
+            {
+                var projectFile = projectFileUrlList[0];
+
+                // check preference
+                var choice = UM.Preferences.getValue("cura/choice_on_open_project");
+                if (choice == "open_as_project")
+                {
+                    loadProjectFile(projectFile, addToRecent);
+                }
+                else if (choice == "open_as_model")
+                {
+                    loadModelFiles([projectFile].slice(), addToRecent);
+                }
+                else // always ask
+                {
+                    var askOpenAsProjectOrModelsDialog =
+                        askOpenAsProjectOrModelsDialogComponent.createObject(base,
+                            {
+                                "is_ucp": CuraApplication.isProjectUcp(projectFile),
+                                "fileUrl": projectFile,
+                                "addToRecent": addToRecent
+                            });
+                    askOpenAsProjectOrModelsDialog.show();
+                }
+            }
+        }
+        else
+        {
+            loadModelFiles(fileUrlList.slice(), addToRecent);
         }
     }
 

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -452,10 +452,7 @@ UM.MainWindow
     Component
     {
         id: preferencesDialogComponent
-        Cura.PreferencesDialog
-        {
-            selfDestroy: true
-        }
+        Cura.PreferencesDialog { selfDestroy: true }
     }
 
     function showPreferencesDialog()
@@ -482,7 +479,7 @@ UM.MainWindow
         target: Cura.Actions.addProfile
         function onTriggered()
         {
-            createNewQualityDialog.visible = true;
+            createNewQualityDialogComponent.createObject(base).show()
         }
     }
 
@@ -821,20 +818,17 @@ UM.MainWindow
     Component
     {
         id: discardOrKeepProfileChangesDialogComponent
-        DiscardOrKeepProfileChangesDialog { }
+        DiscardOrKeepProfileChangesDialog { selfDestroy: true }
     }
-    Loader
-    {
-        id: discardOrKeepProfileChangesDialogLoader
-    }
+
     Connections
     {
         target: CuraApplication
         function onShowCompareAndSaveProfileChanges(profileState)
         {
-            discardOrKeepProfileChangesDialogLoader.sourceComponent = discardOrKeepProfileChangesDialogComponent
-            discardOrKeepProfileChangesDialogLoader.item.buttonState = profileState
-            discardOrKeepProfileChangesDialogLoader.item.show()
+            var discardOrKeepProfileChangesDialog = discardOrKeepProfileChangesDialogComponent.createObject(base)
+            discardOrKeepProfileChangesDialog.buttonState = profileState
+            discardOrKeepProfileChangesDialog.show()
         }
         function onShowDiscardOrKeepProfileChanges()
         {
@@ -899,15 +893,16 @@ UM.MainWindow
         }
     }
 
-    AboutDialog
+    Component
     {
-        id: aboutDialog
+        id: aboutDialogComponent
+        AboutDialog { selfDestroy: true }
     }
 
     Connections
     {
         target: Cura.Actions.about
-        function onTriggered() { aboutDialog.visible = true; }
+        function onTriggered() { aboutDialogComponent.createObject(base).show(); }
     }
 
     Timer
@@ -925,47 +920,52 @@ UM.MainWindow
         }
     }
 
-    Cura.RenameDialog
+    Component
     {
-        id: createNewQualityDialog
-        title: catalog.i18nc("@title:window", "Save Custom Profile")
-        objectPlaceholder: catalog.i18nc("@textfield:placeholder", "New Custom Profile")
-        explanation: catalog.i18nc("@info", "Custom profile name:")
-        extraInfo:
-        [
-            UM.ColorImage
-            {
-                width: UM.Theme.getSize("message_type_icon").width
-                height: UM.Theme.getSize("message_type_icon").height
-                source: UM.Theme.getIcon("Information")
-                color: UM.Theme.getColor("text")
-            },
-            Column
-            {
-                UM.Label
-                {
-                    text: catalog.i18nc
-                    (
-                        "@label %i will be replaced with a profile name",
-                        "<b>Only user changed settings will be saved in the custom profile.</b><br/>" +
-                        "For materials that support it, the new custom profile will inherit properties from <b>%1</b>."
-                    ).arg(Cura.MachineManager.activeQualityOrQualityChangesName)
-                    wrapMode: Text.WordWrap
-                    width: parent.parent.width - 2 * UM.Theme.getSize("message_type_icon").width
-                }
-                Cura.TertiaryButton
-                {
-                    text: catalog.i18nc("@action:button", "Learn more about Cura print profiles")
-                    iconSource: UM.Theme.getIcon("LinkExternal")
-                    isIconOnRightSide: true
-                    leftPadding: 0
-                    rightPadding: 0
-                    onClicked: Qt.openUrlExternally("https://support.ultimaker.com/s/article/1667337576882")
-                }
-            }
-        ]
-        okButtonText: catalog.i18nc("@button", "Save new profile")
-        onAccepted: CuraApplication.getQualityManagementModel().createQualityChanges(newName, true);
+        id: createNewQualityDialogComponent
+
+        Cura.RenameDialog
+        {
+            selfDestroy: true
+            title: catalog.i18nc("@title:window", "Save Custom Profile")
+            objectPlaceholder: catalog.i18nc("@textfield:placeholder", "New Custom Profile")
+            explanation: catalog.i18nc("@info", "Custom profile name:")
+            extraInfo:
+                [
+                    UM.ColorImage
+                    {
+                        width: UM.Theme.getSize("message_type_icon").width
+                        height: UM.Theme.getSize("message_type_icon").height
+                        source: UM.Theme.getIcon("Information")
+                        color: UM.Theme.getColor("text")
+                    },
+                    Column
+                    {
+                        UM.Label
+                        {
+                            text: catalog.i18nc
+                            (
+                                "@label %i will be replaced with a profile name",
+                                "<b>Only user changed settings will be saved in the custom profile.</b><br/>" +
+                                "For materials that support it, the new custom profile will inherit properties from <b>%1</b>."
+                            ).arg(Cura.MachineManager.activeQualityOrQualityChangesName)
+                            wrapMode: Text.WordWrap
+                            width: parent.parent.width - 2 * UM.Theme.getSize("message_type_icon").width
+                        }
+                        Cura.TertiaryButton
+                        {
+                            text: catalog.i18nc("@action:button", "Learn more about Cura print profiles")
+                            iconSource: UM.Theme.getIcon("LinkExternal")
+                            isIconOnRightSide: true
+                            leftPadding: 0
+                            rightPadding: 0
+                            onClicked: Qt.openUrlExternally("https://support.ultimaker.com/s/article/1667337576882")
+                        }
+                    }
+                ]
+            okButtonText: catalog.i18nc("@button", "Save new profile")
+            onAccepted: CuraApplication.getQualityManagementModel().createQualityChanges(newName, true);
+        }
     }
 
     /**

--- a/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml
+++ b/resources/qml/Dialogs/OpenFilesIncludingProjectsDialog.qml
@@ -27,21 +27,6 @@ UM.Dialog
     property var fileUrls: []
     property var addToRecent: true
 
-    function loadProjectFile(projectFile)
-    {
-        UM.WorkspaceFileHandler.readLocalFile(projectFile, base.addToRecent);
-    }
-
-    function loadModelFiles(fileUrls)
-    {
-        for (var i in fileUrls)
-        {
-            CuraApplication.readLocalFile(fileUrls[i], "open_as_model", base.addToRecent);
-        }
-    }
-
-    onAccepted: loadModelFiles(base.fileUrls)
-
     UM.Label
     {
         text: catalog.i18nc("@text:window", "We have found one or more project file(s) within the files you have selected. You can open only one project file at a time. We suggest to only import models from those files. Would you like to proceed?")

--- a/resources/qml/MainWindow/ApplicationMenu.qml
+++ b/resources/qml/MainWindow/ApplicationMenu.qml
@@ -73,11 +73,16 @@ Item
     // Definition of other components that are linked to the menus
     // ###############################################################################################
 
-    WorkspaceSummaryDialog
+    Component
     {
-        id: saveWorkspaceDialog
-        property var args
-        onAccepted: UM.OutputDeviceManager.requestWriteToDevice("local_file", PrintInformation.jobName, args)
+        id: saveWorkspaceDialogComponent
+
+        WorkspaceSummaryDialog
+        {
+            property var args
+            onAccepted: UM.OutputDeviceManager.requestWriteToDevice("local_file", PrintInformation.jobName, args)
+            selfDestroy: true
+        }
     }
 
     Cura.MessageDialog

--- a/resources/qml/Menus/ContextMenu.qml
+++ b/resources/qml/Menus/ContextMenu.qml
@@ -101,7 +101,7 @@ Cura.Menu
     Connections
     {
         target: Cura.Actions.multiplySelection
-        function onTriggered() { multiplyDialog.open() }
+        function onTriggered() { multiplyDialogComponent.createObject(base).open() }
     }
 
     UM.SettingPropertyProvider
@@ -113,76 +113,81 @@ Cura.Menu
         watchedProperties: [ "value" ]
     }
 
-    UM.Dialog
+    Component
     {
-        id: multiplyDialog
+        id: multiplyDialogComponent
 
-        title: catalog.i18ncp("@title:window", "Multiply Selected Model", "Multiply Selected Models", UM.Selection.selectionCount)
-
-        width: UM.Theme.getSize("small_popup_dialog").width
-        height: UM.Theme.getSize("small_popup_dialog").height
-        minimumWidth: UM.Theme.getSize("small_popup_dialog").width
-        minimumHeight: UM.Theme.getSize("small_popup_dialog").height
-        onAccepted: gridPlacementSelected.checked? CuraActions.multiplySelectionToGrid(copiesField.value) : CuraActions.multiplySelection(copiesField.value)
-        buttonSpacing: UM.Theme.getSize("thin_margin").width
-
-        rightButtons:
-        [
-            Cura.SecondaryButton
-            {
-                text: "Cancel"
-                onClicked: multiplyDialog.reject()
-            },
-            Cura.PrimaryButton
-            {
-                text: "Ok"
-                onClicked: multiplyDialog.accept()
-            }
-        ]
-
-        Column
+        UM.Dialog
         {
-            spacing: UM.Theme.getSize("default_margin").height
+            id: multiplyDialog
+            title: catalog.i18ncp("@title:window", "Multiply Selected Model", "Multiply Selected Models", UM.Selection.selectionCount)
 
-            Row
+            width: UM.Theme.getSize("small_popup_dialog").width
+            height: UM.Theme.getSize("small_popup_dialog").height
+            minimumWidth: UM.Theme.getSize("small_popup_dialog").width
+            minimumHeight: UM.Theme.getSize("small_popup_dialog").height
+            onAccepted: gridPlacementSelected.checked ? CuraActions.multiplySelectionToGrid(copiesField.value) : CuraActions.multiplySelection(copiesField.value)
+            buttonSpacing: UM.Theme.getSize("thin_margin").width
+            selfDestroy: true
+
+            rightButtons:
+                [
+                    Cura.SecondaryButton
+                    {
+                        text: "Cancel"
+                        onClicked: multiplyDialog.reject()
+                    },
+                    Cura.PrimaryButton
+                    {
+                        text: "Ok"
+                        onClicked: multiplyDialog.accept()
+                    }
+                ]
+
+            Column
             {
-                spacing: UM.Theme.getSize("default_margin").width
+                spacing: UM.Theme.getSize("default_margin").height
 
-                UM.Label
+                Row
                 {
-                    text: catalog.i18nc("@label", "Number of Copies")
-                    anchors.verticalCenter: copiesField.verticalCenter
-                    width: contentWidth
-                    wrapMode: Text.NoWrap
+                    spacing: UM.Theme.getSize("default_margin").width
+
+                    UM.Label
+                    {
+                        text: catalog.i18nc("@label", "Number of Copies")
+                        anchors.verticalCenter: copiesField.verticalCenter
+                        width: contentWidth
+                        wrapMode: Text.NoWrap
+                    }
+
+                    Cura.SpinBox
+                    {
+                        id: copiesField
+                        editable: true
+                        focus: true
+                        from: 1
+                        to: 99
+                        width: 2 * UM.Theme.getSize("button").width
+                        value: 1
+                    }
                 }
 
-                Cura.SpinBox
+                UM.CheckBox
                 {
-                    id: copiesField
-                    editable: true
-                    focus: true
-                    from: 1
-                    to: 99
-                    width: 2 * UM.Theme.getSize("button").width
-                    value: 1
+                    id: gridPlacementSelected
+                    text: catalog.i18nc("@label", "Grid Placement")
+
+                    UM.ToolTip
+                    {
+                        visible: parent.hovered
+                        targetPoint: Qt.point(parent.x + Math.round(parent.width / 2), parent.y)
+                        x: 0
+                        y: parent.y + parent.height + UM.Theme.getSize("default_margin").height
+                        tooltipText: catalog.i18nc("@info", "Multiply selected item and place them in a grid of build plate.")
+                    }
                 }
+
             }
-
-            UM.CheckBox
-            {
-                id: gridPlacementSelected
-                text: catalog.i18nc("@label", "Grid Placement")
-
-                UM.ToolTip
-                {
-                    visible: parent.hovered
-                    targetPoint: Qt.point(parent.x + Math.round(parent.width / 2), parent.y)
-                    x: 0
-                    y: parent.y + parent.height + UM.Theme.getSize("default_margin").height
-                    tooltipText: catalog.i18nc("@info", "Multiply selected item and place them in a grid of build plate.")
-                }
-            }
-
         }
     }
 }

--- a/resources/qml/Menus/FileMenu.qml
+++ b/resources/qml/Menus/FileMenu.qml
@@ -55,8 +55,7 @@ Cura.Menu
             };
             if (UM.Preferences.getValue("cura/dialog_on_project_save"))
             {
-                saveWorkspaceDialog.args = args
-                saveWorkspaceDialog.open()
+                saveWorkspaceDialogComponent.createObject(base, {"args": args}).open()
             }
             else
             {

--- a/resources/qml/Menus/SaveProjectMenu.qml
+++ b/resources/qml/Menus/SaveProjectMenu.qml
@@ -36,9 +36,7 @@ Cura.Menu
                 };
                 if (UM.Preferences.getValue("cura/dialog_on_project_save"))
                 {
-                    saveWorkspaceDialog.deviceId = model.id
-                    saveWorkspaceDialog.args = args
-                    saveWorkspaceDialog.open()
+                    saveWorkspaceDialogComponent.createObject(base, {"args": args, "deviceId": model.id}).open()
                 }
                 else
                 {
@@ -52,11 +50,15 @@ Cura.Menu
         onObjectRemoved: function(index, object) {  saveProjectMenu.removeItem(object)}
     }
 
-    WorkspaceSummaryDialog
+    Component
     {
-        id: saveWorkspaceDialog
-        property var args
-        property var deviceId
-        onAccepted: UM.OutputDeviceManager.requestWriteToDevice(deviceId, PrintInformation.jobName, args)
+        id: saveWorkspaceDialogComponent
+        WorkspaceSummaryDialog
+        {
+            property var args
+            property var deviceId
+            onAccepted: UM.OutputDeviceManager.requestWriteToDevice(deviceId, PrintInformation.jobName, args)
+            selfDestroy: true
+        }
     }
 }

--- a/resources/qml/MonitorButton.qml
+++ b/resources/qml/MonitorButton.qml
@@ -316,17 +316,21 @@ Item
             height: UM.Theme.getSize("save_button_save_to_button").height
 
             text: catalog.i18nc("@label", "Abort Print")
-            onClicked: confirmationDialog.open()
+            onClicked: confirmationDialogComponent.createObject(base).open()
         }
 
-        Cura.MessageDialog
+        Component
         {
-            id: confirmationDialog
+            id: confirmationDialogComponent
 
-            title: catalog.i18nc("@window:title", "Abort print")
-            text: catalog.i18nc("@label", "Are you sure you want to abort the print?")
-            standardButtons: Cura.MessageDialog.Yes | Cura.MessageDialog.No
-            onAccepted: activePrintJob.setState("abort")
+            Cura.MessageDialog
+            {
+                title: catalog.i18nc("@window:title", "Abort print")
+                text: catalog.i18nc("@label", "Are you sure you want to abort the print?")
+                standardButtons: Cura.MessageDialog.Yes | Cura.MessageDialog.No
+                onAccepted: activePrintJob.setState("abort")
+                selfDestroy: true
+            }
         }
     }
 }

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -110,11 +110,6 @@ UM.ManagementPage
                 maximumHeight: minimumHeight * 3
                 backgroundColor: UM.Theme.getColor("main_background")
                 selfDestroy: true
-
-                Component.onCompleted:
-                {
-                    console.log("dialog ready")
-                }
             }
         }
 

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -75,12 +75,18 @@ UM.ManagementPage
                     onClicked:
                     {
                         var currentItem = machineActionRepeater.model[index]
-                        if (currentItem.shouldOpenAsDialog) {
-                            actionDialog.loader.manager = currentItem
-                            actionDialog.loader.source = currentItem.qmlPath
-                            actionDialog.title = currentItem.label
+                        if (currentItem.shouldOpenAsDialog)
+                        {
+                            var actionDialog = actionDialogComponent.createObject(base,
+                                {
+                                    "title": currentItem.label,
+                                    "loader.manager": currentItem,
+                                    "loader.source": currentItem.qmlPath
+                                });
                             actionDialog.show()
-                        } else {
+                        }
+                        else
+                        {
                             currentItem.execute()
                         }
                     }
@@ -91,52 +97,66 @@ UM.ManagementPage
 
     Item
     {
-        UM.Dialog
+        Component
         {
-            id: actionDialog
-            minimumWidth: UM.Theme.getSize("modal_window_minimum").width
-            minimumHeight: UM.Theme.getSize("modal_window_minimum").height
-            maximumWidth: minimumWidth * 3
-            maximumHeight: minimumHeight * 3
-            backgroundColor: UM.Theme.getColor("main_background")
-            onVisibleChanged:
+            id: actionDialogComponent
+
+            UM.Dialog
             {
-                if(!visible)
+                id: actionDialog
+                minimumWidth: UM.Theme.getSize("modal_window_minimum").width
+                minimumHeight: UM.Theme.getSize("modal_window_minimum").height
+                maximumWidth: minimumWidth * 3
+                maximumHeight: minimumHeight * 3
+                backgroundColor: UM.Theme.getColor("main_background")
+                selfDestroy: true
+
+                Component.onCompleted:
                 {
-                    actionDialog.loader.item.focus = true
+                    console.log("dialog ready")
                 }
             }
         }
 
-        UM.ConfirmRemoveDialog
+        Component
         {
-            id: confirmDialog
-            object: base.currentItem && base.currentItem.name ? base.currentItem.name : ""
-            text: base.currentItem ? base.currentItem.removalWarning : ""
+            id: confirmDialogComponent
 
-            onAccepted:
+            UM.ConfirmRemoveDialog
             {
-                Cura.MachineManager.removeMachine(base.currentItem.id)
-                if(!base.currentItem)
+                object: base.currentItem && base.currentItem.name ? base.currentItem.name : ""
+                text: base.currentItem ? base.currentItem.removalWarning : ""
+                selfDestroy: true
+
+                onAccepted:
                 {
-                    objectList.currentIndex = activeMachineIndex()
+                    Cura.MachineManager.removeMachine(base.currentItem.id)
+                    if (!base.currentItem) {
+                        objectList.currentIndex = activeMachineIndex()
+                    }
+                    //Force updating currentItem and the details panel
+                    objectList.onCurrentIndexChanged()
                 }
-                //Force updating currentItem and the details panel
-                objectList.onCurrentIndexChanged()
             }
         }
 
-        Cura.RenameDialog
+        Component
         {
-            id: renameDialog
-            object: base.currentItem && base.currentItem.name ? base.currentItem.name : ""
-            property var machine_name_validator: Cura.MachineNameValidator { }
-            validName: renameDialog.newName.match(renameDialog.machine_name_validator.machineNameRegex) != null
-            onAccepted:
+            id: renameDialogComponent
+
+            Cura.RenameDialog
             {
-                Cura.MachineManager.renameMachine(base.currentItem.id, newName.trim())
-                //Force updating currentItem and the details panel
-                objectList.onCurrentIndexChanged()
+                object: base.currentItem && base.currentItem.name ? base.currentItem.name : ""
+                property var machine_name_validator: Cura.MachineNameValidator {}
+                validName: renameDialog.newName.match(renameDialog.machine_name_validator.machineNameRegex) != null
+                selfDestroy: true
+
+                onAccepted:
+                {
+                    Cura.MachineManager.renameMachine(base.currentItem.id, newName.trim())
+                    //Force updating currentItem and the details panel
+                    objectList.onCurrentIndexChanged()
+                }
             }
         }
 
@@ -153,13 +173,13 @@ UM.ManagementPage
             {
                 text: catalog.i18nc("@action:button", "Remove")
                 enabled: base.currentItem != null && model.count > 1
-                onTriggered: confirmDialog.open()
+                onTriggered: confirmDialogComponent.createObject(base).open()
             }
             Cura.MenuItem
             {
                 text: catalog.i18nc("@action:button", "Rename")
                 enabled: base.currentItem != null && base.currentItem.metadata.group_name == null
-                onTriggered:  renameDialog.open()
+                onTriggered: renameDialogComponent.createObject(base).open()
             }
        }
 

--- a/resources/qml/Preferences/ProfilesPage.qml
+++ b/resources/qml/Preferences/ProfilesPage.qml
@@ -49,7 +49,8 @@ UM.ManagementPage
 
     onCreateProfile:
     {
-        createQualityDialog.object = Cura.ContainerManager.makeUniqueName(Cura.MachineManager.activeQualityOrQualityChangesName);
+        var name = Cura.ContainerManager.makeUniqueName(Cura.MachineManager.activeQualityOrQualityChangesName);
+        var createQualityDialog = createQualityDialogComponent.createObject(base, {"object": name});
         createQualityDialog.open();
         createQualityDialog.selectText();
     }
@@ -86,7 +87,7 @@ UM.ManagementPage
         Cura.SecondaryButton
         {
             text: catalog.i18nc("@action:button", "Import")
-            onClicked:importDialog.open()
+            onClicked: importDialogComponent.createObject(base).open()
         },
         Cura.SecondaryButton
         {
@@ -98,9 +99,10 @@ UM.ManagementPage
             tooltip: catalog.i18nc("@action:tooltip", "Create new profile from current settings/overrides")
             onClicked:
             {
-                createQualityDialog.object = Cura.ContainerManager.makeUniqueName("<new name>")
-                createQualityDialog.open()
-                createQualityDialog.selectText()
+                var name = Cura.ContainerManager.makeUniqueName("<new name>");
+                var createQualityDialog = createQualityDialogComponent.createObject(base, {"object": name});
+                createQualityDialog.open();
+                createQualityDialog.selectText();
             }
         }
     ]
@@ -265,24 +267,35 @@ UM.ManagementPage
                 base.toActivateNewQuality = false;
             }
         }
-        Cura.MessageDialog
+
+        Component
         {
-            id: messageDialog
-            standardButtons: Dialog.Ok
+            id: messageDialogComponent
+
+            Cura.MessageDialog
+            {
+                standardButtons: Dialog.Ok
+                selfDestroy: true
+            }
         }
 
         // Dialog to request a name when creating a new profile
-        Cura.RenameDialog
+        Component
         {
-            id: createQualityDialog
-            title: catalog.i18nc("@title:window", "Create Profile")
-            object: "<new name>"
-            explanation: catalog.i18nc("@info", "Please provide a name for this profile.")
-            onAccepted:
+            id: createQualityDialogComponent
+
+            Cura.RenameDialog
             {
-                base.newQualityNameToSelect = newName;  // We want to switch to the new profile once it's created
-                base.toActivateNewQuality = true;
-                base.qualityManagementModel.createQualityChanges(newName);
+                title: catalog.i18nc("@title:window", "Create Profile")
+                object: "<new name>"
+                explanation: catalog.i18nc("@info", "Please provide a name for this profile.")
+                selfDestroy: true
+                onAccepted:
+                {
+                    base.newQualityNameToSelect = newName;  // We want to switch to the new profile once it's created
+                    base.toActivateNewQuality = true;
+                    base.qualityManagementModel.createQualityChanges(newName);
+                }
             }
         }
 
@@ -313,7 +326,7 @@ UM.ManagementPage
                 onTriggered:
                 {
                     forceActiveFocus()
-                    duplicateQualityDialog.open()
+                    duplicateQualityDialogComponent.createObject(base).open()
                 }
             }
             Cura.MenuItem
@@ -323,7 +336,7 @@ UM.ManagementPage
                 onTriggered:
                 {
                     forceActiveFocus()
-                    confirmRemoveQualityDialog.open()
+                    confirmRemoveQualityDialogComponent.createObject(base).open()
                 }
             }
             Cura.MenuItem
@@ -332,7 +345,7 @@ UM.ManagementPage
                 enabled: base.hasCurrentItem && !base.currentItem.is_read_only
                 onTriggered:
                 {
-                    renameQualityDialog.object = base.currentItem.name
+                    var renameQualityDialog = renameQualityDialogComponent.createObject(base, {"object": base.currentItem.name})
                     renameQualityDialog.open()
                     renameQualityDialog.selectText()
                 }
@@ -341,95 +354,124 @@ UM.ManagementPage
             {
                 text: catalog.i18nc("@action:button", "Export")
                 enabled: base.hasCurrentItem && !base.currentItem.is_read_only
-                onTriggered: exportDialog.open()
+                onTriggered: exportDialogComponent.createObject(base).open()
             }
         }
 
         // Dialog for exporting a quality profile
-        FileDialog
+        Component
         {
-            id: exportDialog
-            title: catalog.i18nc("@title:window", "Export Profile")
-            fileMode: FileDialog.SaveFile
-            nameFilters: base.qualityManagementModel.getFileNameFilters("profile_writer")
-            currentFolder: CuraApplication.getDefaultPath("dialog_profile_path")
-            onAccepted:
+            id: exportDialogComponent
+
+            FileDialog
             {
-
-                // If nameFilters contains only 1 item, the index of selectedNameFilter will always be -1
-                // This fetches the nameFilter at index selectedNameFilter.index if it is positive
-                const nameFilterString = selectedNameFilter.index >= 0 ? nameFilters[selectedNameFilter.index] : nameFilters[0];
-
-                var result = Cura.ContainerManager.exportQualityChangesGroup(base.currentItem.quality_changes_group,
-                                                                             selectedFile, nameFilterString);
-
-                if (result && result.status == "error")
+                title: catalog.i18nc("@title:window", "Export Profile")
+                fileMode: FileDialog.SaveFile
+                nameFilters: base.qualityManagementModel.getFileNameFilters("profile_writer")
+                currentFolder: CuraApplication.getDefaultPath("dialog_profile_path")
+                onAccepted:
                 {
-                    messageDialog.title = catalog.i18nc("@title:window", "Export Profile")
-                    messageDialog.text = result.message;
-                    messageDialog.open();
-                }
 
-                // else pop-up Message thing from python code
-                CuraApplication.setDefaultPath("dialog_profile_path", currentFolder);
+                    // If nameFilters contains only 1 item, the index of selectedNameFilter will always be -1
+                    // This fetches the nameFilter at index selectedNameFilter.index if it is positive
+                    const nameFilterString = selectedNameFilter.index >= 0 ? nameFilters[selectedNameFilter.index] : nameFilters[0];
+
+                    var result = Cura.ContainerManager.exportQualityChangesGroup(base.currentItem.quality_changes_group,
+                        selectedFile, nameFilterString);
+
+                    if (result && result.status == "error")
+                    {
+                        var messageDialog = messageDialogComponent.createObject(base,
+                            {
+                                "title": catalog.i18nc("@title:window", "Export Profile"),
+                                "text": result.message
+                            }
+                        )
+                        messageDialog.open();
+                    }
+
+                    // else pop-up Message thing from python code
+                    CuraApplication.setDefaultPath("dialog_profile_path", currentFolder);
+                }
             }
         }
 
         // Dialog to request a name when duplicating a new profile
-        Cura.RenameDialog
+        Component
         {
-            id: duplicateQualityDialog
-            title: catalog.i18nc("@title:window", "Duplicate Profile")
-            object: "<new name>"
-            onAccepted: base.qualityManagementModel.duplicateQualityChanges(newName, base.currentItem)
+            id: duplicateQualityDialogComponent
+
+            Cura.RenameDialog
+            {
+                title: catalog.i18nc("@title:window", "Duplicate Profile")
+                object: "<new name>"
+                selfDestroy: true
+                onAccepted: base.qualityManagementModel.duplicateQualityChanges(newName, base.currentItem)
+            }
         }
 
         // Confirmation dialog for removing a profile
-        Cura.MessageDialog
+        Component
         {
-            id: confirmRemoveQualityDialog
+            id: confirmRemoveQualityDialogComponent
 
-            title: catalog.i18nc("@title:window", "Confirm Remove")
-            text: catalog.i18nc("@label (%1 is object name)", "Are you sure you wish to remove %1? This cannot be undone!").arg(base.currentItemName)
-            standardButtons: Dialog.Yes | Dialog.No
-            modal: true
-
-            onAccepted:
+            Cura.MessageDialog
             {
-                base.qualityManagementModel.removeQualityChangesGroup(base.currentItem.quality_changes_group);
-                // reset current item to the first if available
-                qualityListView.currentIndex = -1;  // Reset selection.
+                title: catalog.i18nc("@title:window", "Confirm Remove")
+                text: catalog.i18nc("@label (%1 is object name)", "Are you sure you wish to remove %1? This cannot be undone!").arg(base.currentItemName)
+                standardButtons: Dialog.Yes | Dialog.No
+                selfDestroy: true
+
+                onAccepted:
+                {
+                    base.qualityManagementModel.removeQualityChangesGroup(base.currentItem.quality_changes_group);
+                    // reset current item to the first if available
+                    qualityListView.currentIndex = -1;  // Reset selection.
+                }
             }
         }
 
         // Dialog to rename a quality profile
-        Cura.RenameDialog
+        Component
         {
-            id: renameQualityDialog
-            title: catalog.i18nc("@title:window", "Rename Profile")
-            object: "<new name>"
-            onAccepted:
+            id: renameQualityDialogComponent
+
+            Cura.RenameDialog
             {
-                var actualNewName = base.qualityManagementModel.renameQualityChangesGroup(base.currentItem.quality_changes_group, newName);
-                base.newQualityNameToSelect = actualNewName;  // Select the new name after the model gets updated
+                title: catalog.i18nc("@title:window", "Rename Profile")
+                object: "<new name>"
+                selfDestroy: true
+                onAccepted:
+                {
+                    var actualNewName = base.qualityManagementModel.renameQualityChangesGroup(base.currentItem.quality_changes_group, newName);
+                    base.newQualityNameToSelect = actualNewName;  // Select the new name after the model gets updated
+                }
             }
         }
 
         // Dialog for importing a quality profile
-        FileDialog
+        Component
         {
-            id: importDialog
-            title: catalog.i18nc("@title:window", "Import Profile")
-            fileMode: FileDialog.OpenFile
-            nameFilters: base.qualityManagementModel.getFileNameFilters("profile_reader")
-            currentFolder: CuraApplication.getDefaultPath("dialog_profile_path")
-            onAccepted:
+            id: importDialogComponent
+
+            FileDialog
             {
-                var result = Cura.ContainerManager.importProfile(selectedFile);
-                messageDialog.title = catalog.i18nc("@title:window", "Import Profile")
-                messageDialog.text = result.message;
-                messageDialog.open();
-                CuraApplication.setDefaultPath("dialog_profile_path", folder);
+                title: catalog.i18nc("@title:window", "Import Profile")
+                fileMode: FileDialog.OpenFile
+                nameFilters: base.qualityManagementModel.getFileNameFilters("profile_reader")
+                currentFolder: CuraApplication.getDefaultPath("dialog_profile_path")
+                onAccepted:
+                {
+                    var result = Cura.ContainerManager.importProfile(selectedFile);
+                    var messageDialog = messageDialogComponent.createObject(base,
+                        {
+                            "title": catalog.i18nc("@title:window", "Import Profile"),
+                            "text": result.message
+                        }
+                    )
+                    messageDialog.open();
+                    CuraApplication.setDefaultPath("dialog_profile_path", folder);
+                }
             }
         }
     }

--- a/resources/qml/WelcomePages/WelcomeDialogItem.qml
+++ b/resources/qml/WelcomePages/WelcomeDialogItem.qml
@@ -14,53 +14,44 @@ import Cura 1.1 as Cura
 //
 Item
 {
-    UM.I18nCatalog { id: catalog; name: "cura" }
-
-    id: dialog
-
-    anchors.centerIn: parent
-
-    width: UM.Theme.getSize("welcome_wizard_window").width
-    height: UM.Theme.getSize("welcome_wizard_window").height
-
-    property int shadowOffset: 1 * screenScaleFactor
-
+    property alias model: wizardPanel.model
     property alias progressBarVisible: wizardPanel.progressBarVisible
-    property var model: CuraApplication.getWelcomePagesModel()
 
-    onVisibleChanged:
+    id: base
+
+    anchors.fill: parent
+    z: 100
+
+    MouseArea
     {
-        if (visible)
-        {
-            model.resetState()
-        }
+        // Prevent all mouse events from passing through.
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.AllButtons
+    }
+
+    Rectangle
+    {
+        color: UM.Theme.getColor("window_disabled_background")
+        opacity: 0.7
+        anchors.fill: parent
     }
 
     WizardPanel
     {
         id: wizardPanel
-        anchors.fill: parent
-        model: dialog.model
-    }
+        UM.I18nCatalog { id: catalog; name: "cura" }
 
-    // Drop shadow around the panel
-    // TODO: Maybe re-implement this some other way.
-    /*DropShadow
-    {
-        id: shadow
-        radius: UM.Theme.getSize("first_run_shadow_radius").width
-        anchors.fill: wizardPanel
-        source: wizardPanel
-        horizontalOffset: shadowOffset
-        verticalOffset: shadowOffset
-        color: UM.Theme.getColor("first_run_shadow")
-        transparentBorder: true
-    }*/
+        anchors.centerIn: parent
+
+        width: UM.Theme.getSize("welcome_wizard_window").width
+        height: UM.Theme.getSize("welcome_wizard_window").height
+    }
 
     // Close this dialog when there's no more page to show
     Connections
     {
         target: model
-        function onAllFinished() { dialog.visible = false }
+        function onAllFinished() { base.destroy() }
     }
 }

--- a/resources/qml/WelcomePages/WhatsNewContent.qml
+++ b/resources/qml/WelcomePages/WhatsNewContent.qml
@@ -15,7 +15,7 @@ import Cura 1.1 as Cura
 //
 Item
 {
-    property var manager: CuraApplication.getWhatsNewPagesModel()
+    property var manager: Cura.WhatsNewSubPagesModel{}
 
     UM.I18nCatalog { id: catalog; name: "cura" }
 

--- a/resources/qml/WelcomePages/WizardDialog.qml
+++ b/resources/qml/WelcomePages/WizardDialog.qml
@@ -46,4 +46,12 @@ Window
         target: model
         function onAllFinished() { dialog.hide() }
     }
+
+    onVisibleChanged:
+    {
+        if(!visible)
+        {
+            destroy();
+        }
+    }
 }


### PR DESCRIPTION
This PR attemps to reduce the number of dialogs/objects loaded in the background that are not actually used by the application. In QML it is very easy to declare a Dialog and just display it when you need it, however this instanciates QML/Python resources that will possibly never be used. This is OK as long as it concerns a small number of elements, but when having tens of those, it is starting to consume a lot of unnecessary resources.
* Dialogs improvements: place the dialogs inside `Component` items, instanciate them only when necessary, and destroy them as soon as they are hidden.
* Models improvements: do not load all the models at startup, because they keep updating in the background even if they are never displayed. Instead, the QML file creates a local model when it is displayed, and it gets released when hidden.

Requires https://github.com/Ultimaker/Uranium/pull/1038
CURA-12754