### PR TITLE
[CURA-13271] Revert pySavitar version

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -7,7 +7,7 @@ requirements:
   - "cura_binary_data/5.14.0-alpha.0@ultimaker/testing"
   - "fdm_materials/5.14.0-alpha.0@ultimaker/testing"
   - "dulcificum/5.11.0-alpha.0"
-  - "pysavitar/5.12.0"
+  - "pysavitar/5.11.1-alpha.0"
   - "pynest2d/5.11.0-alpha.0"
   - "shapely/2.1.2"
 requirements_internal:


### PR DESCRIPTION
the 5.12.0 version breaks several functionalities, reverting the changes until the issues have been addressed.

CURA-13271
