### PR TITLE
Fix per-mesh setting filter in object panel

### DIFF
--- a/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
+++ b/plugins/PerObjectSettingsTool/PerObjectSettingsPanel.qml
@@ -208,11 +208,11 @@ Item
                         {
                             return { settable_per_meshgroup: true }
                         }
-                        return { settable_per_meshgroup: true }
+                        return { settable_per_mesh: true }
                     }
                     exclude:
                     {
-                        const excluded_settings = ["support_mesh", "anti_overhang_mesh", "cutting_mesh", "infill_mesh"]
+                        var excluded_settings = ["support_mesh", "anti_overhang_mesh", "cutting_mesh", "infill_mesh"]
 
                         if (currentMeshType === "support_mesh")
                         {


### PR DESCRIPTION
Settings such as "Enable Bridge Settings" could still be picked from the "Select settings" dialog, but would not show up in the per-model settings list afterwards. We were using the one_at_a_time filter (meshgroups) for both conditions to determine the state.

Also fixes a potential crash/qml fail when assigning a model as a support mesh, caused by reassigning a const array.

<img width="1558" height="1010" alt="image" src="https://github.com/user-attachments/assets/dad5d27d-84a6-48b6-bbaf-fee92bf5fb84" />

CURA-13322
