### PR TITLE
[CURA-13167] Set the transient parent for the open project dialog in 3MFReader

### DIFF
--- a/plugins/3MFReader/WorkspaceDialog.py
+++ b/plugins/3MFReader/WorkspaceDialog.py
@@ -81,6 +81,7 @@ class WorkspaceDialog(QObject):
         if three_mf_reader_path:
             path = os.path.join(three_mf_reader_path, "WorkspaceDialog.qml")
             self._view = CuraApplication.getInstance().createQmlComponent(path, initial_properties = {"manager": self})
+            self._view.setTransientParent(CuraApplication.getInstance().getMainWindow())
             self._view.show()
 
     machineConflictChanged = pyqtSignal()


### PR DESCRIPTION
Ensure the dialog is properly modal and opens within the application window

CURA-13167
