### PR TITLE
Cura 13289

### DIFF
--- a/cura/CuraApplication.py
+++ b/cura/CuraApplication.py
@@ -642,6 +642,8 @@ class CuraApplication(QtApplication):
 
             preferences.addPreference("local_file/%s" % key, os.path.expanduser("~/"))
 
+        preferences.addPreference("local_file/use_fixed_dialog_paths", False)
+
         preferences.setDefault("local_file/last_used_type", "text/x-gcode")
 
         self.applicationShuttingDown.connect(self.saveSettings)

--- a/resources/qml/Cura.qml
+++ b/resources/qml/Cura.qml
@@ -618,13 +618,14 @@ UM.MainWindow
             currentFolder: CuraApplication.getDefaultPath("dialog_load_path")
             onAccepted:
             {
-                // Because several implementations of the file dialog only update the folder
-                // when it is explicitly set.
-                var f = currentFolder;
-                currentFolder = f;
-
-                CuraApplication.setDefaultPath("dialog_load_path", currentFolder);
-
+                if (!UM.Preferences.getValue("local_file/use_fixed_dialog_paths"))
+                {
+                    // Because several implementations of the file dialog only update the folder
+                    // when it is explicitly set.
+                    var f = currentFolder;
+                    currentFolder = f;
+                    CuraApplication.setDefaultPath("dialog_load_path", currentFolder);
+                }
                 base.handleOpenFileUrls(selectedFiles);
             }
         }

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -893,7 +893,15 @@ UM.PreferencesPage
                     id: fixedPathsCheckbox
                     text: catalog.i18nc("@option:check", "Always use the same default locations for opening and saving files")
                     checked: boolCheck(UM.Preferences.getValue("local_file/use_fixed_dialog_paths"))
-                    onCheckedChanged: UM.Preferences.setValue("local_file/use_fixed_dialog_paths", checked)
+                    onCheckedChanged:
+                    {
+                        UM.Preferences.setValue("local_file/use_fixed_dialog_paths", checked)
+                        if (checked)
+                        {
+                            dialogLoadPathField.text = UM.Preferences.getValue("local_file/dialog_load_path")
+                            dialogSavePathField.text = UM.Preferences.getValue("local_file/dialog_save_path")
+                        }
+                    }
                 }
             }
 

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -911,6 +911,8 @@ UM.PreferencesPage
                 height: childrenRect.height
                 enabled: fixedPathsCheckbox.checked
                 opacity: fixedPathsCheckbox.checked ? 1.0 : 0.5
+                anchors.left: parent.left
+                anchors.leftMargin: UM.Theme.getSize("default_margin").width
                 text: catalog.i18nc("@info:tooltip", "The default folder to open when loading files.")
 
                 Column
@@ -952,6 +954,8 @@ UM.PreferencesPage
                 height: childrenRect.height
                 enabled: fixedPathsCheckbox.checked
                 opacity: fixedPathsCheckbox.checked ? 1.0 : 0.5
+                anchors.left: parent.left
+                anchors.leftMargin: UM.Theme.getSize("default_margin").width
                 text: catalog.i18nc("@info:tooltip", "The default folder to open when saving files.")
 
                 Column

--- a/resources/qml/Preferences/GeneralPage.qml
+++ b/resources/qml/Preferences/GeneralPage.qml
@@ -3,6 +3,7 @@
 
 import QtQuick 2.10
 import QtQuick.Controls 2.15
+import QtQuick.Dialogs
 import QtQuick.Layouts 1.1
 
 import UM 1.5 as UM
@@ -140,6 +141,9 @@ UM.PreferencesPage
         UM.Preferences.resetPreference("info/latest_update_source")
         UM.Preferences.resetPreference("info/automatic_plugin_update_check")
         pluginNotificationsUpdateCheckbox.checked = boolCheck(UM.Preferences.getValue("info/automatic_plugin_update_check"))
+
+        UM.Preferences.resetPreference("local_file/use_fixed_dialog_paths")
+        fixedPathsCheckbox.checked = boolCheck(UM.Preferences.getValue("local_file/use_fixed_dialog_paths"))
     }
 
     buttons: [
@@ -878,6 +882,103 @@ UM.PreferencesPage
                 }
             }
 
+            UM.TooltipArea
+            {
+                width: childrenRect.width
+                height: childrenRect.height
+                text: catalog.i18nc("@info:tooltip", "When enabled, file open and save dialogs will always start at the specified locations below. When disabled, dialogs remember the last folder you navigated to.")
+
+                UM.CheckBox
+                {
+                    id: fixedPathsCheckbox
+                    text: catalog.i18nc("@option:check", "Always use the same default locations for opening and saving files")
+                    checked: boolCheck(UM.Preferences.getValue("local_file/use_fixed_dialog_paths"))
+                    onCheckedChanged: UM.Preferences.setValue("local_file/use_fixed_dialog_paths", checked)
+                }
+            }
+
+            UM.TooltipArea
+            {
+                width: childrenRect.width
+                height: childrenRect.height
+                enabled: fixedPathsCheckbox.checked
+                opacity: fixedPathsCheckbox.checked ? 1.0 : 0.5
+                text: catalog.i18nc("@info:tooltip", "The default folder to open when loading files.")
+
+                Column
+                {
+                    spacing: UM.Theme.getSize("narrow_margin").height
+
+                    UM.Label
+                    {
+                        text: catalog.i18nc("@window:text", "Default file load location:")
+                    }
+
+                    Row
+                    {
+                        spacing: UM.Theme.getSize("narrow_margin").width
+
+                        Cura.TextField
+                        {
+                            id: dialogLoadPathField
+                            selectByMouse: true
+                            text: UM.Preferences.getValue("local_file/dialog_load_path")
+                            implicitWidth: UM.Theme.getSize("combobox_wide").width
+                            implicitHeight: UM.Theme.getSize("setting_control").height
+                            onEditingFinished: UM.Preferences.setValue("local_file/dialog_load_path", text)
+                        }
+
+                        Cura.SecondaryButton
+                        {
+                            text: catalog.i18nc("@action:button", "Browse")
+                            implicitHeight: UM.Theme.getSize("setting_control").height
+                            onClicked: dialogLoadPathDialog.open()
+                        }
+                    }
+                }
+            }
+
+            UM.TooltipArea
+            {
+                width: childrenRect.width
+                height: childrenRect.height
+                enabled: fixedPathsCheckbox.checked
+                opacity: fixedPathsCheckbox.checked ? 1.0 : 0.5
+                text: catalog.i18nc("@info:tooltip", "The default folder to open when saving files.")
+
+                Column
+                {
+                    spacing: UM.Theme.getSize("narrow_margin").height
+
+                    UM.Label
+                    {
+                        text: catalog.i18nc("@window:text", "Default file save location:")
+                    }
+
+                    Row
+                    {
+                        spacing: UM.Theme.getSize("narrow_margin").width
+
+                        Cura.TextField
+                        {
+                            id: dialogSavePathField
+                            selectByMouse: true
+                            text: UM.Preferences.getValue("local_file/dialog_save_path")
+                            implicitWidth: UM.Theme.getSize("combobox_wide").width
+                            implicitHeight: UM.Theme.getSize("setting_control").height
+                            onEditingFinished: UM.Preferences.setValue("local_file/dialog_save_path", text)
+                        }
+
+                        Cura.SecondaryButton
+                        {
+                            text: catalog.i18nc("@action:button", "Browse")
+                            implicitHeight: UM.Theme.getSize("setting_control").height
+                            onClicked: dialogSavePathDialog.open()
+                        }
+                    }
+                }
+            }
+
             Item
             {
                 //: Spacer
@@ -1174,6 +1275,30 @@ UM.PreferencesPage
                     }
 
                     sendDataCheckbox.checked = boolCheck(UM.Preferences.getValue("info/send_slice_info"))
+                }
+            }
+
+            FolderDialog
+            {
+                id: dialogLoadPathDialog
+                title: catalog.i18nc("@title:window", "Select Default Load Folder")
+                currentFolder: CuraApplication.getDefaultPath("dialog_load_path")
+                onAccepted:
+                {
+                    CuraApplication.setDefaultPath("dialog_load_path", selectedFolder)
+                    dialogLoadPathField.text = UM.Preferences.getValue("local_file/dialog_load_path")
+                }
+            }
+
+            FolderDialog
+            {
+                id: dialogSavePathDialog
+                title: catalog.i18nc("@title:window", "Select Default Save Folder")
+                currentFolder: CuraApplication.getDefaultPath("dialog_save_path")
+                onAccepted:
+                {
+                    CuraApplication.setDefaultPath("dialog_save_path", selectedFolder)
+                    dialogSavePathField.text = UM.Preferences.getValue("local_file/dialog_save_path")
                 }
             }
         }


### PR DESCRIPTION
This pull request introduces a new user preference that allows users to choose whether file open and save dialogs always start at fixed default locations or remember the last used folder. The implementation includes both backend preference handling and frontend UI elements in the Preferences dialog, giving users control over dialog path behavior and allowing them to set default load/save directories.
<img width="769" height="671" alt="image" src="https://github.com/user-attachments/assets/9644167e-0afc-46aa-aaf1-1344a098b503" />
<img width="768" height="678" alt="image" src="https://github.com/user-attachments/assets/5acde4c0-43b1-4a7c-9dfe-10968817c69d" />


Requires:
https://github.com/Ultimaker/Uranium/pull/1045


CURA-13289