### PR TITLE
[CURA-13283] Add Context menu option to show selected file location

### DIFF
--- a/cura/CuraActions.py
+++ b/cura/CuraActions.py
@@ -1,5 +1,8 @@
 # Copyright (c) 2023 UltiMaker
 # Cura is released under the terms of the LGPLv3 or higher.
+import os
+import platform
+import subprocess
 from typing import List, cast
 
 from PyQt6.QtCore import QObject, QUrl, pyqtSignal, pyqtProperty
@@ -19,6 +22,7 @@ from UM.Operations.TranslateOperation import TranslateOperation
 
 import cura.CuraApplication
 from cura.Operations.SetParentOperation import SetParentOperation
+from cura.Scene.CuraSceneNode import CuraSceneNode
 from cura.MultiplyObjectsJob import MultiplyObjectsJob
 from cura.Settings.SetObjectExtruderOperation import SetObjectExtruderOperation
 from cura.Settings.ExtruderManager import ExtruderManager
@@ -39,7 +43,56 @@ class CuraActions(QObject):
         self._operation_stack = Application.getInstance().getOperationStack()
         self._operation_stack.changed.connect(self._onUndoStackChanged)
 
+        Selection.selectionChanged.connect(self._onSelectionChanged)
+
     undoStackChanged = pyqtSignal()
+    showFileLocationEnabledChanged = pyqtSignal()
+
+    def _onSelectionChanged(self) -> None:
+        self.showFileLocationEnabledChanged.emit()
+
+    @pyqtProperty(bool, notify = showFileLocationEnabledChanged)
+    def canShowFileLocation(self) -> bool:
+        """Returns True when exactly one normal printable model is selected and it has a known file path."""
+        selected = Selection.getAllSelectedObjects()
+        if len(selected) != 1:
+            return False
+        node = selected[0]
+        mesh_data = node.getMeshData()
+        return (
+            isinstance(node, CuraSceneNode)
+            and not node.callDecoration("isGroup")
+            and not node.callDecoration("isAntiOverhangMesh")
+            and not node.callDecoration("isSupportMesh")
+            and not node.callDecoration("isCuttingMesh")
+            and not node.callDecoration("isInfillMesh")
+            and mesh_data is not None
+            and bool(mesh_data.getFileName())
+        )
+
+    @pyqtSlot()
+    def showFileLocation(self) -> None:
+        """Reveal the source file of the selected model in the OS file manager."""
+        selected = Selection.getAllSelectedObjects()
+        if len(selected) != 1:
+            return
+        node = selected[0]
+        mesh_data = node.getMeshData()
+        if not mesh_data:
+            return
+        file_path = mesh_data.getFileName()
+        if not file_path or not os.path.exists(file_path):
+            Logger.warning(f"Cannot show file location: path is missing or does not exist: {file_path}")
+            return
+
+        system = platform.system()
+        if system == "Windows":
+            subprocess.Popen(["explorer", "/select," + os.path.normpath(file_path)])
+        elif system == "Darwin":
+            subprocess.Popen(["open", "-R", file_path])
+        else:
+            QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.dirname(file_path)))
+
     @pyqtSlot()
     def openDocumentation(self) -> None:
         # Starting a web browser from a signal handler connected to a menu will crash on windows.

--- a/cura/CuraActions.py
+++ b/cura/CuraActions.py
@@ -3,7 +3,7 @@
 import os
 import platform
 import subprocess
-from typing import List, cast
+from typing import List, Optional, cast
 
 from UM.i18n import i18nCatalog
 from UM.Message import Message
@@ -60,51 +60,33 @@ class CuraActions(QObject):
     def _onSceneChanged(self, source: SceneNode) -> None:
         self.showFileLocationEnabledChanged.emit()
 
-    @pyqtProperty(bool, notify = showFileLocationEnabledChanged)
-    def canShowFileLocation(self) -> bool:
-        """Returns True when exactly one model is selected and it has a known file path."""
+    def _getSelectedNodeFilePath(self) -> Optional[str]:
+        """Returns the source file path of the selected node if the selection is valid, or None."""
         selected = Selection.getAllSelectedObjects()
         if len(selected) != 1:
-            return False
+            return None
         node = selected[0]
+        if not isinstance(node, CuraSceneNode) or node.callDecoration("isGroup"):
+            return None
         mesh_data = node.getMeshData()
-        return (
-            isinstance(node, CuraSceneNode)
-            and not node.callDecoration("isGroup")
-            and mesh_data is not None
-            and bool(mesh_data.getFileName())
-        )
+        if mesh_data is None:
+            return None
+        return mesh_data.getFileName() or None
+
+    @pyqtProperty(bool, notify = showFileLocationEnabledChanged)
+    def canShowFileLocation(self) -> bool:
+        """Returns True when exactly one model is selected and its source file is accessible."""
+        file_path = self._getSelectedNodeFilePath()
+        return file_path is not None and os.path.exists(file_path)
 
     @pyqtSlot()
     def showFileLocation(self) -> None:
         """Reveal the source file of the selected model in the OS file manager."""
-        selected = Selection.getAllSelectedObjects()
-        if len(selected) != 1:
-            Message(
-                i18n_catalog.i18nc("@info:status", "Please select exactly one object to show its file location."),
-                title=i18n_catalog.i18nc("@info:title", "Show File Location"),
-                message_type=Message.MessageType.WARNING,
-            ).show()
+        file_path = self._getSelectedNodeFilePath()
+        if file_path is None:
             return
-        node = selected[0]
-        if not isinstance(node, CuraSceneNode):
-            Message(
-                i18n_catalog.i18nc("@info:status", "The selected object does not support showing a file location."),
-                title=i18n_catalog.i18nc("@info:title", "Show File Location"),
-                message_type=Message.MessageType.WARNING,
-            ).show()
-            return
-        mesh_data = node.getMeshData()
-        if not mesh_data:
-            Message(
-                i18n_catalog.i18nc("@info:status", "The selected object has no mesh data."),
-                title=i18n_catalog.i18nc("@info:title", "Show File Location"),
-                message_type=Message.MessageType.WARNING,
-            ).show()
-            return
-        file_path = mesh_data.getFileName()
-        if not file_path or not os.path.exists(file_path):
-            Logger.warning(f"Cannot show file location: path is missing or does not exist: {file_path}")
+        if not os.path.exists(file_path):
+            Logger.warning(f"Cannot show file location: file no longer exists: {file_path}")
             Message(
                 i18n_catalog.i18nc("@info:status", "The source file could not be found. It may have been moved or deleted."),
                 title=i18n_catalog.i18nc("@info:title", "File Not Found"),

--- a/cura/CuraActions.py
+++ b/cura/CuraActions.py
@@ -57,7 +57,7 @@ class CuraActions(QObject):
     def _onSelectionChanged(self) -> None:
         self.showFileLocationEnabledChanged.emit()
 
-    def _onSceneChanged(self, source: SceneNode) -> None:
+    def _onSceneChanged(self, _source: SceneNode) -> None:
         self.showFileLocationEnabledChanged.emit()
 
     def _getSelectedNodeFilePath(self) -> Optional[str]:

--- a/cura/CuraActions.py
+++ b/cura/CuraActions.py
@@ -5,6 +5,11 @@ import platform
 import subprocess
 from typing import List, cast
 
+from UM.i18n import i18nCatalog
+from UM.Message import Message
+
+i18n_catalog = i18nCatalog("cura")
+
 from PyQt6.QtCore import QObject, QUrl, pyqtSignal, pyqtProperty
 from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtWidgets import QApplication
@@ -44,6 +49,7 @@ class CuraActions(QObject):
         self._operation_stack.changed.connect(self._onUndoStackChanged)
 
         Selection.selectionChanged.connect(self._onSelectionChanged)
+        Application.getInstance().getController().getScene().sceneChanged.connect(self._onSceneChanged)
 
     undoStackChanged = pyqtSignal()
     showFileLocationEnabledChanged = pyqtSignal()
@@ -51,9 +57,12 @@ class CuraActions(QObject):
     def _onSelectionChanged(self) -> None:
         self.showFileLocationEnabledChanged.emit()
 
+    def _onSceneChanged(self, source: SceneNode) -> None:
+        self.showFileLocationEnabledChanged.emit()
+
     @pyqtProperty(bool, notify = showFileLocationEnabledChanged)
     def canShowFileLocation(self) -> bool:
-        """Returns True when exactly one normal printable model is selected and it has a known file path."""
+        """Returns True when exactly one model is selected and it has a known file path."""
         selected = Selection.getAllSelectedObjects()
         if len(selected) != 1:
             return False
@@ -62,10 +71,6 @@ class CuraActions(QObject):
         return (
             isinstance(node, CuraSceneNode)
             and not node.callDecoration("isGroup")
-            and not node.callDecoration("isAntiOverhangMesh")
-            and not node.callDecoration("isSupportMesh")
-            and not node.callDecoration("isCuttingMesh")
-            and not node.callDecoration("isInfillMesh")
             and mesh_data is not None
             and bool(mesh_data.getFileName())
         )
@@ -75,14 +80,36 @@ class CuraActions(QObject):
         """Reveal the source file of the selected model in the OS file manager."""
         selected = Selection.getAllSelectedObjects()
         if len(selected) != 1:
+            Message(
+                i18n_catalog.i18nc("@info:status", "Please select exactly one object to show its file location."),
+                title=i18n_catalog.i18nc("@info:title", "Show File Location"),
+                message_type=Message.MessageType.WARNING,
+            ).show()
             return
         node = selected[0]
+        if not isinstance(node, CuraSceneNode):
+            Message(
+                i18n_catalog.i18nc("@info:status", "The selected object does not support showing a file location."),
+                title=i18n_catalog.i18nc("@info:title", "Show File Location"),
+                message_type=Message.MessageType.WARNING,
+            ).show()
+            return
         mesh_data = node.getMeshData()
         if not mesh_data:
+            Message(
+                i18n_catalog.i18nc("@info:status", "The selected object has no mesh data."),
+                title=i18n_catalog.i18nc("@info:title", "Show File Location"),
+                message_type=Message.MessageType.WARNING,
+            ).show()
             return
         file_path = mesh_data.getFileName()
         if not file_path or not os.path.exists(file_path):
             Logger.warning(f"Cannot show file location: path is missing or does not exist: {file_path}")
+            Message(
+                i18n_catalog.i18nc("@info:status", "The source file could not be found. It may have been moved or deleted."),
+                title=i18n_catalog.i18nc("@info:title", "File Not Found"),
+                message_type=Message.MessageType.ERROR,
+            ).show()
             return
 
         system = platform.system()

--- a/resources/qml/Actions.qml
+++ b/resources/qml/Actions.qml
@@ -83,6 +83,7 @@ Item
     property alias copy: copyAction
     property alias cut: cutAction
     property alias exportProjectForSupport: exportProjectForSupportAction
+    property alias showFileLocation: showFileLocationAction
 
     readonly property bool copy_paste_enabled: {
         const all_enabled_packages = CuraApplication.getPackageManager().allEnabledPackages;
@@ -619,5 +620,13 @@ Item
             };
             UM.OutputDeviceManager.requestWriteToDevice("local_file", exportName, args)
         }
+    }
+
+    Action
+    {
+        id: showFileLocationAction
+        text: catalog.i18nc("@action:inmenu", "Show File Location")
+        enabled: CuraActions.canShowFileLocation
+        onTriggered: CuraActions.showFileLocation()
     }
 }

--- a/resources/qml/Menus/ContextMenu.qml
+++ b/resources/qml/Menus/ContextMenu.qml
@@ -17,6 +17,7 @@ Cura.Menu
     property var multiBuildPlateModel: CuraApplication.getMultiBuildPlateModel()
 
     // Selection-related actions.
+    Cura.MenuItem { action: Cura.Actions.showFileLocation; }
     Cura.MenuItem { action: Cura.Actions.centerSelection; }
     Cura.MenuItem { action: Cura.Actions.deleteSelection; }
     Cura.MenuItem { action: Cura.Actions.copy; }

--- a/resources/qml/Menus/ContextMenu.qml
+++ b/resources/qml/Menus/ContextMenu.qml
@@ -17,12 +17,14 @@ Cura.Menu
     property var multiBuildPlateModel: CuraApplication.getMultiBuildPlateModel()
 
     // Selection-related actions.
-    Cura.MenuItem { action: Cura.Actions.showFileLocation; }
     Cura.MenuItem { action: Cura.Actions.centerSelection; }
     Cura.MenuItem { action: Cura.Actions.deleteSelection; }
     Cura.MenuItem { action: Cura.Actions.copy; }
     Cura.MenuItem { action: Cura.Actions.paste; }
     Cura.MenuItem { action: Cura.Actions.multiplySelection; }
+
+    Cura.MenuSeparator {}
+    Cura.MenuItem { action: Cura.Actions.showFileLocation; }
 
     // Extruder selection - only visible if there is more than 1 extruder
     Cura.MenuSeparator { visible: base.shouldShowExtruders }


### PR DESCRIPTION
Adds a new "Show File Location" feature to Cura, allowing users to quickly reveal the source file of a selected model in their operating system's file manager. The feature is integrated into the context menu and is only enabled when a single, standard model with a known file path is selected.

<img width="758" height="891" alt="image" src="https://github.com/user-attachments/assets/9058afa5-6361-48ef-bb38-0a995a27f0b8" />

<img width="951" height="825" alt="image" src="https://github.com/user-attachments/assets/878246d2-bd51-4068-b6c9-a3039e513da8" />

**Test Configuration**:

- Windows 11
- macOS 26

CURA-13283