### PR TITLE
[CURA-13168] Fix layer slider upper handle becoming unresponsive to keyboard navigation

### DIFF
--- a/plugins/SimulationView/LayerSlider.qml
+++ b/plugins/SimulationView/LayerSlider.qml
@@ -219,13 +219,6 @@ Item
             // Normalize values between range, since using arrow keys will create out-of-the-range values
             value = sliderRoot.normalizeValue(value)
 
-            if (value == getValue())
-            {
-                return;
-            }
-
-            UM.SimulationView.setCurrentLayer(value)
-
             var diff = (value - sliderRoot.maximumValue) / (sliderRoot.minimumValue - sliderRoot.maximumValue)
             // In case there is only one layer, the diff value results in a NaN, so this is for catching this specific case
             if (isNaN(diff))
@@ -233,6 +226,15 @@ Item
                 diff = 0
             }
             var newUpperYPosition = Math.round(diff * (sliderRoot.height - (2 * sliderRoot.handleSize + sliderRoot.minimumRangeHandleSize)))
+
+            // Skip update only when both the value and pixel position are already correct,
+            // preventing signal feedback loops while allowing re-initialization after a new slice.
+            if (value == sliderRoot.upperValue && newUpperYPosition == y)
+            {
+                return;
+            }
+
+            UM.SimulationView.setCurrentLayer(value)
             y = newUpperYPosition
 
             // update the range handle


### PR DESCRIPTION
When a print has many layers, multiple consecutive layer indices map to the same sub-pixel position on the slider track. The upper handle's setValue used the pixel-derived getValue() to detect duplicate calls, which meant navigating by one layer at a time would silently no-op whenever two adjacent layers shared a pixel — giving the impression of an invisible wall that blocked further movement.

The guard is replaced with a two-condition check: skip the update only when the requested value matches the already-committed layer value AND the handle is already at the correct pixel position. This preserves the original intent of preventing feedback loops (backend signal → setValue → setCurrentLayer → signal again) while ensuring the handle always repositions itself correctly, including after a fresh slice where the pixel position may be stale even though the layer value has not changed.

CURA-13168
