### PR TITLE
Value correction

### DIFF
--- a/resources/definitions/fdmprinter.def.json
+++ b/resources/definitions/fdmprinter.def.json
@@ -5760,7 +5760,7 @@
                     "maximum_value_warning": "support_line_distance / support_line_width",
                     "enabled": "(support_enable or support_meshes_present) and support_line_distance > 0 and support_pattern != 'zigzag'",
                     "limit_to_extruder": "support_infill_extruder_nr",
-                    "settable_per_mesh": true
+                    "settable_per_mesh": false
                 },
                 "support_interface_wall_count":
                 {


### PR DESCRIPTION
This pull request makes a small change to the `resources/definitions/fdmprinter.def.json` file. The change updates the `settable_per_mesh` property for a support setting, making the setting value in line with the engine implementation.

* Set `settable_per_mesh` to `false` for the relevant support setting, preventing users from configuring this parameter on a per-mesh basis as changing the value per mesh does not translate into a difference in slicing results.


CURA-13325