### PR TITLE
Add Fracktal Works printer definitions (Julia, Snowflake, Dragon, Twin Dragon, Volterra)

### DIFF
--- a/resources/definitions/base_fracktal_dual_printer.def.json
+++ b/resources/definitions/base_fracktal_dual_printer.def.json
@@ -2,118 +2,53 @@
     "version": 2,
     "name": "Fracktal Works Dual Printer Base Description",
     "inherits": "base_fracktal_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": false,
         "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "machine_extruder_trains": {
+        "machine_extruder_trains":
+        {
             "0": "base_fracktal_dual_extruder_0",
             "1": "base_fracktal_dual_extruder_1"
         },
         "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "adhesion_extruder_nr": {
-            "value": "0"
-        },
-        "bridge_fan_speed": {
-            "value": "0 if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else cool_fan_speed_max"
-        },
-        "bridge_skin_speed": {
-            "value": "min(round(speed_topbottom * 0.6),40) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else min(round(speed_topbottom * 0.75),50)"
-        },
-        "bridge_wall_speed": {
-            "value": "min(round(speed_wall * 0.6),40) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else min(round(speed_wall * 0.75),50)"
-        },
-        "machine_end_gcode": {
-            "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 X-20 Y-20 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning"
-        },
-        "machine_extruder_count": {
-            "default_value": 2
-        },
-        "machine_start_gcode": {
-            "default_value": ";Machine Model: {machine_name} \n;Nozzles used: {'T0 ' + str(extruderValue(0, 'machine_nozzle_size'))  + ' T1 ' + str(extruderValue(1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nT0;always start probe with T0\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\n "
-        },
-        "prime_tower_base_curve_magnitude": {
-            "value": "4"
-        },
-        "prime_tower_base_height": {
-            "value": "5"
-        },
-        "prime_tower_base_size": {
-            "value": "line_width*5"
-        },
-        "prime_tower_brim_enable": {
-            "value": "True"
-        },
-        "prime_tower_enable": {
-            "value": "True"
-        },
-        "prime_tower_flow": {
-            "value": 100
-        },
-        "prime_tower_max_bridging_distance": {
-            "value": "line_width*3"
-        },
-        "prime_tower_position_x": {
-            "value": "prime_tower_size + 20"
-        },
-        "prime_tower_position_y": {
-            "value": "20"
-        },
-        "prime_tower_size": {
-            "value": "30"
-        },
-        "prime_tower_wipe_enabled": {
-            "value": "False"
-        },
-        "raft_airgap": {
-            "value": "0 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 0.15 if machine_nozzle_size <= 0.25 else 0.25 if machine_nozzle_size <= 0.4 else 0.3 if machine_nozzle_size <= 0.6 else 0.35"
-        },
-        "raft_interface_extruder_nr": {
-            "value": "0"
-        },
-        "raft_surface_extruder_nr": {
-            "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else raft_base_extruder_nr"
-        },
-        "speed_prime_tower": {
-            "value": "speed_wall_0"
-        },
-        "support_extruder_nr_layer_0": {
-            "value": "support_infill_extruder_nr"
-        },
-        "support_interface_density": {
-            "value": "100 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 33.3"
-        },
-        "support_interface_height": {
-            "value": "3 * layer_height if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 2 * layer_height"
-        },
-        "support_interface_pattern": {
-            "value": "'concentric' if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 'grid'"
-        },
-        "support_offset": {
-            "value": "machine_nozzle_size * 2"
-        },
-        "support_skip_some_zags": {
-            "value": "False if extruderValue(support_extruder_nr,'material_is_support_material') else True if support_pattern == 'zigzag' else False"
-        },
-        "support_tree_rest_preference": {
-            "value": "'graceful' if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 'buildplate'"
-        },
-        "support_tree_top_rate": {
-            "value": "30 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 20"
-        },
-        "switch_extruder_extra_prime_amount": {
-            "value": "0.5"
-        },
-        "switch_extruder_prime_speed": {
-            "value": "25"
-        },
-        "switch_extruder_retraction_amount": {
-            "value": "machine_heat_zone_length * 0.75"
-        },
-        "switch_extruder_retraction_speeds": {
-            "value": "45"
-        }
+    "overrides":
+    {
+        "adhesion_extruder_nr": { "value": "0" },
+        "bridge_fan_speed": { "value": "0 if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else cool_fan_speed_max" },
+        "bridge_skin_speed": { "value": "min(round(speed_topbottom * 0.6),40) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else min(round(speed_topbottom * 0.75),50)" },
+        "bridge_wall_speed": { "value": "min(round(speed_wall * 0.6),40) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else min(round(speed_wall * 0.75),50)" },
+        "machine_end_gcode": { "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 X-20 Y-20 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning" },
+        "machine_extruder_count": { "default_value": 2 },
+        "machine_start_gcode": { "default_value": ";Machine Model: {machine_name} \n;Nozzles used: {'T0 ' + str(extruderValue(0, 'machine_nozzle_size'))  + ' T1 ' + str(extruderValue(1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nT0;always start probe with T0\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\n " },
+        "prime_tower_base_curve_magnitude": { "value": "4" },
+        "prime_tower_base_height": { "value": "5" },
+        "prime_tower_base_size": { "value": "line_width*5" },
+        "prime_tower_brim_enable": { "value": "True" },
+        "prime_tower_enable": { "value": "True" },
+        "prime_tower_flow": { "value": 100 },
+        "prime_tower_max_bridging_distance": { "value": "line_width*3" },
+        "prime_tower_position_x": { "value": "prime_tower_size + 20" },
+        "prime_tower_position_y": { "value": "20" },
+        "prime_tower_size": { "value": "30" },
+        "prime_tower_wipe_enabled": { "value": "False" },
+        "raft_airgap": { "value": "0 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 0.15 if machine_nozzle_size <= 0.25 else 0.25 if machine_nozzle_size <= 0.4 else 0.3 if machine_nozzle_size <= 0.6 else 0.35" },
+        "raft_interface_extruder_nr": { "value": "0" },
+        "raft_surface_extruder_nr": { "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else raft_base_extruder_nr" },
+        "speed_prime_tower": { "value": "speed_wall_0" },
+        "support_extruder_nr_layer_0": { "value": "support_infill_extruder_nr" },
+        "support_interface_density": { "value": "100 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 33.3" },
+        "support_interface_height": { "value": "3 * layer_height if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 2 * layer_height" },
+        "support_interface_pattern": { "value": "'concentric' if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 'grid'" },
+        "support_offset": { "value": "machine_nozzle_size * 2" },
+        "support_skip_some_zags": { "value": "False if extruderValue(support_extruder_nr,'material_is_support_material') else True if support_pattern == 'zigzag' else False" },
+        "support_tree_rest_preference": { "value": "'graceful' if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 'buildplate'" },
+        "support_tree_top_rate": { "value": "30 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 20" },
+        "switch_extruder_extra_prime_amount": { "value": "0.5" },
+        "switch_extruder_prime_speed": { "value": "25" },
+        "switch_extruder_retraction_amount": { "value": "machine_heat_zone_length * 0.75" },
+        "switch_extruder_retraction_speeds": { "value": "45" }
     }
 }

--- a/resources/definitions/base_fracktal_dual_printer.def.json
+++ b/resources/definitions/base_fracktal_dual_printer.def.json
@@ -1,0 +1,119 @@
+{
+    "version": 2,
+    "name": "Fracktal Works Dual Printer Base Description",
+    "inherits": "base_fracktal_printer",
+    "metadata": {
+        "visible": false,
+        "author": "Fracktal Works",
+        "manufacturer": "Fracktal Works",
+        "machine_extruder_trains": {
+            "0": "base_fracktal_dual_extruder_0",
+            "1": "base_fracktal_dual_extruder_1"
+        },
+        "preferred_quality_type": "normal"
+    },
+    "overrides": {
+        "adhesion_extruder_nr": {
+            "value": "0"
+        },
+        "bridge_fan_speed": {
+            "value": "0 if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else cool_fan_speed_max"
+        },
+        "bridge_skin_speed": {
+            "value": "min(round(speed_topbottom * 0.6),40) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else min(round(speed_topbottom * 0.75),50)"
+        },
+        "bridge_wall_speed": {
+            "value": "min(round(speed_wall * 0.6),40) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else min(round(speed_wall * 0.75),50)"
+        },
+        "machine_end_gcode": {
+            "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 X-20 Y-20 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning"
+        },
+        "machine_extruder_count": {
+            "default_value": 2
+        },
+        "machine_start_gcode": {
+            "default_value": ";Machine Model: {machine_name} \n;Nozzles used: {'T0 ' + str(extruderValue(0, 'machine_nozzle_size'))  + ' T1 ' + str(extruderValue(1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nT0;always start probe with T0\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\n "
+        },
+        "prime_tower_base_curve_magnitude": {
+            "value": "4"
+        },
+        "prime_tower_base_height": {
+            "value": "5"
+        },
+        "prime_tower_base_size": {
+            "value": "line_width*5"
+        },
+        "prime_tower_brim_enable": {
+            "value": "True"
+        },
+        "prime_tower_enable": {
+            "value": "True"
+        },
+        "prime_tower_flow": {
+            "value": 100
+        },
+        "prime_tower_max_bridging_distance": {
+            "value": "line_width*3"
+        },
+        "prime_tower_position_x": {
+            "value": "prime_tower_size + 20"
+        },
+        "prime_tower_position_y": {
+            "value": "20"
+        },
+        "prime_tower_size": {
+            "value": "30"
+        },
+        "prime_tower_wipe_enabled": {
+            "value": "False"
+        },
+        "raft_airgap": {
+            "value": "0 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 0.15 if machine_nozzle_size <= 0.25 else 0.25 if machine_nozzle_size <= 0.4 else 0.3 if machine_nozzle_size <= 0.6 else 0.35"
+        },
+        "raft_interface_extruder_nr": {
+            "value": "0"
+        },
+        "raft_surface_extruder_nr": {
+            "value": "int(anyExtruderWithMaterial('material_is_support_material')) if support_enable and extruderValue(support_extruder_nr,'material_is_support_material') else raft_base_extruder_nr"
+        },
+        "speed_prime_tower": {
+            "value": "speed_wall_0"
+        },
+        "support_extruder_nr_layer_0": {
+            "value": "support_infill_extruder_nr"
+        },
+        "support_interface_density": {
+            "value": "100 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 33.3"
+        },
+        "support_interface_height": {
+            "value": "3 * layer_height if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 2 * layer_height"
+        },
+        "support_interface_pattern": {
+            "value": "'concentric' if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 'grid'"
+        },
+        "support_offset": {
+            "value": "machine_nozzle_size * 2"
+        },
+        "support_skip_some_zags": {
+            "value": "False if extruderValue(support_extruder_nr,'material_is_support_material') else True if support_pattern == 'zigzag' else False"
+        },
+        "support_tree_rest_preference": {
+            "value": "'graceful' if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 'buildplate'"
+        },
+        "support_tree_top_rate": {
+            "value": "30 if extruderValue(support_interface_extruder_nr,'material_is_support_material') else 20"
+        },
+        "switch_extruder_extra_prime_amount": {
+            "value": "0.5"
+        },
+        "switch_extruder_prime_speed": {
+            "value": "25"
+        },
+        "switch_extruder_retraction_amount": {
+            "value": "machine_heat_zone_length * 0.75"
+        },
+        "switch_extruder_retraction_speeds": {
+            "value": "45"
+        }
+    }
+}

--- a/resources/definitions/base_fracktal_idex_printer.def.json
+++ b/resources/definitions/base_fracktal_idex_printer.def.json
@@ -1,0 +1,89 @@
+{
+    "version": 2,
+    "name": "Fracktal Works IDEX Printer Base Description",
+    "inherits": "base_fracktal_dual_printer",
+    "metadata": {
+        "visible": false,
+        "author": "Fracktal Works",
+        "manufacturer": "Fracktal Works",
+        "machine_extruder_trains": {
+            "0": "base_fracktal_idex_extruder_0",
+            "1": "base_fracktal_idex_extruder_1"
+        }
+    },
+    "overrides": {
+        "gantry_height": {
+            "value": "20"
+        },
+        "machine_end_gcode": {
+            "default_value": "M104 S0 T0               ;left extruder heater off\nM104 S0 T1               ;right extruder heater off\nM140 S0                  ;heated bed heater off\nG91                      ;relative positioning\nG1 Z+0.5 E-5 Y+10 F12000 ;move Z up a bit and retract filament\nG28 X0 Y0                ;move X/Y to min endstops so the head is out of the way\nM84                      ;steppers off\nG90                      ;absolute positioning\n"
+        },
+        "machine_head_with_fans_polygon": {
+            "default_value": [
+                [
+                    -50,
+                    50
+                ],
+                [
+                    50,
+                    50
+                ],
+                [
+                    50,
+                    -50
+                ],
+                [
+                    -50,
+                    -50
+                ]
+            ]
+        },
+        "material_bed_temp_prepend": {
+            "value": false
+        },
+        "material_print_temp_prepend": {
+            "value": false
+        },
+        "material_print_temp_wait": {
+            "value": false
+        },
+        "prime_tower_position_x": {
+            "value": "(machine_width / 2) - (prime_tower_size / 2)"
+        },
+        "prime_tower_position_y": {
+            "value": "20"
+        },
+        "retraction_extra_prime_amount": {
+            "value": "0.025 if machine_nozzle_size <= 0.25 else 0.05 if machine_nozzle_size <= 0.4 else 0.1 if machine_nozzle_size <= 0.6 else 0.15"
+        },
+        "retraction_hop_after_extruder_switch": {
+            "value": false
+        },
+        "speed_roofing": {
+            "value": "speed_wall"
+        },
+        "speed_travel": {
+            "maximum_value": "600",
+            "maximum_value_warning": "600",
+            "value": "max(200,speed_print)"
+        },
+        "speed_travel_layer_0": {
+            "value": "100"
+        },
+        "switch_extruder_extra_prime_amount": {
+            "value": "retraction_extra_prime_amount"
+        },
+        "switch_extruder_retraction_amount": {
+            "value": "retraction_amount"
+        },
+        "machine_start_gcode": {
+            "default_value": ";Machine Model: {machine_name}\n;Sliced at: {day} {date} {time}\nM140 S{material_bed_temperature_layer_0} \t;Heat build surface\nM104 T0 S{material_print_temperature_layer_0, 0}\t;Heat extruder 0\nM104 T1 S{material_print_temperature_layer_0, 1}\t;Heat extruder 1\nM190 S{material_bed_temperature_layer_0} \t;Wait until bed temperature reached \nM109 T0 S{material_print_temperature_layer_0, 0}\t;Heat extruder 0 and wait\nM109 T1 S{material_print_temperature_layer_0, 1}\t;Heat extruder 1 and wait\nG21 \t\t;metric values \nG90 \t\t;absolute positioning \nM107 \t\t;start with the fan off \nG28 Z0 \t\t;move Z to min endstops \nG28 X0 Y0 \t;move X/Y to min endstops \nG1 X0 Y0 Z5 F5000 \t;safety Z axis movement\n\nT0\nG4 P1\nG4 P2\nG4 P3\n\nG29  \t;Auto Bed Level\nM500  \t;Save Bed Level\n\n; Extrude purge line\nG1 X0 Y0 F10000\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X38 Z0.05 F8000 ; wipe, move close to the bed\nG0 X41 Z0.2 F8000 ; wipe, move quickly away from the bed\nG1 X0 Y0 Z3 F5000 \t;safety Z axis movement\nG92 E0 ; zero the extruded length again\n"
+        },
+        "machine_disallowed_areas": {
+            "value": "[[[-(machine_width / 2), machine_depth / 2], [-(machine_width / 2), -machine_depth / 2], [-(machine_width / 2) + abs(machine_head_with_fans_polygon[0][0]), -machine_depth / 2], [-(machine_width / 2) + abs(machine_head_with_fans_polygon[0][0]), machine_depth / 2]], [[machine_width / 2 - abs(machine_head_with_fans_polygon[2][0]), machine_depth / 2], [machine_width / 2 - abs(machine_head_with_fans_polygon[2][0]), -machine_depth / 2], [machine_width / 2, -machine_depth / 2], [machine_width / 2, machine_depth / 2]]]"
+        },
+        "prime_tower_enable": {
+            "value": "extruders_enabled_count > 1"
+        }
+    }
+}

--- a/resources/definitions/base_fracktal_idex_printer.def.json
+++ b/resources/definitions/base_fracktal_idex_printer.def.json
@@ -2,88 +2,49 @@
     "version": 2,
     "name": "Fracktal Works IDEX Printer Base Description",
     "inherits": "base_fracktal_dual_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": false,
         "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "machine_extruder_trains": {
+        "machine_extruder_trains":
+        {
             "0": "base_fracktal_idex_extruder_0",
             "1": "base_fracktal_idex_extruder_1"
         }
     },
-    "overrides": {
-        "gantry_height": {
-            "value": "20"
-        },
-        "machine_end_gcode": {
-            "default_value": "M104 S0 T0               ;left extruder heater off\nM104 S0 T1               ;right extruder heater off\nM140 S0                  ;heated bed heater off\nG91                      ;relative positioning\nG1 Z+0.5 E-5 Y+10 F12000 ;move Z up a bit and retract filament\nG28 X0 Y0                ;move X/Y to min endstops so the head is out of the way\nM84                      ;steppers off\nG90                      ;absolute positioning\n"
-        },
-        "machine_head_with_fans_polygon": {
+    "overrides":
+    {
+        "gantry_height": { "value": "20" },
+        "machine_disallowed_areas": { "value": "[[[-(machine_width / 2), machine_depth / 2], [-(machine_width / 2), -machine_depth / 2], [-(machine_width / 2) + abs(machine_head_with_fans_polygon[0][0]), -machine_depth / 2], [-(machine_width / 2) + abs(machine_head_with_fans_polygon[0][0]), machine_depth / 2]], [[machine_width / 2 - abs(machine_head_with_fans_polygon[2][0]), machine_depth / 2], [machine_width / 2 - abs(machine_head_with_fans_polygon[2][0]), -machine_depth / 2], [machine_width / 2, -machine_depth / 2], [machine_width / 2, machine_depth / 2]]]" },
+        "machine_end_gcode": { "default_value": "M104 S0 T0               ;left extruder heater off\nM104 S0 T1               ;right extruder heater off\nM140 S0                  ;heated bed heater off\nG91                      ;relative positioning\nG1 Z+0.5 E-5 Y+10 F12000 ;move Z up a bit and retract filament\nG28 X0 Y0                ;move X/Y to min endstops so the head is out of the way\nM84                      ;steppers off\nG90                      ;absolute positioning\n" },
+        "machine_head_with_fans_polygon":
+        {
             "default_value": [
-                [
-                    -50,
-                    50
-                ],
-                [
-                    50,
-                    50
-                ],
-                [
-                    50,
-                    -50
-                ],
-                [
-                    -50,
-                    -50
-                ]
+                [-50, 50],
+                [50, 50],
+                [50, -50],
+                [-50, -50]
             ]
         },
-        "material_bed_temp_prepend": {
-            "value": false
-        },
-        "material_print_temp_prepend": {
-            "value": false
-        },
-        "material_print_temp_wait": {
-            "value": false
-        },
-        "prime_tower_position_x": {
-            "value": "(machine_width / 2) - (prime_tower_size / 2)"
-        },
-        "prime_tower_position_y": {
-            "value": "20"
-        },
-        "retraction_extra_prime_amount": {
-            "value": "0.025 if machine_nozzle_size <= 0.25 else 0.05 if machine_nozzle_size <= 0.4 else 0.1 if machine_nozzle_size <= 0.6 else 0.15"
-        },
-        "retraction_hop_after_extruder_switch": {
-            "value": false
-        },
-        "speed_roofing": {
-            "value": "speed_wall"
-        },
-        "speed_travel": {
+        "machine_start_gcode": { "default_value": ";Machine Model: {machine_name}\n;Sliced at: {day} {date} {time}\nM140 S{material_bed_temperature_layer_0} \t;Heat build surface\nM104 T0 S{material_print_temperature_layer_0, 0}\t;Heat extruder 0\nM104 T1 S{material_print_temperature_layer_0, 1}\t;Heat extruder 1\nM190 S{material_bed_temperature_layer_0} \t;Wait until bed temperature reached \nM109 T0 S{material_print_temperature_layer_0, 0}\t;Heat extruder 0 and wait\nM109 T1 S{material_print_temperature_layer_0, 1}\t;Heat extruder 1 and wait\nG21 \t\t;metric values \nG90 \t\t;absolute positioning \nM107 \t\t;start with the fan off \nG28 Z0 \t\t;move Z to min endstops \nG28 X0 Y0 \t;move X/Y to min endstops \nG1 X0 Y0 Z5 F5000 \t;safety Z axis movement\n\nT0\nG4 P1\nG4 P2\nG4 P3\n\nG29  \t;Auto Bed Level\nM500  \t;Save Bed Level\n\n; Extrude purge line\nG1 X0 Y0 F10000\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X38 Z0.05 F8000 ; wipe, move close to the bed\nG0 X41 Z0.2 F8000 ; wipe, move quickly away from the bed\nG1 X0 Y0 Z3 F5000 \t;safety Z axis movement\nG92 E0 ; zero the extruded length again\n" },
+        "material_bed_temp_prepend": { "value": false },
+        "material_print_temp_prepend": { "value": false },
+        "material_print_temp_wait": { "value": false },
+        "prime_tower_enable": { "value": "extruders_enabled_count > 1" },
+        "prime_tower_position_x": { "value": "(machine_width / 2) - (prime_tower_size / 2)" },
+        "prime_tower_position_y": { "value": "20" },
+        "retraction_extra_prime_amount": { "value": "0.025 if machine_nozzle_size <= 0.25 else 0.05 if machine_nozzle_size <= 0.4 else 0.1 if machine_nozzle_size <= 0.6 else 0.15" },
+        "retraction_hop_after_extruder_switch": { "value": false },
+        "speed_roofing": { "value": "speed_wall" },
+        "speed_travel":
+        {
             "maximum_value": "600",
             "maximum_value_warning": "600",
             "value": "max(200,speed_print)"
         },
-        "speed_travel_layer_0": {
-            "value": "100"
-        },
-        "switch_extruder_extra_prime_amount": {
-            "value": "retraction_extra_prime_amount"
-        },
-        "switch_extruder_retraction_amount": {
-            "value": "retraction_amount"
-        },
-        "machine_start_gcode": {
-            "default_value": ";Machine Model: {machine_name}\n;Sliced at: {day} {date} {time}\nM140 S{material_bed_temperature_layer_0} \t;Heat build surface\nM104 T0 S{material_print_temperature_layer_0, 0}\t;Heat extruder 0\nM104 T1 S{material_print_temperature_layer_0, 1}\t;Heat extruder 1\nM190 S{material_bed_temperature_layer_0} \t;Wait until bed temperature reached \nM109 T0 S{material_print_temperature_layer_0, 0}\t;Heat extruder 0 and wait\nM109 T1 S{material_print_temperature_layer_0, 1}\t;Heat extruder 1 and wait\nG21 \t\t;metric values \nG90 \t\t;absolute positioning \nM107 \t\t;start with the fan off \nG28 Z0 \t\t;move Z to min endstops \nG28 X0 Y0 \t;move X/Y to min endstops \nG1 X0 Y0 Z5 F5000 \t;safety Z axis movement\n\nT0\nG4 P1\nG4 P2\nG4 P3\n\nG29  \t;Auto Bed Level\nM500  \t;Save Bed Level\n\n; Extrude purge line\nG1 X0 Y0 F10000\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X38 Z0.05 F8000 ; wipe, move close to the bed\nG0 X41 Z0.2 F8000 ; wipe, move quickly away from the bed\nG1 X0 Y0 Z3 F5000 \t;safety Z axis movement\nG92 E0 ; zero the extruded length again\n"
-        },
-        "machine_disallowed_areas": {
-            "value": "[[[-(machine_width / 2), machine_depth / 2], [-(machine_width / 2), -machine_depth / 2], [-(machine_width / 2) + abs(machine_head_with_fans_polygon[0][0]), -machine_depth / 2], [-(machine_width / 2) + abs(machine_head_with_fans_polygon[0][0]), machine_depth / 2]], [[machine_width / 2 - abs(machine_head_with_fans_polygon[2][0]), machine_depth / 2], [machine_width / 2 - abs(machine_head_with_fans_polygon[2][0]), -machine_depth / 2], [machine_width / 2, -machine_depth / 2], [machine_width / 2, machine_depth / 2]]]"
-        },
-        "prime_tower_enable": {
-            "value": "extruders_enabled_count > 1"
-        }
+        "speed_travel_layer_0": { "value": "100" },
+        "switch_extruder_extra_prime_amount": { "value": "retraction_extra_prime_amount" },
+        "switch_extruder_retraction_amount": { "value": "retraction_amount" }
     }
 }

--- a/resources/definitions/base_fracktal_printer.def.json
+++ b/resources/definitions/base_fracktal_printer.def.json
@@ -1,0 +1,568 @@
+{
+    "version": 2,
+    "name": "Base Fracktal 3D Printer Definition",
+    "inherits": "fdmprinter",
+    "metadata": {
+        "visible": false,
+        "author": "Fracktal Works",
+        "manufacturer": "Fracktal Works",
+        "file_formats": "text/x-gcode",
+        "machine_extruder_trains": {
+            "0": "base_fracktal_extruder_0"
+        },
+        "preferred_quality_type": "normal"
+    },
+    "overrides": {
+        "acceleration_print": {
+            "default_value": 1000
+        },
+        "acceleration_travel": {
+            "value": 1000
+        },
+        "alternate_carve_order": {
+            "value": true
+        },
+        "bridge_enable_more_layers": {
+            "value": true
+        },
+        "bridge_fan_speed_2": {
+            "value": "(cool_fan_speed_max + cool_fan_speed_min) / 2"
+        },
+        "bridge_fan_speed_3": {
+            "value": "cool_fan_speed_min"
+        },
+        "bridge_settings_enabled": {
+            "value": true
+        },
+        "bridge_skin_density": {
+            "value": 100
+        },
+        "bridge_skin_density_2": {
+            "value": 100
+        },
+        "bridge_skin_density_3": {
+            "value": 100
+        },
+        "bridge_skin_material_flow": {
+            "value": "material_flow if support_enable else material_flow * 0.95"
+        },
+        "bridge_skin_material_flow_2": {
+            "value": "material_flow"
+        },
+        "bridge_skin_material_flow_3": {
+            "value": "material_flow"
+        },
+        "bridge_skin_speed": {
+            "value": "min(round(speed_topbottom * 0.75),50)"
+        },
+        "bridge_skin_speed_2": {
+            "value": "speed_topbottom"
+        },
+        "bridge_skin_speed_3": {
+            "value": "speed_topbottom"
+        },
+        "bridge_wall_coast": {
+            "value": 0
+        },
+        "bridge_wall_material_flow": {
+            "value": "material_flow if support_enable else material_flow * 0.95"
+        },
+        "bridge_wall_speed": {
+            "value": "min(round(speed_wall * 0.75),40)"
+        },
+        "brim_line_count": {
+            "value": "6"
+        },
+        "brim_replaces_support": {
+            "value": false
+        },
+        "carve_multiple_volumes": {
+            "value": true
+        },
+        "cool_fan_speed": {
+            "resolve": "min(extruderValues('cool_fan_speed'))",
+            "settable_per_extruder": false
+        },
+        "cool_fan_speed_0": {
+            "value": 0
+        },
+        "cool_fan_speed_max": {
+            "resolve": "min(extruderValues('cool_fan_speed_max'))",
+            "settable_per_extruder": false
+        },
+        "cool_min_layer_time": {
+            "value": 6
+        },
+        "cool_min_layer_time_fan_speed_max": {
+            "value": "cool_min_layer_time + 5"
+        },
+        "cool_min_speed": {
+            "value": "round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)"
+        },
+        "cool_min_temperature": {
+            "maximum_value": "500",
+            "value": "min([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])"
+        },
+        "default_material_print_temperature": {
+            "maximum_value": "500"
+        },
+        "gradual_flow_discretisation_step_size": {
+            "value": 0.2
+        },
+        "gradual_flow_enabled": {
+            "value": true
+        },
+        "gradual_support_infill_step_height": {
+            "value": "4 * layer_height"
+        },
+        "gradual_support_infill_steps": {
+            "value": "2 if support_interface_enable and support_structure != 'tree' else 0"
+        },
+        "group_outer_walls": {
+            "value": false
+        },
+        "infill_before_walls": {
+            "value": false
+        },
+        "infill_overlap": {
+            "value": 0
+        },
+        "infill_pattern": {
+            "value": "'zigzag' if infill_sparse_density > 80 else 'triangles'"
+        },
+        "infill_sparse_density": {
+            "value": "20"
+        },
+        "infill_wipe_dist": {
+            "value": "0 if infill_before_walls == True else wall_line_width_x / 4"
+        },
+        "initial_bottom_layers": {
+            "value": "3 if bottom_layers == 4 else bottom_layers"
+        },
+        "initial_layer_line_width_factor": {
+            "value": 105
+        },
+        "jerk_print": {
+            "default_value": 10
+        },
+        "jerk_travel": {
+            "value": 10
+        },
+        "layer_start_x": {
+            "value": "machine_width/2"
+        },
+        "layer_start_y": {
+            "value": "machine_depth"
+        },
+        "line_width": {
+            "value": "round(machine_nozzle_size * 1.05, 2)"
+        },
+        "machine_acceleration": {
+            "default_value": 1000
+        },
+        "machine_end_gcode": {
+            "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning\n\nM300 S0 P333\nM300 S880 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\n"
+        },
+        "machine_heat_zone_length": {
+            "default_value": 12
+        },
+        "machine_heated_bed": {
+            "default_value": true
+        },
+        "machine_max_acceleration_x": {
+            "default_value": 1000
+        },
+        "machine_max_acceleration_y": {
+            "default_value": 1000
+        },
+        "machine_max_acceleration_z": {
+            "default_value": 50
+        },
+        "machine_max_feedrate_e": {
+            "default_value": 80
+        },
+        "machine_max_feedrate_x": {
+            "default_value": 500
+        },
+        "machine_max_feedrate_y": {
+            "default_value": 500
+        },
+        "machine_max_feedrate_z": {
+            "default_value": 50
+        },
+        "machine_max_jerk_e": {
+            "default_value": 20
+        },
+        "machine_max_jerk_z": {
+            "default_value": 0.8
+        },
+        "machine_min_cool_heat_time_window": {
+            "default_value": 60
+        },
+        "machine_nozzle_cool_down_speed": {
+            "default_value": 1
+        },
+        "machine_nozzle_heat_up_speed": {
+            "default_value": 0.5
+        },
+        "machine_show_variants": {
+            "default_value": true
+        },
+        "machine_start_gcode": {
+            "default_value": ";Machine Model: {machine_name} \n;Nozzle Size: {str(extruderValue(-1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\nM117 Printing...\n\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\n"
+        },
+        "material_bed_temperature_layer_0": {
+            "value": "resolveOrValue('material_bed_temperature') + 10"
+        },
+        "material_break_preparation_temperature": {
+            "maximum_value": "500"
+        },
+        "material_break_temperature": {
+            "maximum_value": "500"
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        },
+        "material_extrusion_cool_down_speed": {
+            "value": "0.5"
+        },
+        "material_final_print_temperature": {
+            "maximum_value": "500"
+        },
+        "material_flow": {
+            "value": "90 if machine_nozzle_size <= 0.25 else 95"
+        },
+        "material_flow_layer_0": {
+            "value": "material_flow * 1.05"
+        },
+        "material_initial_print_temperature": {
+            "maximum_value": "500"
+        },
+        "material_print_temperature": {
+            "maximum_value": "500"
+        },
+        "material_print_temperature_layer_0": {
+            "maximum_value": "500",
+            "value": "material_print_temperature + 10"
+        },
+        "material_standby_temperature": {
+            "maximum_value": "500",
+            "value": "175"
+        },
+        "max_flow_acceleration": {
+            "value": "0.4 if machine_nozzle_size <= 0.25 else 0.8 if machine_nozzle_size <= 0.4 else 1 if machine_nozzle_size <= 0.6 else 2.0"
+        },
+        "max_skin_angle_for_expansion": {
+            "value": 45
+        },
+        "meshfix_maximum_deviation": {
+            "value": "0.02"
+        },
+        "meshfix_maximum_resolution": {
+            "value": "0.5"
+        },
+        "meshfix_union_all": {
+            "value": false
+        },
+        "min_bead_width": {
+            "value": "0.8 * machine_nozzle_size"
+        },
+        "min_feature_size": {
+            "value": "0.05"
+        },
+        "min_wall_line_width": {
+            "value": "0.8 * machine_nozzle_size"
+        },
+        "minimum_interface_area": {
+            "value": 15
+        },
+        "minimum_support_area": {
+            "value": "6 if support_structure == 'tree' else 10"
+        },
+        "optimize_wall_printing_order": {
+            "value": true
+        },
+        "raft_airgap": {
+            "value": "0.1 if machine_nozzle_size <= 0.25 else 0.2 if machine_nozzle_size <= 0.4 else 0.25 if machine_nozzle_size <= 0.6 else 0.35"
+        },
+        "raft_base_line_spacing": {
+            "value": "2*raft_base_line_width"
+        },
+        "raft_base_line_width": {
+            "value": "machine_nozzle_size *2"
+        },
+        "raft_base_speed": {
+            "value": "speed_layer_0 * 0.7"
+        },
+        "raft_base_thickness": {
+            "value": "machine_nozzle_size "
+        },
+        "raft_interface_extruder_nr": {
+            "value": "raft_surface_extruder_nr"
+        },
+        "raft_interface_layers": {
+            "value": 1
+        },
+        "raft_interface_line_width": {
+            "value": 0.7
+        },
+        "raft_interface_speed": {
+            "value": "speed_print * 0.9"
+        },
+        "raft_interface_thickness": {
+            "value": 0.3
+        },
+        "raft_interface_wall_count": {
+            "value": "raft_wall_count"
+        },
+        "raft_margin": {
+            "value": 1.2
+        },
+        "raft_surface_fan_speed": {
+            "value": "cool_fan_speed_max"
+        },
+        "raft_surface_monotonic": {
+            "value": true
+        },
+        "raft_surface_wall_count": {
+            "value": "raft_wall_count"
+        },
+        "retract_at_layer_change": {
+            "value": true
+        },
+        "retraction_amount": {
+            "value": "machine_heat_zone_length * 0.1"
+        },
+        "retraction_combing": {
+            "value": "'off'"
+        },
+        "retraction_combing_max_distance": {
+            "value": "machine_nozzle_size * 5"
+        },
+        "retraction_count_max": {
+            "value": "int(15 * retraction_extrusion_window)"
+        },
+        "retraction_enable": {
+            "value": true
+        },
+        "retraction_extra_prime_amount": {
+            "value": "0.05 if machine_nozzle_size <= 0.25 else 0.08 if machine_nozzle_size <= 0.4 else 0.12 if machine_nozzle_size <= 0.6 else 0.16"
+        },
+        "retraction_extrusion_window": {
+            "value": "retraction_amount"
+        },
+        "retraction_hop": {
+            "value": "layer_height"
+        },
+        "retraction_hop_enabled": {
+            "value": true
+        },
+        "retraction_hop_only_when_collides": {
+            "value": true
+        },
+        "retraction_min_travel": {
+            "value": "machine_nozzle_size * 5"
+        },
+        "retraction_prime_speed": {
+            "value": "retraction_speed * 0.75"
+        },
+        "retraction_speed": {
+            "value": "60"
+        },
+        "roofing_layer_count": {
+            "value": "1"
+        },
+        "seam_overhang_angle": {
+            "value": 40
+        },
+        "skin_material_flow_layer_0": {
+            "value": "material_flow_layer_0 - 5"
+        },
+        "skin_monotonic": {
+            "value": true
+        },
+        "skin_outline_count": {
+            "value": "1"
+        },
+        "skin_overlap": {
+            "value": 25
+        },
+        "skirt_brim_minimal_length": {
+            "value": 150
+        },
+        "skirt_height": {
+            "value": 1
+        },
+        "small_skin_width": {
+            "value": 4
+        },
+        "speed_layer_0": {
+            "value": "min(25, round(speed_print * 0.4, 0))"
+        },
+        "speed_print": {
+            "value": "60"
+        },
+        "speed_support": {
+            "value": "speed_print * 0.60 if support_structure == 'tree' and strengthen_tree_support == True else speed_print * 0.70 if support_structure == 'tree' and strengthen_tree_support == False else speed_print * 0.80"
+        },
+        "speed_support_bottom": {
+            "value": "speed_support * 0.9"
+        },
+        "speed_support_infill": {
+            "value": "speed_support"
+        },
+        "speed_support_interface": {
+            "value": "speed_support * 0.70"
+        },
+        "speed_topbottom": {
+            "value": "min(round(speed_print * 0.8, 0),100)"
+        },
+        "speed_travel": {
+            "value": "max(80,speed_print)"
+        },
+        "speed_travel_layer_0": {
+            "value": "60"
+        },
+        "speed_wall": {
+            "value": "min(round(speed_print * 0.75, 0),100)"
+        },
+        "speed_wall_0": {
+            "value": "min(round(speed_wall * 0.75, 0),80)"
+        },
+        "speed_wall_x": {
+            "value": "speed_wall"
+        },
+        "support_brim_enable": {
+            "value": true
+        },
+        "support_brim_line_count": {
+            "value": "10 if support_structure == 'tree' else brim_line_count"
+        },
+        "support_fan_enable": {
+            "value": true
+        },
+        "support_infill_angles": {
+            "default_value": "[0]"
+        },
+        "support_infill_rate": {
+            "value": "0 if support_structure == 'tree' else 66.6 if gradual_support_infill_steps != 0 else 15"
+        },
+        "support_initial_layer_line_distance": {
+            "minimum_value_warning": "0 if support_structure == 'tree' else support_line_width"
+        },
+        "support_interface_angles": {
+            "default_value": "[0]"
+        },
+        "support_interface_density": {
+            "value": "33.3"
+        },
+        "support_interface_enable": {
+            "value": true
+        },
+        "support_interface_height": {
+            "value": "2 * layer_height"
+        },
+        "support_interface_material_flow": {
+            "value": "0.95 * material_flow"
+        },
+        "support_interface_offset": {
+            "value": "line_width/2"
+        },
+        "support_interface_pattern": {
+            "value": "'grid'"
+        },
+        "support_interface_wall_count": {
+            "value": "1"
+        },
+        "support_material_flow": {
+            "value": "material_flow if support_structure == 'tree' else 0.95 * material_flow"
+        },
+        "support_offset": {
+            "value": "machine_nozzle_size * 2"
+        },
+        "support_pattern": {
+            "value": "'zigzag'"
+        },
+        "support_skip_some_zags": {
+            "value": "True if support_pattern== 'zigzag' else False"
+        },
+        "support_skip_zag_per_mm": {
+            "value": 10
+        },
+        "support_structure": {
+            "value": "'tree'"
+        },
+        "support_tower_diameter": {
+            "value": "5"
+        },
+        "support_tower_maximum_supported_diameter": {
+            "value": "support_tower_diameter"
+        },
+        "support_tower_roof_angle": {
+            "value": "0 if support_interface_enable else 65"
+        },
+        "support_tree_angle": {
+            "value": 30
+        },
+        "support_tree_branch_diameter": {
+            "value": 1
+        },
+        "support_tree_branch_diameter_angle": {
+            "value": 15
+        },
+        "support_tree_branch_reach_limit": {
+            "value": 35
+        },
+        "support_tree_max_diameter": {
+            "value": 50
+        },
+        "support_tree_rest_preference": {
+            "value": "buildplate"
+        },
+        "support_tree_tip_diameter": {
+            "value": 0.8
+        },
+        "support_tree_top_rate": {
+            "value": 20
+        },
+        "support_use_towers": {
+            "value": "False"
+        },
+        "support_wall_count": {
+            "value": "2 if support_structure == 'tree' and strengthen_tree_support else 1 if support_structure == 'tree' else 0"
+        },
+        "support_xy_distance": {
+            "value": "machine_nozzle_size * 1.7"
+        },
+        "support_xy_distance_overhang": {
+            "value": "machine_nozzle_size / 2"
+        },
+        "support_z_distance": {
+            "value": "min(0.2, layer_height)"
+        },
+        "support_zag_skip_count": {
+            "minimum_value": 0
+        },
+        "top_bottom_thickness": {
+            "value": "4 * layer_height if 4 * layer_height > 0.8 else 0.8"
+        },
+        "wall_0_wipe_dist": {
+            "value": "2 * line_width"
+        },
+        "wall_thickness": {
+            "value": "wall_line_width_0 + wall_line_width_x"
+        },
+        "z_seam_corner": {
+            "value": "'z_seam_corner_none'"
+        },
+        "z_seam_on_vertex": {
+            "value": true
+        },
+        "z_seam_type": {
+            "value": "'shortest'"
+        },
+        "zig_zaggify_infill": {
+            "value": true
+        }
+    }
+}

--- a/resources/definitions/base_fracktal_printer.def.json
+++ b/resources/definitions/base_fracktal_printer.def.json
@@ -2,567 +2,218 @@
     "version": 2,
     "name": "Base Fracktal 3D Printer Definition",
     "inherits": "fdmprinter",
-    "metadata": {
+    "metadata":
+    {
         "visible": false,
         "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
         "file_formats": "text/x-gcode",
-        "machine_extruder_trains": {
-            "0": "base_fracktal_extruder_0"
-        },
+        "machine_extruder_trains": { "0": "base_fracktal_extruder_0" },
         "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "acceleration_print": {
-            "default_value": 1000
-        },
-        "acceleration_travel": {
-            "value": 1000
-        },
-        "alternate_carve_order": {
-            "value": true
-        },
-        "bridge_enable_more_layers": {
-            "value": true
-        },
-        "bridge_fan_speed_2": {
-            "value": "(cool_fan_speed_max + cool_fan_speed_min) / 2"
-        },
-        "bridge_fan_speed_3": {
-            "value": "cool_fan_speed_min"
-        },
-        "bridge_settings_enabled": {
-            "value": true
-        },
-        "bridge_skin_density": {
-            "value": 100
-        },
-        "bridge_skin_density_2": {
-            "value": 100
-        },
-        "bridge_skin_density_3": {
-            "value": 100
-        },
-        "bridge_skin_material_flow": {
-            "value": "material_flow if support_enable else material_flow * 0.95"
-        },
-        "bridge_skin_material_flow_2": {
-            "value": "material_flow"
-        },
-        "bridge_skin_material_flow_3": {
-            "value": "material_flow"
-        },
-        "bridge_skin_speed": {
-            "value": "min(round(speed_topbottom * 0.75),50)"
-        },
-        "bridge_skin_speed_2": {
-            "value": "speed_topbottom"
-        },
-        "bridge_skin_speed_3": {
-            "value": "speed_topbottom"
-        },
-        "bridge_wall_coast": {
-            "value": 0
-        },
-        "bridge_wall_material_flow": {
-            "value": "material_flow if support_enable else material_flow * 0.95"
-        },
-        "bridge_wall_speed": {
-            "value": "min(round(speed_wall * 0.75),40)"
-        },
-        "brim_line_count": {
-            "value": "6"
-        },
-        "brim_replaces_support": {
-            "value": false
-        },
-        "carve_multiple_volumes": {
-            "value": true
-        },
-        "cool_fan_speed": {
+    "overrides":
+    {
+        "acceleration_print": { "default_value": 1000 },
+        "acceleration_travel": { "value": 1000 },
+        "alternate_carve_order": { "value": true },
+        "bridge_enable_more_layers": { "value": true },
+        "bridge_fan_speed_2": { "value": "(cool_fan_speed_max + cool_fan_speed_min) / 2" },
+        "bridge_fan_speed_3": { "value": "cool_fan_speed_min" },
+        "bridge_settings_enabled": { "value": true },
+        "bridge_skin_density": { "value": 100 },
+        "bridge_skin_density_2": { "value": 100 },
+        "bridge_skin_density_3": { "value": 100 },
+        "bridge_skin_material_flow": { "value": "material_flow if support_enable else material_flow * 0.95" },
+        "bridge_skin_material_flow_2": { "value": "material_flow" },
+        "bridge_skin_material_flow_3": { "value": "material_flow" },
+        "bridge_skin_speed": { "value": "min(round(speed_topbottom * 0.75),50)" },
+        "bridge_skin_speed_2": { "value": "speed_topbottom" },
+        "bridge_skin_speed_3": { "value": "speed_topbottom" },
+        "bridge_wall_coast": { "value": 0 },
+        "bridge_wall_material_flow": { "value": "material_flow if support_enable else material_flow * 0.95" },
+        "bridge_wall_speed": { "value": "min(round(speed_wall * 0.75),40)" },
+        "brim_line_count": { "value": "6" },
+        "brim_replaces_support": { "value": false },
+        "carve_multiple_volumes": { "value": true },
+        "cool_fan_speed":
+        {
             "resolve": "min(extruderValues('cool_fan_speed'))",
             "settable_per_extruder": false
         },
-        "cool_fan_speed_0": {
-            "value": 0
-        },
-        "cool_fan_speed_max": {
+        "cool_fan_speed_0": { "value": 0 },
+        "cool_fan_speed_max":
+        {
             "resolve": "min(extruderValues('cool_fan_speed_max'))",
             "settable_per_extruder": false
         },
-        "cool_min_layer_time": {
-            "value": 6
-        },
-        "cool_min_layer_time_fan_speed_max": {
-            "value": "cool_min_layer_time + 5"
-        },
-        "cool_min_speed": {
-            "value": "round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)"
-        },
-        "cool_min_temperature": {
+        "cool_min_layer_time": { "value": 6 },
+        "cool_min_layer_time_fan_speed_max": { "value": "cool_min_layer_time + 5" },
+        "cool_min_speed": { "value": "round(speed_wall_0 * 3 / 4) if cool_lift_head else round(speed_wall_0 / 5)" },
+        "cool_min_temperature":
+        {
             "maximum_value": "500",
             "value": "min([material_final_print_temperature, material_initial_print_temperature, material_print_temperature - 15])"
         },
-        "default_material_print_temperature": {
-            "maximum_value": "500"
-        },
-        "gradual_flow_discretisation_step_size": {
-            "value": 0.2
-        },
-        "gradual_flow_enabled": {
-            "value": true
-        },
-        "gradual_support_infill_step_height": {
-            "value": "4 * layer_height"
-        },
-        "gradual_support_infill_steps": {
-            "value": "2 if support_interface_enable and support_structure != 'tree' else 0"
-        },
-        "group_outer_walls": {
-            "value": false
-        },
-        "infill_before_walls": {
-            "value": false
-        },
-        "infill_overlap": {
-            "value": 0
-        },
-        "infill_pattern": {
-            "value": "'zigzag' if infill_sparse_density > 80 else 'triangles'"
-        },
-        "infill_sparse_density": {
-            "value": "20"
-        },
-        "infill_wipe_dist": {
-            "value": "0 if infill_before_walls == True else wall_line_width_x / 4"
-        },
-        "initial_bottom_layers": {
-            "value": "3 if bottom_layers == 4 else bottom_layers"
-        },
-        "initial_layer_line_width_factor": {
-            "value": 105
-        },
-        "jerk_print": {
-            "default_value": 10
-        },
-        "jerk_travel": {
-            "value": 10
-        },
-        "layer_start_x": {
-            "value": "machine_width/2"
-        },
-        "layer_start_y": {
-            "value": "machine_depth"
-        },
-        "line_width": {
-            "value": "round(machine_nozzle_size * 1.05, 2)"
-        },
-        "machine_acceleration": {
-            "default_value": 1000
-        },
-        "machine_end_gcode": {
-            "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning\n\nM300 S0 P333\nM300 S880 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\n"
-        },
-        "machine_heat_zone_length": {
-            "default_value": 12
-        },
-        "machine_heated_bed": {
-            "default_value": true
-        },
-        "machine_max_acceleration_x": {
-            "default_value": 1000
-        },
-        "machine_max_acceleration_y": {
-            "default_value": 1000
-        },
-        "machine_max_acceleration_z": {
-            "default_value": 50
-        },
-        "machine_max_feedrate_e": {
-            "default_value": 80
-        },
-        "machine_max_feedrate_x": {
-            "default_value": 500
-        },
-        "machine_max_feedrate_y": {
-            "default_value": 500
-        },
-        "machine_max_feedrate_z": {
-            "default_value": 50
-        },
-        "machine_max_jerk_e": {
-            "default_value": 20
-        },
-        "machine_max_jerk_z": {
-            "default_value": 0.8
-        },
-        "machine_min_cool_heat_time_window": {
-            "default_value": 60
-        },
-        "machine_nozzle_cool_down_speed": {
-            "default_value": 1
-        },
-        "machine_nozzle_heat_up_speed": {
-            "default_value": 0.5
-        },
-        "machine_show_variants": {
-            "default_value": true
-        },
-        "machine_start_gcode": {
-            "default_value": ";Machine Model: {machine_name} \n;Nozzle Size: {str(extruderValue(-1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\nM117 Printing...\n\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\n"
-        },
-        "material_bed_temperature_layer_0": {
-            "value": "resolveOrValue('material_bed_temperature') + 10"
-        },
-        "material_break_preparation_temperature": {
-            "maximum_value": "500"
-        },
-        "material_break_temperature": {
-            "maximum_value": "500"
-        },
-        "material_diameter": {
-            "default_value": 1.75
-        },
-        "material_extrusion_cool_down_speed": {
-            "value": "0.5"
-        },
-        "material_final_print_temperature": {
-            "maximum_value": "500"
-        },
-        "material_flow": {
-            "value": "90 if machine_nozzle_size <= 0.25 else 95"
-        },
-        "material_flow_layer_0": {
-            "value": "material_flow * 1.05"
-        },
-        "material_initial_print_temperature": {
-            "maximum_value": "500"
-        },
-        "material_print_temperature": {
-            "maximum_value": "500"
-        },
-        "material_print_temperature_layer_0": {
+        "default_material_print_temperature": { "maximum_value": "500" },
+        "gradual_flow_discretisation_step_size": { "value": 0.2 },
+        "gradual_flow_enabled": { "value": true },
+        "gradual_support_infill_step_height": { "value": "4 * layer_height" },
+        "gradual_support_infill_steps": { "value": "2 if support_interface_enable and support_structure != 'tree' else 0" },
+        "group_outer_walls": { "value": false },
+        "infill_before_walls": { "value": false },
+        "infill_overlap": { "value": 0 },
+        "infill_pattern": { "value": "'zigzag' if infill_sparse_density > 80 else 'triangles'" },
+        "infill_sparse_density": { "value": "20" },
+        "infill_wipe_dist": { "value": "0 if infill_before_walls == True else wall_line_width_x / 4" },
+        "initial_bottom_layers": { "value": "3 if bottom_layers == 4 else bottom_layers" },
+        "initial_layer_line_width_factor": { "value": 105 },
+        "jerk_print": { "default_value": 10 },
+        "jerk_travel": { "value": 10 },
+        "layer_start_x": { "value": "machine_width/2" },
+        "layer_start_y": { "value": "machine_depth" },
+        "line_width": { "value": "round(machine_nozzle_size * 1.05, 2)" },
+        "machine_acceleration": { "default_value": 1000 },
+        "machine_end_gcode": { "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off (if you have it)\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning\n\nM300 S0 P333\nM300 S880 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\n" },
+        "machine_heat_zone_length": { "default_value": 12 },
+        "machine_heated_bed": { "default_value": true },
+        "machine_max_acceleration_x": { "default_value": 1000 },
+        "machine_max_acceleration_y": { "default_value": 1000 },
+        "machine_max_acceleration_z": { "default_value": 50 },
+        "machine_max_feedrate_e": { "default_value": 80 },
+        "machine_max_feedrate_x": { "default_value": 500 },
+        "machine_max_feedrate_y": { "default_value": 500 },
+        "machine_max_feedrate_z": { "default_value": 50 },
+        "machine_max_jerk_e": { "default_value": 20 },
+        "machine_max_jerk_z": { "default_value": 0.8 },
+        "machine_min_cool_heat_time_window": { "default_value": 60 },
+        "machine_nozzle_cool_down_speed": { "default_value": 1 },
+        "machine_nozzle_heat_up_speed": { "default_value": 0.5 },
+        "machine_show_variants": { "default_value": true },
+        "machine_start_gcode": { "default_value": ";Machine Model: {machine_name} \n;Nozzle Size: {str(extruderValue(-1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\nM117 Printing...\n\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\n" },
+        "material_bed_temperature_layer_0": { "value": "resolveOrValue('material_bed_temperature') + 10" },
+        "material_break_preparation_temperature": { "maximum_value": "500" },
+        "material_break_temperature": { "maximum_value": "500" },
+        "material_diameter": { "default_value": 1.75 },
+        "material_extrusion_cool_down_speed": { "value": "0.5" },
+        "material_final_print_temperature": { "maximum_value": "500" },
+        "material_flow": { "value": "90 if machine_nozzle_size <= 0.25 else 95" },
+        "material_flow_layer_0": { "value": "material_flow * 1.05" },
+        "material_initial_print_temperature": { "maximum_value": "500" },
+        "material_print_temperature": { "maximum_value": "500" },
+        "material_print_temperature_layer_0":
+        {
             "maximum_value": "500",
             "value": "material_print_temperature + 10"
         },
-        "material_standby_temperature": {
+        "material_standby_temperature":
+        {
             "maximum_value": "500",
             "value": "175"
         },
-        "max_flow_acceleration": {
-            "value": "0.4 if machine_nozzle_size <= 0.25 else 0.8 if machine_nozzle_size <= 0.4 else 1 if machine_nozzle_size <= 0.6 else 2.0"
-        },
-        "max_skin_angle_for_expansion": {
-            "value": 45
-        },
-        "meshfix_maximum_deviation": {
-            "value": "0.02"
-        },
-        "meshfix_maximum_resolution": {
-            "value": "0.5"
-        },
-        "meshfix_union_all": {
-            "value": false
-        },
-        "min_bead_width": {
-            "value": "0.8 * machine_nozzle_size"
-        },
-        "min_feature_size": {
-            "value": "0.05"
-        },
-        "min_wall_line_width": {
-            "value": "0.8 * machine_nozzle_size"
-        },
-        "minimum_interface_area": {
-            "value": 15
-        },
-        "minimum_support_area": {
-            "value": "6 if support_structure == 'tree' else 10"
-        },
-        "optimize_wall_printing_order": {
-            "value": true
-        },
-        "raft_airgap": {
-            "value": "0.1 if machine_nozzle_size <= 0.25 else 0.2 if machine_nozzle_size <= 0.4 else 0.25 if machine_nozzle_size <= 0.6 else 0.35"
-        },
-        "raft_base_line_spacing": {
-            "value": "2*raft_base_line_width"
-        },
-        "raft_base_line_width": {
-            "value": "machine_nozzle_size *2"
-        },
-        "raft_base_speed": {
-            "value": "speed_layer_0 * 0.7"
-        },
-        "raft_base_thickness": {
-            "value": "machine_nozzle_size "
-        },
-        "raft_interface_extruder_nr": {
-            "value": "raft_surface_extruder_nr"
-        },
-        "raft_interface_layers": {
-            "value": 1
-        },
-        "raft_interface_line_width": {
-            "value": 0.7
-        },
-        "raft_interface_speed": {
-            "value": "speed_print * 0.9"
-        },
-        "raft_interface_thickness": {
-            "value": 0.3
-        },
-        "raft_interface_wall_count": {
-            "value": "raft_wall_count"
-        },
-        "raft_margin": {
-            "value": 1.2
-        },
-        "raft_surface_fan_speed": {
-            "value": "cool_fan_speed_max"
-        },
-        "raft_surface_monotonic": {
-            "value": true
-        },
-        "raft_surface_wall_count": {
-            "value": "raft_wall_count"
-        },
-        "retract_at_layer_change": {
-            "value": true
-        },
-        "retraction_amount": {
-            "value": "machine_heat_zone_length * 0.1"
-        },
-        "retraction_combing": {
-            "value": "'off'"
-        },
-        "retraction_combing_max_distance": {
-            "value": "machine_nozzle_size * 5"
-        },
-        "retraction_count_max": {
-            "value": "int(15 * retraction_extrusion_window)"
-        },
-        "retraction_enable": {
-            "value": true
-        },
-        "retraction_extra_prime_amount": {
-            "value": "0.05 if machine_nozzle_size <= 0.25 else 0.08 if machine_nozzle_size <= 0.4 else 0.12 if machine_nozzle_size <= 0.6 else 0.16"
-        },
-        "retraction_extrusion_window": {
-            "value": "retraction_amount"
-        },
-        "retraction_hop": {
-            "value": "layer_height"
-        },
-        "retraction_hop_enabled": {
-            "value": true
-        },
-        "retraction_hop_only_when_collides": {
-            "value": true
-        },
-        "retraction_min_travel": {
-            "value": "machine_nozzle_size * 5"
-        },
-        "retraction_prime_speed": {
-            "value": "retraction_speed * 0.75"
-        },
-        "retraction_speed": {
-            "value": "60"
-        },
-        "roofing_layer_count": {
-            "value": "1"
-        },
-        "seam_overhang_angle": {
-            "value": 40
-        },
-        "skin_material_flow_layer_0": {
-            "value": "material_flow_layer_0 - 5"
-        },
-        "skin_monotonic": {
-            "value": true
-        },
-        "skin_outline_count": {
-            "value": "1"
-        },
-        "skin_overlap": {
-            "value": 25
-        },
-        "skirt_brim_minimal_length": {
-            "value": 150
-        },
-        "skirt_height": {
-            "value": 1
-        },
-        "small_skin_width": {
-            "value": 4
-        },
-        "speed_layer_0": {
-            "value": "min(25, round(speed_print * 0.4, 0))"
-        },
-        "speed_print": {
-            "value": "60"
-        },
-        "speed_support": {
-            "value": "speed_print * 0.60 if support_structure == 'tree' and strengthen_tree_support == True else speed_print * 0.70 if support_structure == 'tree' and strengthen_tree_support == False else speed_print * 0.80"
-        },
-        "speed_support_bottom": {
-            "value": "speed_support * 0.9"
-        },
-        "speed_support_infill": {
-            "value": "speed_support"
-        },
-        "speed_support_interface": {
-            "value": "speed_support * 0.70"
-        },
-        "speed_topbottom": {
-            "value": "min(round(speed_print * 0.8, 0),100)"
-        },
-        "speed_travel": {
-            "value": "max(80,speed_print)"
-        },
-        "speed_travel_layer_0": {
-            "value": "60"
-        },
-        "speed_wall": {
-            "value": "min(round(speed_print * 0.75, 0),100)"
-        },
-        "speed_wall_0": {
-            "value": "min(round(speed_wall * 0.75, 0),80)"
-        },
-        "speed_wall_x": {
-            "value": "speed_wall"
-        },
-        "support_brim_enable": {
-            "value": true
-        },
-        "support_brim_line_count": {
-            "value": "10 if support_structure == 'tree' else brim_line_count"
-        },
-        "support_fan_enable": {
-            "value": true
-        },
-        "support_infill_angles": {
-            "default_value": "[0]"
-        },
-        "support_infill_rate": {
-            "value": "0 if support_structure == 'tree' else 66.6 if gradual_support_infill_steps != 0 else 15"
-        },
-        "support_initial_layer_line_distance": {
-            "minimum_value_warning": "0 if support_structure == 'tree' else support_line_width"
-        },
-        "support_interface_angles": {
-            "default_value": "[0]"
-        },
-        "support_interface_density": {
-            "value": "33.3"
-        },
-        "support_interface_enable": {
-            "value": true
-        },
-        "support_interface_height": {
-            "value": "2 * layer_height"
-        },
-        "support_interface_material_flow": {
-            "value": "0.95 * material_flow"
-        },
-        "support_interface_offset": {
-            "value": "line_width/2"
-        },
-        "support_interface_pattern": {
-            "value": "'grid'"
-        },
-        "support_interface_wall_count": {
-            "value": "1"
-        },
-        "support_material_flow": {
-            "value": "material_flow if support_structure == 'tree' else 0.95 * material_flow"
-        },
-        "support_offset": {
-            "value": "machine_nozzle_size * 2"
-        },
-        "support_pattern": {
-            "value": "'zigzag'"
-        },
-        "support_skip_some_zags": {
-            "value": "True if support_pattern== 'zigzag' else False"
-        },
-        "support_skip_zag_per_mm": {
-            "value": 10
-        },
-        "support_structure": {
-            "value": "'tree'"
-        },
-        "support_tower_diameter": {
-            "value": "5"
-        },
-        "support_tower_maximum_supported_diameter": {
-            "value": "support_tower_diameter"
-        },
-        "support_tower_roof_angle": {
-            "value": "0 if support_interface_enable else 65"
-        },
-        "support_tree_angle": {
-            "value": 30
-        },
-        "support_tree_branch_diameter": {
-            "value": 1
-        },
-        "support_tree_branch_diameter_angle": {
-            "value": 15
-        },
-        "support_tree_branch_reach_limit": {
-            "value": 35
-        },
-        "support_tree_max_diameter": {
-            "value": 50
-        },
-        "support_tree_rest_preference": {
-            "value": "buildplate"
-        },
-        "support_tree_tip_diameter": {
-            "value": 0.8
-        },
-        "support_tree_top_rate": {
-            "value": 20
-        },
-        "support_use_towers": {
-            "value": "False"
-        },
-        "support_wall_count": {
-            "value": "2 if support_structure == 'tree' and strengthen_tree_support else 1 if support_structure == 'tree' else 0"
-        },
-        "support_xy_distance": {
-            "value": "machine_nozzle_size * 1.7"
-        },
-        "support_xy_distance_overhang": {
-            "value": "machine_nozzle_size / 2"
-        },
-        "support_z_distance": {
-            "value": "min(0.2, layer_height)"
-        },
-        "support_zag_skip_count": {
-            "minimum_value": 0
-        },
-        "top_bottom_thickness": {
-            "value": "4 * layer_height if 4 * layer_height > 0.8 else 0.8"
-        },
-        "wall_0_wipe_dist": {
-            "value": "2 * line_width"
-        },
-        "wall_thickness": {
-            "value": "wall_line_width_0 + wall_line_width_x"
-        },
-        "z_seam_corner": {
-            "value": "'z_seam_corner_none'"
-        },
-        "z_seam_on_vertex": {
-            "value": true
-        },
-        "z_seam_type": {
-            "value": "'shortest'"
-        },
-        "zig_zaggify_infill": {
-            "value": true
-        }
+        "max_flow_acceleration": { "value": "0.4 if machine_nozzle_size <= 0.25 else 0.8 if machine_nozzle_size <= 0.4 else 1 if machine_nozzle_size <= 0.6 else 2.0" },
+        "max_skin_angle_for_expansion": { "value": 45 },
+        "meshfix_maximum_deviation": { "value": "0.02" },
+        "meshfix_maximum_resolution": { "value": "0.5" },
+        "meshfix_union_all": { "value": false },
+        "min_bead_width": { "value": "0.8 * machine_nozzle_size" },
+        "min_feature_size": { "value": "0.05" },
+        "min_wall_line_width": { "value": "0.8 * machine_nozzle_size" },
+        "minimum_interface_area": { "value": 15 },
+        "minimum_support_area": { "value": "6 if support_structure == 'tree' else 10" },
+        "optimize_wall_printing_order": { "value": true },
+        "raft_airgap": { "value": "0.1 if machine_nozzle_size <= 0.25 else 0.2 if machine_nozzle_size <= 0.4 else 0.25 if machine_nozzle_size <= 0.6 else 0.35" },
+        "raft_base_line_spacing": { "value": "2*raft_base_line_width" },
+        "raft_base_line_width": { "value": "machine_nozzle_size *2" },
+        "raft_base_speed": { "value": "speed_layer_0 * 0.7" },
+        "raft_base_thickness": { "value": "machine_nozzle_size " },
+        "raft_interface_extruder_nr": { "value": "raft_surface_extruder_nr" },
+        "raft_interface_layers": { "value": 1 },
+        "raft_interface_line_width": { "value": 0.7 },
+        "raft_interface_speed": { "value": "speed_print * 0.9" },
+        "raft_interface_thickness": { "value": 0.3 },
+        "raft_interface_wall_count": { "value": "raft_wall_count" },
+        "raft_margin": { "value": 1.2 },
+        "raft_surface_fan_speed": { "value": "cool_fan_speed_max" },
+        "raft_surface_monotonic": { "value": true },
+        "raft_surface_wall_count": { "value": "raft_wall_count" },
+        "retract_at_layer_change": { "value": true },
+        "retraction_amount": { "value": "machine_heat_zone_length * 0.1" },
+        "retraction_combing": { "value": "'off'" },
+        "retraction_combing_max_distance": { "value": "machine_nozzle_size * 5" },
+        "retraction_count_max": { "value": "int(15 * retraction_extrusion_window)" },
+        "retraction_enable": { "value": true },
+        "retraction_extra_prime_amount": { "value": "0.05 if machine_nozzle_size <= 0.25 else 0.08 if machine_nozzle_size <= 0.4 else 0.12 if machine_nozzle_size <= 0.6 else 0.16" },
+        "retraction_extrusion_window": { "value": "retraction_amount" },
+        "retraction_hop": { "value": "layer_height" },
+        "retraction_hop_enabled": { "value": true },
+        "retraction_hop_only_when_collides": { "value": true },
+        "retraction_min_travel": { "value": "machine_nozzle_size * 5" },
+        "retraction_prime_speed": { "value": "retraction_speed * 0.75" },
+        "retraction_speed": { "value": "60" },
+        "roofing_layer_count": { "value": "1" },
+        "seam_overhang_angle": { "value": 40 },
+        "skin_material_flow_layer_0": { "value": "material_flow_layer_0 - 5" },
+        "skin_monotonic": { "value": true },
+        "skin_outline_count": { "value": "1" },
+        "skin_overlap": { "value": 25 },
+        "skirt_brim_minimal_length": { "value": 150 },
+        "skirt_height": { "value": 1 },
+        "small_skin_width": { "value": 4 },
+        "speed_layer_0": { "value": "min(25, round(speed_print * 0.4, 0))" },
+        "speed_print": { "value": "60" },
+        "speed_support": { "value": "speed_print * 0.60 if support_structure == 'tree' and strengthen_tree_support == True else speed_print * 0.70 if support_structure == 'tree' and strengthen_tree_support == False else speed_print * 0.80" },
+        "speed_support_bottom": { "value": "speed_support * 0.9" },
+        "speed_support_infill": { "value": "speed_support" },
+        "speed_support_interface": { "value": "speed_support * 0.70" },
+        "speed_topbottom": { "value": "min(round(speed_print * 0.8, 0),100)" },
+        "speed_travel": { "value": "max(80,speed_print)" },
+        "speed_travel_layer_0": { "value": "60" },
+        "speed_wall": { "value": "min(round(speed_print * 0.75, 0),100)" },
+        "speed_wall_0": { "value": "min(round(speed_wall * 0.75, 0),80)" },
+        "speed_wall_x": { "value": "speed_wall" },
+        "support_brim_enable": { "value": true },
+        "support_brim_line_count": { "value": "10 if support_structure == 'tree' else brim_line_count" },
+        "support_fan_enable": { "value": true },
+        "support_infill_angles": { "default_value": "[0]" },
+        "support_infill_rate": { "value": "0 if support_structure == 'tree' else 66.6 if gradual_support_infill_steps != 0 else 15" },
+        "support_initial_layer_line_distance": { "minimum_value_warning": "0 if support_structure == 'tree' else support_line_width" },
+        "support_interface_angles": { "default_value": "[0]" },
+        "support_interface_density": { "value": "33.3" },
+        "support_interface_enable": { "value": true },
+        "support_interface_height": { "value": "2 * layer_height" },
+        "support_interface_material_flow": { "value": "0.95 * material_flow" },
+        "support_interface_offset": { "value": "line_width/2" },
+        "support_interface_pattern": { "value": "'grid'" },
+        "support_interface_wall_count": { "value": "1" },
+        "support_material_flow": { "value": "material_flow if support_structure == 'tree' else 0.95 * material_flow" },
+        "support_offset": { "value": "machine_nozzle_size * 2" },
+        "support_pattern": { "value": "'zigzag'" },
+        "support_skip_some_zags": { "value": "True if support_pattern== 'zigzag' else False" },
+        "support_skip_zag_per_mm": { "value": 10 },
+        "support_structure": { "value": "'tree'" },
+        "support_tower_diameter": { "value": "5" },
+        "support_tower_maximum_supported_diameter": { "value": "support_tower_diameter" },
+        "support_tower_roof_angle": { "value": "0 if support_interface_enable else 65" },
+        "support_tree_angle": { "value": 30 },
+        "support_tree_branch_diameter": { "value": 1 },
+        "support_tree_branch_diameter_angle": { "value": 15 },
+        "support_tree_branch_reach_limit": { "value": 35 },
+        "support_tree_max_diameter": { "value": 50 },
+        "support_tree_rest_preference": { "value": "buildplate" },
+        "support_tree_tip_diameter": { "value": 0.8 },
+        "support_tree_top_rate": { "value": 20 },
+        "support_use_towers": { "value": "False" },
+        "support_wall_count": { "value": "2 if support_structure == 'tree' and strengthen_tree_support else 1 if support_structure == 'tree' else 0" },
+        "support_xy_distance": { "value": "machine_nozzle_size * 1.7" },
+        "support_xy_distance_overhang": { "value": "machine_nozzle_size / 2" },
+        "support_z_distance": { "value": "min(0.2, layer_height)" },
+        "support_zag_skip_count": { "minimum_value": 0 },
+        "top_bottom_thickness": { "value": "4 * layer_height if 4 * layer_height > 0.8 else 0.8" },
+        "wall_0_wipe_dist": { "value": "2 * line_width" },
+        "wall_thickness": { "value": "wall_line_width_0 + wall_line_width_x" },
+        "z_seam_corner": { "value": "'z_seam_corner_none'" },
+        "z_seam_on_vertex": { "value": true },
+        "z_seam_type": { "value": "'shortest'" },
+        "zig_zaggify_infill": { "value": true }
     }
 }

--- a/resources/definitions/dragon_400.def.json
+++ b/resources/definitions/dragon_400.def.json
@@ -1,0 +1,42 @@
+{
+    "version": 2,
+    "name": "Fracktal Dragon 400",
+    "inherits": "base_fracktal_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 300
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 600
+        },
+        "machine_max_feedrate_y": {
+            "value": 300
+        },
+        "machine_name": {
+            "default_value": "Dragon 400"
+        },
+        "machine_width": {
+            "default_value": 410
+        },
+        "speed_print": {
+            "value": "120"
+        },
+        "speed_roofing": {
+            "value": "speed_wall"
+        },
+        "speed_travel": {
+            "maximum_value": "600",
+            "maximum_value_warning": "600",
+            "value": "max(400,speed_print)"
+        }
+    }
+}

--- a/resources/definitions/dragon_400.def.json
+++ b/resources/definitions/dragon_400.def.json
@@ -2,38 +2,25 @@
     "version": 2,
     "name": "Fracktal Dragon 400",
     "inherits": "base_fracktal_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 300
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 600
-        },
-        "machine_max_feedrate_y": {
-            "value": 300
-        },
-        "machine_name": {
-            "default_value": "Dragon 400"
-        },
-        "machine_width": {
-            "default_value": 410
-        },
-        "speed_print": {
-            "value": "120"
-        },
-        "speed_roofing": {
-            "value": "speed_wall"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 300 },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 600 },
+        "machine_max_feedrate_y": { "value": 300 },
+        "machine_name": { "default_value": "Dragon 400" },
+        "machine_width": { "default_value": 410 },
+        "speed_print": { "value": "120" },
+        "speed_roofing": { "value": "speed_wall" },
+        "speed_travel":
+        {
             "maximum_value": "600",
             "maximum_value_warning": "600",
             "value": "max(400,speed_print)"

--- a/resources/definitions/dragon_500.def.json
+++ b/resources/definitions/dragon_500.def.json
@@ -2,38 +2,25 @@
     "version": 2,
     "name": "Fracktal Dragon 500",
     "inherits": "base_fracktal_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 400
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 600
-        },
-        "machine_max_feedrate_y": {
-            "value": 300
-        },
-        "machine_name": {
-            "default_value": "Dragon 500"
-        },
-        "machine_width": {
-            "default_value": 510
-        },
-        "speed_print": {
-            "value": "120"
-        },
-        "speed_roofing": {
-            "value": "speed_wall"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 400 },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 600 },
+        "machine_max_feedrate_y": { "value": 300 },
+        "machine_name": { "default_value": "Dragon 500" },
+        "machine_width": { "default_value": 510 },
+        "speed_print": { "value": "120" },
+        "speed_roofing": { "value": "speed_wall" },
+        "speed_travel":
+        {
             "maximum_value": "600",
             "maximum_value_warning": "600",
             "value": "max(350,speed_print)"

--- a/resources/definitions/dragon_500.def.json
+++ b/resources/definitions/dragon_500.def.json
@@ -1,0 +1,42 @@
+{
+    "version": 2,
+    "name": "Fracktal Dragon 500",
+    "inherits": "base_fracktal_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 400
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 600
+        },
+        "machine_max_feedrate_y": {
+            "value": 300
+        },
+        "machine_name": {
+            "default_value": "Dragon 500"
+        },
+        "machine_width": {
+            "default_value": 510
+        },
+        "speed_print": {
+            "value": "120"
+        },
+        "speed_roofing": {
+            "value": "speed_wall"
+        },
+        "speed_travel": {
+            "maximum_value": "600",
+            "maximum_value_warning": "600",
+            "value": "max(350,speed_print)"
+        }
+    }
+}

--- a/resources/definitions/dragon_700.def.json
+++ b/resources/definitions/dragon_700.def.json
@@ -2,38 +2,25 @@
     "version": 2,
     "name": "Fracktal Dragon 700",
     "inherits": "base_fracktal_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 600
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 600
-        },
-        "machine_max_feedrate_y": {
-            "value": 300
-        },
-        "machine_name": {
-            "default_value": "Dragon 700"
-        },
-        "machine_width": {
-            "default_value": 710
-        },
-        "speed_print": {
-            "value": "120"
-        },
-        "speed_roofing": {
-            "value": "speed_wall"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 600 },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 600 },
+        "machine_max_feedrate_y": { "value": 300 },
+        "machine_name": { "default_value": "Dragon 700" },
+        "machine_width": { "default_value": 710 },
+        "speed_print": { "value": "120" },
+        "speed_roofing": { "value": "speed_wall" },
+        "speed_travel":
+        {
             "maximum_value": "600",
             "maximum_value_warning": "600",
             "value": "max(300,speed_print)"

--- a/resources/definitions/dragon_700.def.json
+++ b/resources/definitions/dragon_700.def.json
@@ -1,0 +1,42 @@
+{
+    "version": 2,
+    "name": "Fracktal Dragon 700",
+    "inherits": "base_fracktal_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 600
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 600
+        },
+        "machine_max_feedrate_y": {
+            "value": 300
+        },
+        "machine_name": {
+            "default_value": "Dragon 700"
+        },
+        "machine_width": {
+            "default_value": 710
+        },
+        "speed_print": {
+            "value": "120"
+        },
+        "speed_roofing": {
+            "value": "speed_wall"
+        },
+        "speed_travel": {
+            "maximum_value": "600",
+            "maximum_value_warning": "600",
+            "value": "max(300,speed_print)"
+        }
+    }
+}

--- a/resources/definitions/julia.def.json
+++ b/resources/definitions/julia.def.json
@@ -5,7 +5,7 @@
     "metadata":
     {
         "visible": true,
-        "manufacturer": "Fracktal",
+        "manufacturer": "Fracktal Works",
         "file_formats": "text/x-gcode",
         "machine_extruder_trains": { "0": "julia_extruder_0" },
         "platform_offset": [

--- a/resources/definitions/julia_200.def.json
+++ b/resources/definitions/julia_200.def.json
@@ -2,43 +2,28 @@
     "version": 2,
     "name": "Fracktal Julia 200",
     "inherits": "base_fracktal_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
-        "manufacturer": "Fracktal Works",
-        "author": "Fracktal Works"
+        "author": "Fracktal Works",
+        "manufacturer": "Fracktal Works"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 200
-        },
-        "machine_height": {
-            "default_value": 200
-        },
-        "machine_max_feedrate_x": {
-            "value": 200
-        },
-        "machine_max_feedrate_y": {
-            "value": 200
-        },
-        "machine_name": {
-            "default_value": "Julia 200"
-        },
-        "machine_width": {
-            "default_value": 200
-        },
-        "speed_print": {
-            "value": "80"
-        },
-        "speed_roofing": {
-            "value": "speed_wall"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 200 },
+        "machine_height": { "default_value": 200 },
+        "machine_max_feedrate_x": { "value": 200 },
+        "machine_max_feedrate_y": { "value": 200 },
+        "machine_name": { "default_value": "Julia 200" },
+        "machine_width": { "default_value": 200 },
+        "speed_print": { "value": "80" },
+        "speed_roofing": { "value": "speed_wall" },
+        "speed_travel":
+        {
             "maximum_value": "200",
             "maximum_value_warning": "200",
             "value": "max(120,speed_print)"
         },
-        "speed_travel_layer_0": {
-            "value": "80"
-        }
+        "speed_travel_layer_0": { "value": "80" }
     }
 }

--- a/resources/definitions/julia_200.def.json
+++ b/resources/definitions/julia_200.def.json
@@ -1,0 +1,44 @@
+{
+    "version": 2,
+    "name": "Fracktal Julia 200",
+    "inherits": "base_fracktal_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 200
+        },
+        "machine_height": {
+            "default_value": 200
+        },
+        "machine_max_feedrate_x": {
+            "value": 200
+        },
+        "machine_max_feedrate_y": {
+            "value": 200
+        },
+        "machine_name": {
+            "default_value": "Julia 200"
+        },
+        "machine_width": {
+            "default_value": 200
+        },
+        "speed_print": {
+            "value": "80"
+        },
+        "speed_roofing": {
+            "value": "speed_wall"
+        },
+        "speed_travel": {
+            "maximum_value": "200",
+            "maximum_value_warning": "200",
+            "value": "max(120,speed_print)"
+        },
+        "speed_travel_layer_0": {
+            "value": "80"
+        }
+    }
+}

--- a/resources/definitions/julia_250.def.json
+++ b/resources/definitions/julia_250.def.json
@@ -1,0 +1,44 @@
+{
+    "version": 2,
+    "name": "Fracktal Julia 250",
+    "inherits": "base_fracktal_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 250
+        },
+        "machine_height": {
+            "default_value": 300
+        },
+        "machine_max_feedrate_x": {
+            "value": 200
+        },
+        "machine_max_feedrate_y": {
+            "value": 200
+        },
+        "machine_name": {
+            "default_value": "Julia 250"
+        },
+        "machine_width": {
+            "default_value": 250
+        },
+        "speed_print": {
+            "value": "60"
+        },
+        "speed_roofing": {
+            "value": "speed_wall"
+        },
+        "speed_travel": {
+            "maximum_value": "200",
+            "maximum_value_warning": "200",
+            "value": "max(120,speed_print)"
+        },
+        "speed_travel_layer_0": {
+            "value": "80"
+        }
+    }
+}

--- a/resources/definitions/julia_250.def.json
+++ b/resources/definitions/julia_250.def.json
@@ -2,43 +2,28 @@
     "version": 2,
     "name": "Fracktal Julia 250",
     "inherits": "base_fracktal_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
-        "manufacturer": "Fracktal Works",
-        "author": "Fracktal Works"
+        "author": "Fracktal Works",
+        "manufacturer": "Fracktal Works"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 250
-        },
-        "machine_height": {
-            "default_value": 300
-        },
-        "machine_max_feedrate_x": {
-            "value": 200
-        },
-        "machine_max_feedrate_y": {
-            "value": 200
-        },
-        "machine_name": {
-            "default_value": "Julia 250"
-        },
-        "machine_width": {
-            "default_value": 250
-        },
-        "speed_print": {
-            "value": "60"
-        },
-        "speed_roofing": {
-            "value": "speed_wall"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 250 },
+        "machine_height": { "default_value": 300 },
+        "machine_max_feedrate_x": { "value": 200 },
+        "machine_max_feedrate_y": { "value": 200 },
+        "machine_name": { "default_value": "Julia 250" },
+        "machine_width": { "default_value": 250 },
+        "speed_print": { "value": "60" },
+        "speed_roofing": { "value": "speed_wall" },
+        "speed_travel":
+        {
             "maximum_value": "200",
             "maximum_value_warning": "200",
             "value": "max(120,speed_print)"
         },
-        "speed_travel_layer_0": {
-            "value": "80"
-        }
+        "speed_travel_layer_0": { "value": "80" }
     }
 }

--- a/resources/definitions/snowflake.def.json
+++ b/resources/definitions/snowflake.def.json
@@ -2,43 +2,28 @@
     "version": 2,
     "name": "Fracktal Snowflake",
     "inherits": "base_fracktal_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
-        "manufacturer": "Fracktal Works",
-        "author": "Fracktal Works"
+        "author": "Fracktal Works",
+        "manufacturer": "Fracktal Works"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 200
-        },
-        "machine_height": {
-            "default_value": 200
-        },
-        "machine_max_feedrate_x": {
-            "value": 350
-        },
-        "machine_max_feedrate_y": {
-            "value": 350
-        },
-        "machine_name": {
-            "default_value": "Snowflake"
-        },
-        "machine_width": {
-            "default_value": 200
-        },
-        "speed_print": {
-            "value": "80"
-        },
-        "speed_roofing": {
-            "value": "speed_wall"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 200 },
+        "machine_height": { "default_value": 200 },
+        "machine_max_feedrate_x": { "value": 350 },
+        "machine_max_feedrate_y": { "value": 350 },
+        "machine_name": { "default_value": "Snowflake" },
+        "machine_width": { "default_value": 200 },
+        "speed_print": { "value": "80" },
+        "speed_roofing": { "value": "speed_wall" },
+        "speed_travel":
+        {
             "maximum_value": "300",
             "maximum_value_warning": "300",
             "value": "max(120,speed_print)"
         },
-        "speed_travel_layer_0": {
-            "value": "80"
-        }
+        "speed_travel_layer_0": { "value": "80" }
     }
 }

--- a/resources/definitions/snowflake.def.json
+++ b/resources/definitions/snowflake.def.json
@@ -1,0 +1,44 @@
+{
+    "version": 2,
+    "name": "Fracktal Snowflake",
+    "inherits": "base_fracktal_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 200
+        },
+        "machine_height": {
+            "default_value": 200
+        },
+        "machine_max_feedrate_x": {
+            "value": 350
+        },
+        "machine_max_feedrate_y": {
+            "value": 350
+        },
+        "machine_name": {
+            "default_value": "Snowflake"
+        },
+        "machine_width": {
+            "default_value": 200
+        },
+        "speed_print": {
+            "value": "80"
+        },
+        "speed_roofing": {
+            "value": "speed_wall"
+        },
+        "speed_travel": {
+            "maximum_value": "300",
+            "maximum_value_warning": "300",
+            "value": "max(120,speed_print)"
+        },
+        "speed_travel_layer_0": {
+            "value": "80"
+        }
+    }
+}

--- a/resources/definitions/twin_dragon_300.def.json
+++ b/resources/definitions/twin_dragon_300.def.json
@@ -2,35 +2,24 @@
     "version": 2,
     "name": "Fracktal Twin Dragon 300",
     "inherits": "base_fracktal_idex_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 300
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 300
-        },
-        "machine_max_feedrate_y": {
-            "value": 300
-        },
-        "machine_name": {
-            "default_value": "Twin Dragon 300"
-        },
-        "machine_width": {
-            "default_value": 400
-        },
-        "speed_print": {
-            "value": "100"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 300 },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 300 },
+        "machine_max_feedrate_y": { "value": 300 },
+        "machine_name": { "default_value": "Twin Dragon 300" },
+        "machine_width": { "default_value": 400 },
+        "speed_print": { "value": "100" },
+        "speed_travel":
+        {
             "maximum_value": "600",
             "maximum_value_warning": "600",
             "value": "max(350,speed_print)"

--- a/resources/definitions/twin_dragon_300.def.json
+++ b/resources/definitions/twin_dragon_300.def.json
@@ -1,0 +1,39 @@
+{
+    "version": 2,
+    "name": "Fracktal Twin Dragon 300",
+    "inherits": "base_fracktal_idex_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 300
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 300
+        },
+        "machine_max_feedrate_y": {
+            "value": 300
+        },
+        "machine_name": {
+            "default_value": "Twin Dragon 300"
+        },
+        "machine_width": {
+            "default_value": 400
+        },
+        "speed_print": {
+            "value": "100"
+        },
+        "speed_travel": {
+            "maximum_value": "600",
+            "maximum_value_warning": "600",
+            "value": "max(350,speed_print)"
+        }
+    }
+}

--- a/resources/definitions/twin_dragon_400.def.json
+++ b/resources/definitions/twin_dragon_400.def.json
@@ -2,35 +2,24 @@
     "version": 2,
     "name": "Fracktal Twin Dragon 400",
     "inherits": "base_fracktal_idex_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 400
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 300
-        },
-        "machine_max_feedrate_y": {
-            "value": 300
-        },
-        "machine_name": {
-            "default_value": "Twin Dragon 400"
-        },
-        "machine_width": {
-            "default_value": 500
-        },
-        "speed_print": {
-            "value": "100"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 400 },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 300 },
+        "machine_max_feedrate_y": { "value": 300 },
+        "machine_name": { "default_value": "Twin Dragon 400" },
+        "machine_width": { "default_value": 500 },
+        "speed_print": { "value": "100" },
+        "speed_travel":
+        {
             "maximum_value": "600",
             "maximum_value_warning": "600",
             "value": "max(300,speed_print)"

--- a/resources/definitions/twin_dragon_400.def.json
+++ b/resources/definitions/twin_dragon_400.def.json
@@ -1,0 +1,39 @@
+{
+    "version": 2,
+    "name": "Fracktal Twin Dragon 400",
+    "inherits": "base_fracktal_idex_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 400
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 300
+        },
+        "machine_max_feedrate_y": {
+            "value": 300
+        },
+        "machine_name": {
+            "default_value": "Twin Dragon 400"
+        },
+        "machine_width": {
+            "default_value": 500
+        },
+        "speed_print": {
+            "value": "100"
+        },
+        "speed_travel": {
+            "maximum_value": "600",
+            "maximum_value_warning": "600",
+            "value": "max(300,speed_print)"
+        }
+    }
+}

--- a/resources/definitions/twin_dragon_600.def.json
+++ b/resources/definitions/twin_dragon_600.def.json
@@ -1,0 +1,39 @@
+{
+    "version": 2,
+    "name": "Fracktal Twin Dragon 600",
+    "inherits": "base_fracktal_idex_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 600
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 300
+        },
+        "machine_max_feedrate_y": {
+            "value": 300
+        },
+        "machine_name": {
+            "default_value": "Twin Dragon 600"
+        },
+        "machine_width": {
+            "default_value": 700
+        },
+        "speed_print": {
+            "value": "100"
+        },
+        "speed_travel": {
+            "maximum_value": "600",
+            "maximum_value_warning": "600",
+            "value": "max(250,speed_print)"
+        }
+    }
+}

--- a/resources/definitions/twin_dragon_600.def.json
+++ b/resources/definitions/twin_dragon_600.def.json
@@ -2,35 +2,24 @@
     "version": 2,
     "name": "Fracktal Twin Dragon 600",
     "inherits": "base_fracktal_idex_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 600
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 300
-        },
-        "machine_max_feedrate_y": {
-            "value": 300
-        },
-        "machine_name": {
-            "default_value": "Twin Dragon 600"
-        },
-        "machine_width": {
-            "default_value": 700
-        },
-        "speed_print": {
-            "value": "100"
-        },
-        "speed_travel": {
+    "overrides":
+    {
+        "machine_depth": { "default_value": 600 },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 300 },
+        "machine_max_feedrate_y": { "value": 300 },
+        "machine_name": { "default_value": "Twin Dragon 600" },
+        "machine_width": { "default_value": 700 },
+        "speed_print": { "value": "100" },
+        "speed_travel":
+        {
             "maximum_value": "600",
             "maximum_value_warning": "600",
             "value": "max(250,speed_print)"

--- a/resources/definitions/twin_dragon_600x300.def.json
+++ b/resources/definitions/twin_dragon_600x300.def.json
@@ -2,39 +2,23 @@
     "version": 2,
     "name": "Fracktal Twin Dragon 600x300",
     "inherits": "base_fracktal_idex_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "machine_depth": {
-            "default_value": 300
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 300
-        },
-        "machine_max_feedrate_y": {
-            "value": 300
-        },
-        "machine_name": {
-            "default_value": "Twin Dragon 600 x 300"
-        },
-        "machine_width": {
-            "default_value": 600
-        },
-        "speed_print": {
-            "value": "100"
-        },
-        "speed_roofing": {
-            "value": "speed_wall"
-        },
-        "speed_travel": {
-            "value": "max(150,speed_print)"
-        }
+    "overrides":
+    {
+        "machine_depth": { "default_value": 300 },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 300 },
+        "machine_max_feedrate_y": { "value": 300 },
+        "machine_name": { "default_value": "Twin Dragon 600 x 300" },
+        "machine_width": { "default_value": 600 },
+        "speed_print": { "value": "100" },
+        "speed_roofing": { "value": "speed_wall" },
+        "speed_travel": { "value": "max(150,speed_print)" }
     }
 }

--- a/resources/definitions/twin_dragon_600x300.def.json
+++ b/resources/definitions/twin_dragon_600x300.def.json
@@ -1,0 +1,40 @@
+{
+    "version": 2,
+    "name": "Fracktal Twin Dragon 600x300",
+    "inherits": "base_fracktal_idex_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "machine_depth": {
+            "default_value": 300
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 300
+        },
+        "machine_max_feedrate_y": {
+            "value": 300
+        },
+        "machine_name": {
+            "default_value": "Twin Dragon 600 x 300"
+        },
+        "machine_width": {
+            "default_value": 600
+        },
+        "speed_print": {
+            "value": "100"
+        },
+        "speed_roofing": {
+            "value": "speed_wall"
+        },
+        "speed_travel": {
+            "value": "max(150,speed_print)"
+        }
+    }
+}

--- a/resources/definitions/volterra_300_alf.def.json
+++ b/resources/definitions/volterra_300_alf.def.json
@@ -1,0 +1,50 @@
+{
+    "version": 2,
+    "name": "Fracktal Volterra 300 ALF",
+    "inherits": "base_fracktal_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "build_volume_temperature": {
+            "enabled": true
+        },
+        "default_material_print_temperature": {
+            "maximum_value": "450",
+            "maximum_value_warning": "350"
+        },
+        "machine_depth": {
+            "default_value": 300
+        },
+        "machine_end_gcode": {
+            "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off\nM141 S0 ;chamber heater off\nM144 ;ring heater off\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning\n\nM300 S0 P333\nM300 S880 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\n"
+        },
+        "machine_heated_build_volume": {
+            "default_value": true
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 150
+        },
+        "machine_max_feedrate_y": {
+            "value": 150
+        },
+        "machine_name": {
+            "default_value": "Volterra 300 ALF"
+        },
+        "machine_start_gcode": {
+            "default_value": ";Machine Model: {machine_name} \n;Nozzle Size: {str(extruderValue(-1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\n\n;Ring Heater Control\n{'M143 S' + str(int(ring_heater_power * 2.55)) + ' ;Set ring heater power' if ring_heater_enable else ';Ring heater disabled'}\n\n;Build Volume Temperature\n{'M141 S' + str(build_volume_temperature) + ' ;Set chamber temperature' if build_volume_temperature > 0 else ';Chamber heating disabled'}\n\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\nM117 Printing...\n\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\n"
+        },
+        "machine_width": {
+            "default_value": 300
+        },
+        "speed_layer_0": {
+            "value": "min(25, round(speed_print * 0.3, 0))"
+        }
+    }
+}

--- a/resources/definitions/volterra_300_alf.def.json
+++ b/resources/definitions/volterra_300_alf.def.json
@@ -2,49 +2,30 @@
     "version": 2,
     "name": "Fracktal Volterra 300 ALF",
     "inherits": "base_fracktal_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "build_volume_temperature": {
-            "enabled": true
-        },
-        "default_material_print_temperature": {
+    "overrides":
+    {
+        "build_volume_temperature": { "enabled": true },
+        "default_material_print_temperature":
+        {
             "maximum_value": "450",
             "maximum_value_warning": "350"
         },
-        "machine_depth": {
-            "default_value": 300
-        },
-        "machine_end_gcode": {
-            "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off\nM141 S0 ;chamber heater off\nM144 ;ring heater off\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning\n\nM300 S0 P333\nM300 S880 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\n"
-        },
-        "machine_heated_build_volume": {
-            "default_value": true
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 150
-        },
-        "machine_max_feedrate_y": {
-            "value": 150
-        },
-        "machine_name": {
-            "default_value": "Volterra 300 ALF"
-        },
-        "machine_start_gcode": {
-            "default_value": ";Machine Model: {machine_name} \n;Nozzle Size: {str(extruderValue(-1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\n\n;Ring Heater Control\n{'M143 S' + str(int(ring_heater_power * 2.55)) + ' ;Set ring heater power' if ring_heater_enable else ';Ring heater disabled'}\n\n;Build Volume Temperature\n{'M141 S' + str(build_volume_temperature) + ' ;Set chamber temperature' if build_volume_temperature > 0 else ';Chamber heating disabled'}\n\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\nM117 Printing...\n\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\n"
-        },
-        "machine_width": {
-            "default_value": 300
-        },
-        "speed_layer_0": {
-            "value": "min(25, round(speed_print * 0.3, 0))"
-        }
+        "machine_depth": { "default_value": 300 },
+        "machine_end_gcode": { "default_value": ";End GCode\nM104 T0 S0 ;extruder heater off\nM104 T1 S0 ;extruder heater off\nM140 S0 ;heated bed heater off\nM141 S0 ;chamber heater off\nM144 ;ring heater off\nG91 ;relative positioning\nG1 E-1 F300 ;retract the filament a bit before lifting the nozzle, to release some of the pressure\nG1 Z+0.5 E-5 F3000 ;move Z up a bit and retract filament even more\nG28;move X/Y to min endstops, so the head is out of the way\nM84 ;steppers off\nM107\nG90 ;absolute positioning\n\nM300 S0 P333\nM300 S880 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S0 P166\nM300 S1567 P166\nM300 S0 P166\nM300 S880 P166\n" },
+        "machine_heated_build_volume": { "default_value": true },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 150 },
+        "machine_max_feedrate_y": { "value": 150 },
+        "machine_name": { "default_value": "Volterra 300 ALF" },
+        "machine_start_gcode": { "default_value": ";Machine Model: {machine_name} \n;Nozzle Size: {str(extruderValue(-1, 'machine_nozzle_size'))}\n;Sliced at: {day} {date} {time}\nG21 ;metric values\nM107\nG28\nM420 S1\nG90 ;absolute positioning\nG1 X0 Y0 Z5 F5000 ;move nozzle up 5mm for safe homing\nG29;ABL\nM500\nM82 ;set extruder to absolute mode\nM107 ;start with the fan off\n\n;Ring Heater Control\n{'M143 S' + str(int(ring_heater_power * 2.55)) + ' ;Set ring heater power' if ring_heater_enable else ';Ring heater disabled'}\n\n;Build Volume Temperature\n{'M141 S' + str(build_volume_temperature) + ' ;Set chamber temperature' if build_volume_temperature > 0 else ';Chamber heating disabled'}\n\nG1 X0 Y0 Z15.0 F5000 ;move the platform down 15mm\n\n; Extrude purge line\n\nG92 E0 ; reset extruder position\nG0 Z0.2 F500 ; purge\nG0 X15 E2.5 F500 ; purge\nG92 E0 ; reset extruder position\nG0 X25 E2.5 F650 ; purge\nG92 E0 ; reset extruder position\nG0 X35 E2.5 F800 ; purge\nG0 X{35 + 3} Z{0.05} F{8000} ; wipe, move close to the bed\nG0 X{35 + 3 * 2} Z0.2 F{8000} ; wipe, move quickly away from the bed\n\nG92 E0 ; zero the extruded length again\nM117 Printing...\n\nM300 S880 P166\nM300 S0 P166\nM300 S880 P166\nM300 S1318 P166\nM300 S1567 P166\nM300 S0 P166\n" },
+        "machine_width": { "default_value": 300 },
+        "speed_layer_0": { "value": "min(25, round(speed_print * 0.3, 0))" }
     }
 }

--- a/resources/definitions/volterra_dual.def.json
+++ b/resources/definitions/volterra_dual.def.json
@@ -1,0 +1,35 @@
+{
+    "version": 2,
+    "name": "Fracktal Volterra 400",
+    "inherits": "base_fracktal_dual_printer",
+    "metadata": {
+        "visible": true,
+        "manufacturer": "Fracktal Works",
+        "preferred_quality_type": "normal",
+        "author": "Fracktal Works"
+    },
+    "overrides": {
+        "default_material_print_temperature": {
+            "maximum_value": "450",
+            "maximum_value_warning": "350"
+        },
+        "machine_depth": {
+            "default_value": 400
+        },
+        "machine_height": {
+            "default_value": 400
+        },
+        "machine_name": {
+            "default_value": "Volterra 400"
+        },
+        "machine_width": {
+            "default_value": 400
+        },
+        "machine_max_feedrate_x": {
+            "value": 150
+        },
+        "machine_max_feedrate_y": {
+            "value": 150
+        }
+    }
+}

--- a/resources/definitions/volterra_dual.def.json
+++ b/resources/definitions/volterra_dual.def.json
@@ -2,34 +2,25 @@
     "version": 2,
     "name": "Fracktal Volterra 400",
     "inherits": "base_fracktal_dual_printer",
-    "metadata": {
+    "metadata":
+    {
         "visible": true,
+        "author": "Fracktal Works",
         "manufacturer": "Fracktal Works",
-        "preferred_quality_type": "normal",
-        "author": "Fracktal Works"
+        "preferred_quality_type": "normal"
     },
-    "overrides": {
-        "default_material_print_temperature": {
+    "overrides":
+    {
+        "default_material_print_temperature":
+        {
             "maximum_value": "450",
             "maximum_value_warning": "350"
         },
-        "machine_depth": {
-            "default_value": 400
-        },
-        "machine_height": {
-            "default_value": 400
-        },
-        "machine_name": {
-            "default_value": "Volterra 400"
-        },
-        "machine_width": {
-            "default_value": 400
-        },
-        "machine_max_feedrate_x": {
-            "value": 150
-        },
-        "machine_max_feedrate_y": {
-            "value": 150
-        }
+        "machine_depth": { "default_value": 400 },
+        "machine_height": { "default_value": 400 },
+        "machine_max_feedrate_x": { "value": 150 },
+        "machine_max_feedrate_y": { "value": 150 },
+        "machine_name": { "default_value": "Volterra 400" },
+        "machine_width": { "default_value": 400 }
     }
 }

--- a/resources/extruders/base_fracktal_dual_extruder_0.def.json
+++ b/resources/extruders/base_fracktal_dual_extruder_0.def.json
@@ -1,0 +1,42 @@
+{
+    "version": 2,
+    "name": "Extruder 1",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "base_fracktal_printer",
+        "position": "0"
+    },
+    "overrides": {
+        "extruder_nr": {
+            "default_value": 0,
+            "maximum_value": "1"
+        },
+        "machine_extruder_end_code": {
+            "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG4 P2000\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n"
+        },
+        "machine_extruder_end_pos_abs": {
+            "default_value": true
+        },
+        "machine_extruder_end_pos_x": {
+            "value": "prime_tower_position_x"
+        },
+        "machine_extruder_end_pos_y": {
+            "value": "prime_tower_position_y + (prime_tower_size/2)"
+        },
+        "machine_extruder_start_code": {
+            "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n"
+        },
+        "machine_extruder_start_pos_abs": {
+            "default_value": true
+        },
+        "machine_extruder_start_pos_x": {
+            "value": "prime_tower_position_x"
+        },
+        "machine_extruder_start_pos_y": {
+            "value": "prime_tower_position_y + (prime_tower_size/2)"
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        }
+    }
+}

--- a/resources/extruders/base_fracktal_dual_extruder_0.def.json
+++ b/resources/extruders/base_fracktal_dual_extruder_0.def.json
@@ -2,41 +2,26 @@
     "version": 2,
     "name": "Extruder 1",
     "inherits": "fdmextruder",
-    "metadata": {
+    "metadata":
+    {
         "machine": "base_fracktal_printer",
         "position": "0"
     },
-    "overrides": {
-        "extruder_nr": {
+    "overrides":
+    {
+        "extruder_nr":
+        {
             "default_value": 0,
             "maximum_value": "1"
         },
-        "machine_extruder_end_code": {
-            "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG4 P2000\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n"
-        },
-        "machine_extruder_end_pos_abs": {
-            "default_value": true
-        },
-        "machine_extruder_end_pos_x": {
-            "value": "prime_tower_position_x"
-        },
-        "machine_extruder_end_pos_y": {
-            "value": "prime_tower_position_y + (prime_tower_size/2)"
-        },
-        "machine_extruder_start_code": {
-            "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n"
-        },
-        "machine_extruder_start_pos_abs": {
-            "default_value": true
-        },
-        "machine_extruder_start_pos_x": {
-            "value": "prime_tower_position_x"
-        },
-        "machine_extruder_start_pos_y": {
-            "value": "prime_tower_position_y + (prime_tower_size/2)"
-        },
-        "material_diameter": {
-            "default_value": 1.75
-        }
+        "machine_extruder_end_code": { "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG4 P2000\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n" },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y + (prime_tower_size/2)" },
+        "machine_extruder_start_code": { "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y + (prime_tower_size/2)" },
+        "material_diameter": { "default_value": 1.75 }
     }
 }

--- a/resources/extruders/base_fracktal_dual_extruder_1.def.json
+++ b/resources/extruders/base_fracktal_dual_extruder_1.def.json
@@ -1,0 +1,42 @@
+{
+    "version": 2,
+    "name": "Extruder 2",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "base_fracktal_printer",
+        "position": "1"
+    },
+    "overrides": {
+        "extruder_nr": {
+            "default_value": 1,
+            "maximum_value": "1"
+        },
+        "machine_extruder_end_code": {
+            "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG4 P2000\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n"
+        },
+        "machine_extruder_end_pos_abs": {
+            "default_value": true
+        },
+        "machine_extruder_end_pos_x": {
+            "value": "prime_tower_position_x"
+        },
+        "machine_extruder_end_pos_y": {
+            "value": "prime_tower_position_y + (prime_tower_size/2)"
+        },
+        "machine_extruder_start_code": {
+            "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n"
+        },
+        "machine_extruder_start_pos_abs": {
+            "default_value": true
+        },
+        "machine_extruder_start_pos_x": {
+            "value": "prime_tower_position_x"
+        },
+        "machine_extruder_start_pos_y": {
+            "value": "prime_tower_position_y + (prime_tower_size/2)"
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        }
+    }
+}

--- a/resources/extruders/base_fracktal_dual_extruder_1.def.json
+++ b/resources/extruders/base_fracktal_dual_extruder_1.def.json
@@ -2,41 +2,26 @@
     "version": 2,
     "name": "Extruder 2",
     "inherits": "fdmextruder",
-    "metadata": {
+    "metadata":
+    {
         "machine": "base_fracktal_printer",
         "position": "1"
     },
-    "overrides": {
-        "extruder_nr": {
+    "overrides":
+    {
+        "extruder_nr":
+        {
             "default_value": 1,
             "maximum_value": "1"
         },
-        "machine_extruder_end_code": {
-            "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG4 P2000\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n"
-        },
-        "machine_extruder_end_pos_abs": {
-            "default_value": true
-        },
-        "machine_extruder_end_pos_x": {
-            "value": "prime_tower_position_x"
-        },
-        "machine_extruder_end_pos_y": {
-            "value": "prime_tower_position_y + (prime_tower_size/2)"
-        },
-        "machine_extruder_start_code": {
-            "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n"
-        },
-        "machine_extruder_start_pos_abs": {
-            "default_value": true
-        },
-        "machine_extruder_start_pos_x": {
-            "value": "prime_tower_position_x"
-        },
-        "machine_extruder_start_pos_y": {
-            "value": "prime_tower_position_y + (prime_tower_size/2)"
-        },
-        "material_diameter": {
-            "default_value": 1.75
-        }
+        "machine_extruder_end_code": { "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG4 P2000\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n" },
+        "machine_extruder_end_pos_abs": { "default_value": true },
+        "machine_extruder_end_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "prime_tower_position_y + (prime_tower_size/2)" },
+        "machine_extruder_start_code": { "default_value": ";WIPE\nG91\nG1 X-5 F{speed_travel*60}\nG1 X10\nG1 X-10\nG1 X10\nG1 X-10\nG1 X5\nG90\n" },
+        "machine_extruder_start_pos_abs": { "default_value": true },
+        "machine_extruder_start_pos_x": { "value": "prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "prime_tower_position_y + (prime_tower_size/2)" },
+        "material_diameter": { "default_value": 1.75 }
     }
 }

--- a/resources/extruders/base_fracktal_extruder_0.def.json
+++ b/resources/extruders/base_fracktal_extruder_0.def.json
@@ -2,16 +2,14 @@
     "version": 2,
     "name": "Extruder",
     "inherits": "fdmextruder",
-    "metadata": {
+    "metadata":
+    {
         "machine": "base_fracktal_printer",
         "position": "0"
     },
-    "overrides": {
-        "extruder_nr": {
-            "default_value": 0
-        },
-        "material_diameter": {
-            "default_value": 1.75
-        }
+    "overrides":
+    {
+        "extruder_nr": { "default_value": 0 },
+        "material_diameter": { "default_value": 1.75 }
     }
 }

--- a/resources/extruders/base_fracktal_extruder_0.def.json
+++ b/resources/extruders/base_fracktal_extruder_0.def.json
@@ -1,0 +1,17 @@
+{
+    "version": 2,
+    "name": "Extruder",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "base_fracktal_printer",
+        "position": "0"
+    },
+    "overrides": {
+        "extruder_nr": {
+            "default_value": 0
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        }
+    }
+}

--- a/resources/extruders/base_fracktal_idex_extruder_0.def.json
+++ b/resources/extruders/base_fracktal_idex_extruder_0.def.json
@@ -1,0 +1,42 @@
+{
+    "version": 2,
+    "name": "Extruder 0",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "base_fracktal_idex_printer",
+        "position": "0"
+    },
+    "overrides": {
+        "extruder_nr": {
+            "default_value": 0,
+            "maximum_value": "1"
+        },
+        "machine_extruder_end_code": {
+            "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG4 P2000\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'"
+        },
+        "machine_extruder_end_pos_abs": {
+            "value": "True if prime_tower_enable else False"
+        },
+        "machine_extruder_end_pos_x": {
+            "value": "0.0 if not prime_tower_enable else prime_tower_position_x"
+        },
+        "machine_extruder_end_pos_y": {
+            "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)"
+        },
+        "machine_extruder_start_code": {
+            "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'"
+        },
+        "machine_extruder_start_pos_abs": {
+            "value": "True if prime_tower_enable else False"
+        },
+        "machine_extruder_start_pos_x": {
+            "value": "0.0 if not prime_tower_enable else prime_tower_position_x"
+        },
+        "machine_extruder_start_pos_y": {
+            "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)"
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        }
+    }
+}

--- a/resources/extruders/base_fracktal_idex_extruder_0.def.json
+++ b/resources/extruders/base_fracktal_idex_extruder_0.def.json
@@ -2,41 +2,26 @@
     "version": 2,
     "name": "Extruder 0",
     "inherits": "fdmextruder",
-    "metadata": {
+    "metadata":
+    {
         "machine": "base_fracktal_idex_printer",
         "position": "0"
     },
-    "overrides": {
-        "extruder_nr": {
+    "overrides":
+    {
+        "extruder_nr":
+        {
             "default_value": 0,
             "maximum_value": "1"
         },
-        "machine_extruder_end_code": {
-            "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG4 P2000\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'"
-        },
-        "machine_extruder_end_pos_abs": {
-            "value": "True if prime_tower_enable else False"
-        },
-        "machine_extruder_end_pos_x": {
-            "value": "0.0 if not prime_tower_enable else prime_tower_position_x"
-        },
-        "machine_extruder_end_pos_y": {
-            "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)"
-        },
-        "machine_extruder_start_code": {
-            "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'"
-        },
-        "machine_extruder_start_pos_abs": {
-            "value": "True if prime_tower_enable else False"
-        },
-        "machine_extruder_start_pos_x": {
-            "value": "0.0 if not prime_tower_enable else prime_tower_position_x"
-        },
-        "machine_extruder_start_pos_y": {
-            "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)"
-        },
-        "material_diameter": {
-            "default_value": 1.75
-        }
+        "machine_extruder_end_code": { "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG4 P2000\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'" },
+        "machine_extruder_end_pos_abs": { "value": "True if prime_tower_enable else False" },
+        "machine_extruder_end_pos_x": { "value": "0.0 if not prime_tower_enable else prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)" },
+        "machine_extruder_start_code": { "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'" },
+        "machine_extruder_start_pos_abs": { "value": "True if prime_tower_enable else False" },
+        "machine_extruder_start_pos_x": { "value": "0.0 if not prime_tower_enable else prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)" },
+        "material_diameter": { "default_value": 1.75 }
     }
 }

--- a/resources/extruders/base_fracktal_idex_extruder_1.def.json
+++ b/resources/extruders/base_fracktal_idex_extruder_1.def.json
@@ -1,0 +1,42 @@
+{
+    "version": 2,
+    "name": "Extruder 1",
+    "inherits": "fdmextruder",
+    "metadata": {
+        "machine": "base_fracktal_idex_printer",
+        "position": "1"
+    },
+    "overrides": {
+        "extruder_nr": {
+            "default_value": 1,
+            "maximum_value": "1"
+        },
+        "machine_extruder_end_code": {
+            "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG4 P2000\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'"
+        },
+        "machine_extruder_end_pos_abs": {
+            "value": "True if prime_tower_enable else False"
+        },
+        "machine_extruder_end_pos_x": {
+            "value": "0.0 if not prime_tower_enable else prime_tower_position_x"
+        },
+        "machine_extruder_end_pos_y": {
+            "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)"
+        },
+        "machine_extruder_start_code": {
+            "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'"
+        },
+        "machine_extruder_start_pos_abs": {
+            "value": "True if prime_tower_enable else False"
+        },
+        "machine_extruder_start_pos_x": {
+            "value": "0.0 if not prime_tower_enable else prime_tower_position_x"
+        },
+        "machine_extruder_start_pos_y": {
+            "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)"
+        },
+        "material_diameter": {
+            "default_value": 1.75
+        }
+    }
+}

--- a/resources/extruders/base_fracktal_idex_extruder_1.def.json
+++ b/resources/extruders/base_fracktal_idex_extruder_1.def.json
@@ -2,41 +2,26 @@
     "version": 2,
     "name": "Extruder 1",
     "inherits": "fdmextruder",
-    "metadata": {
+    "metadata":
+    {
         "machine": "base_fracktal_idex_printer",
         "position": "1"
     },
-    "overrides": {
-        "extruder_nr": {
+    "overrides":
+    {
+        "extruder_nr":
+        {
             "default_value": 1,
             "maximum_value": "1"
         },
-        "machine_extruder_end_code": {
-            "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG4 P2000\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'"
-        },
-        "machine_extruder_end_pos_abs": {
-            "value": "True if prime_tower_enable else False"
-        },
-        "machine_extruder_end_pos_x": {
-            "value": "0.0 if not prime_tower_enable else prime_tower_position_x"
-        },
-        "machine_extruder_end_pos_y": {
-            "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)"
-        },
-        "machine_extruder_start_code": {
-            "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'"
-        },
-        "machine_extruder_start_pos_abs": {
-            "value": "True if prime_tower_enable else False"
-        },
-        "machine_extruder_start_pos_x": {
-            "value": "0.0 if not prime_tower_enable else prime_tower_position_x"
-        },
-        "machine_extruder_start_pos_y": {
-            "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)"
-        },
-        "material_diameter": {
-            "default_value": 1.75
-        }
+        "machine_extruder_end_code": { "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG4 P2000\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'" },
+        "machine_extruder_end_pos_abs": { "value": "True if prime_tower_enable else False" },
+        "machine_extruder_end_pos_x": { "value": "0.0 if not prime_tower_enable else prime_tower_position_x" },
+        "machine_extruder_end_pos_y": { "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)" },
+        "machine_extruder_start_code": { "value": "'' if not prime_tower_enable else ';WIPE\\nG91\\nG1 X-5 F{speed_travel*60}\\nG1 X10\\nG1 X-10\\nG1 X10\\nG1 X-10\\nG1 X5\\nG90\\n'" },
+        "machine_extruder_start_pos_abs": { "value": "True if prime_tower_enable else False" },
+        "machine_extruder_start_pos_x": { "value": "0.0 if not prime_tower_enable else prime_tower_position_x" },
+        "machine_extruder_start_pos_y": { "value": "0.0 if not prime_tower_enable else prime_tower_position_y + (prime_tower_size / 2)" },
+        "material_diameter": { "default_value": 1.75 }
     }
 }


### PR DESCRIPTION
## Description

This PR adds machine definitions for the current range of **Fracktal Works** FDM printers, manufactured in Bengaluru, India:

| Machine | Build volume (mm) | Extruders |
|---|---|---|
| Fracktal Snowflake | 200 × 200 × 200 | 1 |
| Fracktal Julia 200 | 200 × 200 × 200 | 1 |
| Fracktal Julia 250 | 250 × 250 × 300 | 1 |
| Fracktal Dragon 400 | 410 × 300 × 400 | 1 |
| Fracktal Dragon 500 | 510 × 400 × 400 | 1 |
| Fracktal Dragon 700 | 710 × 600 × 400 | 1 |
| Fracktal Twin Dragon 300 | 400 × 300 × 400 (union) | 2 (IDEX) |
| Fracktal Twin Dragon 400 | 500 × 400 × 400 (union) | 2 (IDEX) |
| Fracktal Twin Dragon 600 | 700 × 600 × 400 (union) | 2 (IDEX) |
| Fracktal Twin Dragon 600x300 | 600 × 300 × 400 (union) | 2 (IDEX) |
| Fracktal Volterra 300 ALF | 300 × 300 × 400 | 1 |
| Fracktal Volterra 400 | 400 × 400 × 400 | 2 |

Files added: 3 hidden base definitions (single / dual / IDEX), 12 visible machine definitions, 5 shared extruder definitions (the Creality-style shared-extruder pattern).

Also changed: the existing `julia.def.json` (the 2016 Julia V2, already in Cura) gets `manufacturer` normalised from `Fracktal` to `Fracktal Works` so all machines from this manufacturer group together in the add-printer dialog. No other change to that file.

## Where the values come from

We are the manufacturer. These definitions are extracted from our own Cura fork, [Fracktory-5](https://github.com/FracktalWorks/Fracktory-5), which ships with these machines and has been field-tested on them for years. For this upstream PR we removed everything that depends on fork-only custom settings and plugins:

- The IDEX machines (Twin Dragon series) are configured as standard dual-extruder printers with parking strips as `machine_disallowed_areas`. Mirror/duplication modes need our fork's plugin and are intentionally not part of this PR.
- No machine-specific quality/variant/material profiles are included; the machines use the global quality profiles. Tuned profiles remain available in Fracktory.
- Overrides that restate `fdmprinter.def.json` defaults were removed per the wiki checklist.

## Maintenance

Fracktal Works will maintain these definitions. Issues about these machines can be assigned to us (@FracktalWorks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
