### PR TITLE
CURA-13226 Frontend adjustments for benchmark tooling

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -57,7 +57,7 @@ jobs:
       always() &&
       needs.check_actor.outputs.proceed == 'true' &&
       needs.find-ticket-packages.result == 'success'
-    uses: ultimaker/cura-workflows/.github/workflows/unit-test.yml@CURA-13226_slice-speed-benchmark-tooling
+    uses: ultimaker/cura-workflows/.github/workflows/unit-test.yml@main
     with:
       test_use_pytest: true
       package_overrides: ${{ needs.find-ticket-packages.outputs.package_overrides || '' }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -57,7 +57,7 @@ jobs:
       always() &&
       needs.check_actor.outputs.proceed == 'true' &&
       needs.find-ticket-packages.result == 'success'
-    uses: ultimaker/cura-workflows/.github/workflows/unit-test.yml@main
+    uses: ultimaker/cura-workflows/.github/workflows/unit-test.yml@CURA-13226_slice-speed-benchmark-tooling
     with:
       test_use_pytest: true
       package_overrides: ${{ needs.find-ticket-packages.outputs.package_overrides || '' }}

--- a/conandata.yml
+++ b/conandata.yml
@@ -7,7 +7,7 @@ requirements:
   - "cura_binary_data/5.14.0-alpha.0@ultimaker/testing"
   - "fdm_materials/5.14.0-alpha.0@ultimaker/testing"
   - "dulcificum/5.11.0-alpha.0"
-  - "pysavitar/5.11.1-alpha.0"
+  - "pysavitar/5.12.0"
   - "pynest2d/5.11.0-alpha.0"
   - "shapely/2.1.2"
 requirements_internal:

--- a/plugins/CuraEngineBackend/Cura.proto
+++ b/plugins/CuraEngineBackend/Cura.proto
@@ -172,10 +172,6 @@ message SettingExtruder {
     int32 extruder = 2; //From which extruder stack the setting should inherit.
 }
 
-message GCodePrefix {
-    bytes data = 2; //Header string to be prepended before the rest of the g-code sent from the engine.
-}
-
 message SliceUUID {
     string slice_uuid = 1; //The UUID of the slice.
 }

--- a/plugins/CuraEngineBackend/CuraEngineBackend.py
+++ b/plugins/CuraEngineBackend/CuraEngineBackend.py
@@ -154,7 +154,6 @@ class CuraEngineBackend(QObject, Backend):
         self._message_handlers["cura.proto.LayerOptimized"] = self._onOptimizedLayerMessage
         self._message_handlers["cura.proto.Progress"] = self._onProgressMessage
         self._message_handlers["cura.proto.GCodeLayer"] = self._onGCodeLayerMessage
-        self._message_handlers["cura.proto.GCodePrefix"] = self._onGCodePrefixMessage
         self._message_handlers["cura.proto.SliceUUID"] = self._onSliceUUIDMessage
         self._message_handlers["cura.proto.PrintTimeMaterialEstimates"] = self._onPrintTimeMaterialEstimates
         self._message_handlers["cura.proto.InitialExtruder"] = self._onInitialExtruder
@@ -910,19 +909,6 @@ class CuraEngineBackend(QObject, Backend):
 
         try:
             self._scene.gcode_dict[self._start_slice_job_build_plate].append(message.data.decode("utf-8", "replace")) #type: ignore #Because we generate this attribute dynamically.
-        except KeyError:
-            # Can occur if the g-code has been cleared while a slice message is still arriving from the other end.
-            pass  # Throw the message away.
-
-    def _onGCodePrefixMessage(self, message: Arcus.PythonMessage) -> None:
-        """Called when a g-code prefix message is received from the engine.
-
-        :param message: The protobuf message containing the g-code prefix,
-        encoded as UTF-8.
-        """
-
-        try:
-            self._scene.gcode_dict[self._start_slice_job_build_plate].insert(0, message.data.decode("utf-8", "replace")) #type: ignore #Because we generate this attribute dynamically.
         except KeyError:
             # Can occur if the g-code has been cleared while a slice message is still arriving from the other end.
             pass  # Throw the message away.

--- a/resources/conanfile.py
+++ b/resources/conanfile.py
@@ -46,9 +46,9 @@ class CuraResource(ConanFile):
 
     def package_info(self):
         self.cpp_info.includedirs = []
-        self.runenv_info.define("CURA_RESOURCES", os.path.join(self.package_folder, "res"))
-        self.runenv_info.define("CURA_ENGINE_SEARCH_PATH", os.path.join(self.package_folder, "res", "definitions"))
-        self.runenv_info.define("CURA_ENGINE_SEARCH_PATH", os.path.join(self.package_folder, "res", "extruders"))
+        self.runenv_info.append_path("CURA_RESOURCES", os.path.join(self.package_folder, "res"))
+        self.runenv_info.append_path("CURA_ENGINE_SEARCH_PATH", os.path.join(self.package_folder, "res", "definitions"))
+        self.runenv_info.append_path("CURA_ENGINE_SEARCH_PATH", os.path.join(self.package_folder, "res", "extruders"))
 
     def package_id(self):
         self.info.clear()


### PR DESCRIPTION
This PR provides two minor improvements that were necessary for the new benchmarking tools:
* Remove the specific GCodePrefix message. The header is now treated as a regular GCode part, so this message is no more required.
* Append the environment variables for the cura resources, instead of defining them. This was we can more easily combine them with the variables defined by e.g. `fdm_materials`

CURA-13226
Requires https://github.com/Ultimaker/CuraEngine/pull/2345