### PR TITLE
Fix degree symbols

### DIFF
--- a/plugins/PostProcessingPlugin/scripts/AnnealingOrDrying.py
+++ b/plugins/PostProcessingPlugin/scripts/AnnealingOrDrying.py
@@ -118,7 +118,7 @@ class AnnealingOrDrying(Script):
                     "description": "Enter the temperature to start at.  This is typically the bed temperature during the print but can be changed here.  This is also the temperature used when drying filament.",
                     "type": "int",
                     "value": 30,
-                    "unit": "°C/F ",
+                    "unit": "\u00b0C/F ",
                     "minimum_value": 30,
                     "maximum_value": 110,
                     "maximum_value_warning": 100,
@@ -130,7 +130,7 @@ class AnnealingOrDrying(Script):
                     "description": "Enter the lowest temperature to control the cool down.  This is the shut-off temperature for the build plate and (when applicable) the Heated Chamber.  The minimum value is 30",
                     "type": "int",
                     "default_value": 30,
-                    "unit": "°C/F ",
+                    "unit": "\u00b0C/F ",
                     "minimum_value": 30,
                     "enabled": "enable_script and cycle_type == 'anneal_cycle'"
                 },
@@ -140,7 +140,7 @@ class AnnealingOrDrying(Script):
                     "description": "Enter the temperature for the Build Volume (Heated Chamber).  This is typically the temperature during the print but can be changed here.",
                     "type": "int",
                     "value": 24,
-                    "unit": "°C/F ",
+                    "unit": "\u00b0C/F ",
                     "minimum_value": 0,
                     "maximum_value": 90,
                     "maximum_value_warning": 75,
@@ -168,7 +168,7 @@ class AnnealingOrDrying(Script):
                 "time_span":
                 {
                     "label": "Cool Down Time Span:",
-                    "description": "The total amount of time (in decimal hours) to control the cool down.  The build plate temperature will be dropped in 3° increments across this time span.  'Cool Down Time' starts at the end of the 'Hold Time' if you entered one.",
+                    "description": "The total amount of time (in decimal hours) to control the cool down.  The build plate temperature will be dropped in 3\u00b0 increments across this time span.  'Cool Down Time' starts at the end of the 'Hold Time' if you entered one.",
                     "type": "float",
                     "default_value": 1.0,
                     "unit": "Hrs ",
@@ -241,7 +241,7 @@ class AnnealingOrDrying(Script):
         # If the shutoff temp is under 30° then exit as a safety precaution so the bed doesn't stay on.
         if lowest_temp < 30:
             data[0] += ";  Anneal or Dry Filament did not run.  Shutoff Temp < 30\n"
-            Message(title = "[Anneal or Dry Filament]", text = "The script did not run because the Shutoff Temp is less than 30°.").show()
+            Message(title = "[Anneal or Dry Filament]", text = "The script did not run because the Shutoff Temp is less than 30\u00b0.").show()
             return data
         extruders = self.global_stack.extruderList
         bed_temperature = int(self.getSettingValueByKey("startout_temp"))
@@ -569,9 +569,9 @@ class AnnealingOrDrying(Script):
                 lines[index] = front_txt + str(" " * (30 - len(front_txt))) +";" +  back_txt
         drydata[1] = "\n".join(lines) + "\n"
         dry_txt = "; Drying time ............... " + str(self.getSettingValueByKey("dry_time")) + " hrs\n"
-        dry_txt += "; Drying temperature ........ " + str(bed_temperature) + "°\n"
+        dry_txt += "; Drying temperature ........ " + str(bed_temperature) + "\u00b0\n"
         if heated_chamber and heating_zone == "bed_chamber":
-            dry_txt += "; Chamber temperature ....... " + str(chamber_temp) + "°\n"
+            dry_txt += "; Chamber temperature ....... " + str(chamber_temp) + "\u00b0\n"
         Message(title = "[Dry Filament]", text = dry_txt).show()
         # UM machines require the existing 'data[0]' with some alteration
         if active_machine == "UM":

--- a/plugins/PostProcessingPlugin/scripts/DisplayInfoOnLCD.py
+++ b/plugins/PostProcessingPlugin/scripts/DisplayInfoOnLCD.py
@@ -696,8 +696,8 @@ class DisplayInfoOnLCD(Script):
         filament_line_t0 += f";  Filament Type: {self.global_stack.extruderList[0].material.getMetaDataEntry("material", "")}\n"
         filament_line_t0 += f";  Filament Dia.: {self.global_stack.extruderList[0].getProperty("material_diameter", "value")}mm\n"
         filament_line_t0 += f";  Nozzle Size  : {self.global_stack.extruderList[0].getProperty("machine_nozzle_size", "value")}mm\n"
-        filament_line_t0 += f";  Print Temp.  : {self.global_stack.extruderList[0].getProperty("material_print_temperature", "value")}°\n"
-        filament_line_t0 += f";  Bed Temp.    : {self.global_stack.extruderList[0].getProperty("material_bed_temperature", "value")}°"
+        filament_line_t0 += f";  Print Temp.  : {self.global_stack.extruderList[0].getProperty("material_print_temperature", "value")}\u00b0\n"
+        filament_line_t0 += f";  Bed Temp.    : {self.global_stack.extruderList[0].getProperty("material_bed_temperature", "value")}\u00b0"
 
         # if there is more than one extruder then get the stats for the second one.
         filament_line_t1 = ""
@@ -707,7 +707,7 @@ class DisplayInfoOnLCD(Script):
             filament_line_t1 += f";  Filament Type: {self.global_stack.extruderList[1].material.getMetaDataEntry("material", "")}\n"
             filament_line_t1 += f";  Filament Dia.: {self.global_stack.extruderList[1].getProperty("material_diameter", "value")}mm\n"
             filament_line_t1 += f";  Nozzle Size  : {self.global_stack.extruderList[1].getProperty("machine_nozzle_size", "value")}mm\n"
-            filament_line_t1 += f";  Print Temp.  : {self.global_stack.extruderList[1].getProperty("material_print_temperature", "value")}°"
+            filament_line_t1 += f";  Print Temp.  : {self.global_stack.extruderList[1].getProperty("material_print_temperature", "value")}\u00b0"
 
         # Calculate the cost of electricity for the print
         electric_line = self.getElectricCostLine()

--- a/plugins/PostProcessingPlugin/scripts/PurgeLinesAndUnload.py
+++ b/plugins/PostProcessingPlugin/scripts/PurgeLinesAndUnload.py
@@ -91,7 +91,7 @@ class PurgeLinesAndUnload(Script):
                 "purge_line_location":
                 {
                     "label": "    Purge Line Location",
-                    "description": "What edge of the build plate should have the purge lines.  If the printer is 'Elliptical' then it is assumed to be an 'Origin At Center' printer and the purge lines are 90° arcs.",
+                    "description": "What edge of the build plate should have the purge lines.  If the printer is 'Elliptical' then it is assumed to be an 'Origin At Center' printer and the purge lines are 90\u00b0 arcs.",
                     "type": "enum",
                     "options": {
                         "left": "On left edge (Xmin)",

--- a/plugins/PostProcessingPlugin/scripts/TweakAtZ.py
+++ b/plugins/PostProcessingPlugin/scripts/TweakAtZ.py
@@ -217,7 +217,7 @@ class TweakAtZ(Script):
                 "d_bedTemp": {
                     "label": "    Bed Temp",
                     "description": "New Bed Temperature",
-                    "unit": "°C  ",
+                    "unit": "\u00b0C  ",
                     "type": "int",
                     "default_value": 60,
                     "minimum_value": 0,
@@ -242,7 +242,7 @@ class TweakAtZ(Script):
                 "e_build_volume_temperature": {
                     "label": "    Build Volume Temperature",
                     "description": "New Build Volume Temperature.  This will revert at the end of the End Layer.",
-                    "unit": "°C  ",
+                    "unit": "\u00b0C  ",
                     "type": "int",
                     "default_value": 20,
                     "minimum_value": 0,
@@ -260,7 +260,7 @@ class TweakAtZ(Script):
                 "f_extruder_temperature_t0": {
                     "label": "    Extruder 1 Temp (T0)",
                     "description": "New temperature for Extruder 1 (T0).",
-                    "unit": "°C  ",
+                    "unit": "\u00b0C  ",
                     "type": "int",
                     "default_value": 190,
                     "minimum_value": 0,
@@ -271,7 +271,7 @@ class TweakAtZ(Script):
                 "f_extruder_temperature_t1": {
                     "label": "    Extruder 2 Temp (T1)",
                     "description": "New temperature for Extruder 2 (T1).",
-                    "unit": "°C  ",
+                    "unit": "\u00b0C  ",
                     "type": "int",
                     "default_value": 190,
                     "minimum_value": 0,


### PR DESCRIPTION
Change temperature symbols from ' ° ' to "\u00b0"
Noted in bug report #21624 
# Description

Some operating system flavors may not like the " ° " symbol and would prefer \u00b0.
This PR includes all the post processors that included the actual "degree symbol".  There are other instances of the symbol elsewhere in Cura.
This went unnoticed for a long time.  I only have a Windows 10 system to check on.

- [ X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Operating System:  Windows only.  Not checked on other systems