### PR TITLE
[CURA-12685] Fix group model position not respected when opening 3mf

### DIFF
--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -320,11 +320,14 @@ class ThreeMFReader(MeshReader):
                 node_meshdata = um_node.getMeshData()
                 if node_meshdata is not None:
                     aabb = node_meshdata.getExtents(um_node.getWorldTransformation())
-                    if aabb is not None:
-                        minimum_z_value = aabb.minimum.y  # y is z in transformation coordinates
-                        if minimum_z_value < 0:
-                            um_node.addDecorator(ZOffsetDecorator())
-                            um_node.callDecoration("setZOffset", minimum_z_value)
+                else:
+                    # For group nodes (no mesh data, but has children), use the combined bounding box of all children
+                    aabb = um_node.getBoundingBox()
+                if aabb is not None:
+                    minimum_z_value = aabb.minimum.y  # y is z in transformation coordinates
+                    if minimum_z_value < 0:
+                        um_node.addDecorator(ZOffsetDecorator())
+                        um_node.callDecoration("setZOffset", minimum_z_value)
 
                 result.append(um_node)
 

--- a/plugins/3MFReader/ThreeMFReader.py
+++ b/plugins/3MFReader/ThreeMFReader.py
@@ -320,8 +320,8 @@ class ThreeMFReader(MeshReader):
                 node_meshdata = um_node.getMeshData()
                 if node_meshdata is not None:
                     aabb = node_meshdata.getExtents(um_node.getWorldTransformation())
-                else:
-                    # For group nodes (no mesh data, but has children), use the combined bounding box of all children
+                elif len(um_node.getChildren()) > 0:
+                    # For group nodes, use the combined bounding box of all children
                     aabb = um_node.getBoundingBox()
                 if aabb is not None:
                     minimum_z_value = aabb.minimum.y  # y is z in transformation coordinates


### PR DESCRIPTION
This pull request makes a small change to the `_read` method in `ThreeMFReader.py`. The change ensures that for group nodes (nodes without mesh data but with children), the combined bounding box of all children is used to calculate extents, improving accuracy when handling hierarchical 3MF files.


CURA-12685
