### PR TITLE
[CURA-13125] Add setting dependency for cooling enabled for feature cooling settings

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5137,6 +5137,7 @@
                     "unit": "s",
                     "type": "float",
                     "default_value": 10,
+                    "enabled": "cool_fan_enabled",
                     "maximum_value_warning": "600",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true
@@ -5166,6 +5167,7 @@
                     "maximum_value_warning": "10.0",
                     "settable_per_mesh": false,
                     "settable_per_extruder": true,
+                    "enabled": "cool_fan_enabled",
                     "children":
                     {
                         "cool_fan_full_layer":

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5176,6 +5176,7 @@
                             "description": "The layer at which the fans spin on regular fan speed. If regular fan speed at height is set, this value is calculated and rounded to a whole number.",
                             "type": "int",
                             "default_value": 2,
+                            "enabled": "cool_fan_enabled",
                             "minimum_value": "1",
                             "maximum_value_warning": "10 / resolveOrValue('layer_height')",
                             "value": "max(1, int(math.floor((cool_fan_full_at_height - resolveOrValue('layer_height_0')) / resolveOrValue('layer_height')) + 2))",

--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -2541,7 +2541,7 @@
                     "default_value": 100,
                     "value": "bridge_fan_speed",
                     "type": "float",
-                    "enabled": "skin_support",
+                    "enabled": "skin_support and cool_fan_enabled",
                     "settable_per_mesh": true,
                     "settable_per_extruder": true
                 },
@@ -6516,7 +6516,7 @@
                     "description": "When enabled, the print cooling fan speed is altered for the skin regions immediately above the support.",
                     "type": "bool",
                     "default_value": false,
-                    "enabled": "support_enable or support_meshes_present",
+                    "enabled": "(support_enable or support_meshes_present) and cool_fan_enabled",
                     "settable_per_mesh": false
                 },
                 "support_supported_skin_fan_speed":
@@ -6528,7 +6528,7 @@
                     "maximum_value": "100",
                     "default_value": 100,
                     "type": "float",
-                    "enabled": "(support_enable or support_meshes_present) and support_fan_enable",
+                    "enabled": "(support_enable or support_meshes_present) and support_fan_enable and cool_fan_enabled",
                     "settable_per_mesh": false
                 },
                 "support_use_towers":
@@ -9207,7 +9207,7 @@
                     "maximum_value": "100",
                     "default_value": 100,
                     "type": "float",
-                    "enabled": "bridge_settings_enabled",
+                    "enabled": "bridge_settings_enabled and cool_fan_enabled",
                     "settable_per_mesh": true
                 },
                 "bridge_interlace_lines":
@@ -9277,7 +9277,7 @@
                     "maximum_value": "100",
                     "default_value": 0,
                     "type": "float",
-                    "enabled": "bridge_settings_enabled and bridge_enable_more_layers",
+                    "enabled": "bridge_settings_enabled and bridge_enable_more_layers and cool_fan_enabled",
                     "settable_per_mesh": true
                 },
                 "bridge_skin_speed_3":
@@ -9329,7 +9329,7 @@
                     "maximum_value": "100",
                     "default_value": 0,
                     "type": "float",
-                    "enabled": "bridge_settings_enabled and bridge_enable_more_layers",
+                    "enabled": "bridge_settings_enabled and bridge_enable_more_layers and cool_fan_enabled",
                     "settable_per_mesh": true
                 },
                 "clean_between_layers":


### PR DESCRIPTION
Decision related to larger setting structure:
- Multiple settings that would set fan speed → all of these should not be set when print cooling is disabled
- If you want to disable cooling for certain features → set fan speed to 0%
- If you want fan speed unchanged from current fan speed → use setting formula

Comes with:
https://github.com/Ultimaker/CuraEngine/pull/2344

CURA-13125
