### PR TITLE
Add the update all button to the manage packages tab

### DIFF
--- a/plugins/Marketplace/Constants.py
+++ b/plugins/Marketplace/Constants.py
@@ -10,3 +10,6 @@ ROOT_USER_URL = f"{ROOT_URL}/user"
 PACKAGES_URL = f"{ROOT_CURA_URL}/packages"  # URL to use for requesting the list of packages.
 PACKAGE_UPDATES_URL = f"{PACKAGES_URL}/package-updates"  # URL to use for requesting the list of packages that can be updated.
 USER_PACKAGES_URL = f"{ROOT_USER_URL}/packages"
+
+PACKAGE_TYPE_PLUGIN = "plugin"    # Package type identifier for plugins, as returned by the Marketplace API.
+PACKAGE_TYPE_MATERIAL = "material"  # Package type identifier for materials, as returned by the Marketplace API.

--- a/plugins/Marketplace/LocalPackageList.py
+++ b/plugins/Marketplace/LocalPackageList.py
@@ -12,7 +12,7 @@ from UM.Logger import Logger
 
 from .PackageList import PackageList
 from .PackageModel import PackageModel
-from .Constants import PACKAGE_UPDATES_URL
+from .Constants import PACKAGE_UPDATES_URL, PACKAGE_TYPE_PLUGIN
 
 if TYPE_CHECKING:
     from PyQt6.QtCore import QObject
@@ -43,8 +43,15 @@ class LocalPackageList(PackageList):
         self._package_manager.packageUninstalled.connect(self._removePackageModel)
 
     def _sortSectionsOnUpdate(self) -> None:
-        section_order = dict(zip([i for k, v in self.PACKAGE_CATEGORIES.items() for i in self.PACKAGE_CATEGORIES[k].values()], ["a", "b", "c", "d"]))
-        self.sort(lambda model: (section_order[model.sectionTitle], not model.canUpdate, model.displayName.lower()), key = "package")
+        """
+        Sort the list of packages based on the following criteria:
+            1. Bundled packages are sorted to the bottom of the list.
+            2. Plugins before materials/other future packageTypes within each group.
+            3. Packages that can be updated are sorted to the top of the list. (not canUpdate = False → sorts first = lower value).
+            4. Packages are sorted alphabetically by their display name as tie breaker.
+        """
+
+        self.sort(lambda model: (model.isBundled, model.packageType != PACKAGE_TYPE_PLUGIN, not model.canUpdate, model.displayName.lower()), key = "package")
 
     def _removePackageModel(self, package_id: str) -> None:
         """

--- a/plugins/Marketplace/Marketplace.py
+++ b/plugins/Marketplace/Marketplace.py
@@ -32,6 +32,7 @@ class Marketplace(Extension, QObject):
         preferences = CuraApplication.getInstance().getPreferences()
         preferences.addPreference("info/automatic_plugin_update_check", True)
         self._local_package_list = LocalPackageList(self)
+        self._local_package_list.bulkUpdateInProgressChanged.connect(self._onBulkUpdateInProgressChanged)
         if preferences.getValue("info/automatic_plugin_update_check"):
             self._local_package_list.checkForUpdates(self._package_manager.local_packages)
 
@@ -57,6 +58,7 @@ class Marketplace(Extension, QObject):
         if self._material_package_list is None:
             self._material_package_list = RemotePackageList()
             self._material_package_list.packageTypeFilter = "material"
+            self._material_package_list.bulkUpdateInProgressChanged.connect(self._onBulkUpdateInProgressChanged)
 
         return self._material_package_list
 
@@ -65,6 +67,7 @@ class Marketplace(Extension, QObject):
         if self._plugin_package_list is None:
             self._plugin_package_list = RemotePackageList()
             self._plugin_package_list.packageTypeFilter = "plugin"
+            self._plugin_package_list.bulkUpdateInProgressChanged.connect(self._onBulkUpdateInProgressChanged)
         return self._plugin_package_list
 
     @pyqtProperty(QObject, constant=True)
@@ -108,9 +111,22 @@ class Marketplace(Extension, QObject):
 
     showRestartNotificationChanged = pyqtSignal()
 
+    @pyqtSlot()
+    def _onBulkUpdateInProgressChanged(self) -> None:
+        self.showRestartNotificationChanged.emit()
+
+    def _isBulkUpdateInProgress(self) -> bool:
+        if self._local_package_list.bulkUpdateInProgress:
+            return True
+        if self._material_package_list and self._material_package_list.bulkUpdateInProgress:
+            return True
+        if self._plugin_package_list and self._plugin_package_list.bulkUpdateInProgress:
+            return True
+        return False
+
     @pyqtProperty(bool, notify = showRestartNotificationChanged)
     def showRestartNotification(self) -> bool:
-        return self._restart_needed
+        return self._restart_needed and not self._isBulkUpdateInProgress()
 
     def showInstallMissingPackageDialog(self, packages_metadata: List[Dict[str, str]], ignore_warning_callback: Callable[[], None]) -> None:
         """

--- a/plugins/Marketplace/PackageList.py
+++ b/plugins/Marketplace/PackageList.py
@@ -232,7 +232,7 @@ class PackageList(ListModel):
         This acts only on the package models present in this specific list instance, which keeps
         the action scoped to the currently visible tab.
         """
-        if self._active_bulk_update_id:
+        if self._bulk_update_in_progress:
             return
 
         self._pending_bulk_update_ids = []

--- a/plugins/Marketplace/PackageList.py
+++ b/plugins/Marketplace/PackageList.py
@@ -175,12 +175,7 @@ class PackageList(ListModel):
     @pyqtProperty(bool, notify = hasUpdatablePackagesChanged)
     def hasUpdatablePackages(self) -> bool:
         """True when at least one package in this list has a pending update available."""
-        for index in range(self.rowCount()):
-            data = self.getItem(index)
-            package = data.get("package") if data else None
-            if package and package.canUpdate and not package.isMissingPackageInformation:
-                return True
-        return False
+        return self.updatablePackagesCount() >= 1
 
     @pyqtProperty(int, notify = hasUpdatablePackagesChanged)
     def updatablePackagesCount(self) -> int:

--- a/plugins/Marketplace/PackageList.py
+++ b/plugins/Marketplace/PackageList.py
@@ -52,7 +52,6 @@ class PackageList(ListModel):
         self._license_dialogs: Dict[str, QObject] = {}
 
         self._sort_by_install_status = False
-        self._pre_sort_order: List[str] = []  # Package IDs in order before install-status sort was applied.
 
         # Queue for sequential bulk updates triggered from the tab-level "Update all" button.
         self._pending_bulk_update_ids: List[str] = []
@@ -175,7 +174,7 @@ class PackageList(ListModel):
     @pyqtProperty(bool, notify = hasUpdatablePackagesChanged)
     def hasUpdatablePackages(self) -> bool:
         """True when at least one package in this list has a pending update available."""
-        return self.updatablePackagesCount() >= 1
+        return self.updatablePackagesCount >= 1
 
     @pyqtProperty(int, notify = hasUpdatablePackagesChanged)
     def updatablePackagesCount(self) -> int:
@@ -195,7 +194,6 @@ class PackageList(ListModel):
             self._sort_by_install_status = value
             self.sortByInstallStatusChanged.emit()
             if value:
-                self._saveOrder()
                 self._applyInstallStatusSort()
             else:
                 self._restoreOrder()
@@ -223,22 +221,9 @@ class PackageList(ListModel):
             return 2
         self.sort(_priority, key = "package")
 
-    def _saveOrder(self) -> None:
-        """Snapshot the current package ID order so it can be restored later."""
-        self._pre_sort_order = []
-        for index in range(self.rowCount()):
-            data = self.getItem(index)
-            package = data.get("package") if data else None
-            if package:
-                self._pre_sort_order.append(package.packageId)
-
     def _restoreOrder(self) -> None:
-        """Restore the item order that was saved before the install-status sort was applied."""
-        if not self._pre_sort_order:
-            return
-        order_map = {pkg_id: i for i, pkg_id in enumerate(self._pre_sort_order)}
-        self.sort(lambda model: order_map.get(model.packageId, len(self._pre_sort_order)), key = "package")
-        self._pre_sort_order = []
+        """Re-sort items back into their original API/insertion order."""
+        self.sort(lambda model: model._insertion_index, key = "package")
 
     @pyqtSlot()
     def updateAllPackages(self) -> None:

--- a/plugins/Marketplace/PackageList.py
+++ b/plugins/Marketplace/PackageList.py
@@ -5,7 +5,7 @@ import json
 import os.path
 
 from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, Qt
-from typing import cast, Dict, Optional, Set, TYPE_CHECKING
+from typing import cast, Dict, List, Optional, Set, TYPE_CHECKING
 
 from UM.i18n import i18nCatalog
 from UM.Qt.ListModel import ListModel
@@ -51,11 +51,26 @@ class PackageList(ListModel):
         self._scope = JsonDecoratorScope(UltimakerCloudScope(CuraApplication.getInstance()))
         self._license_dialogs: Dict[str, QObject] = {}
 
+        # Queue for sequential bulk updates triggered from the tab-level "Update all" button.
+        self._pending_bulk_update_ids: List[str] = []
+        self._active_bulk_update_id: Optional[str] = None
+        self._bulk_update_in_progress = False
+        self._package_manager.packageInstalled.connect(self._onBulkUpdateFinished)
+        self._package_manager.packageInstallingFailed.connect(self._onBulkUpdateFinished)
+        self._package_manager.packagesWithUpdateChanged.connect(self.hasUpdatablePackagesChanged)
+
     def __del__(self) -> None:
         """ When this object is deleted it will loop through all registered API requests and aborts them """
         try:
             self.isLoadingChanged.disconnect()
             self.hasMoreChanged.disconnect()
+        except RuntimeError:
+            pass
+
+        try:
+            self._package_manager.packageInstalled.disconnect(self._onBulkUpdateFinished)
+            self._package_manager.packageInstallingFailed.disconnect(self._onBulkUpdateFinished)
+            self._package_manager.packagesWithUpdateChanged.disconnect(self.hasUpdatablePackagesChanged)
         except RuntimeError:
             pass
 
@@ -137,6 +152,73 @@ class PackageList(ListModel):
         if data:
             return data.get("package")
         return None
+
+    bulkUpdateInProgressChanged = pyqtSignal()
+
+    def setBulkUpdateInProgress(self, value: bool) -> None:
+        if self._bulk_update_in_progress != value:
+            self._bulk_update_in_progress = value
+            self.bulkUpdateInProgressChanged.emit()
+            self.hasUpdatablePackagesChanged.emit()
+
+    @pyqtProperty(bool, notify = bulkUpdateInProgressChanged)
+    def bulkUpdateInProgress(self) -> bool:
+        return self._bulk_update_in_progress
+
+    hasUpdatablePackagesChanged = pyqtSignal()
+
+    @pyqtProperty(bool, notify = hasUpdatablePackagesChanged)
+    def hasUpdatablePackages(self) -> bool:
+        """True when at least one package in this list has a pending update available."""
+        for index in range(self.rowCount()):
+            data = self.getItem(index)
+            package = data.get("package") if data else None
+            if package and package.canUpdate and not package.isMissingPackageInformation:
+                return True
+        return False
+
+    @pyqtSlot()
+    def updateAllPackages(self) -> None:
+        """Queue updates for all currently listed packages that can be updated.
+
+        This acts only on the package models present in this specific list instance, which keeps
+        the action scoped to the currently visible tab.
+        """
+        if self._active_bulk_update_id:
+            return
+
+        self._pending_bulk_update_ids = []
+        for index in range(self.rowCount()):
+            data = self.getItem(index)
+            package = data.get("package") if data else None
+            if not package or not package.canUpdate or package.isMissingPackageInformation:
+                continue
+            self._pending_bulk_update_ids.append(package.packageId)
+
+        self.setBulkUpdateInProgress(len(self._pending_bulk_update_ids) > 0)
+
+        self._startNextBulkUpdate()
+
+    def _startNextBulkUpdate(self) -> None:
+        while self._pending_bulk_update_ids:
+            package_id = self._pending_bulk_update_ids.pop(0)
+            package = self.getPackageModel(package_id)
+            if not package or not package.canUpdate or package.isMissingPackageInformation or package.busy:
+                continue
+
+            self._active_bulk_update_id = package_id
+            package.update()
+            return
+
+        self._active_bulk_update_id = None
+        self.setBulkUpdateInProgress(False)
+
+    @pyqtSlot(str)
+    def _onBulkUpdateFinished(self, package_id: str) -> None:
+        if package_id != self._active_bulk_update_id:
+            return
+        self._active_bulk_update_id = None
+        self._startNextBulkUpdate()
 
     def _openLicenseDialog(self, package_id: str, license_content: str) -> None:
         plugin_path = self._plugin_registry.getPluginPath("Marketplace")

--- a/plugins/Marketplace/PackageList.py
+++ b/plugins/Marketplace/PackageList.py
@@ -51,6 +51,9 @@ class PackageList(ListModel):
         self._scope = JsonDecoratorScope(UltimakerCloudScope(CuraApplication.getInstance()))
         self._license_dialogs: Dict[str, QObject] = {}
 
+        self._sort_by_install_status = False
+        self._pre_sort_order: List[str] = []  # Package IDs in order before install-status sort was applied.
+
         # Queue for sequential bulk updates triggered from the tab-level "Update all" button.
         self._pending_bulk_update_ids: List[str] = []
         self._active_bulk_update_id: Optional[str] = None
@@ -189,6 +192,58 @@ class PackageList(ListModel):
             if package and package.canUpdate and not package.isMissingPackageInformation:
                 count += 1
         return count
+
+    sortByInstallStatusChanged = pyqtSignal()
+
+    def setSortByInstallStatus(self, value: bool) -> None:
+        if self._sort_by_install_status != value:
+            self._sort_by_install_status = value
+            self.sortByInstallStatusChanged.emit()
+            if value:
+                self._saveOrder()
+                self._applyInstallStatusSort()
+            else:
+                self._restoreOrder()
+
+    @pyqtProperty(bool, fset = setSortByInstallStatus, notify = sortByInstallStatusChanged)
+    def sortByInstallStatus(self) -> bool:
+        """When True the list is sorted so packages with updates bubble to the top, followed by
+        installed packages without updates, then the rest ordered by their original release date."""
+        return self._sort_by_install_status
+
+    def _applyInstallStatusSort(self) -> None:
+        """Re-sort the current items using install/update-status as the primary key.
+
+        Priority order (lower number = closer to top):
+          0 – installed and has an update available (Update button)
+          1 – installed, no update pending (Uninstall button)
+          2 – not installed; preserves original relative order (release date from API)
+        Within each priority group the existing relative order is preserved (stable sort).
+        """
+        def _priority(model) -> int:
+            if model.canUpdate:
+                return 0
+            if model.isInstalled or model.isToBeInstalled:
+                return 1
+            return 2
+        self.sort(_priority, key = "package")
+
+    def _saveOrder(self) -> None:
+        """Snapshot the current package ID order so it can be restored later."""
+        self._pre_sort_order = []
+        for index in range(self.rowCount()):
+            data = self.getItem(index)
+            package = data.get("package") if data else None
+            if package:
+                self._pre_sort_order.append(package.packageId)
+
+    def _restoreOrder(self) -> None:
+        """Restore the item order that was saved before the install-status sort was applied."""
+        if not self._pre_sort_order:
+            return
+        order_map = {pkg_id: i for i, pkg_id in enumerate(self._pre_sort_order)}
+        self.sort(lambda model: order_map.get(model.packageId, len(self._pre_sort_order)), key = "package")
+        self._pre_sort_order = []
 
     @pyqtSlot()
     def updateAllPackages(self) -> None:

--- a/plugins/Marketplace/PackageList.py
+++ b/plugins/Marketplace/PackageList.py
@@ -102,6 +102,8 @@ class PackageList(ListModel):
         if self._is_loading != value:
             self._is_loading = value
             self.isLoadingChanged.emit()
+            if not value:
+                self.hasUpdatablePackagesChanged.emit()
 
     @pyqtProperty(bool, fset = setIsLoading, notify = isLoadingChanged)
     def isLoading(self) -> bool:
@@ -176,6 +178,17 @@ class PackageList(ListModel):
             if package and package.canUpdate and not package.isMissingPackageInformation:
                 return True
         return False
+
+    @pyqtProperty(int, notify = hasUpdatablePackagesChanged)
+    def updatablePackagesCount(self) -> int:
+        """Returns the number of packages in this list that have a pending update available."""
+        count = 0
+        for index in range(self.rowCount()):
+            data = self.getItem(index)
+            package = data.get("package") if data else None
+            if package and package.canUpdate and not package.isMissingPackageInformation:
+                count += 1
+        return count
 
     @pyqtSlot()
     def updateAllPackages(self) -> None:

--- a/plugins/Marketplace/PackageModel.py
+++ b/plugins/Marketplace/PackageModel.py
@@ -68,6 +68,7 @@ class PackageModel(QObject):
 
         self._can_update = False
         self._section_title = section_title
+        self._insertion_index: int = 0  # Set by the list when this package is appended; used to restore original order.
         self.sdk_version = package_data.get("sdk_version_semver", "")
         # Note that there's a lot more info in the package_data than just these specified here.
 

--- a/plugins/Marketplace/PackageModel.py
+++ b/plugins/Marketplace/PackageModel.py
@@ -79,6 +79,7 @@ class PackageModel(QObject):
         self._package_manager.packageUninstalled.connect(lambda pkg_id: self._packageInstalled(pkg_id))
         self._package_manager.packageInstallingFailed.connect(lambda pkg_id: self._packageInstalled(pkg_id))
         self._package_manager.packagesWithUpdateChanged.connect(self._processUpdatedPackages)
+        self._processUpdatedPackages()  # Initialize canUpdate based on current state, in case the signal already fired.
 
         self._is_busy = False
 

--- a/plugins/Marketplace/RemotePackageList.py
+++ b/plugins/Marketplace/RemotePackageList.py
@@ -124,6 +124,7 @@ class RemotePackageList(PackageList):
         for package_data in response_data["data"]:
             try:
                 package = PackageModel(package_data, parent = self)
+                package._insertion_index = self.rowCount()
                 self._connectManageButtonSignals(package)
                 self.appendItem({"package": package})  # Add it to this list model.
             except RuntimeError:

--- a/plugins/Marketplace/RemotePackageList.py
+++ b/plugins/Marketplace/RemotePackageList.py
@@ -132,6 +132,9 @@ class RemotePackageList(PackageList):
                 # was deleted when it was still parsing the response
                 continue
 
+        if self._sort_by_install_status:
+            self._applyInstallStatusSort()
+
         self._request_url = response_data["links"].get("next", "")  # Use empty string to signify that there is no next page.
         self._ongoing_requests["get_packages"] = None
         self.setIsLoading(False)

--- a/plugins/Marketplace/plugin.json
+++ b/plugins/Marketplace/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Marketplace",
     "author": "Ultimaker B.V.",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "api": 8,
     "description": "Manages extensions to the application and allows browsing extensions from the UltiMaker website.",
     "i18n-catalog": "cura"

--- a/plugins/Marketplace/resources/qml/ManagedPackages.qml
+++ b/plugins/Marketplace/resources/qml/ManagedPackages.qml
@@ -21,6 +21,7 @@ Packages
     }
     searchInBrowserUrl: "https://marketplace.ultimaker.com/app/cura/plugins?utm_source=cura&utm_medium=software&utm_campaign=marketplace-search-plugins-browser"
     showUpdateButton: true
+    showUpdateAllButton: true
     showInstallButton: true
     showDisableButton: true
     model: manager.LocalPackageList

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -45,6 +45,8 @@ UM.Dialog
             {
                 id: packageBrowse
 
+                property bool sortByInstallStatus: false
+
                 spacing: UM.Theme.getSize("narrow_margin").height
 
                 // Page title.
@@ -172,17 +174,43 @@ UM.Dialog
                     font: UM.Theme.getFont("default")
                 }
 
-                Cura.TertiaryButton
+                RowLayout
                 {
-                    text: catalog.i18nc("@info", "Search in the browser")
-                    iconSource: UM.Theme.getIcon("LinkExternal")
+                    Layout.fillWidth: true
+                    Layout.leftMargin: UM.Theme.getSize("default_margin").width
+                    Layout.rightMargin: UM.Theme.getSize("default_margin").width
                     visible: pageSelectionTabBar.currentItem.hasSearch && searchHeader.visible
-                    isIconOnRightSide: true
-                    height: fontMetrics.height
-                    textFont: fontMetrics.font
-                    textColor: UM.Theme.getColor("text")
 
-                    onClicked: content.item && Qt.openUrlExternally(content.item.searchInBrowserUrl)
+                    Cura.TertiaryButton
+                    {
+                        text: catalog.i18nc("@info", "Search in the browser")
+                        iconSource: UM.Theme.getIcon("LinkExternal")
+                        isIconOnRightSide: true
+                        height: fontMetrics.height
+                        textFont: fontMetrics.font
+                        textColor: UM.Theme.getColor("text")
+
+                        onClicked: content.item && Qt.openUrlExternally(content.item.searchInBrowserUrl)
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    UM.CheckBox
+                    {
+                        id: sortByInstallStatusCheckbox
+                        LayoutMirroring.enabled: true
+                        LayoutMirroring.childrenInherit: false
+                        text: catalog.i18nc("@option:check", "Sort by installed")
+                        checked: packageBrowse.sortByInstallStatus
+                        onClicked:
+                        {
+                            packageBrowse.sortByInstallStatus = checked
+                            if (content.item && content.item.model)
+                            {
+                                content.item.model.sortByInstallStatus = checked
+                            }
+                        }
+                    }
                 }
 
                 // Page contents.
@@ -208,6 +236,10 @@ UM.Dialog
                             {
                                 pageTitle.text = content.item.pageTitle
                                 searchStringChanged.connect(handleSearchStringChanged)
+                                if (content.item.model)
+                                {
+                                    content.item.model.sortByInstallStatus = packageBrowse.sortByInstallStatus
+                                }
                             }
 
                             function handleSearchStringChanged(new_search)

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -172,17 +172,36 @@ UM.Dialog
                     font: UM.Theme.getFont("default")
                 }
 
-                Cura.TertiaryButton
+                Item
                 {
-                    text: catalog.i18nc("@info", "Search in the browser")
-                    iconSource: UM.Theme.getIcon("LinkExternal")
-                    visible: pageSelectionTabBar.currentItem.hasSearch && searchHeader.visible
-                    isIconOnRightSide: true
-                    height: fontMetrics.height
-                    textFont: fontMetrics.font
-                    textColor: UM.Theme.getColor("text")
+                    implicitHeight: Math.max(fontMetrics.height, updateAllButton.implicitHeight)
+                    Layout.fillWidth: true
 
-                    onClicked: content.item && Qt.openUrlExternally(content.item.searchInBrowserUrl)
+                    Cura.TertiaryButton
+                    {
+                        anchors.left: parent.left
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: catalog.i18nc("@info", "Search in the browser")
+                        iconSource: UM.Theme.getIcon("LinkExternal")
+                        visible: pageSelectionTabBar.currentItem.hasSearch && searchHeader.visible
+                        isIconOnRightSide: true
+                        height: fontMetrics.height
+                        textFont: fontMetrics.font
+                        textColor: UM.Theme.getColor("text")
+
+                        onClicked: content.item && Qt.openUrlExternally(content.item.searchInBrowserUrl)
+                    }
+
+                    Cura.SecondaryButton
+                    {
+                        id: updateAllButton
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: catalog.i18nc("@button", "Update all")
+                        visible: content.item !== null && content.item.showUpdateAllButton
+                        enabled: content.item !== null && !content.item.model.isLoading && content.item.model.hasUpdatablePackages
+                        onClicked: if (content.item) { content.item.model.updateAllPackages() }
+                    }
                 }
 
                 // Page contents.

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -198,8 +198,6 @@ UM.Dialog
                     UM.CheckBox
                     {
                         id: sortByInstallStatusCheckbox
-                        LayoutMirroring.enabled: true
-                        LayoutMirroring.childrenInherit: false
                         text: catalog.i18nc("@option:check", "Sort by installed")
                         checked: packageBrowse.sortByInstallStatus
                         onClicked:

--- a/plugins/Marketplace/resources/qml/Marketplace.qml
+++ b/plugins/Marketplace/resources/qml/Marketplace.qml
@@ -172,36 +172,17 @@ UM.Dialog
                     font: UM.Theme.getFont("default")
                 }
 
-                Item
+                Cura.TertiaryButton
                 {
-                    implicitHeight: Math.max(fontMetrics.height, updateAllButton.implicitHeight)
-                    Layout.fillWidth: true
+                    text: catalog.i18nc("@info", "Search in the browser")
+                    iconSource: UM.Theme.getIcon("LinkExternal")
+                    visible: pageSelectionTabBar.currentItem.hasSearch && searchHeader.visible
+                    isIconOnRightSide: true
+                    height: fontMetrics.height
+                    textFont: fontMetrics.font
+                    textColor: UM.Theme.getColor("text")
 
-                    Cura.TertiaryButton
-                    {
-                        anchors.left: parent.left
-                        anchors.verticalCenter: parent.verticalCenter
-                        text: catalog.i18nc("@info", "Search in the browser")
-                        iconSource: UM.Theme.getIcon("LinkExternal")
-                        visible: pageSelectionTabBar.currentItem.hasSearch && searchHeader.visible
-                        isIconOnRightSide: true
-                        height: fontMetrics.height
-                        textFont: fontMetrics.font
-                        textColor: UM.Theme.getColor("text")
-
-                        onClicked: content.item && Qt.openUrlExternally(content.item.searchInBrowserUrl)
-                    }
-
-                    Cura.SecondaryButton
-                    {
-                        id: updateAllButton
-                        anchors.right: parent.right
-                        anchors.verticalCenter: parent.verticalCenter
-                        text: catalog.i18nc("@button", "Update all")
-                        visible: content.item !== null && content.item.showUpdateAllButton
-                        enabled: content.item !== null && !content.item.model.isLoading && content.item.model.hasUpdatablePackages
-                        onClicked: if (content.item) { content.item.model.updateAllPackages() }
-                    }
+                    onClicked: content.item && Qt.openUrlExternally(content.item.searchInBrowserUrl)
                 }
 
                 // Page contents.

--- a/plugins/Marketplace/resources/qml/Materials.qml
+++ b/plugins/Marketplace/resources/qml/Materials.qml
@@ -17,7 +17,9 @@ Packages
     }
     searchInBrowserUrl: "https://marketplace.ultimaker.com/app/cura/materials?utm_source=cura&utm_medium=software&utm_campaign=marketplace-search-materials-browser"
     showUpdateButton: true
+    showUpdateAllButton: true
     showInstallButton: true
+    updateAllText: catalog.i18nc("@label", "Update all the Materials: %1 materials have a new version available.").arg(updatablePackagesCount)
 
     model: manager.MaterialPackageList
 }

--- a/plugins/Marketplace/resources/qml/Packages.qml
+++ b/plugins/Marketplace/resources/qml/Packages.qml
@@ -25,6 +25,8 @@ ListView
     property bool showUpdateAllButton: false
     property bool showDisableButton
     property bool showInstallButton
+    property int updatablePackagesCount: model.updatablePackagesCount
+    property string updateAllText: catalog.i18nc("@label", "Update all the packages: %1 packages have a new version available.").arg(packages.updatablePackagesCount)
 
     clip: true
 
@@ -32,6 +34,47 @@ ListView
     Component.onDestruction: model.cleanUpAPIRequest()
 
     spacing: UM.Theme.getSize("default_margin").height
+
+    header: Item
+    {
+        width: packages.width
+        height: updateAllCard.height + UM.Theme.getSize("default_margin").height
+        visible: packages.showUpdateAllButton
+
+        Rectangle
+        {
+            id: updateAllCard
+            anchors.top: parent.top
+            width: verticalScrollBar.visible
+                ? parent.width - 2 * UM.Theme.getSize("default_margin").width
+                : parent.width - UM.Theme.getSize("default_margin").width
+            height: Math.max(updateAllHeaderText.implicitHeight, updateAllButton.implicitHeight) + UM.Theme.getSize("wide_margin").height
+            color: UM.Theme.getColor("main_background")
+            radius: UM.Theme.getSize("default_radius").width
+
+            UM.Label
+            {
+                id: updateAllHeaderText
+                anchors.left: parent.left
+                anchors.leftMargin: UM.Theme.getSize("default_margin").width
+                anchors.verticalCenter: parent.verticalCenter
+                text: packages.updateAllText
+                font: UM.Theme.getFont("large")
+            }
+
+            ManageButton
+            {
+                id: updateAllButton
+                anchors.right: parent.right
+                anchors.rightMargin: UM.Theme.getSize("default_margin").width
+                anchors.verticalCenter: parent.verticalCenter
+                text: busy ? catalog.i18nc("@button", "Updating...") : catalog.i18nc("@button", "Update all")
+                busy: packages.model.bulkUpdateInProgress
+                enabled: packages.model.hasUpdatablePackages && !packages.model.isLoading && !packages.model.bulkUpdateInProgress
+                onClicked: packages.model.updateAllPackages()
+            }
+        }
+    }
 
     section.property: "package.sectionTitle"
     section.delegate: Rectangle

--- a/plugins/Marketplace/resources/qml/Packages.qml
+++ b/plugins/Marketplace/resources/qml/Packages.qml
@@ -22,6 +22,7 @@ ListView
     property var onRemoveBanner
 
     property bool showUpdateButton
+    property bool showUpdateAllButton: false
     property bool showDisableButton
     property bool showInstallButton
 

--- a/plugins/Marketplace/resources/qml/Plugins.qml
+++ b/plugins/Marketplace/resources/qml/Plugins.qml
@@ -17,7 +17,9 @@ Packages
     }
     searchInBrowserUrl: "https://marketplace.ultimaker.com/app/cura/plugins?utm_source=cura&utm_medium=software&utm_campaign=marketplace-search-plugins-browser"
     showUpdateButton: true
+    showUpdateAllButton: true
     showInstallButton: true
+    updateAllText: catalog.i18nc("@label", "Update all the Plugins: %1 plugins have a new version available.").arg(updatablePackagesCount)
 
     model: manager.PluginPackageList
 }


### PR DESCRIPTION
# Description

Allows the users to update all the packages that have the Update available state automatically in sequence.
It delays the Restart prompt until all the packages have been updated successfully through the update all flow.

Fixed a bug where the update button would not be visible for a plugin with a new version available until the user navigated to the manages packages and back to the plugins tab.

<img width="885" height="748" alt="MarketplaceUpdate" src="https://github.com/user-attachments/assets/0e586eee-2bd9-4510-9abd-8f307d9ea5c6" />

Sort by installed: Moving the packages that are installed to the top of the list

<img width="795" height="1023" alt="image" src="https://github.com/user-attachments/assets/d2246b27-a712-40a9-bc10-4d8aacba4bed" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Updating multiple plugins from plugins tab and package manager tab

**Test Configuration**:
* Operating System: Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change
