### PR TITLE
CURA-13021 new linux runner

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,16 +30,15 @@ on:
       operating_system:
         description: 'OS'
         required: true
-        default: 'self-hosted-Ubuntu22-X64'
+        default: 'self-hosted-Ubuntu24-X64'
         type: choice
         options:
-          - ubuntu-22.04
-          - self-hosted-Ubuntu22-X64
+          - ubuntu-24.04
           - self-hosted-Ubuntu24-X64
 
 jobs:
   linux-installer:
-    uses: ultimaker/cura-workflows/.github/workflows/cura-installer-linux.yml@CURA-13021-new-linux-runner
+    uses: ultimaker/cura-workflows/.github/workflows/cura-installer-linux.yml@main
     with:
       cura_conan_version: ${{ inputs.cura_conan_version }}
       package_overrides: ${{ inputs.package_overrides }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,6 +35,7 @@ on:
         options:
           - ubuntu-22.04
           - self-hosted-Ubuntu22-X64
+          - self-hosted-Ubuntu24-X64
 
 jobs:
   linux-installer:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   linux-installer:
-    uses: ultimaker/cura-workflows/.github/workflows/cura-installer-linux.yml@main
+    uses: ultimaker/cura-workflows/.github/workflows/cura-installer-linux.yml@CURA-13021-new-linux-runner
     with:
       cura_conan_version: ${{ inputs.cura_conan_version }}
       package_overrides: ${{ inputs.package_overrides }}


### PR DESCRIPTION
Use the new Ubuntu 24.04 Linux runner to generate Cura installers.
Since 22.04 is soon end-of-life and 26.04 is raising, it makes sense to do it now to remain up-to-date.

Requires https://github.com/Ultimaker/cura-workflows/pull/62
CURA-13021