### PR TITLE
Machine page destruction

### DIFF
--- a/resources/qml/MachineSettings/GcodeTextArea.qml
+++ b/resources/qml/MachineSettings/GcodeTextArea.qml
@@ -79,7 +79,11 @@ Item
 
             Component.onDestruction:
             {
-                propertyProvider.setPropertyValue("value", text)
+                var currentValue = propertyProvider.properties.value ? propertyProvider.properties.value : ""
+                if (currentValue !== text)
+                {
+                    propertyProvider.setPropertyValue("value", text)
+                }
             }
 
             background: Rectangle

--- a/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
+++ b/resources/qml/MachineSettings/NumericTextFieldWithUnit.qml
@@ -151,12 +151,17 @@ UM.TooltipArea
         color: UM.Theme.getColor("text")
         renderType: Text.NativeRendering
 
-        // When the textbox gets focused by TAB, select all text
+        // When the textbox gets focused by TAB, select all text.
+        // When focus is lost (including dialog close), commit any in-progress edit.
         onActiveFocusChanged:
         {
             if (activeFocus && (focusReason == Qt.TabFocusReason || focusReason == Qt.BacktabFocusReason))
             {
                 selectAll()
+            }
+            else if (!activeFocus && propertyProvider && text != propertyProvider.properties.value)
+            {
+                editingFinishedFunction()
             }
         }
 
@@ -200,8 +205,6 @@ UM.TooltipArea
         }
 
         onEditingFinished: editingFinishedFunction()
-
-        Component.onDestruction: editingFinishedFunction()
 
         property var editingFinishedFunction: defaultEditingFinishedFunction
 

--- a/resources/qml/MachineSettings/PrintHeadMinMaxTextField.qml
+++ b/resources/qml/MachineSettings/PrintHeadMinMaxTextField.qml
@@ -67,8 +67,14 @@ NumericTextFieldWithUnit
 
     editingFinishedFunction: function()
     {
-        var polygon = JSON.parse(propertyProvider.properties.value)
         var newValue = parseFloat(valueText.replace(',', '.'))
+        if (newValue === axisValue)
+        {
+            // Value unchanged; just restore the binding and skip the expensive JSON round-trip.
+            valueText = Qt.binding(function() { return axisValue })
+            return
+        }
+        var polygon = JSON.parse(propertyProvider.properties.value)
 
         if (axisName == "x")  // x min/x max
         {

--- a/resources/qml/Preferences/MachinesPage.qml
+++ b/resources/qml/Preferences/MachinesPage.qml
@@ -109,7 +109,22 @@ UM.ManagementPage
                 maximumWidth: minimumWidth * 3
                 maximumHeight: minimumHeight * 3
                 backgroundColor: UM.Theme.getColor("main_background")
-                selfDestroy: true
+
+                // Do not use selfDestroy so we can commit any active edit first.
+                selfDestroy: false
+                onVisibleChanged:
+                {
+                    if (!visible)
+                    {
+                        // Commit the value of whichever single field currently has focus,
+                        // without triggering it for every field on the page.
+                        if (activeFocusItem && typeof activeFocusItem.editingFinishedFunction === "function")
+                        {
+                            activeFocusItem.editingFinishedFunction()
+                        }
+                        destroy()
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This pull request improves how in-progress edits are committed in machine settings dialogs, ensuring user changes are saved more reliably when dialogs are closed or focus is lost. It also optimizes value updates to avoid unnecessary processing when values haven't changed.

**User input commit and dialog behavior improvements:**

* In `MachineSettings/NumericTextFieldWithUnit.qml`, edits are now automatically committed when the text field loses focus (including when dialogs close), ensuring user changes aren't lost if the dialog is closed without explicit confirmation.
* The `Component.onDestruction` handler was removed in favor of the improved focus handling, preventing redundant or mistimed commits.
* In `Preferences/MachinesPage.qml`, the dialog no longer self-destroys immediately, allowing any active edit to be committed before the dialog is closed. The field with focus has its `editingFinishedFunction` called before destruction, preventing data loss.

**Optimizations and correctness:**

* In `PrintHeadMinMaxTextField.qml`, the code now checks if the value was actually changed before updating, skipping unnecessary JSON parsing and updates if the value is unchanged.
* In `GcodeTextArea.qml`, the property value is only updated if the text has actually changed, avoiding redundant updates.



CURA-13309
