### PR TITLE
Add i18n catalog to SaveAreaButton

### DIFF
--- a/plugins/PostProcessingPlugin/SaveAreaButton.qml
+++ b/plugins/PostProcessingPlugin/SaveAreaButton.qml
@@ -14,6 +14,8 @@ Item
 {
     id: base
     objectName: "postProcessingSaveAreaButton"
+
+    UM.I18nCatalog { id: catalog; name: "cura" }
     visible: manager.scriptList.length > 0
     height: UM.Theme.getSize("action_button").height
     width: height


### PR DESCRIPTION
Register the Cura i18n catalog in `SaveAreaButton.qml` so localized strings in this component can resolve correctly. This aligns the button with other QML components that explicitly define a catalog.

CURA-13263