### PR TITLE
Add value translation logic for the user change model

### DIFF
--- a/cura/API/Interface/Settings.py
+++ b/cura/API/Interface/Settings.py
@@ -3,11 +3,14 @@
 
 from dataclasses import asdict
 
-from typing import cast, Dict, TYPE_CHECKING, Any
+from typing import cast, Dict, Optional, TYPE_CHECKING, Any
 
+from UM.i18n import i18nCatalog
 from UM.Settings.InstanceContainer import InstanceContainer
 from UM.Settings.SettingFunction import SettingFunction
 from cura.Settings.GlobalStack import GlobalStack
+
+catalog = i18nCatalog("cura")
 
 if TYPE_CHECKING:
     from cura.CuraApplication import CuraApplication
@@ -108,6 +111,43 @@ class Settings:
                 settings[f"extruder_{i}"]["all_settings"][setting] = self._retrieveValue(extruder, setting)
 
         return settings
+
+    def getSettingDisplayValue(self, setting_key: str, value, stack, i18n_catalog: Optional[i18nCatalog] = None) -> str:
+        """Convert a raw setting value to the display string shown in the UI.
+
+        :param setting_key: The key of the setting.
+        :param value: The raw value to convert.
+        :param stack: The container stack to retrieve setting properties from.
+        :param i18n_catalog: Optional machine-definition catalog for translating enum option labels.
+        :return: Human-readable display string.
+        """
+        if value is None:
+            return ""
+        setting_type = stack.getProperty(setting_key, "type")
+
+        if setting_type in ("extruder", "optional_extruder"):
+            try:
+                int_value = int(value)
+            except (ValueError, TypeError):
+                return str(value)
+            if int_value == -1:
+                return catalog.i18nc("@menuitem", "Auto")
+            global_stack = self.application.getMachineManager().activeMachine
+            if global_stack and 0 <= int_value < len(global_stack.extruderList):
+                return global_stack.extruderList[int_value].getName()
+            return str(int_value + 1)
+
+        if setting_type == "enum":
+            options = stack.getProperty(setting_key, "options")
+            if options:
+                str_value = str(value)
+                option_label = options.get(str_value)
+                if option_label:
+                    if i18n_catalog:
+                        return i18n_catalog.i18nc(f"{setting_key} option {str_value}", option_label)
+                    return option_label
+
+        return str(value)
 
     @staticmethod
     def _retrieveValue(container: InstanceContainer, setting_: str):

--- a/cura/Machines/Models/QualitySettingsModel.py
+++ b/cura/Machines/Models/QualitySettingsModel.py
@@ -136,6 +136,8 @@ class QualitySettingsModel(ListModel):
         # We iterate over all definitions instead of settings in a quality/quality_changes group is because in the GUI,
         # the settings are grouped together by categories, and we had to go over all the definitions to figure out
         # which setting belongs in which category.
+        api_settings = self._application.getCuraAPI().interface.settings
+
         current_category = ""
         for definition in definition_container.findDefinitions():
             if definition.type == "category":
@@ -163,10 +165,10 @@ class QualitySettingsModel(ListModel):
                     break
 
             if self._selected_position == self.GLOBAL_STACK_POSITION:
-                user_value = global_container_stack.userChanges.getProperty(definition.key, "value")
+                display_stack = global_container_stack
             else:
-                extruder_stack = global_container_stack.extruderList[self._selected_position]
-                user_value = extruder_stack.userChanges.getProperty(definition.key, "value")
+                display_stack = global_container_stack.extruderList[self._selected_position]
+            user_value = display_stack.userChanges.getProperty(definition.key, "value")
 
             if profile_value is None and user_value is None:
                 continue
@@ -183,7 +185,7 @@ class QualitySettingsModel(ListModel):
                 else:
                     profile_value_display = "Calculated"
             else:
-                profile_value_display = "" if profile_value is None else str(profile_value)
+                profile_value_display = api_settings.getSettingDisplayValue(definition.key, profile_value, display_stack, self._i18n_catalog)
 
             items.append({
                 "key": definition.key,
@@ -191,7 +193,7 @@ class QualitySettingsModel(ListModel):
                 "unit": definition.unit,
                 "profile_value": profile_value_display,
                 "profile_value_source": profile_value_source,
-                "user_value": "" if user_value is None else str(user_value),
+                "user_value": api_settings.getSettingDisplayValue(definition.key, user_value, display_stack, self._i18n_catalog),
                 "category": current_category
             })
 

--- a/cura/Machines/Models/UserChangesModel.py
+++ b/cura/Machines/Models/UserChangesModel.py
@@ -13,8 +13,6 @@ from UM.i18n import i18nCatalog
 from UM.Settings.SettingFunction import SettingFunction
 from UM.Qt.ListModel import ListModel
 
-catalog = i18nCatalog("cura")
-
 
 class UserChangesModel(ListModel):
     KeyRole = Qt.ItemDataRole.UserRole + 1
@@ -38,35 +36,9 @@ class UserChangesModel(ListModel):
         self._update()
 
     def _getDisplayValue(self, setting_key: str, value, stack) -> str:
-        """Convert a raw setting value to the display string shown in the UI."""
-        if value is None:
-            return ""
-        setting_type = stack.getProperty(setting_key, "type")
-
-        if setting_type in ("extruder", "optional_extruder"):
-            try:
-                int_value = int(value)
-            except (ValueError, TypeError):
-                return str(value)
-            if int_value == -1:
-                # Auto has been chosen based on the defined requirements, otherwise the value should be 'Not overridden'
-                return catalog.i18nc("@menuitem", "Auto")
-            global_stack = Application.getInstance().getMachineManager().activeMachine
-            if global_stack and 0 <= int_value < len(global_stack.extruderList):
-                return global_stack.extruderList[int_value].getName()
-            return str(int_value + 1)
-
-        if setting_type == "enum":
-            options = stack.getProperty(setting_key, "options")
-            if options:
-                str_value = str(value)
-                option_label = options.get(str_value) or options.get(value)
-                if option_label:
-                    if self._i18n_catalog:
-                        return self._i18n_catalog.i18nc(f"{setting_key} option {str_value}", option_label)
-                    return option_label
-
-        return str(value)
+        return Application.getInstance().getCuraAPI().interface.settings.getSettingDisplayValue(
+            setting_key, value, stack, self._i18n_catalog
+        )
 
     @pyqtSlot()
     def forceUpdate(self):

--- a/cura/Machines/Models/UserChangesModel.py
+++ b/cura/Machines/Models/UserChangesModel.py
@@ -13,6 +13,8 @@ from UM.i18n import i18nCatalog
 from UM.Settings.SettingFunction import SettingFunction
 from UM.Qt.ListModel import ListModel
 
+catalog = i18nCatalog("cura")
+
 
 class UserChangesModel(ListModel):
     KeyRole = Qt.ItemDataRole.UserRole + 1
@@ -34,6 +36,37 @@ class UserChangesModel(ListModel):
         self._i18n_catalog = None
 
         self._update()
+
+    def _getDisplayValue(self, setting_key: str, value, stack) -> str:
+        """Convert a raw setting value to the display string shown in the UI."""
+        if value is None:
+            return ""
+        setting_type = stack.getProperty(setting_key, "type")
+
+        if setting_type in ("extruder", "optional_extruder"):
+            try:
+                int_value = int(value)
+            except (ValueError, TypeError):
+                return str(value)
+            if int_value == -1:
+                # Auto has been chosen based on the defined requirements, otherwise the value should be 'Not overridden'
+                return catalog.i18nc("@menuitem", "Auto")
+            global_stack = Application.getInstance().getMachineManager().activeMachine
+            if global_stack and 0 <= int_value < len(global_stack.extruderList):
+                return global_stack.extruderList[int_value].getName()
+            return str(int_value + 1)
+
+        if setting_type == "enum":
+            options = stack.getProperty(setting_key, "options")
+            if options:
+                str_value = str(value)
+                option_label = options.get(str_value) or options.get(value)
+                if option_label:
+                    if self._i18n_catalog:
+                        return self._i18n_catalog.i18nc(f"{setting_key} option {str_value}", option_label)
+                    return option_label
+
+        return str(value)
 
     @pyqtSlot()
     def forceUpdate(self):
@@ -57,15 +90,15 @@ class UserChangesModel(ListModel):
         definition = global_stack.getBottom()
 
         definition_suffix = ContainerRegistry.getMimeTypeForContainer(type(definition)).preferredSuffix
-        catalog = i18nCatalog(os.path.basename(definition.getId() + "." + definition_suffix))
+        definition_catalog = i18nCatalog(os.path.basename(definition.getId() + "." + definition_suffix))
 
-        if catalog.hasTranslationLoaded():
-            self._i18n_catalog = catalog
+        if definition_catalog.hasTranslationLoaded():
+            self._i18n_catalog = definition_catalog
 
         for file_name in definition.getInheritedFiles():
-            catalog = i18nCatalog(os.path.basename(file_name))
-            if catalog.hasTranslationLoaded():
-                self._i18n_catalog = catalog
+            definition_catalog = i18nCatalog(os.path.basename(file_name))
+            if definition_catalog.hasTranslationLoaded():
+                self._i18n_catalog = definition_catalog
 
         for stack in stacks:
             # Make a list of all containers in the stack.
@@ -121,8 +154,8 @@ class UserChangesModel(ListModel):
                 item_to_add = {
                     "key": setting_key,
                     "label": label,
-                    "user_value": str(user_changes.getProperty(setting_key, "value", default_value_resolve_context)),
-                    "original_value": str(original_value),
+                    "user_value": self._getDisplayValue(setting_key, user_changes.getProperty(setting_key, "value", default_value_resolve_context), stack),
+                    "original_value": self._getDisplayValue(setting_key, original_value, stack),
                     "extruder": "",
                     "category": category_label,
                 }

--- a/plugins/3MFReader/SpecificSettingsModel.py
+++ b/plugins/3MFReader/SpecificSettingsModel.py
@@ -8,6 +8,8 @@ from UM.Logger import Logger
 from UM.Settings.SettingDefinition import SettingDefinition
 from UM.Qt.ListModel import ListModel
 
+from cura.CuraApplication import CuraApplication
+
 
 class SpecificSettingsModel(ListModel):
     CategoryRole = Qt.ItemDataRole.UserRole + 1
@@ -31,16 +33,14 @@ class SpecificSettingsModel(ListModel):
             unit = stack.getProperty(setting, "unit")
 
             setting_type = stack.getProperty(setting, "type")
-            if setting_type is not None:
-                # This is not very good looking, but will do for now
+            if setting_type in ("enum", "extruder", "optional_extruder"):
+                value = CuraApplication.getInstance().getCuraAPI().interface.settings.getSettingDisplayValue(
+                    setting, value, stack, self._settings_catalog
+                )
+            elif setting_type is not None:
                 value = str(SettingDefinition.settingValueToString(setting_type, value))
                 if unit:
                     value += " " + str(unit)
-                if setting_type  == "enum":
-                    options = stack.getProperty(setting, "options")
-                    value_msgctxt = f"{str(setting)} option {str(value)}"
-                    value_msgid = options[stack.getProperty(setting, "value")]
-                    value = self._settings_catalog.i18nc(value_msgctxt, value_msgid)
             else:
                 value = str(value)
 

--- a/plugins/3MFWriter/SettingsExportModel.py
+++ b/plugins/3MFWriter/SettingsExportModel.py
@@ -125,14 +125,14 @@ class SettingsExportModel(QObject):
             value = settings_stack.getProperty(setting_to_export, "value")
             unit = settings_stack.getProperty(setting_to_export, "unit")
             setting_type = settings_stack.getProperty(setting_to_export, "type")
-            value_name = str(SettingDefinition.settingValueToString(setting_type, value))
-            if unit:
-                value_name += " " + str(unit)
-            if setting_type == "enum":
-                options = settings_stack.getProperty(setting_to_export, "options")
-                value_msgctxt = f"{str(setting_to_export)} option {str(value)}"
-                value_msgid = options.get(value, "")
-                value_name = settings_catalog.i18nc(value_msgctxt, value_msgid)
+            if setting_type in ("enum", "extruder", "optional_extruder"):
+                value_name = CuraApplication.getInstance().getCuraAPI().interface.settings.getSettingDisplayValue(
+                    setting_to_export, value, settings_stack, settings_catalog
+                )
+            else:
+                value_name = str(SettingDefinition.settingValueToString(setting_type, value))
+                if unit:
+                    value_name += " " + str(unit)
 
             if setting_type is not None:
                 value = f"{str(SettingDefinition.settingValueToString(setting_type, value))} {unit}"


### PR DESCRIPTION
Updated the value shown to the user in the changed settings dialog to line up with the labels shown to the users on the UI.

1. If it is a -1 for not overridden, it should turn into Auto.
2. If it is a -1 because the setting numerical value, such as expand distance, is that value, then it should remain unchanged.

Before:
<img width="503" height="482" alt="image" src="https://github.com/user-attachments/assets/0f590952-5e5a-4e30-af42-ad5b09ce6122" />

After:
<img width="513" height="488" alt="image" src="https://github.com/user-attachments/assets/6bab9f46-886a-4627-b6b1-e9b642efb670" />


CURA-10005