### PR TITLE
CURA-13264 linter fix items on profiles

### DIFF
--- a/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_abs_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_abs_0.2mm_quick.inst.cfg
@@ -16,7 +16,7 @@ cool_min_layer_time = 5
 cool_min_layer_time_overhang = 9
 cool_min_speed = 6
 cool_min_temperature = =material_print_temperature - 15
-gradual_flow_enable = False
+gradual_flow_enabled = False
 hole_xy_offset = 0.075
 inset_direction = outside_in
 speed_wall = =speed_print

--- a/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_petg_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_petg_0.2mm_quick.inst.cfg
@@ -16,7 +16,7 @@ cool_min_layer_time = 5
 cool_min_layer_time_overhang = 9
 cool_min_speed = 6
 cool_min_temperature = =material_print_temperature - 15
-gradual_flow_enable = False
+gradual_flow_enabled = False
 hole_xy_offset = 0.075
 inset_direction = outside_in
 speed_wall = =speed_print

--- a/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_pla_0.2mm_quick.inst.cfg
@@ -16,7 +16,7 @@ cool_min_layer_time = 5
 cool_min_layer_time_overhang = 9
 cool_min_speed = 6
 cool_min_temperature = =material_print_temperature - 15
-gradual_flow_enable = False
+gradual_flow_enabled = False
 hole_xy_offset = 0.075
 inset_direction = outside_in
 speed_wall = =speed_print

--- a/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_tough-pla_0.2mm_quick.inst.cfg
+++ b/resources/intent/ultimaker_s8/um_s8_aa_plus_0.4_tough-pla_0.2mm_quick.inst.cfg
@@ -16,7 +16,7 @@ cool_min_layer_time = 5
 cool_min_layer_time_overhang = 9
 cool_min_speed = 6
 cool_min_temperature = =material_print_temperature - 15
-gradual_flow_enable = False
+gradual_flow_enabled = False
 hole_xy_offset = 0.075
 inset_direction = outside_in
 speed_wall = =speed_print

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-abs_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_fan_speed_0 = 0
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-petg_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-pla_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.25_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.25_um-tough-pla_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.15mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -1
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.1mm.inst.cfg
@@ -13,9 +13,9 @@ weight = 0
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_tpu_0.2mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -2
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.06mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.15mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.2mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-abs_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.06mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.15mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.2mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-petg_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.06mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.15mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.2mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-pla_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.06mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.2mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -2
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 machine_nozzle_cool_down_speed = 0.5

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.3mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -3
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 infill_sparse_density = 15

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_tpu_0.4mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -4
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 infill_sparse_density = 15

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.2mm.inst.cfg
@@ -22,9 +22,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-abs_0.4mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.2mm.inst.cfg
@@ -22,7 +22,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.3mm.inst.cfg
@@ -22,7 +22,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 100
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 100
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-petg_0.4mm.inst.cfg
@@ -22,7 +22,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 100
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 100
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.2mm.inst.cfg
@@ -22,9 +22,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-pla_0.4mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -22,9 +22,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s3/um_s3_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-abs_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_fan_speed_0 = 0
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-petg_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-pla_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.25_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.25_um-tough-pla_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.15mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -1
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.1mm.inst.cfg
@@ -13,9 +13,9 @@ weight = 0
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_tpu_0.2mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -2
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.06mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.15mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.2mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-abs_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.06mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.15mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.2mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-petg_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.06mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.15mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.2mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-pla_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.06mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.1mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.2mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -2
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 machine_nozzle_cool_down_speed = 0.5

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.3mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -3
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 infill_sparse_density = 15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_tpu_0.4mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -4
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 infill_sparse_density = 15

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.2mm.inst.cfg
@@ -22,9 +22,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-abs_0.4mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.2mm.inst.cfg
@@ -22,7 +22,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.3mm.inst.cfg
@@ -22,7 +22,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 100
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 100
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-petg_0.4mm.inst.cfg
@@ -22,7 +22,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 100
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 100
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.2mm.inst.cfg
@@ -22,9 +22,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-pla_0.4mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -22,9 +22,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s5/um_s5_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -21,8 +21,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_um-abs_0.1mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_fan_speed_0 = 0
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_um-petg_0.1mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_um-pla_0.1mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.25_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.25_um-tough-pla_0.1mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.15mm.inst.cfg
@@ -14,9 +14,9 @@ weight = -1
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.1mm.inst.cfg
@@ -14,9 +14,9 @@ weight = 0
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_tpu_0.2mm.inst.cfg
@@ -14,9 +14,9 @@ weight = -2
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.06mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.15mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.1mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.2mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-abs_0.3mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.06mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.15mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.1mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.2mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-petg_0.3mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.06mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.15mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.1mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.2mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-pla_0.3mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.06mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.06mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.15mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.15mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.1mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.1mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.2mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.4_um-tough-pla_0.3mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.2mm.inst.cfg
@@ -14,9 +14,9 @@ weight = -2
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 machine_nozzle_cool_down_speed = 0.5

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.3mm.inst.cfg
@@ -14,9 +14,9 @@ weight = -3
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 infill_sparse_density = 15

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_tpu_0.4mm.inst.cfg
@@ -14,9 +14,9 @@ weight = -4
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'
 infill_sparse_density = 15

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.2mm.inst.cfg
@@ -23,9 +23,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.3mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-abs_0.4mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 4
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.2mm.inst.cfg
@@ -23,7 +23,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.3mm.inst.cfg
@@ -23,7 +23,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 100
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 100
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-petg_0.4mm.inst.cfg
@@ -23,7 +23,7 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 100
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 100
 bridge_wall_speed = 20
 cool_min_layer_time = 4

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.2mm.inst.cfg
@@ -23,9 +23,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.3mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-pla_0.4mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.2mm.inst.cfg
@@ -23,9 +23,9 @@ acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 30
 bridge_wall_material_flow = 200
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.3mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.3mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.4mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa0.8_um-tough-pla_0.4mm.inst.cfg
@@ -22,8 +22,8 @@ acceleration_topbottom = =acceleration_wall
 acceleration_wall = =acceleration_infill
 acceleration_wall_0 = 1500
 acceleration_wall_x = =acceleration_wall
-bridge_skin_speed = =bridge_wall_speed
-bridge_wall_speed = 30
+bridge_skin_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 gradual_flow_discretisation_step_size = 0.2
 gradual_flow_enabled = True

--- a/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_tpu_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_aa_plus_0.4_tpu_0.2mm.inst.cfg
@@ -13,9 +13,9 @@ weight = -2
 
 [values]
 bridge_skin_material_flow = 200
-bridge_skin_speed = =bridge_wall_speed
+bridge_skin_speed = 10
 bridge_wall_material_flow = =bridge_skin_material_flow
-bridge_wall_speed = 10
+bridge_wall_speed = =bridge_skin_speed
 brim_width = 8.75
 gradual_infill_step_height = =5 * layer_height
 infill_pattern = ='zigzag' if infill_sparse_density > 80 else 'cross_3d'

--- a/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_petcf_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc_plus_0.4_petcf_0.2mm.inst.cfg
@@ -23,7 +23,7 @@ bridge_skin_speed = 30
 bridge_skin_speed_2 = =speed_print*2/3
 bridge_wall_material_flow = 100
 bridge_wall_min_length = 2
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = 11
 cool_min_temperature = =material_print_temperature-10

--- a/resources/quality/ultimaker_s8/um_s8_cc_plus_0.6_petcf_0.2mm.inst.cfg
+++ b/resources/quality/ultimaker_s8/um_s8_cc_plus_0.6_petcf_0.2mm.inst.cfg
@@ -22,7 +22,7 @@ bridge_skin_speed = 30
 bridge_skin_speed_2 = =speed_print*2/3
 bridge_wall_material_flow = 100
 bridge_wall_min_length = 2
-bridge_wall_speed = 30
+bridge_wall_speed = =bridge_skin_speed
 cool_min_layer_time = 6
 cool_min_layer_time_overhang = 11
 cool_min_temperature = =material_print_temperature-10


### PR DESCRIPTION
This commit should remove circular dependencies in bridging settings and incorrect gradual flow enable(d) setting name.

# Description

Fixes many circular dependencies in the profiles by following up on the suggestions in ticket CURA-13264

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Printer definition file(s)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Deployed in Cura 5.13
- [x] Went through the profiles in Cura that did not show both bridging settings in the same quality file

**Test Configuration**:
* Operating System:

# Checklist:
<!-- Check if relevant -->

- [x] My code follows the style guidelines of this project as described in [UltiMaker Meta](https://github.com/Ultimaker/Meta) and [Cura QML best practices](https://github.com/Ultimaker/Cura/wiki/QML-Best-Practices)
- [x] I have read the [Contribution guide](https://github.com/Ultimaker/Cura/blob/main/CONTRIBUTING.md) 
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have uploaded any files required to test this change

CURA-13264
