### PR TITLE
[CURA-13089] Don't re-use webserver on restart.

### DIFF
--- a/cura/OAuth2/LocalAuthorizationServer.py
+++ b/cura/OAuth2/LocalAuthorizationServer.py
@@ -52,11 +52,10 @@ class LocalAuthorizationServer:
         """
 
         if self._web_server:
-            # If the server is already running (because of a previously aborted auth flow), we don't have to start it.
-            # We still inject the new verification code though.
-            Logger.log("d", "Auth web server was already running. Updating the verification code")
-            self._web_server.setVerificationCode(verification_code)
-            return
+            # Previously, we re-injected the verification code. This went wrong when the server was going to restart when it's in the middle of starting though.
+            Logger.log("d", "Auth web server was already running. Shut-down & restart.")
+            self._web_server.shutdown()
+            # NOTE: The above shutdown will also end the associated thread, so don't manually join that thread here.
 
         if self._web_server_port is None:
             raise Exception("Unable to start server without specifying the port.")


### PR DESCRIPTION
This turned out not to work in some circumstances. Shutting down the server entirely and doing a cold restart is a bit more clean than trying to insert (a) new value(s) anyway.

---

This came from reports from the DF crew that people couldn't log in under certain circumstances when using (mostly??) Chrome or Safari as their default browser.

I couldn't reproduce the exact steps (which are a bit more like what an actual user would do over a session), but I got (hopefully) the same error by just clicking the sign-in button rapidly.

I think it still isn't guaranteed to work all of the time, but it now seems more robust (in that the rapidly click thing used to be 100% reproducible, and now it actually logs me in in one of the opened tabs most of the time), and even if it fails it has a chance of working each subsequent time you click sign-in, which I think was just broken before once you got it into the state where it stopped working.