### PR TITLE
Tighten infill_sparse value condition

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2468,7 +2468,7 @@
                     "description": "Print a solid infill pattern just below skin to avoid printing the skin over air.",
                     "type": "bool",
                     "default_value": true,
-                    "value": "infill_sparse_density < 40",
+                    "value": "infill_sparse_density < 40 and gradual_infill_steps == 0 and infill_sparse_thickness == layer_height",
                     "enabled": "infill_sparse_density > 0 and top_layers > 0",
                     "settable_per_mesh": true,
                     "settable_per_extruder": true


### PR DESCRIPTION
# Description

Infill skin support is conflicting with gradual infill steps and trying to achieve the same goal. Infill skin support is not generated when infill height is not the  same as the layer height so this condition aligns the setting with the behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Functional test
- [x] Regression test
- [x] System test

**Test Configuration**:
* Operating System: Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
