### PR TITLE
Revert change in S8 for non-plus cores

### DIFF
--- a/resources/variants/ultimaker_s6_aa025.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa025.inst.cfg
@@ -150,6 +150,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s6_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa04.inst.cfg
@@ -149,6 +149,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s6_aa08.inst.cfg
+++ b/resources/variants/ultimaker_s6_aa08.inst.cfg
@@ -160,6 +160,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s6_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s6_cc04.inst.cfg
@@ -149,6 +149,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s6_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s6_cc06.inst.cfg
@@ -149,6 +149,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s8_aa025.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa025.inst.cfg
@@ -150,6 +150,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s8_aa04.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa04.inst.cfg
@@ -149,6 +149,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s8_aa08.inst.cfg
+++ b/resources/variants/ultimaker_s8_aa08.inst.cfg
@@ -160,6 +160,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s8_cc04.inst.cfg
+++ b/resources/variants/ultimaker_s8_cc04.inst.cfg
@@ -149,6 +149,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15

--- a/resources/variants/ultimaker_s8_cc06.inst.cfg
+++ b/resources/variants/ultimaker_s8_cc06.inst.cfg
@@ -149,6 +149,7 @@ speed_wall_x_roofing = =speed_wall_x
 support_angle = 60
 support_bottom_distance = =support_z_distance / 2
 support_bottom_offset = =extruderValue(support_bottom_extruder_nr, 'support_interface_offset')
+support_brim_minimum_hole_area = =skirt_brim_line_width * skirt_brim_line_width * 100
 support_brim_width = =(skirt_brim_line_width * initial_layer_line_width_factor / 100.0) * 3
 support_infill_multiplier = 1
 support_infill_rate = =0 if support_structure == 'tree' else 80 if gradual_support_infill_steps != 0 else 15


### PR DESCRIPTION
The setting `support_brim_minimum_hole_area` was added to the S8 definition in da0bda8f0d171333ac434f97515c3f784d30bae1. This should be reverted in the non-plus cores to keep the profiles the same as S5.

This is automatically done with the non-plus variant templates for the S6/S8 machines in autogenerate.