### PR TITLE
Improve method profile to more explicitly use the support extruder for the raft-interface

### DIFF
--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -478,7 +478,7 @@
         },
         "raft_base_wall_count": { "value": "raft_wall_count" },
         "raft_interface_acceleration": { "enabled": false },
-        "raft_interface_extruder_nr": { "value": "max(extruderValues('extruder_nr'))" },
+        "raft_interface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable else 0" },
         "raft_interface_fan_speed": { "value": 0 },
         "raft_interface_infill_overlap":
         {
@@ -522,7 +522,7 @@
         "raft_smoothing": { "value": 9.5 },
         "raft_speed": { "value": 10 },
         "raft_surface_acceleration": { "enabled": false },
-        "raft_surface_extruder_nr": { "value": "max(extruderValues('extruder_nr'))" },
+        "raft_surface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable else 0" },
         "raft_surface_fan_speed": { "value": 0 },
         "raft_surface_flow":
         {

--- a/resources/definitions/ultimaker_method_base.def.json
+++ b/resources/definitions/ultimaker_method_base.def.json
@@ -478,7 +478,7 @@
         },
         "raft_base_wall_count": { "value": "raft_wall_count" },
         "raft_interface_acceleration": { "enabled": false },
-        "raft_interface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable else 0" },
+        "raft_interface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable else adhesion_extruder_nr" },
         "raft_interface_fan_speed": { "value": 0 },
         "raft_interface_infill_overlap":
         {
@@ -522,7 +522,7 @@
         "raft_smoothing": { "value": 9.5 },
         "raft_speed": { "value": 10 },
         "raft_surface_acceleration": { "enabled": false },
-        "raft_surface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable else 0" },
+        "raft_surface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable else adhesion_extruder_nr" },
         "raft_surface_fan_speed": { "value": 0 },
         "raft_surface_flow":
         {


### PR DESCRIPTION
CURA-13169

# Description
The makerbot strategy is to have the raft support interface be the support material. However, you only want this in the situation where the support material is being used. When we introduced makerbot profiles we did not have a good method of detecting which extruder was the support extruder. As such we used the following reflect this behavior.
```python
max(extruderValues('extruder_nr'))
```
This PR changes this to more explicitly use the support material for the interface.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Printer definition file(s)
- [ ] Translations

# How Has This Been Tested?
**Test Configuration**:
* Operating System:
N/A

# Checklist:
- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
