### PR TITLE
[CURA-13247] Adjust the "support_brim_minimum_hole_area" enable condition

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5918,7 +5918,7 @@
                     "type": "float",
                     "default_value": 16,
                     "value": "skirt_brim_line_width * skirt_brim_line_width * 100",
-                    "enabled": "support_brim_enable",
+                    "enabled": "(support_enable or support_meshes_present) and support_brim_enable",
                     "limit_to_extruder": "support_infill_extruder_nr",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true


### PR DESCRIPTION
The setting should be visible when there is support brim enabled in addition to either support being enabled or a support mesh being present. With the previous support_brim_enable condition in isolation, the setting would be visible when no support is generated or no support mesh is present.

CURA-13247
