### PR TITLE
Fix Windows file reveal command

### DIFF
--- a/cura/CuraActions.py
+++ b/cura/CuraActions.py
@@ -96,7 +96,7 @@ class CuraActions(QObject):
 
         system = platform.system()
         if system == "Windows":
-            subprocess.Popen(["explorer", "/select," + os.path.normpath(file_path)])
+            subprocess.Popen(f'explorer /select,"{os.path.normpath(file_path)}"', shell = False)
         elif system == "Darwin":
             subprocess.Popen(["open", "-R", file_path])
         else:


### PR DESCRIPTION
Use a quoted Explorer command on Windows when revealing a file in the file manager, avoiding path parsing issues with `explorer /select`.

CURA-13295